### PR TITLE
WIP: Change pickers to stop working on previous prompt when prompt changes

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -52,7 +52,13 @@ function config.set_defaults(defaults)
   set("border", {})
   set("borderchars", { '─', '│', '─', '│', '╭', '╮', '╯', '╰'})
 
-  set("get_status_text", function(self) return string.format("%s / %s", self.stats.processed - self.stats.filtered, self.stats.processed) end)
+  set("get_status_text", function(self)
+    return string.format(
+      "%s / %s",
+      (self.stats.processed or 0) - (self.stats.filtered or 0),
+      self.stats.processed or 0
+    )
+  end)
 
   -- Builtin configuration
 

--- a/lua/telescope/finders.lua
+++ b/lua/telescope/finders.lua
@@ -176,17 +176,53 @@ function OneshotJobFinder:new(opts)
 
     while true do
       finder, _, process_result, process_complete = coroutine.yield()
-      num_execution = num_execution + 1
 
-      local current_count = num_results
-      for index = 1, current_count do
-        process_result(results[index])
+      local scheduled_count = 1
+      local process_next_result
+      process_next_result = function()
+        if process_result(results[scheduled_count]) then
+          vim.schedule(function()
+            print("YOOO, we cancelled!!")
+            print("YOOO, we cancelled!!")
+            print("YOOO, we cancelled!!")
+          end)
+          return
+        end
+
+        scheduled_count = scheduled_count + 1
+
+        if scheduled_count >= num_results then
+          process_complete()
+          return
+        end
+
+        if false and scheduled_count % 10000 then
+          vim.defer_fn(process_next_result, 1)
+        else
+          vim.schedule(process_next_result)
+        end
       end
 
-      if completed then
-        process_complete()
-      end
+      vim.schedule(process_next_result)
     end
+
+    -- local process_em_all = function()
+    --   finder, _, process_result, process_complete = coroutine.yield()
+    --   num_execution = num_execution + 1
+
+    --   local current_count = num_results
+    --   for index = 1, current_count do
+    --     vim.schedule(function() process_result(results[index]) end)
+    --   end
+
+    --   if completed then
+    --     vim.schedule(process_complete)
+    --   end
+    -- end
+
+    -- while true do
+    --   process_em_all()
+    -- end
   end)
 
   return obj

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -337,7 +337,11 @@ function Picker:find()
     log.debug("ITERATION:", self.iteration)
 
     local current_iteration = self.iteration
-    local prompt = a.nvim_buf_get_lines(self.prompt_bufnr, 0, 1, false)[1]
+    local prompt = vim.trim(vim.api.nvim_buf_get_lines(prompt_bufnr, first_line, last_line, false)[1]:sub(#prompt_prefix))
+
+    if self.sorter then
+      self.sorter:_start(prompt)
+    end
 
     -- vim.defer_fn(function()
       -- TODO: Entry manager should have a "bulk" setter. This can prevent a lot of redraws from display
@@ -717,8 +721,6 @@ function Picker:get_result_processor(prompt, iteration, status_updater)
       return
     end
 
-    log.debug("Processing result... ", entry.value)
-
     for _, v in ipairs(self.file_ignore_patterns or {}) do
       if string.find(entry.value, v) then
         log.debug("SKPIPING", entry.value, "because", v)
@@ -729,7 +731,6 @@ function Picker:get_result_processor(prompt, iteration, status_updater)
     local sort_ok, sort_score = nil, 0
     if self.sorter then
       sort_ok, sort_score = self:_track("_sort_time", pcall, self.sorter.score, self.sorter, prompt, entry)
-      log.debug(sort_score, prompt, entry.ordinal)
 
       if not sort_ok then
         log.warn("Sorting failed with:", prompt, entry, sort_score)

--- a/lua/telescope/pickers/display.lua
+++ b/lua/telescope/pickers/display.lua
@@ -1,0 +1,78 @@
+local picker_display = {}
+
+picker_display.bind_handle_strategy = function(picker)
+  if picker.scroll_strategy == "cycle" then
+    return function(self, row)
+      if row >= self.max_results then
+        return 0
+      elseif row < 0 then
+        return self.max_results - 1
+      end
+
+      return row
+    end
+  else
+    return function(self, row)
+      if row >= self.max_results then
+        return self.max_results - 1
+      elseif row < 0 then
+        return 0
+      end
+
+      return row
+    end
+  end
+end
+
+
+picker_display.bind_can_select_row = function(picker)
+  if picker.sorting_strategy == 'ascending' then
+    return function(self, row)
+      return row <= self.manager:num_results()
+    end
+  else
+    return function(self, row)
+      return row <= self.max_results
+              and row >= self.max_results - self.manager:num_results()
+    end
+  end
+end
+
+
+
+picker_display.bind_get_row = function(picker)
+  --- Take a row and get an index.
+  ---@note: Rows are 0-indexed, and `index` is 1 indexed (table index)
+  ---@param index number: The row being displayed
+  ---@return number The row for the picker to display in
+
+  if picker.sorting_strategy == 'ascending' then
+    return function(_, index) return index - 1 end
+  else
+    return function(self, index) return self.max_results - index end
+  end
+end
+
+picker_display.bind_get_index = function(picker)
+  --- Take a row and get an index
+  ---@note: Rows are 0-indexed, and `index` is 1 indexed (table index)
+  ---@param row number: The row being displayed
+  ---@return number The index in line_manager
+  if picker.sorting_strategy == 'ascending' then
+    return function(_, row) return row + 1 end
+  else
+    return function(self, row) return self.max_results - row end
+  end
+end
+
+picker_display.bind_get_reset_row = function(picker)
+  if picker.sorting_strategy == 'ascending' then
+    return function(_) return 0 end
+  else
+    return function(self) return self.max_results - 1 end
+  end
+end
+
+
+
+return picker_display

--- a/lua/tests/manual/auto_picker.lua
+++ b/lua/tests/manual/auto_picker.lua
@@ -68,7 +68,7 @@ local find_files = function(opts)
     end
 
     vim.wait(300, function() end)
-    feed("<CR>", '')
+    feed("<c-c>", '')
 
     coroutine.yield()
   end))
@@ -76,4 +76,4 @@ local find_files = function(opts)
   p:find()
 end
 
-find_files()
+find_files { cwd = '~/build/neovim' }


### PR DESCRIPTION
This should greatly increase "snappiness" feeling and also prevent us from doing tons of wasted work on fast keystroke situations.

Also a good opportunity to  clean up some things. We'll see how things go.