### PR TITLE
Buffers rework (indicators and sorting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,14 +451,15 @@ This section is an overview of how custom pickers can be created any configured.
 ```lua
 -- lua/telescope/pickers.lua
 Picker:new{
-  prompt_title       = "", -- REQUIRED
-  finder             = FUNCTION, -- see lua/telescope/finder.lua
-  sorter             = FUNCTION, -- see lua/telescope/sorter.lua
-  previewer          = FUNCTION, -- see lua/telescope/previewer.lua
-  selection_strategy = "reset", -- follow, reset, row
-  border             = {},
-  borderchars        = {"─", "│", "─", "│", "┌", "┐", "┘", "└"},
-  preview_cutoff     = 120,
+  prompt_title            = "", -- REQUIRED
+  finder                  = FUNCTION, -- see lua/telescope/finder.lua
+  sorter                  = FUNCTION, -- see lua/telescope/sorter.lua
+  previewer               = FUNCTION, -- see lua/telescope/previewer.lua
+  selection_strategy      = "reset", -- follow, reset, row
+  border                  = {},
+  borderchars             = {"─", "│", "─", "│", "┌", "┐", "┘", "└"},
+  preview_cutoff          = 120,
+  default_selection_index = 1, -- Change the index of the initial selection row
 }
 ```
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -96,7 +96,15 @@ function actions._goto_file_selection(prompt_bufnr, command)
     actions.close(prompt_bufnr)
 
     if entry_bufnr then
-      vim.cmd(string.format(":%s #%d", command, entry_bufnr))
+      if command == 'edit' then
+        vim.cmd(string.format(":buffer %d", entry_bufnr))
+      elseif command == 'new' then
+        vim.cmd(string.format(":sbuffer %d", entry_bufnr))
+      elseif command == 'vnew' then
+        vim.cmd(string.format(":vert sbuffer %d", entry_bufnr))
+      elseif command == 'tabedit' then
+        vim.cmd(string.format(":tab sb %d", entry_bufnr))
+      end
     else
       filename = path.normalize(filename, vim.fn.getcwd())
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -612,16 +612,38 @@ builtin.fd = builtin.find_files
 builtin.buffers = function(opts)
   opts = opts or {}
 
-  local buffers = filter(function(b)
+  local bufnrs = filter(function(b)
     return
       (opts.show_all_buffers
       or vim.api.nvim_buf_is_loaded(b))
       and 1 == vim.fn.buflisted(b)
-
   end, vim.api.nvim_list_bufs())
 
+  local buffers = {}
+  local default_selection_idx = 1
+  for _, bufnr in ipairs(bufnrs) do
+    local flag = bufnr == vim.fn.bufnr('') and '%' or (bufnr == vim.fn.bufnr('#') and '#' or ' ')
+
+    if opts.sort_lastused and flag == "#" then
+      default_selection_idx = 2
+    end
+
+    local element = {
+      bufnr = bufnr,
+      flag = flag,
+      info = vim.fn.getbufinfo(bufnr)[1],
+    }
+
+    if opts.sort_lastused and (flag == "#" or flag == "%") then
+      local idx = ((buffers[1] ~= nil and buffers[1].flag == "%") and 2 or 1)
+      table.insert(buffers, idx, element)
+    else
+      table.insert(buffers, element)
+    end
+  end
+
   if not opts.bufnr_width then
-    local max_bufnr = math.max(unpack(buffers))
+    local max_bufnr = math.max(unpack(bufnrs))
     opts.bufnr_width = #tostring(max_bufnr)
   end
 
@@ -631,9 +653,9 @@ builtin.buffers = function(opts)
       results = buffers,
       entry_maker = make_entry.gen_from_buffer(opts)
     },
-    -- previewer = previewers.vim_buffer.new(opts),
-    previewer = previewers.vimgrep.new(opts),
+    previewer = previewers.vim_buffer.new(opts),
     sorter = conf.generic_sorter(opts),
+    default_selection_index = default_selection_idx,
   }):find()
 end
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -79,6 +79,7 @@ function Picker:new(opts)
     finder = opts.finder,
     sorter = opts.sorter,
     previewer = opts.previewer,
+    default_selection_index = opts.default_selection_index,
 
     _completion_callbacks = {},
 
@@ -470,18 +471,30 @@ function Picker:find()
 
       -- TODO: We should either: always leave one result or make sure we actually clean up the results when nothing matches
       if selection_strategy == 'row' then
-        self:set_selection(self:get_selection_row())
+        if self._selection_row == nil and self.default_selection_index ~= nil then
+          self:set_selection(self:get_row(self.default_selection_index))
+        else
+          self:set_selection(self:get_selection_row())
+        end
       elseif selection_strategy == 'follow' then
-        local index = self.manager:find_entry(self:get_selection())
+        if self._selection_row == nil and self.default_selection_index ~= nil then
+          self:set_selection(self:get_row(self.default_selection_index))
+        else
+          local index = self.manager:find_entry(self:get_selection())
 
-        if index then
-          local follow_row = self:get_row(index)
-          self:set_selection(follow_row)
+          if index then
+            local follow_row = self:get_row(index)
+            self:set_selection(follow_row)
+          else
+            self:set_selection(self:get_reset_row())
+          end
+        end
+      elseif selection_strategy == 'reset' then
+        if self.default_selection_index ~= nil then
+          self:set_selection(self:get_row(self.default_selection_index))
         else
           self:set_selection(self:get_reset_row())
         end
-      elseif selection_strategy == 'reset' then
-        self:set_selection(self:get_reset_row())
       else
         error('Unknown selection strategy: ' .. selection_strategy)
       end

--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -356,53 +356,27 @@ previewers.vim_buffer = defaulter(function(_)
     end,
 
     preview_fn = function(self, entry, status)
-      -- TODO: Consider using path here? Might not work otherwise.
-      local filename = entry.filename
+      local bufnr = tonumber(entry.bufnr)
 
-      if filename == nil then
-        filename = entry.path
-      end
-
-      if filename == nil then
-        local value = entry.value
-        filename = vim.split(value, ":")[1]
-      end
-
-      if filename == nil then
-        return
-      end
-
-      log.info("Previewing File:", filename)
-
-      local bufnr = vim.fn.bufnr(filename)
-      if bufnr == -1 then
-        -- TODO: Is this the best way to load the buffer?... I'm not sure tbh
-        bufnr = vim.fn.bufadd(filename)
+      if not vim.api.nvim_buf_is_loaded(bufnr) then
         vim.fn.bufload(bufnr)
-
-        vim.cmd([[doautocmd filetypedetect BufRead ]] .. filename)
       end
 
       self.state.last_set_bufnr = bufnr
 
-      -- TODO: We should probably call something like this because we're not always getting highlight and all that stuff.
-      -- api.nvim_command('doautocmd filetypedetect BufRead ' .. vim.fn.fnameescape(filename))
       vim.api.nvim_win_set_buf(status.preview_win, bufnr)
       vim.api.nvim_win_set_option(status.preview_win, 'wrap', false)
       vim.api.nvim_win_set_option(status.preview_win, 'winhl', 'Normal:Normal')
-      -- vim.api.nvim_win_set_option(preview_win, 'winblend', 20)
       vim.api.nvim_win_set_option(status.preview_win, 'signcolumn', 'no')
       vim.api.nvim_win_set_option(status.preview_win, 'foldlevel', 100)
-
       if entry.lnum then
         vim.api.nvim_buf_add_highlight(bufnr, previewer_ns, "Visual", entry.lnum - 1, 0, -1)
-        vim.api.nvim_win_set_option(status.preview_win, 'scrolloff', 10)
+        vim.api.nvim_win_set_option(status.preview_win, 'scrolloff', 999)
         vim.api.nvim_win_set_cursor(status.preview_win, {entry.lnum, 0})
         -- print("LNUM:", entry.lnum)
       end
 
-      vim.api.nvim_win_set_option(status.preview_win, 'scrolloff', 999)
-      log.info("Previewed bufnr", bufnr)
+      self.state.hl_win = status.preview_win
     end,
   }
 end, {})


### PR DESCRIPTION
Close #179
Close #245

~~This is currently WIP. Basically it is hacked together.~~

This reworks `builtin.buffers`, so that we also display the indicators.
I'm currently parsing the output of `:buffers`. I'm not sure if i can get the indicators on another way.
~~This currently shows all buffer, also unloaded buffers. (So `show_all_buffers = true` does nothing)~~(Should now work as before)

This also adds a function, which could help us display outputs in a more table like format, like suggested in #118.
This does not change the other builtins to be to a table format. (I plan to do this in another pr).

~~I also briefly looked into  #179 and i think we can use `unpack(vim.fn.getbufinfo(tonumber(bufnr))).lastused` to sort the buffers list. (I think this should be configurable. either pick the current solution or based on lastused.). I might do this in this PR aswell. If I can figure out how the whole sorting part works.~~
Previous Buffer is default selection. Should be configurable. Configurable with `sort_lastused = true`
 
Before PR | New
:-------------:|:-------------------------:
![currently](https://user-images.githubusercontent.com/15233006/97763301-76673e80-1b0b-11eb-9f8c-b2c1a5703045.png)|![new](https://user-images.githubusercontent.com/15233006/97780340-5162e200-1b84-11eb-8a0d-11bec5ecb3f4.png)


@sunjon Would be great if you could comment the new layout(display output with the indicators).
~~Currently does not handle readonly buffers.~~
~~If no buffer has a write indicator the column will not be printed.~~

@Stanislav-Lapata and @sunjon when i sort the buffers after lastused, do you want the active buffer be displayed or should we filter out the current one?