### PR TITLE
Add tags builtin

### DIFF
--- a/lua/telescope/pickers/entry_display.lua
+++ b/lua/telescope/pickers/entry_display.lua
@@ -43,8 +43,8 @@ end
 
 local function truncate(str, len)
   -- TODO: This doesn't handle multi byte chars...
-  if vim.fn.strdisplaywidth(str) > len - 1 then
-    str = str:sub(1, len)
+  if vim.fn.strdisplaywidth(str) > len then
+    str = str:sub(1, len - 1)
     str = str .. "…"
   end
   return str
@@ -68,8 +68,10 @@ entry_display.create = function(configuration)
 
   return function(self, picker)
     local results = {}
-    for k, v in ipairs(self) do
-      table.insert(results, generator[k](v, picker))
+    for i = 1, table.getn(generator) do
+      if self[i] ~= nil then
+        table.insert(results, generator[i](self[i], picker))
+      end
     end
 
     return table.concat(results, configuration.separator or "│")


### PR DESCRIPTION
Close #209 

~~Written in a coffee break, so WIP.~~
~~Currently has to be generated with `--fields=n` to get the line numbers. So `ctags -R --fields=+n`~~

- [x] ~~Create `ctags` for user if file does not exists~~
- [x] Jump does not work
- [x] Write `make_entry` 
- [x] Create `display` with new table create
- [x] ~~Take another look at how lines numbers get retrieved in fzf, so we don't have to use `--fields=+n`. I decided to just force having `--fields=+n`. We could search for the lines but it is kinda unnecessary.~~
- [x] ~~Only `--fields=n` will not generate the other fields like `type` but using `--fields=+n` includes these fields aswell but does not work this current version~~
- [x] Some lines are not displayed. Happens in a file with tabs. has to be fixed by not only splitting with `\t` and don't split if the line has `\^\t`

default | hide_filename | show_line | hide_previewer
:-------------:|:-------------------------:|:-------------------:|:-----------------:
![default](https://user-images.githubusercontent.com/15233006/98025628-3ef9da00-1e0a-11eb-9ae7-396c6e2651a2.png)|![hide_filename](https://user-images.githubusercontent.com/15233006/98025611-3bfee980-1e0a-11eb-9b87-3cdee9a093d9.png)|![show_line](https://user-images.githubusercontent.com/15233006/98025602-386b6280-1e0a-11eb-9fe8-68ba3e22f84f.png)|![hide_previewer](https://user-images.githubusercontent.com/15233006/98025633-402b0700-1e0a-11eb-8bf5-fafaaf746eda.png)



Available options:
```lua
only_current_file = true -- default is false, setting this to true will only show tags for the current file
hide_filename = true     -- default is false
show_line = true           -- default is false
```