### PR TITLE
Fixes previews for files beginning with ~/ and Previewer will now show directories

### DIFF
--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -821,9 +821,7 @@ builtin.man_pages = function(opts)
 
   local cmd = opts.man_cmd or "apropos --sections=1 ''"
 
-  local f = assert(io.popen(cmd, 'r'))
-  local pages = assert(f:read('*a'))
-  f:close()
+  local pages = utils.get_os_command_output(cmd)
 
   local lines = {}
   for s in pages:gmatch("[^\r\n]+") do

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -190,4 +190,11 @@ function utils.display_termcodes(str)
   return str:gsub(string.char(9), "<TAB>"):gsub("", "<C-F>"):gsub(" ", "<Space>")
 end
 
+function utils.get_os_command_output(cmd)
+  local handle = assert(io.popen(cmd, 'r'))
+  local output = assert(handle:read('*a'))
+  assert(handle:close())
+  return output
+end
+
 return utils


### PR DESCRIPTION
Fix #226 

Edit: I will hijack this pr for #226 .
It also fixes the if condition. Its so easier than opening a new pr :laughing: 
It will also show directories. If i recall correctly find_files will only return files but when a directory buffer is opened buffers will show this buffer and preview the directory with `ls -la`

We could change find_files back to also show directories but i don't think its usefull. I don't know. Kinda need input on the whole directory suff @tjdevries  