### PR TITLE
Allow finder to find from multiple dirs

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -53,40 +53,50 @@ files.grep_string = function(opts)
   }):find()
 end
 
--- NOTE(tj): Get clarification on comment and put this in the right place
-local function insert_search_dirs(find_command, search_dirs)
-  local command = find_command[1]
-  local insert_pos = -1
-  if command == 'fd' or command == 'fdfind' then
-    table.insert(find_command, '.')
-  elseif command == 'find' then
-    for idx,val in ipairs(find_command) do
-      if val=='.' then
-        insert_pos = idx
-        break
-      end
-    end
-    table.remove(find_command, insert_pos)
-  end
-  for _,v in pairs(search_dirs) do
-    table.insert(find_command, insert_pos==-1 and (#find_command+1) or insert_pos, vim.fn.expand(v))
-  end
-end
-
 -- TODO: Maybe just change this to `find`.
 --          Support `find` and maybe let people do other stuff with it as well.
 files.find_files = function(opts)
   local find_command = opts.find_command
+  local search_dirs = opts.search_dirs
+
+  if search_dirs then
+    for k,v in pairs(search_dirs) do
+      search_dirs[k] = vim.fn.expand(v)
+    end
+  end
 
   if not find_command then
     if 1 == vim.fn.executable("fd") then
       find_command = { 'fd', '--type', 'f' }
+      if search_dirs then
+        table.insert(find_command, '.')
+        for _,v in pairs(search_dirs) do
+          table.insert(find_command, v)
+        end
+      end
     elseif 1 == vim.fn.executable("fdfind") then
       find_command = { 'fdfind', '--type', 'f' }
+      if search_dirs then
+        table.insert(find_command, '.')
+        for _,v in pairs(search_dirs) do
+          table.insert(find_command, v)
+        end
+      end
     elseif 1 == vim.fn.executable("rg") then
       find_command = { 'rg', '--files' }
+      if search_dirs then
+        for _,v in pairs(search_dirs) do
+          table.insert(find_command, v)
+        end
+      end
     elseif 1 == vim.fn.executable("find") then
       find_command = { 'find', '.', '-type', 'f' }
+      if search_dirs then
+        table.remove(find_command, 2)
+        for _,v in pairs(search_dirs) do
+          table.insert(find_command, 2, v)
+        end
+      end
     end
   end
 
@@ -96,15 +106,9 @@ files.find_files = function(opts)
     return
   end
 
-  local search_dirs = opts.search_dirs
-  if search_dirs then
-    insert_search_dirs(find_command, search_dirs)
-  end
-
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)
   end
-  P(find_command)
 
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)
 

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -53,6 +53,26 @@ files.grep_string = function(opts)
   }):find()
 end
 
+-- NOTE(tj): Get clarification on comment and put this in the right place
+local function insert_search_dirs(find_command, search_dirs)
+  local command = find_command[1]
+  if command == 'fd' or command == 'fdfind' then
+    table.insert(find_command, '.')
+    for _,v in pairs(search_dirs) do
+      table.insert(find_command, v)
+    end
+  elseif command == 'rg' then
+    for _,v in pairs(search_dirs) do
+      table.insert(find_command, v)
+    end
+  elseif command == 'find' then
+    table.remove(find_command, 1)
+    for _,v in pairs(search_dirs) do
+      table.insert(find_command, 2, v)
+    end
+  end
+end
+
 -- TODO: Maybe just change this to `find`.
 --          Support `find` and maybe let people do other stuff with it as well.
 files.find_files = function(opts)
@@ -74,6 +94,10 @@ files.find_files = function(opts)
     print("You need to install either find, fd, or rg. " ..
           "You can also submit a PR to add support for another file finder :)")
     return
+  end
+
+  if search_dirs then
+    insert_search_dirs(find_command, search_dirs)
   end
 
   if opts.cwd then

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -56,20 +56,20 @@ end
 -- NOTE(tj): Get clarification on comment and put this in the right place
 local function insert_search_dirs(find_command, search_dirs)
   local command = find_command[1]
+  local insert_pos = -1
   if command == 'fd' or command == 'fdfind' then
     table.insert(find_command, '.')
-    for _,v in pairs(search_dirs) do
-      table.insert(find_command, v)
-    end
-  elseif command == 'rg' then
-    for _,v in pairs(search_dirs) do
-      table.insert(find_command, v)
-    end
   elseif command == 'find' then
-    table.remove(find_command, 1)
-    for _,v in pairs(search_dirs) do
-      table.insert(find_command, 2, v)
+    for idx,val in ipairs(find_command) do
+      if val=='.' then
+        insert_pos = idx
+        break
+      end
     end
+    table.remove(find_command, insert_pos)
+  end
+  for _,v in pairs(search_dirs) do
+    table.insert(find_command, insert_pos==-1 and (#find_command+1) or insert_pos, vim.fn.expand(v))
   end
 end
 
@@ -104,6 +104,7 @@ files.find_files = function(opts)
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)
   end
+  P(find_command)
 
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)
 

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -96,6 +96,7 @@ files.find_files = function(opts)
     return
   end
 
+  local search_dirs = opts.search_dirs
   if search_dirs then
     insert_search_dirs(find_command, search_dirs)
   end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -77,7 +77,7 @@ do
 
     mt_file_entry.cwd = cwd
     mt_file_entry.display = function(entry)
-      local display, hl_group = entry.value
+      local display, hl_group = path.make_relative(entry.value, cwd), nil
       if shorten_path then
         display = utils.path_shorten(display)
       end
@@ -96,7 +96,11 @@ do
       if raw then return raw end
 
       if k == "path" then
-        return t.cwd .. path.separator .. t.value
+        local retpath = t.cwd .. path.separator .. t.value
+        if not vim.loop.fs_access(retpath, "R", nil) then
+          retpath = t.value
+        end
+        return retpath
       end
 
       return rawget(t, rawget(lookup_keys, k))

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -77,7 +77,8 @@ do
 
     mt_file_entry.cwd = cwd
     mt_file_entry.display = function(entry)
-      local display, hl_group = path.make_relative(entry.value, cwd), nil
+      local hl_group
+      local display = path.make_relative(entry.value, cwd)
       if shorten_path then
         display = utils.path_shorten(display)
       end


### PR DESCRIPTION
Adds functionality for finders to get files from multiple directories. Currently tuned only for the three supported finders, but shouldn't be too hard to add more, as long as the command itself supports searching from multiple directories. This PR adds a search_dirs option, which is injected into the command args to search from multiple directories
Fixes #238 