### PR TITLE
Fix git files in non-git directories

### DIFF
--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -53,8 +53,8 @@ builtin.git_files = function(opts)
     --- Find root of git directory and remove trailing newline characters
     opts.cwd = vim.fn.systemlist("git rev-parse --show-toplevel")[1]
 
-    if not vim.fn.isdirectory(opts.cwd) then
-      error("Not a working directory for git_files:", opts.cwd)
+    if 1 ~= vim.fn.isdirectory(opts.cwd) then
+      error("Not a working directory for git_files:" .. opts.cwd)
     end
   end
 


### PR DESCRIPTION
It appears that the `git_files` picker is supposed to throw an error in a non-git directory, but is not doing so correctly (see commit message for why it happens). This PR fixes the issue. 
Also fixes a consequential issue that the error function was called with the wrong parameters (since the condition was never being met, it was probably missed)