### PR TITLE
fix lsp_code_action error when no code action available

### DIFF
--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -229,7 +229,7 @@ builtin.lsp_code_actions = function(opts)
 
   local results = (results_lsp[1] or results_lsp[2]).result;
 
-  if #results == 0 then
+  if not results or #results == 0 then
     print("No code actions available")
     return
   end


### PR DESCRIPTION
I get an error message executing builtin.lsp_code_action when there's no code action available:

E5108: Error executing lua ...telescope.nvim/lua/telescope/builtin.lua:232: attempt to get length of local 'results' (a nil value)

The reason is that the results variable can be nil when there's no code action available,

check for nil results before checking the length