### PR TITLE
refactor set_opts_cwd function so that git is called only once if cwd is a git dir

### DIFF
--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -144,20 +144,18 @@ git.status = function(opts)
 end
 
 local set_opts_cwd = function(opts)
-  local is_git_dir = function(path)
-    vim.fn.system('cd ' .. path .. ' && git rev-parse HEAD >/dev/null 2>&1')
-    if vim.v.shell_error ~= 0 then
-      error(path .. ' is not a git directory')
-    end
-  end
-
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)
-    is_git_dir(opts.cwd)
   else
-    is_git_dir(vim.fn.expand('%:p:h'))
-    --- Find root of git directory and remove trailing newline characters
-    opts.cwd = vim.fn.systemlist("git rev-parse --show-toplevel")[1]
+    opts.cwd = vim.fn.expand('%:p:h')
+  end
+
+  -- Find root of git directory and remove trailing newline characters
+  opts.cwd = vim.fn.systemlist("git -C " .. opts.cwd .. " rev-parse --show-toplevel")[1]
+
+  -- opts.cwd contains the error message from git command if not in a git dir
+  if 1 ~= vim.fn.isdirectory(opts.cwd) then
+    error(opts.cwd)
   end
 end
 

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -151,11 +151,12 @@ local set_opts_cwd = function(opts)
   end
 
   -- Find root of git directory and remove trailing newline characters
-  opts.cwd = vim.fn.systemlist("git -C " .. opts.cwd .. " rev-parse --show-toplevel")[1]
+  local git_root = vim.fn.systemlist("git -C " .. opts.cwd .. " rev-parse --show-toplevel")[1]
 
-  -- opts.cwd contains the error message from git command if not in a git dir
-  if 1 ~= vim.fn.isdirectory(opts.cwd) then
-    error(opts.cwd)
+  if vim.v.shell_error ~= 0 then
+    error(opts.cwd .. ' is not a git directory')
+  else
+    opts.cwd = git_root
   end
 end
 


### PR DESCRIPTION
The original implementation of set_opts_cwd calls git command twice if current dir is a git dir:
1. `git rev-parse HEAD` : to determine if current dir is a git dir
2. `git rev-parse --show-toplevel`: to find root of git dir

Can we remove the first call and just call `git rev-parse --show-toplevel` instead? It  returns an error message if not we are not in a git dir anyway.
