### PR TITLE
fix cwd detection of builtin.git_files

### DIFF
--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -147,7 +147,7 @@ local set_opts_cwd = function(opts)
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)
   else
-    opts.cwd = vim.fn.expand('%:p:h')
+    opts.cwd = vim.fn.getcwd()
   end
 
   -- Find root of git directory and remove trailing newline characters

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -147,7 +147,7 @@ local set_opts_cwd = function(opts)
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)
   else
-    opts.cwd = vim.fn.getcwd()
+    opts.cwd = vim.loop.cwd()
   end
 
   -- Find root of git directory and remove trailing newline characters


### PR DESCRIPTION
Let's say I'm working in a git dir, and I open a vim help buffer.

If I run `builtin.git_files()` now, it will report we are not in a git dir because `git_files` detects cwd by `expand('%:p:h')`, which is expanded to `/usr/share/nvim/runtime/doc`

`getcwd` is a better way to detect current working dir.