### PR TITLE
Add highlights builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Built-in function ready to be bound to any key you like :smile:.
 | `builtin.vim_options`               | Lists vim options and on enter edit the options value            |
 | `builtin.keymaps`                   | Lists normal-mode mappings                                       |
 | `builtin.filetypes                  | Lists all filetypes                                              |
+| `builtin.highlights                 | Lists all highlights                                             |
 | `builtin.git_commits`               | Lists git commits with diff preview and on enter checkout the commit.|
 | `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and
 checkouts it out on enter|

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -910,6 +910,30 @@ builtin.filetypes = function(opts)
   }):find()
 end
 
+builtin.highlights = function(opts)
+  opts = opts or {}
+
+  local highlights = vim.fn.getcompletion('', 'highlight')
+
+  pickers.new({}, {
+    prompt_title = 'Highlights',
+    finder = finders.new_table {
+      results = highlights,
+      entry_maker = make_entry.gen_from_highlights(opts)
+    },
+    sorter = conf.generic_sorter(),
+    attach_mappings = function(prompt_bufnr)
+      actions.goto_file_selection_edit:replace(function()
+        local selection = actions.get_selected_entry()
+        actions.close(prompt_bufnr)
+        vim.cmd('hi ' .. selection.value)
+      end)
+      return true
+    end,
+    previewer = previewers.display_content.new(opts),
+  }):find()
+end
+
 builtin.tags = function(opts)
   opts = opts or {}
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -453,7 +453,33 @@ function make_entry.gen_from_marks(_)
   end
 end
 
-function make_entry.gen_from_vimoptions(opts)
+function make_entry.gen_from_highlights()
+  return function(entry)
+    local make_display = function(entry)
+      local display = entry.value
+      return display, { { { 0, #display }, display } }
+    end
+
+    local preview_command = function(entry, bufnr)
+      local hl = entry.value
+      vim.api.nvim_buf_set_option(bufnr, 'filetype', 'vim')
+      local output = vim.split(vim.fn.execute('hi ' .. hl), '\n')
+      local start = string.find(output[2], 'xxx', 1, true)
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, output)
+      vim.api.nvim_buf_add_highlight(bufnr, -1, hl, 1, start - 1, start + 2)
+    end
+
+    return {
+      value = entry,
+      display = make_display,
+      ordinal = entry,
+
+      preview_command = preview_command
+    }
+  end
+end
+
+function make_entry.gen_from_vimoptions()
   -- TODO: Can we just remove this from `options.lua`?
   function N_(s)
     return s

--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -680,6 +680,30 @@ previewers.man = defaulter(function(_)
   }
 end)
 
+previewers.display_content = defaulter(function(_)
+  return previewers.new {
+    preview_fn = function(self, entry, status)
+      with_preview_window(status, nil, function()
+        local bufnr = vim.fn.bufadd("Preview command")
+        vim.api.nvim_win_set_buf(status.preview_win, bufnr)
+        vim.api.nvim_win_set_option(status.preview_win, 'wrap', true)
+        vim.api.nvim_win_set_option(status.preview_win, 'winhl', 'Normal:Normal')
+        vim.api.nvim_win_set_option(status.preview_win, 'signcolumn', 'no')
+        vim.api.nvim_win_set_option(status.preview_win, 'foldlevel', 100)
+
+        if type(entry.preview_command) ~= 'function' then
+          print('entry must provide a preview_command function which will put the content into the buffer')
+          return
+        end
+
+        entry.preview_command(entry, bufnr)
+
+        self.state.hl_win = status.preview_win
+      end)
+    end
+  }
+end, {})
+
 previewers.Previewer = Previewer
 
 return previewers


### PR DESCRIPTION
@sharksforarms @clason 

Please try it out thanks :)

Adds a preview window in which we can put any content which is specified in a `preview_command` function.
Is useful for `dap` extensions, so we can basically display any lua table in a preview window.