### PR TITLE
If wildignore is set to tags expand will return '' unless true is passed

### DIFF
--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -938,13 +938,13 @@ builtin.tags = function(opts)
   opts = opts or {}
 
   local ctags_file = opts.ctags_file or 'tags'
+  local fd = vim.loop.fs_open(vim.fn.expand(ctags_file, true), "r", 438)
 
-  if not vim.loop.fs_open(vim.fn.expand(ctags_file), "r", 438) then
+  if fd == nil then
     print('Tags file does not exists. Create one with ctags -R')
     return
   end
 
-  local fd = assert(vim.loop.fs_open(vim.fn.expand(ctags_file), "r", 438))
   local stat = assert(vim.loop.fs_fstat(fd))
   local data = assert(vim.loop.fs_read(fd, stat.size, 0))
   assert(vim.loop.fs_close(fd))

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -641,7 +641,7 @@ function make_entry.gen_from_ctags(opts)
     return {
       valid = true,
 
-      ordinal = file .. ': ' .. tag,
+      ordinal = tag .. ' : ' .. scode,
       display = make_display,
       scode = scode,
       tag = tag,


### PR DESCRIPTION
We could also move to a plenary job @tami5 
And fix ordinal. So don't merge
Thanks for the bug report @yujinyuz