### PR TITLE
Set and unset report to what's needed when deleting buffers.

### DIFF
--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -17,12 +17,6 @@ if 1 ~= vim.fn.has('nvim-0.5') then
   return
 end
 
-if 2 > vim.o.report then
-  vim.api.nvim_err_writeln(string.format("[telescope] It seems you have `set report=%s`", vim.o.report))
-  vim.api.nvim_err_writeln("[telescope] Instead, change 'report' back to its default value. `set report=2`.")
-  vim.api.nvim_err_writeln("[telescope] If you do not, you will have a bad experience")
-end
-
 local builtin = {}
 
 builtin.live_grep = require('telescope.builtin.files').live_grep

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -141,9 +141,15 @@ end
 function utils.buf_delete(bufnr)
   if bufnr == nil then return end
 
+  -- Suppress the buffer deleted message for those with &report<2
+  start_report = vim.o.report
+  if start_report < 2 then vim.o.report = 2 end
+
   if vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_is_loaded(bufnr) then
     vim.cmd(string.format("bdelete! %s", bufnr))
   end
+
+  if start_report < 2 then vim.o.report = start_report end
 end
 
 function utils.max_split(s, pattern, maxsplit)


### PR DESCRIPTION
Fixes #105.

This does the "blunt" seeming just set-and-unset report whilst deleting buffers, which seems to fix the issue for me (in that no message for buffer deletion is shown).

Lemme know if this makes sense to y'all or if there's some obvious issue with it.