### PR TITLE
add back filetypedetect on edit

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -113,6 +113,7 @@ function actions._goto_file_selection(prompt_bufnr, command)
         vim.cmd(string.format(":%s %s", command, filename))
         bufnr = vim.api.nvim_get_current_buf()
         a.nvim_buf_set_option(bufnr, "buflisted", true)
+        vim.api.nvim_command("doautocmd filetypedetect BufRead " .. vim.fn.fnameescape(filename))
       end
 
       if row and col then

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -113,7 +113,6 @@ function actions._goto_file_selection(prompt_bufnr, command)
         vim.cmd(string.format(":%s %s", command, filename))
         bufnr = vim.api.nvim_get_current_buf()
         a.nvim_buf_set_option(bufnr, "buflisted", true)
-        vim.api.nvim_command("doautocmd filetypedetect BufRead " .. vim.fn.fnameescape(filename))
       end
 
       if row and col then
@@ -123,6 +122,7 @@ function actions._goto_file_selection(prompt_bufnr, command)
         end
       end
     end
+    vim.api.nvim_command("doautocmd filetypedetect BufRead " .. vim.fn.fnameescape(filename))
   end
 end
 


### PR DESCRIPTION
Similar to https://github.com/nvim-telescope/telescope.nvim/pull/116 and https://github.com/nvim-telescope/telescope.nvim/issues/115

It seems that this was removed in some refactoring. Without this, any autocmds for filetypes will not run. 