### PR TITLE
Add support for &tags (via tagfiles())

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -254,6 +254,8 @@ files.tags = function(opts)
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_ctags(opts)
   local finder = finders.new_incremental(opts)
 
+  local remaining = #tagfiles
+
   for _, each in ipairs(tagfiles) do
     local tags_directory = vim.fn.fnamemodify(each, ":h")
     local resolve_filename = function(filename)
@@ -264,8 +266,8 @@ files.tags = function(opts)
       for _, line in ipairs(vim.split(data, '\n')) do
         finder:feed({ line = line, resolve_filename = resolve_filename })
       end
+      if remaining == 1 then finder:finish() else remaining = remaining - 1 end
     end)
-    finder:finish()
   end
 
   pickers.new(opts,{

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -262,7 +262,7 @@ files.tags = function(opts)
         return path.exists(filename) and filename or
                path.join(tags_directory, filename)
     end
-    path.read(each, function(err, data)
+    path.read_file_async(each, function(data)
       for _, line in ipairs(vim.split(data, '\n')) do
         finder:feed({ line = line, resolve_filename = resolve_filename })
       end

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -258,17 +258,24 @@ files.tags = function(opts)
         return path.exists(filename) and filename or
                path.join(tags_directory, filename)
     end
-    for line in io.lines(each) do
-      table.insert(results, { line = line, resolve_filename = resolve_filename })
-    end
+    path.read(each, function(err, data)
+      for _, line in ipairs(vim.split(data, '\n')) do
+        table.insert(results, { line = line, resolve_filename = resolve_filename })
+      end
+    end)
   end
 
   pickers.new(opts,{
     prompt = 'Tags',
-    finder = finders.new_table {
-      results = results,
-      entry_maker = opts.entry_maker or make_entry.gen_from_ctags(opts),
-    },
+    finder = finders.new_job(function(prompt)
+      print(prompt)
+      if not prompt or prompt == "" then
+        return nil
+      end
+      return prompt
+    end,
+    opts.entry_maker or make_entry.gen_from_ctags(opts),
+    opts.max_results),
     previewer = previewers.ctags.new(opts),
     sorter = conf.generic_sorter(opts),
     attach_mappings = function()

--- a/lua/telescope/finders.lua
+++ b/lua/telescope/finders.lua
@@ -28,10 +28,10 @@ function IncrementalFinder:new(opts)
 
   obj._find = coroutine.wrap(function(finder, _, process_result, process_complete)
     repeat
-      finder, _, process_result, process_complete = coroutine.yield()
-      for index, result in ipairs(self.results) do
+      for _, result in ipairs(self.results) do
         process_result(finder.entry_maker(result))
       end
+      finder, _, process_result, process_complete = coroutine.yield()
     until self.completed
 
     process_complete()

--- a/lua/telescope/finders.lua
+++ b/lua/telescope/finders.lua
@@ -32,7 +32,7 @@ function IncrementalFinder:new(opts)
         process_result(finder.entry_maker(result))
       end
       finder, _, process_result, process_complete = coroutine.yield()
-    until self.completed
+    until self.finished
 
     process_complete()
   end)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -828,17 +828,21 @@ function make_entry.gen_from_ctags(opts)
     }
   end
 
-  return function(line)
-    if line == '' or line:sub(1, 1) == '!' then
+  return function(result)
+    if result.line == '' or result.line:sub(1, 1) == '!' then
       return nil
     end
 
     local tag, file, scode, lnum
     -- ctags gives us: 'tags\tfile\tsource'
-    tag, file, scode = string.match(line, '([^\t]+)\t([^\t]+)\t/^\t?(.*)/;"\t+.*')
+    tag, file, scode = string.match(result.line, '([^\t]+)\t([^\t]+)\t/^\t?(.*)/;"\t+.*')
     if not tag then
       -- hasktags gives us: 'tags\tfile\tlnum'
-      tag, file, lnum  = string.match(line, '([^\t]+)\t([^\t]+)\t(%d+).*')
+      tag, file, lnum  = string.match(result.line, '([^\t]+)\t([^\t]+)\t(%d+).*')
+    end
+
+    if not path.exists(file) then
+      file = path.join(result.tags_directory, file)
     end
 
     if opts.only_current_file and file ~= current_file then

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -841,10 +841,6 @@ function make_entry.gen_from_ctags(opts)
       tag, file, lnum  = string.match(result.line, '([^\t]+)\t([^\t]+)\t(%d+).*')
     end
 
-    if not path.exists(file) then
-      file = path.join(result.tags_directory, file)
-    end
-
     if opts.only_current_file and file ~= current_file then
       return nil
     end
@@ -858,6 +854,7 @@ function make_entry.gen_from_ctags(opts)
       tag = tag,
 
       filename = file,
+      resolve_filename = result.resolve_filename,
 
       col = 1,
       lnum = lnum and tonumber(lnum) or 1,

--- a/lua/telescope/path.lua
+++ b/lua/telescope/path.lua
@@ -4,6 +4,15 @@ local path = {}
 path.separator = package.config:sub(1, 1)
 path.home = vim.fn.expand("~")
 
+path.exists = function(filepath)
+  return vim.loop.fs_stat(filepath) ~= nil
+end
+
+-- TODO: This is obviously super naive and shouldn't exist in a random library
+path.join = function(filepath, child)
+  return filepath .. path.separator .. child
+end
+
 path.make_relative = function(filepath, cwd)
   if not cwd or not filepath then return filepath end
 

--- a/lua/telescope/path.lua
+++ b/lua/telescope/path.lua
@@ -13,47 +13,6 @@ path.join = function(filepath, child)
   return filepath .. path.separator .. child
 end
 
--- Taken with trivial modification from luvit's readFile
--- (which is Apache 2.0 licensed)
-local function noop() end
-path.read = function (filepath, callback)
-  local fd, onStat, onRead, onChunk, pos, chunks
-  vim.loop.fs_open(filepath, "r", 438 --[[ 0666 ]], function (err, result)
-    if err then return callback(err) end
-    fd = result
-    vim.loop.fs_fstat(fd, onStat)
-  end)
-  function onStat(err, stat)
-    if err then return onRead(err) end
-    if stat.size > 0 then
-      vim.loop.fs_read(fd, stat.size, 0, onRead)
-    else
-      -- the kernel lies about many files.
-      -- Go ahead and try to read some bytes.
-      pos = 0
-      chunks = {}
-      vim.loop.fs_read(fd, 8192, 0, onChunk)
-    end
-  end
-  function onRead(err, chunk)
-    vim.loop.fs_close(fd, noop)
-    return callback(err, chunk)
-  end
-  function onChunk(err, chunk)
-    if err then
-      vim.loop.fs_close(fd, noop)
-      return callback(err)
-    end
-    if chunk and #chunk > 0 then
-      chunks[#chunks + 1] = chunk
-      pos = pos + #chunk
-      return vim.loop.fs_read(fd, 8192, pos, onChunk)
-    end
-    vim.loop.fs_close(fd, noop)
-    return callback(nil, table.concat(chunks))
-  end
-end
-
 path.make_relative = function(filepath, cwd)
   if not cwd or not filepath then return filepath end
 

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -260,7 +260,7 @@ previewers.ctags = defaulter(function(_)
     end,
 
     get_buffer_by_name = function(_, entry)
-      return entry.filename
+      return entry.resolve_filename(entry.filename)
     end,
 
     define_preview = function(self, entry, status)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -265,7 +265,7 @@ previewers.ctags = defaulter(function(_)
 
     define_preview = function(self, entry, status)
       putils.with_preview_window(status, nil, function()
-        conf.buffer_previewer_maker(entry.filename, self.state.bufnr, self.state.bufname, true, function(bufnr)
+        conf.buffer_previewer_maker(entry.resolve_filename(entry.filename), self.state.bufnr, self.state.bufname, true, function(bufnr)
           vim.api.nvim_buf_call(bufnr, function()
             determine_jump(entry)(self, bufnr)
           end)


### PR DESCRIPTION
I.e., search the locations specified for possible locations of tag files,
stopping on the first found tag file.

C.f. e.g. https://github.com/Shougo/denite.nvim/blob/0639e67a33df9f62065889a2feda8c5648c633b3/rplugin/python3/denite/source/tag.py#L98-L102

This isn't ready to merge yet though, or if it is there's a follow-up issue to fix, which is paths aren't resolved relative to the tag file location, so my tag files (which contain e.g. `../foo/bar`) don't get that relative path resolved relative to where the found tagfile lives (they're instead resolved relative to cwd).

I think I see where to fix that as well, but putting this up for review because I'm sure there may be some even more idiomatic lua way to do this.

EDIT: also... I see that tagfiles() contains all found tag files, so I shouldn't be breaking on the first one, I guess you get to union all the tag files... So yeah this really isn't correct yet.