### PR TITLE
Vim Buffers everywhere we look

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 >
 > — thefreedictionary
 
-![by @glepnir](https://user-images.githubusercontent.com/41671631/100819597-6f737900-3487-11eb-8621-37ec1ffabe4b.gif) 
+![by @glepnir](https://user-images.githubusercontent.com/41671631/100819597-6f737900-3487-11eb-8621-37ec1ffabe4b.gif)
 
 
 `Telescope.nvim` is a next generation library for creating floating pickers
@@ -142,7 +142,7 @@ require('telescope').setup{
     layout_defaults = {
       -- TODO add builtin options.
     },
-    file_sorter =  require'telescope.sorters'.get_fuzzy_file ,
+    file_sorter =  require'telescope.sorters'.get_fuzzy_file,
     file_ignore_patterns = {},
     generic_sorter =  require'telescope.sorters'.get_generic_fuzzy_sorter,
     shorten_path = true,
@@ -156,6 +156,9 @@ require('telescope').setup{
     color_devicons = true,
     use_less = true,
     set_env = { ['COLORTERM'] = 'truecolor' }, -- default { }, currently unsupported for shells like cmd.exe / powershell.exe
+    file_previewer = require'telescope.previewers'.cat.new, -- For buffer previewer use `require'telescope.previewers'.vim_buffer_cat.new`
+    grep_previewer = require'telescope.previewers'.vimgrep.new, -- For buffer previewer use `require'telescope.previewers'.vim_buffer_vimgrep.new`
+    qflist_previewer = require'telescope.previewers'.qflist.new, -- For buffer previewer use `require'telescope.previewers'.vim_buffer_qflist.new`
   }
 }
 ```
@@ -193,6 +196,9 @@ EOF
 | `use_less`             | Whether to use less with bat or less/cat if bat not installed | boolean                    |
 | `set_env`              | Set environment variables for previewer               | dict                       |
 | `scroll_strategy`      | How to behave when the when there are no more item next/prev | cycle, nil          |
+| `file_previewer`       | What telescope previewer to use for files.            | [Previewers](#built-in-previewers) |
+| `grep_previewer`       | What telescope previewer to use for grep and similar  | [Previewers](#built-in-previewers) |
+| `qflist_previewer`     | What telescope previewer to use for qflist            | [Previewers](#built-in-previewers) |
 
 #### Options affecting Sorting
 
@@ -386,6 +392,24 @@ Built-in function ready to be bound to any key you like :smile:.
 | `builtin.git_branches`              | Lists all branches with log preview and checkout action.                                    |
 | `builtin.git_status`                | Lists current changes per file with diff preview and add action. (Multiselection still WIP) |
 | ..................................  | Your next awesome finder function here :D                                                   |
+
+#### Built-in Previewers
+
+| Previewers                         | Description                                                     |
+|------------------------------------|-----------------------------------------------------------------|
+| `previewers.cat.new`               | Default previewer for files. Uses `cat`/`bat`                   |
+| `previewers.vimgrep.new`           | Default previewer for grep and similar. Uses `cat`/`bat`        |
+| `previewers.qflist.new`            | Default previewer for qflist. Uses `cat`/`bat`                  |
+| `previewers.vim_buffer_cat.new`        | Experimental previewer for files. Uses vim buffers              |
+| `previewers.vim_buffer_vimgrep.new`    | Experimental previewer for grep and similar. Uses vim buffers   |
+| `previewers.vim_buffer_qflist.new`     | Experimental previewer for qflist. Uses vim buffers             |
+| .................................. | Your next awesome previewer here :D                             |
+
+By default, telescope.nvim uses `cat`/`bat` for preview. However after telescope's new experimental previewers
+are stable this will change. The new experimental previewers use tree-sitter and vim buffers, provide much
+better performance and are ready for daily usage (`vim_buffer_cat` more than the others), but there might be
+cases where it can't detect a Filetype correctly, thus leading to wrong highlights.
+Also `vimgrep` and `qflist` might be slower due to synchronous file loading.
 
 
 #### Built-in Sorters

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -28,7 +28,7 @@ files.live_grep = function(opts)
   pickers.new(opts, {
     prompt_title = 'Live Grep',
     finder = live_grepper,
-    previewer = previewers.vimgrep.new(opts),
+    previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
   }):find()
 end
@@ -48,7 +48,7 @@ files.grep_string = function(opts)
       flatten { conf.vimgrep_arguments, opts.word_match, search},
       opts
     ),
-    previewer = previewers.vimgrep.new(opts),
+    previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
   }):find()
 end
@@ -87,7 +87,7 @@ files.find_files = function(opts)
       find_command,
       opts
     ),
-    previewer = previewers.cat.new(opts),
+    previewer = conf.file_previewer(opts),
     sorter = conf.file_sorter(opts),
   }):find()
 end
@@ -143,7 +143,7 @@ files.treesitter = function(opts)
       results = results,
       entry_maker = make_entry.gen_from_treesitter(opts)
     },
-    previewer = previewers.vimgrep.new(opts),
+    previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
   }):find()
 end

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -22,7 +22,7 @@ git.files = function(opts)
       { "git", "ls-files", "--exclude-standard", "--cached", show_untracked and "--others" },
       opts
     ),
-    previewer = previewers.cat.new(opts),
+    previewer = conf.file_previewer(opts),
     sorter = conf.file_sorter(opts),
   }):find()
 end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -144,7 +144,7 @@ internal.quickfix = function(opts)
       results     = locations,
       entry_maker = make_entry.gen_from_quickfix(opts),
     },
-    previewer = previewers.qflist.new(opts),
+    previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
   }):find()
 end
@@ -167,7 +167,7 @@ internal.loclist = function(opts)
       results     = locations,
       entry_maker = make_entry.gen_from_quickfix(opts),
     },
-    previewer = previewers.qflist.new(opts),
+    previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
   }):find()
 end
@@ -179,7 +179,7 @@ internal.oldfiles = function(opts)
       return 0 ~= vim.fn.filereadable(val)
     end, vim.v.oldfiles)),
     sorter = conf.file_sorter(opts),
-    previewer = previewers.cat.new(opts),
+    previewer = conf.file_previewer(opts),
   }):find()
 end
 
@@ -422,7 +422,7 @@ internal.buffers = function(opts)
       results = buffers,
       entry_maker = make_entry.gen_from_buffer(opts)
     },
-    previewer = previewers.vim_buffer.new(opts),
+    previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
     default_selection_index = default_selection_idx,
   }):find()
@@ -464,7 +464,7 @@ internal.marks = function(opts)
       results = marks_table,
       entry_maker = make_entry.gen_from_marks(opts),
     },
-    previewer = previewers.vimgrep.new(opts),
+    previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
   }):find()
 end

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -33,7 +33,7 @@ lsp.references = function(opts)
       results = locations,
       entry_maker = make_entry.gen_from_quickfix(opts),
     },
-    previewer = previewers.qflist.new(opts),
+    previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
   }):find()
 end
@@ -62,7 +62,7 @@ lsp.document_symbols = function(opts)
       results = locations,
       entry_maker = make_entry.gen_from_quickfix(opts)
     },
-    previewer = previewers.qflist.new(opts),
+    previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
   }):find()
 end
@@ -167,7 +167,7 @@ lsp.workspace_symbols = function(opts)
       results = locations,
       entry_maker = make_entry.gen_from_quickfix(opts)
     },
-    previewer = previewers.qflist.new(opts),
+    previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
   }):find()
 end

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -88,6 +88,10 @@ function config.set_defaults(defaults)
   set("file_sorter", sorters.get_fuzzy_file)
 
   set("file_ignore_patterns", nil)
+
+  set("file_previewer", function(...) return require('telescope.previewers').cat.new(...) end)
+  set("grep_previewer", function(...) return require('telescope.previewers').vimgrep.new(...) end)
+  set("qflist_previewer", function(...) return require('telescope.previewers').qflist.new(...) end)
 end
 
 function config.clear_defaults()


### PR DESCRIPTION
Fix #163
Close #206 
Close #257

Note: This branch will receive force pushes.

~~More builtins soon.~~ 
Also its currently slower than bat. Especially when scrolling though the results list. I hope i can fix this. Some thoughts on speed:
- Vim buffers as previewer will be way fast for things like `grep`, because we usually have the same file multiple times. With `bat` we have to reload this file every single time, with vim buffers, we have to load it once and can use it as often as we want.
- For `files` and `git_files` we have unique files. Every entry is a new file that we have to load. In this case i am currently losing.

Enable with:
```lua
require('telescope').setup {
  defaults = {
    file_previewer = previewers.vim_buffer_cat.new,
    grep_previewer = previewers.vim_buffer_vimgrep.new,
    qflist_previewer = previewers.vim_buffer_qflist.new,
  }
}
```

Feedback is only useful, if you say which builtin you used.
FYI scrolling for vim buffers is not yet perfect because i am still waiting for this https://github.com/neovim/neovim/pull/13280, so we can do some more cool stuff like smooth scrolling and scrollbar

| Builtin | Support: :white_check_mark: opt in. :heavy_check_mark: means vim buffer is the only option. :negative_squared_cross_mark: means no preview/impossible |
|---|---|
| builtin.live_grep | :white_check_mark: |
| builtin.grep_string | :white_check_mark: |
| builtin.find_files | :white_check_mark: |
| builtin.treesitter | :white_check_mark: |
| builtin.current_buffer_fuzzy_find | :negative_squared_cross_mark: |
| builtin.tags | :heavy_check_mark: |
| builtin.current_buffer_tags | :heavy_check_mark: |
| | |
| builtin.git_files | :white_check_mark: |
| builtin.git_commits | * Possible but why? we have to get the diff with git and then set lines for buffer with filetype diff  |
| builtin.git_bcommits | * |
| builtin.git_branches | :negative_squared_cross_mark:  |
| builtin.git_status | * |
| | |
| builtin.builtin | :heavy_check_mark: |
| builtin.planets | :negative_squared_cross_mark: impossible because vim buffer does not interpret it correctly |
| builtin.commands | :negative_squared_cross_mark: |
| builtin.quickfix | :white_check_mark: |
| builtin.loclist | :white_check_mark: |
| builtin.oldfiles | :white_check_mark: |
| builtin.command_history | :negative_squared_cross_mark: |
| builtin.vim_options | :negative_squared_cross_mark: currently no previewer. has to be fixed later |
| builtin.help_tags | :heavy_check_mark: |
| builtin.man_pages | :heavy_check_mark: |
| builtin.reloader | :negative_squared_cross_mark: |
| builtin.buffers | :white_check_mark: |
| builtin.colorscheme | :negative_squared_cross_mark: i think a previewer who changes the colorscheme only in the window is pretty hard or nearly impossible. |
| builtin.marks | :white_check_mark: |
| builtin.registers | :negative_squared_cross_mark:  |
| builtin.keymaps | :negative_squared_cross_mark:  |
| builtin.filetypes | :heavy_check_mark: |
| builtin.highlights | :heavy_check_mark: |
| | |
| builtin.lsp_references | :white_check_mark:  |
| builtin.lsp_document_symbols | :white_check_mark:  |
| builtin.lsp_code_actions | :negative_squared_cross_mark:  |
| builtin.lsp_range_code_actions | :negative_squared_cross_mark:  |
| builtin.lsp_workspace_symbols | :white_check_mark: |