### PR TITLE
Symbol Picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Built-in function ready to be bound to any key you like :smile:.
 | `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and checkouts it out on enter.                 |
 | `builtin.git_branches`              | Lists all branches with log preview and checkout action.                                    |
 | `builtin.git_status`                | Lists current changes per file with diff preview and add action. (Multiselection still WIP) |
+| `builtin.symbols`                   | Lists symbols inside a file `data/telescope-sources/*.json` found in your rtp. More info and symbol sources can be found [here](https://github.com/nvim-telescope/telescope-symbols.nvim) |
 | ..................................  | Your next awesome finder function here :D                                                   |
 
 #### Built-in Previewers

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -230,6 +230,12 @@ actions.run_builtin = function(prompt_bufnr)
   require('telescope.builtin')[entry.text]()
 end
 
+actions.insert_symbol = function(prompt_bufnr)
+  local selection = actions.get_selected_entry()
+  actions.close(prompt_bufnr)
+  vim.api.nvim_put({selection.value[1]}, '', true, true)
+end
+
 -- TODO: Think about how to do this.
 actions.insert_value = function(prompt_bufnr)
   local entry = actions.get_selected_entry(prompt_bufnr)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -36,6 +36,7 @@ builtin.git_status = require('telescope.builtin.git').status
 
 builtin.builtin = require('telescope.builtin.internal').builtin
 builtin.planets = require('telescope.builtin.internal').planets
+builtin.symbols = require('telescope.builtin.internal').symbols
 builtin.commands = require('telescope.builtin.internal').commands
 builtin.quickfix = require('telescope.builtin.internal').quickfix
 builtin.loclist = require('telescope.builtin.internal').loclist


### PR DESCRIPTION
~~Modified this [file](https://www.unicode.org/Public/emoji/13.1/emoji-test.txt). Is there a better file?~~

More sources (open for suggestions):
- [x] [emoji](https://www.unicode.org/Public/emoji/13.1/emoji-test.txt)
- [x] [kaomoji](https://github.com/kuanyui/kaomoji.el/blob/master/kaomoji-data.el)
- [x] [math](https://raw.githubusercontent.com/wspr/unicode-math/ef5688f303d7010138632ab45ef2440d3ca20ee5/unicode-math-table.tex)
- [x] [latex definitions](https://raw.githubusercontent.com/wspr/unicode-math/ef5688f303d7010138632ab45ef2440d3ca20ee5/unicode-math-table.tex)

Fix Me:
- [ ] Don't use curl. Maybe socket.http
- [x] Support multiple source from picker side. Default all sources, and opts for just some.
- [ ] Docs

Usage:
`:lua require'telescope.builtin'.symbols{} -- all sources`
`:lua require'telescope.builtin'.symbols{ sources = { 'math' } } -- only math`
`:lua require'telescope.builtin'.symbols{ sources = { 'emoji' } } -- only emoji`
`:lua require'telescope.builtin'.symbols{ sources = { 'kaomoji' } } -- only kaomoji`
`:lua require'telescope.builtin'.symbols{ sources = { 'math', 'emoji' } } -- both math and emoji`

Download:
`:lua require'telescope.script'.get_all_sources()`
`:lua require'telescope.script'.get_x_source() -- with x ∈ { 'emoji', 'math', 'kaomoji' }`

Source file format(3 spaces are used because of the fact that kaomoji can include spaces):
`symbol   description`

~~Also can someone explain what kaomoji is and is there a file similar to the used one. We could also make that work.~~

CC @clason 