### PR TITLE
Displayer now supports highlights

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -329,7 +329,7 @@ function make_entry.gen_from_buffer(opts)
       bufnr = entry.bufnr,
       filename = bufname,
 
-      lnum = entry.info.lnum and entry.info.lnum or 1,
+      lnum = entry.info.lnum ~= 0 and entry.info.lnum or 1,
       indicator = indicator,
     }
   end

--- a/lua/telescope/pickers/entry_display.lua
+++ b/lua/telescope/pickers/entry_display.lua
@@ -57,24 +57,52 @@ entry_display.create = function(configuration)
       local justify = not v.right_justify and "-" or ""
       local format_str = "%" .. justify .. v.width .. "s"
       table.insert(generator, function(item)
-        return string.format(format_str, truncate(item, v.width))
+        if type(item) == 'table' then
+          return string.format(format_str, truncate(item[1], v.width)), item[2]
+        else
+          return string.format(format_str, truncate(item, v.width))
+        end
       end)
     else
       table.insert(generator, function(item)
-        return item
+        if type(item) == 'table' then
+          return item[1], item[2]
+        else
+          return item
+        end
       end)
     end
   end
 
   return function(self, picker)
     local results = {}
+    local highlights = {}
     for i = 1, table.getn(generator) do
       if self[i] ~= nil then
-        table.insert(results, generator[i](self[i], picker))
+        local str, hl = generator[i](self[i], picker)
+        if hl then
+          local hl_start = 0
+          for j = 1, (i - 1) do
+            hl_start = hl_start + #results[j] + (#configuration.separator or 1)
+          end
+          local hl_end = hl_start + #str:gsub('%s*$', '')
+          table.insert(highlights, { { hl_start, hl_end }, hl })
+        end
+        table.insert(results, str)
       end
     end
 
-    return table.concat(results, configuration.separator or "│")
+    if configuration.separator_hl then
+      local width = #configuration.separator or 1
+      local hl_start, hl_end = 0, 0
+      for _, v in ipairs(results) do
+        hl_start = hl_end + #tostring(v)
+        hl_end = hl_start + width
+        table.insert(highlights, { { hl_start, hl_end }, configuration.separator_hl })
+      end
+    end
+
+    return table.concat(results, configuration.separator or "│"), highlights
   end
 end
 


### PR DESCRIPTION
@sunjon Does this help?

@tjdevries Do we wanna talk about the interface. I think this is the best way to do this, so people can change the `hl_group` based on the specific value. Like sunjon wants to do: `if x == 'opts' then hl_group1 else hl_group2 end`. 
The other idea i had was to specify the `hl_group` when we create the `displayer`. But that would limit our flexibility.

Separator Example: When creating the displayer
```lua
local hl = 'Visual'
local displayer = entry_display.create {
  separator = " ",
  separator_hl = hl, -- New
  items = {
    { width = opts.bufnr_width },
    { width = 4 },
    { remaining = true },
  },
}
```

Elements Example: When submitting data
```lua
local hl_group = x == y then 'Normal' or 'Visual'

return displayer {
  entry.bufnr,
  { entry.indicator, hl_group },
  display_bufname .. ":" .. entry.lnum,
}
```