### PR TITLE
Feature/git previewer extensions

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -244,8 +244,14 @@ end
 actions.git_checkout = function(prompt_bufnr)
   local selection = actions.get_selected_entry(prompt_bufnr)
   actions.close(prompt_bufnr)
-  local val = selection.value
-  os.execute('git checkout ' .. val)
+  os.execute('git checkout ' .. selection.value)
+end
+
+actions.git_checkout_current_buffer = function(prompt_bufnr)
+  local selection = actions.get_selected_entry(prompt_bufnr)
+  actions.close(prompt_bufnr)
+  local file_of_current_buffer = vim.fn.expand('%')
+  os.execute('git checkout ' .. selection.value .. ' -- ' .. file_of_current_buffer)
 end
 
 actions.git_staging_toggle = function(prompt_bufnr)

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -60,7 +60,7 @@ git.bcommits = function(opts)
     previewer = previewers.git_commit_diff_to_parent.new(opts),
     sorter = conf.file_sorter(opts),
     attach_mappings = function()
-      actions.goto_file_selection_edit:replace(actions.git_checkout)
+      actions.goto_file_selection_edit:replace(actions.git_checkout_current_buffer)
       return true
     end
   }):find()

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -37,7 +37,7 @@ git.commits = function(opts)
       results = results,
       entry_maker = make_entry.gen_from_git_commits(opts),
     },
-    previewer = previewers.git_commit_diff.new(opts),
+    previewer = previewers.git_commit_diff_to_parent.new(opts),
     sorter = conf.file_sorter(opts),
     attach_mappings = function()
       actions.goto_file_selection_edit:replace(actions.git_checkout)
@@ -47,6 +47,7 @@ git.commits = function(opts)
 end
 
 git.bcommits = function(opts)
+  opts.relative_file_path = vim.fn.expand('%')
   local cmd = 'git log --pretty=oneline --abbrev-commit ' .. vim.fn.expand('%')
   local results = vim.split(utils.get_os_command_output(cmd), '\n')
 
@@ -56,7 +57,7 @@ git.bcommits = function(opts)
       results = results,
       entry_maker = make_entry.gen_from_git_commits(opts),
     },
-    previewer = previewers.git_commit_diff.new(opts),
+    previewer = previewers.git_commit_diff_to_parent.new(opts),
     sorter = conf.file_sorter(opts),
     attach_mappings = function()
       actions.goto_file_selection_edit:replace(actions.git_checkout)

--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -381,11 +381,48 @@ previewers.vim_buffer = defaulter(function(_)
   }
 end, {})
 
-previewers.git_commit_diff = defaulter(function(_)
+previewers.git_commit_diff_to_parent = defaulter(function(opts)
   return previewers.new_termopen_previewer {
     get_command = function(entry)
-      local sha = entry.value
-      return { 'git', '-p', 'diff', sha .. '^!' }
+      local command = { 'git', '--paginate', 'diff', entry.value .. '^!' }
+
+      if opts.relative_file_path ~= nil then
+        table.insert(command, '--')
+        table.insert(command, opts.relative_file_path)
+      end
+
+      return command
+    end
+  }
+end, {})
+
+previewers.git_commit_diff_to_head = defaulter(function(opts)
+  return previewers.new_termopen_previewer {
+    get_command = function(entry)
+      local command = { 'git', '--paginate', 'diff', entry.value }
+
+      if opts.relative_file_path ~= nil then
+        table.insert(command, '--')
+        table.insert(command, opts.relative_file_path)
+      end
+
+      return command
+    end
+  }
+end, {})
+
+previewers.git_commit_as_was = defaulter(function(opts)
+  return previewers.new_termopen_previewer {
+    get_command = function(entry)
+      local command = { 'git', '--paginate', 'show' }
+
+      if opts.relative_file_path == nil then
+        table.insert(command, entry.value)
+      else
+        table.insert(command, entry.value .. ':' .. opts.relative_file_path)
+      end
+
+      return command
     end
   }
 end, {})
@@ -393,7 +430,7 @@ end, {})
 previewers.git_branch_log = defaulter(function(_)
   return previewers.new_termopen_previewer {
     get_command = function(entry)
-      return { 'git', '-p', 'log', '--graph',
+      return { 'git', '--paginate', 'log', '--graph',
                "--pretty=format:" .. add_quotes .. "%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)%Creset" .. add_quotes,
                '--abbrev-commit', '--date=relative', entry.value }
     end

--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -399,7 +399,7 @@ end, {})
 previewers.git_commit_diff_to_head = defaulter(function(opts)
   return previewers.new_termopen_previewer {
     get_command = function(entry)
-      local command = { 'git', '--paginate', 'diff', entry.value }
+      local command = { 'git', '--paginate', 'diff', '--cached', entry.value }
 
       if opts.relative_file_path ~= nil then
         table.insert(command, '--')


### PR DESCRIPTION
Closes #307

This is my first attempt with the suggestion of @Conni2461 to just start with the new previewer functions. I extended this with some minor additional features. Still missing is the implementation of changing the previewer without restarting the picker. More detailed information in the commit messages.

I'm not too happy about the integration of the relative file path for the `bcommit` related preview cases. I'm open for better alternatives. E.g. I wasn't sure if the current design is meant to always only have the `opts` as single parameter or if the pickers can simply pass additional parameters. :shrug: 