### PR TITLE
fix: fix non escaped bat theme

### DIFF
--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -145,7 +145,7 @@ local bat_maker = function(filename, lnum, start, finish)
   end
 
   if theme ~= nil then
-    table.insert(command, { "--theme", string.format("%s", theme) })
+    table.insert(command, { "--theme", string.format("%s", vim.fn.shellescape(theme)) })
   end
 
   return flatten {


### PR DESCRIPTION
Fix #318

When a bat theme contained spaces it would crash the bat previewer as described in #318.