### PR TITLE
fix: don't error when no hidden buffers are available

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -437,6 +437,7 @@ internal.buffers = function(opts)
       or vim.api.nvim_buf_is_loaded(b))
       and 1 == vim.fn.buflisted(b)
   end, vim.api.nvim_list_bufs())
+  if not next(bufnrs) then return end
 
   local buffers = {}
   local default_selection_idx = 1


### PR DESCRIPTION
Stops errors should you start the buffer finder on a startup screen that runs in a hidden buffer and there are no buffers to list.