### PR TITLE
Add more colour

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -34,7 +34,7 @@ internal.builtin = function(opts)
     prompt_title = 'Telescope Builtin',
     finder    = finders.new_table {
       results     = objs,
-      entry_maker = make_entry.gen_from_quickfix(opts),
+      entry_maker = make_entry.gen_from_builtin(opts),
     },
     previewer = previewers.builtin.new(opts),
     sorter = conf.generic_sorter(opts),

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -33,17 +33,15 @@ internal.builtin = function(opts)
   pickers.new(opts, {
     prompt_title = 'Telescope Builtin',
     finder    = finders.new_table {
-      results     = objs,
-      entry_maker = function(entry)
-            return {
-              value = entry,
-              text = entry.text,
-              display = entry.text,
-              ordinal = entry.text,
-              filename = entry.filename
-            }
-          end
-    },
+      results = objs,
+      entry_maker = function(entry)return {
+        value = entry,
+        text = entry.text,
+        display = entry.text,
+        ordinal = entry.text,
+        filename = entry.filename
+        }end
+      },
     previewer = previewers.builtin.new(opts),
     sorter = conf.generic_sorter(opts),
     attach_mappings = function(_)

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -34,7 +34,15 @@ internal.builtin = function(opts)
     prompt_title = 'Telescope Builtin',
     finder    = finders.new_table {
       results     = objs,
-      entry_maker = make_entry.gen_from_builtin(opts),
+      entry_maker = function(entry)
+            return {
+              value = entry,
+              text = entry.text,
+              display = entry.text,
+              ordinal = entry.text,
+              filename = entry.filename
+            }
+          end
     },
     previewer = previewers.builtin.new(opts),
     sorter = conf.generic_sorter(opts),

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -59,7 +59,7 @@ lsp.document_symbols = function(opts)
     prompt_title = 'LSP Document Symbols',
     finder    = finders.new_table {
       results = locations,
-      entry_maker = make_entry.gen_from_quickfix(opts)
+      entry_maker = make_entry.gen_from_symbols(opts)
     },
     previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
@@ -169,7 +169,7 @@ lsp.workspace_symbols = function(opts)
     prompt_title = 'LSP Workspace Symbols',
     finder    = finders.new_table {
       results = locations,
-      entry_maker = make_entry.gen_from_quickfix(opts)
+      entry_maker = make_entry.gen_from_symbols(opts)
     },
     previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -548,17 +548,21 @@ end
 
 function make_entry.gen_from_registers(_)
   local displayer = entry_display.create {
-    separator = ":",
+    separator = "",
     items = {
-      { width = 4 },
+      { width = 1 },
+      { width = 1 },
+      { width = 2 },
       { remaining = true },
     },
   }
 
   local make_display = function(entry)
     return displayer {
-      string.format("[%s]", entry.value),
-      entry.content
+      {"[", "TelescopeBorder"},
+      {entry.value, "Number"},
+      {"]", "TelescopeBorder"},
+      entry.content,
     }
   end
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -517,50 +517,6 @@ function make_entry.gen_from_apropos()
   end
 end
 
-function make_entry.gen_from_builtin(opts)
-  opts = opts or {}
-  opts.tail_path = get_default(opts.tail_path, true)
-
-    local displayer = entry_display.create {
-    separator = "▏",
-    items = {
-      { width = 50 },
-      { remaining = true },
-    },
-  }
-
-  local make_display = function(entry)
-    local filename
-    if not opts.hide_filename then
-      filename = entry.filename
-      if opts.tail_path then
-        filename = utils.path_tail(filename)
-      elseif opts.shorten_path then
-        filename = utils.path_shorten(filename)
-      end
-    end
-
-    return displayer {
-      entry.text:gsub(".* | ", ""),
-      filename,
-    }
-  end
-
-  return function(entry)
-    local filename = entry.filename or vim.api.nvim_buf_get_name(entry.bufnr)
-
-    return {
-      valid = true,
-
-      value = entry,
-      text = entry.text,
-      display = make_display,
-      ordinal = entry.text,
-      filename = filename,
-    }
-  end
-end
-
 function make_entry.gen_from_marks(_)
   return function(line)
     local split_value = utils.max_split(line, "%s+", 4)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -295,7 +295,6 @@ function make_entry.gen_from_symbols(opts)
   opts.tail_path = get_default(opts.tail_path, true)
 
     local displayer = entry_display.create {
-    -- separator = "▏",
     separator = "",
     items = {
       { width = 6 },
@@ -344,7 +343,6 @@ function make_entry.gen_from_symbols(opts)
     local symbol_msg = entry.text:gsub(".* | ", "")
     local symbol_type, symbol_name = symbol_msg:match("%[(.+)%]%s+(.*)")
 
-    print(symbol_type)
     return {
       valid = true,
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -387,9 +387,9 @@ function make_entry.gen_from_buffer(opts)
     end
 
     return displayer {
-        {entry.bufnr, "Number"},
-        {entry.indicator, "Comment"},
-        display_bufname .. ":" .. entry.lnum,
+      {entry.bufnr, "Number"},
+      {entry.indicator, "Comment"},
+      display_bufname .. ":" .. entry.lnum
       }
   end
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -289,7 +289,7 @@ function make_entry.gen_from_symbols(opts)
 
     local displayer = entry_display.create {
     -- separator = "▏",
-    separator = " ",
+    separator = "",
     items = {
       { width = 6 },
       { width = 40 },
@@ -310,19 +310,23 @@ function make_entry.gen_from_symbols(opts)
       end
     end
 
-    local type_highlight = {
+    local default_type_highlight = {
+      ["Class"]    = "Function",
       ["Constant"] = "Constant",
       ["Field"]    = "Function",
       ["Function"] = "Function",
       ["Property"] = "Operator",
+      ["Struct"]   = "Struct",
       ["Variable"] = "SpecialChar",
     }
+
+    local type_highlight = opts.symbol_highlights or default_type_highlight
 
     return displayer {
       {entry.lnum .. ":" .. entry.col, "LineNr"},
       entry.symbol_name,
       {"[", "TelescopeBorder"},
-      {entry.symbol_type, type_highlight[entry.symbol_type],type_highlight[entry.symbol_type]},
+      {entry.symbol_type, type_highlight[entry.symbol_type], type_highlight[entry.symbol_type]},
       {"]", "TelescopeBorder"},
       filename,
     }
@@ -333,6 +337,7 @@ function make_entry.gen_from_symbols(opts)
     local symbol_msg = entry.text:gsub(".* | ", "")
     local symbol_type, symbol_name = symbol_msg:match("%[(.+)%]%s+(.*)")
 
+    print(symbol_type)
     return {
       valid = true,
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -253,8 +253,10 @@ function make_entry.gen_from_quickfix(opts)
       end
     end
 
+    local line_info = {table.concat({entry.lnum, entry.col}, ":"), "LineNr"}
+
     return displayer {
-      {entry.lnum .. ":" .. entry.col, "LineNr"},
+      line_info,
       entry.text:gsub(".* | ", ""),
       filename,
     }
@@ -523,6 +525,54 @@ function make_entry.gen_from_apropos()
       description = desc,
       ordinal = cmd,
       display = make_display,
+    }
+  end
+end
+
+function make_entry.gen_from_builtin(opts)
+  opts = opts or {}
+  opts.tail_path = get_default(opts.tail_path, true)
+
+    local displayer = entry_display.create {
+    separator = "▏",
+    items = {
+      { width = 50 },
+      { remaining = true },
+    },
+  }
+
+  local make_display = function(entry)
+    local filename
+    if not opts.hide_filename then
+      filename = entry.filename
+      if opts.tail_path then
+        filename = utils.path_tail(filename)
+      elseif opts.shorten_path then
+        filename = utils.path_shorten(filename)
+      end
+    end
+
+    return displayer {
+      entry.text:gsub(".* | ", ""),
+      filename,
+    }
+  end
+
+  return function(entry)
+    local filename = entry.filename or vim.api.nvim_buf_get_name(entry.bufnr)
+
+    return {
+      valid = true,
+
+      value = entry,
+      ordinal = (
+        not opts.ignore_filename and filename
+        or ''
+        ) .. ' ' .. entry.text,
+      display = make_display,
+
+      filename = filename,
+      text = entry.text,
     }
   end
 end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -500,13 +500,29 @@ function make_entry.gen_from_packages(opts)
 end
 
 function make_entry.gen_from_apropos()
+  local displayer = entry_display.create {
+    separator = "",
+    items = {
+      { width = 30 },
+      { remaining = true },
+    },
+  }
+
+  local make_display = function(entry)
+    return displayer {
+      entry.value,
+      entry.description
+    }
+  end
+
   return function(line)
     local cmd, _, desc = line:match("^(.*)%s+%((.*)%)%s+%-%s(.*)$")
 
     return {
       value = cmd,
+      description = desc,
       ordinal = cmd,
-      display = string.format("%-30s : %s", cmd, desc)
+      display = make_display,
     }
   end
 end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -306,10 +306,10 @@ function make_entry.gen_from_buffer(opts)
     end
 
     return displayer {
-      entry.bufnr,
-      entry.indicator,
-      display_bufname .. ":" .. entry.lnum,
-    }
+        {entry.bufnr, "Number"},
+        {entry.indicator, "Comment"},
+        display_bufname .. ":" .. entry.lnum,
+      }
   end
 
   return function(entry)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -565,14 +565,10 @@ function make_entry.gen_from_builtin(opts)
       valid = true,
 
       value = entry,
-      ordinal = (
-        not opts.ignore_filename and filename
-        or ''
-        ) .. ' ' .. entry.text,
-      display = make_display,
-
-      filename = filename,
       text = entry.text,
+      display = make_display,
+      ordinal = entry.text,
+      filename = filename,
     }
   end
 end


### PR DESCRIPTION
add more colors to finders that would benefit from it now that highlighting is fixed/improved.

Previously I've assigned hl_groups as I'd seen appropriate -  Comment for less important text, Number for numbers..
This isn't ideal, and I'm wondering if/how the current Telescope* groups can be expanded to allow a reasonable amount of customisation without finder specifc configs.

![lsp_symbols](https://raw.githubusercontent.com/sunjon/images/master/lsp_symbols.png)
I've altered the LSP_*_symbol finder to be a bit more readable and tried to relate the display colour to the hl_group used in Vim. As this will change per langauge, I'm not sure what the best way to do this will be. If we decide on a way forward, the Treesitter and perhaps ctags finders can use this display method.

All input welcome