### PR TITLE
More faster previewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@ Gaze deeply into unknown regions using the power of the moon.
 ## What Is Telescope?
 
 `telescope.nvim` is a highly extendable fuzzy finder over lists. Built on the latest
-awesome features from `neovim` core. Telescope is centered around 
-modularity, allowing for easy customization. 
+awesome features from `neovim` core. Telescope is centered around
+modularity, allowing for easy customization.
 
 Community driven built-in [pickers](#pickers), [sorters](#sorters) and [previewers](#previewers).
 
 ### Built-in Support:
-- [Vim](#vim-pickers) 
-- [Files](#file-pickers) 
+- [Vim](#vim-pickers)
+- [Files](#file-pickers)
 - [Git](#git-pickers)
 - [LSP](#lsp-pickers)
 - [Treesitter](#treesitter-pickers)
 
 ![by @glepnir](https://user-images.githubusercontent.com/41671631/100819597-6f737900-3487-11eb-8621-37ec1ffabe4b.gif)
 
- 
+
 <!-- You can read this documentation from start to finish, or you can look at the -->
 <!-- outline and directly jump to the section that interests you most. -->
 
@@ -162,6 +162,9 @@ require('telescope').setup{
     file_previewer = require'telescope.previewers'.cat.new, -- For buffer previewer use `require'telescope.previewers'.vim_buffer_cat.new`
     grep_previewer = require'telescope.previewers'.vimgrep.new, -- For buffer previewer use `require'telescope.previewers'.vim_buffer_vimgrep.new`
     qflist_previewer = require'telescope.previewers'.qflist.new, -- For buffer previewer use `require'telescope.previewers'.vim_buffer_qflist.new`
+
+    -- Developer configurations: Not meant for general override
+    buffer_previewer_maker = require'telescope.previewers'.buffer_previewer_maker
   }
 }
 ```
@@ -202,6 +205,12 @@ EOF
 | `file_previewer`       | What telescope previewer to use for files.            | [Previewers](#previewers)  |
 | `grep_previewer`       | What telescope previewer to use for grep and similar  | [Previewers](#previewers)  |
 | `qflist_previewer`     | What telescope previewer to use for qflist            | [Previewers](#previewers)  |
+
+
+### Options for extension developers
+| Keys                   | Description                                           | Options                    |
+|------------------------|-------------------------------------------------------|----------------------------|
+| `buffer_previewer_maker` | How a file gets loaded and which highlighter will be used. Extensions will change it | function             |
 
 ### Options affecting Sorting
 
@@ -356,7 +365,7 @@ require('telescope.builtin').fd({ -- or new custom picker's attach_mappings fiel
 
 Built-in functions. Ready to be bound to any key you like. :smile:
 
-```vim 
+```vim
 :lua require'telescope.builtin'.planets{}
 
 :nnoremap <Leader>pp :lua require'telescope.builtin'.planets{}
@@ -441,17 +450,24 @@ Built-in functions. Ready to be bound to any key you like. :smile:
 | `previewers.cat.new`               | Default previewer for files. Uses `cat`/`bat`                   |
 | `previewers.vimgrep.new`           | Default previewer for grep and similar. Uses `cat`/`bat`        |
 | `previewers.qflist.new`            | Default previewer for qflist. Uses `cat`/`bat`                  |
-| `previewers.vim_buffer_cat.new`        | Experimental previewer for files. Uses vim buffers              |
-| `previewers.vim_buffer_vimgrep.new`    | Experimental previewer for grep and similar. Uses vim buffers   |
-| `previewers.vim_buffer_qflist.new`     | Experimental previewer for qflist. Uses vim buffers             |
+| `previewers.vim_buffer_cat.new`    | Experimental previewer for files. Uses vim buffers              |
+| `previewers.vim_buffer_vimgrep.new`| Experimental previewer for grep and similar. Uses vim buffers   |
+| `previewers.vim_buffer_qflist.new` | Experimental previewer for qflist. Uses vim buffers             |
 | .................................. | Your next awesome previewer here :D                             |
 
 By default, telescope.nvim uses `cat`/`bat` for preview. However after telescope's new experimental previewers
 are stable this will change. The new experimental previewers use tree-sitter and vim buffers, provide much
-better performance and are ready for daily usage (`vim_buffer_cat` more than the others), but there might be
-cases where it can't detect a Filetype correctly, thus leading to wrong highlights.
-Also `vimgrep` and `qflist` might be slower due to synchronous file loading.
+better performance and are ready for daily usage, but there might be cases where it can't detect a Filetype
+correctly, thus leading to wrong highlights. This is because we can't determine the filetype in the traditional way
+(we don't do `bufload`. We read the file async with `vim.loop.fs_` and attach only a highlighter), because we can't
+execute autocommands, otherwise the speed of the previewer would slow down considerably.
+If you want to configure more filetypes take a look at
+[plenary wiki](https://github.com/nvim-lua/plenary.nvim#plenaryfiletype).
 
+If you want to configure the `vim_buffer_` previewer, e.g. you want the line to wrap do this:
+```vim
+autocmd User TelescopePreviewerLoaded setlocal wrap
+```
 
 ## Sorters
 
@@ -511,7 +527,7 @@ enhancements by using compiled C and interfacing directly with Lua.
 - [telescope-packer.nvim](https://github.com/nvim-telescope/telescope-packer.nvim) - A Telescope extension that provides extra functionality for Packer.nvim
 - [telescope-github.nvim](https://github.com/nvim-telescope/telescope-github.nvim) - Integration with github cli
 - [telescope-vimspector.nvim](https://github.com/nvim-telescope/telescope-vimspector.nvim) - Integration for [vimspector](https://github.com/puremourning/vimspector)
-- [telescope-fzf-writer.nvim](https://github.com/nvim-telescope/telescope-fzf-writer.nvim) - Incorporating some fzf concepts with plenary jobs and telescope 
+- [telescope-fzf-writer.nvim](https://github.com/nvim-telescope/telescope-fzf-writer.nvim) - Incorporating some fzf concepts with plenary jobs and telescope
 - [telescope-symbols.nvim](https://github.com/nvim-telescope/telescope-symbols.nvim) - Picking symbols and insert them at point.
 
 Extensions can be refenced by doing the following:

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -96,6 +96,7 @@ function config.set_defaults(defaults)
   set("file_previewer", function(...) return require('telescope.previewers').cat.new(...) end)
   set("grep_previewer", function(...) return require('telescope.previewers').vimgrep.new(...) end)
   set("qflist_previewer", function(...) return require('telescope.previewers').qflist.new(...) end)
+  set("buffer_previewer_maker", function(...) return require('telescope.previewers').buffer_previewer_maker(...) end)
 end
 
 function config.clear_defaults()

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -270,7 +270,7 @@ function make_entry.gen_from_git_commits()
 
   local make_display = function(entry)
     return displayer {
-      {entry.value, "TelescopeResultsNumber"},
+      {entry.value, "TelescopeResultsIdentifier"},
       entry.msg
     }
   end

--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -9,24 +9,25 @@ previewers.new = function(...)
 end
 
 previewers.new_termopen_previewer = term_previewer.new_termopen_previewer
-previewers.git_commit_diff        = term_previewer.git_commit_diff
-previewers.git_branch_log         = term_previewer.git_branch_log
-previewers.git_file_diff          = term_previewer.git_file_diff
 previewers.cat                    = term_previewer.cat
 previewers.vimgrep                = term_previewer.vimgrep
 previewers.qflist                 = term_previewer.qflist
 
-previewers.new_buffer_previewer = buffer_previewer.new_buffer_previewer
-previewers.vim_buffer_cat       = buffer_previewer.cat
-previewers.vim_buffer_vimgrep   = buffer_previewer.vimgrep
-previewers.vim_buffer_qflist    = buffer_previewer.qflist
-previewers.ctags                = buffer_previewer.ctags
-previewers.builtin              = buffer_previewer.builtin
-previewers.help                 = buffer_previewer.help
-previewers.man                  = buffer_previewer.man
-previewers.autocommands         = buffer_previewer.autocommands
-previewers.highlights           = buffer_previewer.highlights
-previewers.display_content      = buffer_previewer.display_content
+previewers.new_buffer_previewer   = buffer_previewer.new_buffer_previewer
+previewers.buffer_previewer_maker = buffer_previewer.file_maker
+previewers.vim_buffer_cat         = buffer_previewer.cat
+previewers.vim_buffer_vimgrep     = buffer_previewer.vimgrep
+previewers.vim_buffer_qflist      = buffer_previewer.qflist
+previewers.git_branch_log         = buffer_previewer.git_branch_log
+previewers.git_commit_diff        = buffer_previewer.git_commit_diff
+previewers.git_file_diff          = buffer_previewer.git_file_diff
+previewers.ctags                  = buffer_previewer.ctags
+previewers.builtin                = buffer_previewer.builtin
+previewers.help                   = buffer_previewer.help
+previewers.man                    = buffer_previewer.man
+previewers.autocommands           = buffer_previewer.autocommands
+previewers.highlights             = buffer_previewer.highlights
+previewers.display_content        = buffer_previewer.display_content
 
 previewers.Previewer = Previewer
 

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -187,15 +187,18 @@ previewers.new_termopen_previewer = function(opts)
         return opts.get_command(entry, st)
       else
         local env = {}
+        local cmd = opts.get_command(entry, st)
+        if not cmd then return end
         for k, v in pairs(termopen_env) do
           table.insert(env, k .. '=' .. v)
         end
-        return table.concat(env, ' ') .. ' ' .. table.concat(opts.get_command(entry, st), ' ')
+        return table.concat(env, ' ') .. ' ' .. table.concat(cmd, ' ')
       end
     end
 
     putils.with_preview_window(status, bufnr, function()
-      set_term_id(self, vim.fn.termopen(get_cmd(status), term_opts))
+      local cmd = get_cmd(status)
+      if cmd then set_term_id(self, vim.fn.termopen(cmd, term_opts)) end
     end)
 
     vim.api.nvim_buf_set_name(bufnr, tostring(bufnr))
@@ -227,34 +230,6 @@ previewers.new_termopen_previewer = function(opts)
 
   return Previewer:new(opts)
 end
-
-previewers.git_commit_diff = defaulter(function(_)
-  return previewers.new_termopen_previewer {
-    get_command = function(entry)
-      local sha = entry.value
-      return { 'git', '-p', 'diff', sha .. '^!' }
-    end
-  }
-end, {})
-
-previewers.git_branch_log = defaulter(function(_)
-  return previewers.new_termopen_previewer {
-    get_command = function(entry)
-      return { 'git', '-p', 'log', '--graph',
-               "--pretty=format:" .. add_quotes .. "%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)%Creset"
-               .. add_quotes,
-               '--abbrev-commit', '--date=relative', entry.value }
-    end
-  }
-end, {})
-
-previewers.git_file_diff = defaulter(function(_)
-  return previewers.new_termopen_previewer {
-    get_command = function(entry)
-      return { 'git', '-p', 'diff', entry.value }
-    end
-  }
-end, {})
 
 previewers.cat = defaulter(function(opts)
   local maker = get_maker(opts)

--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -1,5 +1,11 @@
 local context_manager = require('plenary.context_manager')
 
+local has_ts, _ = pcall(require, 'nvim-treesitter')
+local _, ts_highlight = pcall(require, 'nvim-treesitter.highlight')
+local _, ts_parsers = pcall(require, 'nvim-treesitter.parsers')
+
+local Job = require('plenary.job')
+
 local utils = {}
 
 utils.with_preview_window = function(status, bufnr, callable)
@@ -11,6 +17,52 @@ utils.with_preview_window = function(status, bufnr, callable)
       coroutine.yield()
       vim.cmd(string.format("noautocmd call nvim_set_current_win(%s)", status.prompt_win))
     end, callable)
+  end
+end
+
+-- API helper functions for buffer previewer
+--- Job maker for buffer previewer
+utils.job_maker = function(cmd, env, value, bufnr, bufname, callback)
+  if bufname ~= value then
+    local command = table.remove(cmd, 1)
+    Job:new({
+      command = command,
+      args = cmd,
+      env = env,
+      on_exit = vim.schedule_wrap(function(j)
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, j:result())
+        if callback then callback(bufnr, j:result()) end
+      end)
+    }):start()
+  else
+    if callback then callback(bufnr) end
+  end
+end
+
+--- Attach default highlighter which will choose between regex and ts
+utils.highlighter = function(bufnr, ft)
+  if ft and ft ~= '' then
+    if has_ts and ts_parsers.has_parser(ft) then
+      ts_highlight.attach(bufnr, ft)
+    else
+      vim.cmd(':ownsyntax ' .. ft)
+    end
+  end
+end
+
+--- Attach regex highlighter
+utils.regex_highlighter = function(_, ft)
+  if ft and ft ~= '' then
+    vim.cmd(':ownsyntax ' .. ft)
+  end
+end
+
+-- Attach ts highlighter
+utils.ts_highlighter = function(bufnr, ft)
+  if ft and ft ~= '' then
+    if has_ts and ts_parsers.has_parser(ft) then
+      ts_highlight.attach(bufnr, ft)
+    end
   end
 end
 

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -35,8 +35,10 @@ highlight default link TelescopeResultsStruct Struct
 highlight default link TelescopeResultsVariable SpecialChar
 
 highlight default link TelescopeResultsLineNr LineNr
+highlight default link TelescopeResultsIdentifier Identifier
 highlight default link TelescopeResultsNumber Number
 highlight default link TelescopeResultsComment Comment
+highlight default link TelescopeResultsSpecialComment SpecialComment
 
 " This is like "<C-R>" in your terminal.
 "   To use it, do `cmap <C-R> <Plug>(TelescopeFuzzyCommandSearch)


### PR DESCRIPTION
Missing:
- [x] git diff without termopen
- [x] document how to add custom filetypes
- [x] `previewers.vim_buffer_vimgrep` and `previewers.vim_buffer_qflist` is now async
- [x] All `buffer` previewer are now async 🎉 
- [x] Refactor `file_maker` maybe make it configurable for rockerBoo
- [x] Make wrap configurable
- [x] Maybe just replace the old git previewers with the new one. Maybe even replace git log and do coloring with `nvim_buf_add_highlight`
- [x] `keep_last_buf` for pwntester
- [x] `job_maker` public with previewer utils

Also requires https://github.com/nvim-lua/plenary.nvim/pull/37 to work perfectly 
