### PR TITLE
README.md | fix lua example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ nnoremap <leader>fh <cmd>Telescope help_tags<cr>
 nnoremap <leader>ff <cmd>lua require('telescope.builtin').find_files()<cr>
 nnoremap <leader>fg <cmd>lua require('telescope.builtin').live_grep()<cr>
 nnoremap <leader>fb <cmd>lua require('telescope.builtin').buffers()<cr>
-nnoremap <leader>ff <cmd>lua require('telescope.builtin').help_tags()<cr>
+nnoremap <leader>fh <cmd>lua require('telescope.builtin').help_tags()<cr>
 ```
 
 See [built-in pickers](#pickers) for the list of all built-in


### PR DESCRIPTION
Both `find_files()` and `help_tags()` were bound to `<leader>ff`. This resulted in `<leader>ff` not opening the `find_files()` dialog