### PR TITLE
fix: builtin.buffers to override entry_maker

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -172,7 +172,7 @@ files.treesitter = function(opts)
     prompt_title = 'Treesitter Symbols',
     finder    = finders.new_table {
       results = results,
-      entry_maker = make_entry.gen_from_treesitter(opts)
+      entry_maker = opts.entry_maker or make_entry.gen_from_treesitter(opts)
     },
     previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
@@ -235,7 +235,7 @@ files.tags = function(opts)
     prompt = 'Tags',
     finder = finders.new_table {
       results = results,
-      entry_maker = make_entry.gen_from_ctags(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_ctags(opts),
     },
     previewer = previewers.ctags.new(opts),
     sorter = conf.generic_sorter(opts),

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -35,7 +35,7 @@ git.commits = function(opts)
     prompt_title = 'Git Commits',
     finder = finders.new_table {
       results = results,
-      entry_maker = make_entry.gen_from_git_commits(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_git_commits(opts),
     },
     previewer = previewers.git_commit_diff.new(opts),
     sorter = conf.file_sorter(opts),
@@ -54,7 +54,7 @@ git.bcommits = function(opts)
     prompt_title = 'Git BCommits',
     finder = finders.new_table {
       results = results,
-      entry_maker = make_entry.gen_from_git_commits(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_git_commits(opts),
     },
     previewer = previewers.git_commit_diff.new(opts),
     sorter = conf.file_sorter(opts),

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -512,7 +512,7 @@ internal.buffers = function(opts)
     prompt_title = 'Buffers',
     finder    = finders.new_table {
       results = buffers,
-      entry_maker = make_entry.gen_from_buffer(opts)
+      entry_maker = opts.entry_maker or make_entry.gen_from_buffer(opts)
     },
     previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -198,7 +198,7 @@ internal.quickfix = function(opts)
     prompt_title  = 'Quickfix',
     finder    = finders.new_table {
       results     = locations,
-      entry_maker = make_entry.gen_from_quickfix(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_quickfix(opts),
     },
     previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
@@ -221,7 +221,7 @@ internal.loclist = function(opts)
     prompt_title = 'Loclist',
     finder    = finders.new_table {
       results     = locations,
-      entry_maker = make_entry.gen_from_quickfix(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_quickfix(opts),
     },
     previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
@@ -275,7 +275,7 @@ internal.vim_options = function(opts)
     prompt = 'options',
     finder = finders.new_table {
       results = vim_opts,
-      entry_maker = make_entry.gen_from_vimoptions(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_vimoptions(opts),
     },
     -- TODO: previewer for Vim options
     -- previewer = previewers.help.new(opts),
@@ -410,7 +410,7 @@ internal.man_pages = function(opts)
     prompt_title = 'Man',
     finder    = finders.new_table {
       results = lines,
-      entry_maker = make_entry.gen_from_apropos(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_apropos(opts),
     },
     previewer = previewers.man.new(opts),
     sorter = conf.generic_sorter(opts),
@@ -452,7 +452,7 @@ internal.reloader = function(opts)
     prompt_title = 'Packages',
     finder = finders.new_table {
       results = package_list,
-      entry_maker = make_entry.gen_from_packages(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_packages(opts),
     },
     -- previewer = previewers.vim_buffer.new(opts),
     sorter = conf.generic_sorter(opts),
@@ -554,7 +554,7 @@ internal.marks = function(opts)
     prompt = 'Marks',
     finder = finders.new_table {
       results = marks_table,
-      entry_maker = make_entry.gen_from_marks(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_marks(opts),
     },
     previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
@@ -578,7 +578,7 @@ internal.registers = function(opts)
     prompt_title = 'Registers',
     finder = finders.new_table {
       results = registers_table,
-      entry_maker = make_entry.gen_from_registers(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_registers(opts),
     },
     -- use levenshtein as n-gram doesn't support <2 char matches
     sorter = sorters.get_levenshtein_sorter(),
@@ -661,7 +661,7 @@ internal.highlights = function(opts)
     prompt_title = 'Highlights',
     finder = finders.new_table {
       results = highlights,
-      entry_maker = make_entry.gen_from_highlights(opts)
+      entry_maker = opts.entry_maker or make_entry.gen_from_highlights(opts)
     },
     sorter = conf.generic_sorter(opts),
     attach_mappings = function(prompt_bufnr)
@@ -751,7 +751,7 @@ internal.autocommands = function(opts)
     prompt_title = 'autocommands',
     finder = finders.new_table {
       results = autocmd_table,
-      entry_maker = make_entry.gen_from_autocommands(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_autocommands(opts),
     },
     previewer = previewers.autocommands.new(opts),
     sorter = conf.generic_sorter(opts),

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -30,7 +30,7 @@ lsp.references = function(opts)
     prompt_title = 'LSP References',
     finder    = finders.new_table {
       results = locations,
-      entry_maker = make_entry.gen_from_quickfix(opts),
+      entry_maker = opts.entry_maker or make_entry.gen_from_quickfix(opts),
     },
     previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
@@ -60,7 +60,7 @@ lsp.document_symbols = function(opts)
     prompt_title = 'LSP Document Symbols',
     finder    = finders.new_table {
       results = locations,
-      entry_maker = make_entry.gen_from_lsp_symbols(opts)
+      entry_maker = opts.entry_maker or make_entry.gen_from_lsp_symbols(opts)
     },
     previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
@@ -174,7 +174,7 @@ lsp.workspace_symbols = function(opts)
     prompt_title = 'LSP Workspace Symbols',
     finder    = finders.new_table {
       results = locations,
-      entry_maker = make_entry.gen_from_lsp_symbols(opts)
+      entry_maker = opts.entry_maker or make_entry.gen_from_lsp_symbols(opts)
     },
     previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -473,14 +473,10 @@ function make_entry.gen_from_buffer(opts)
 
     local icon, hl_group = get_devicons(entry.filename, disable_devicons)
 
-    if hl_group then
-      icon = { icon, hl_group }
-    end
-
     return displayer {
       {entry.bufnr, "TelescopeResultsNumber"},
       {entry.indicator, "TelescopeResultsComment"},
-      icon,
+      { icon, hl_group },
       display_bufname .. ":" .. entry.lnum
       }
   end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -33,6 +33,7 @@ local lsp_type_highlight = {
 local make_entry = {}
 
 local transform_devicons
+local get_devicons
 if has_devicons then
   if not devicons.has_loaded() then
     devicons.setup()
@@ -52,9 +53,26 @@ if has_devicons then
       return icon_display
     end
   end
+
+  get_devicons = function(filename, disable_devicons)
+    if disable_devicons or not filename then
+      return ''
+    end
+
+    local icon, icon_highlight = devicons.get_icon(filename, string.match(filename, '%a+$'), { default = true })
+    if conf.color_devicons then
+      return icon, icon_highlight
+    else
+      return icon
+    end
+  end
 else
   transform_devicons = function(_, display, _)
     return display
+  end
+
+  get_devicons = function(_, _)
+    return ''
   end
 end
 
@@ -426,11 +444,19 @@ end
 function make_entry.gen_from_buffer(opts)
   opts = opts or {}
 
+  local disable_devicons = opts.disable_devicons
+
+  local icon_width = 0
+  if not disable_devicons then
+    icon_width = vim.fn.strdisplaywidth(get_devicons('fname', disable_devicons))
+  end
+
   local displayer = entry_display.create {
     separator = " ",
     items = {
       { width = opts.bufnr_width },
       { width = 4 },
+      { width = icon_width },
       { remaining = true },
     },
   }
@@ -445,9 +471,16 @@ function make_entry.gen_from_buffer(opts)
       display_bufname = entry.filename
     end
 
+    local icon, hl_group = get_devicons(entry.filename, disable_devicons)
+
+    if hl_group then
+      icon = { icon, hl_group }
+    end
+
     return displayer {
       {entry.bufnr, "TelescopeResultsNumber"},
       {entry.indicator, "TelescopeResultsComment"},
+      icon,
       display_bufname .. ":" .. entry.lnum
       }
   end


### PR DESCRIPTION
This will allow for more customization and make telescope more fun to use!

```lua
require('telescope.builtin').buffers {
  ...
  entry_maker = my_entry_maker.gen_from_buffer_better(),
  ...
}
```

Should it be possible to override it with other pickers?