### PR TITLE
Previewer windows fix

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -20,7 +20,7 @@ previewers.file_maker = function(filepath, bufnr, bufname, use_ft_detect, callba
 
   if bufname ~= filepath then
     path.read_file_async(filepath, vim.schedule_wrap(function(data)
-      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(data, "\n"))
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(data, '[\r]?\n'))
 
       if callback then callback(bufnr) end
     end))


### PR DESCRIPTION
Edit: Should work. Just not in general. We need to determine for each file which line endings are used. I think you can also use linux line endings on windows and these change would break it

Edit 2: Should be better now