### PR TITLE
make pickers not block typing when it is processing (using libuv async handle)

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -558,7 +558,7 @@ function Picker:find()
 
   -- Register attach
   vim.api.nvim_buf_attach(prompt_bufnr, false, {
-    on_lines = on_lines,
+    on_lines = utils.async(on_lines),
     on_detach = vim.schedule_wrap(function()
       self:_reset_highlights()
 

--- a/lua/telescope/previewers/previewer.lua
+++ b/lua/telescope/previewers/previewer.lua
@@ -1,3 +1,5 @@
+local utils = require("telescope/utils")
+
 local Previewer = {}
 Previewer.__index = Previewer
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -200,6 +200,50 @@ function utils.get_os_command_output(cmd)
   return output
 end
 
+List = {}
+
+function List.new()
+  return {first = 0, last = -1}
+end
+
+function List.pushleft(list, value)
+  local first = list.first - 1
+  list.first = first
+  list[first] = value
+end
+
+function List.pushright (list, value)
+  local last = list.last + 1
+  list.last = last
+  list[last] = value
+end
+
+function List.popleft (list)
+  local first = list.first
+  if first > list.last then return nil end
+  local value = list[first]
+  list[first] = nil        -- to allow garbage collection
+  list.first = first + 1
+  return value
+end
+
+function List.is_empty(list)
+  return list.first > list.last
+end
+
+function List.popright (list)
+  local last = list.last
+  if list.first > last then return nil end
+  local value = list[last]
+  list[last] = nil         -- to allow garbage collection
+  list.last = last - 1
+  return value
+end
+
+function List.len(list)
+  return list.last - list.first
+end
+
 function utils.async(f)
   return function(...)
     local async_handle
@@ -208,6 +252,58 @@ function utils.async(f)
       async_handle:close()
     end))
     async_handle:send(...)
+  end
+end
+
+function utils.async_queue(fn)
+  local queue = List.new()
+  local running = false
+  local idle = uv.new_idle() -- NOTE: not what the name means
+
+  local function send(...)
+    List.pushleft(queue, {...})
+  end
+
+  local function run()
+    idle:start(function()
+      local res = List.popright(queue)
+      if res then
+        if not running then
+          local handle
+          handle = uv.new_async(vim.schedule_wrap(function(...)
+            fn(...)
+            running = false
+            handle:close()
+          end))
+          handle:send(unpack(res))
+          running = true
+        end
+      end
+    end)
+  end
+
+  local function stop()
+    idle:stop()
+  end
+
+  return send, run, stop
+end
+
+function utils.async_wrap_close_previous(f)
+  local handle
+  return function(...)
+    if handle then
+      handle:close()
+      handle = nil
+    end
+    handle = uv.new_async(vim.schedule_wrap(function(...)
+      f(...)
+      if handle then
+        handle:close()
+        handle = nil
+      end
+    end))
+    handle:send(...)
   end
 end
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -1,3 +1,4 @@
+local uv = vim.loop
 local pathlib = require('telescope.path')
 
 local utils = {}
@@ -197,6 +198,17 @@ function utils.get_os_command_output(cmd)
   local output = assert(handle:read('*a'))
   assert(handle:close())
   return output
+end
+
+function utils.async(f)
+  return function(...)
+    local async_handle
+    async_handle = uv.new_async(vim.schedule_wrap(function(...)
+      f(...)
+      async_handle:close()
+    end))
+    async_handle:send(...)
+  end
 end
 
 return utils


### PR DESCRIPTION
I have made the `on_lines` callback for `nvim_buf_attach` async using `uv_async_t`. This has extreme performance benefits even with such a small code change because the cursor can keep moving while telescope is processing. I am using `uv_async_t` instead of `luv_work_ctx_t` or `luv_thread_t` because I don't think that the thread ones can change state. In my tests they crash while the async one is fine. We probably still need to make the actual picker faster but making it async is a good step as it makes the user feel like it is going fast.