### PR TITLE
allow actions.get_current_line in addition to actions.get_selected_entry

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -43,6 +43,10 @@ function actions.get_selected_entry()
   return state.get_global_key('selected_entry')
 end
 
+function actions.get_current_line()
+  return state.get_global_key('current_line')
+end
+
 function actions.preview_scrolling_up(prompt_bufnr)
   actions.get_current_picker(prompt_bufnr).previewer:scroll_fn(-30)
 end

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -524,6 +524,9 @@ function Picker:find()
         error('Unknown selection strategy: ' .. selection_strategy)
       end
 
+      local current_line = vim.api.nvim_get_current_line():sub(self.prompt_prefix:len() + 1)
+      state.set_global_key('current_line', current_line)
+
       self:clear_extra_rows(results_bufnr)
       self:highlight_displayed_rows(results_bufnr, prompt)
 


### PR DESCRIPTION
This can be useful for example if the user has typed in something that does not match any entry. Then we want to perform something else. A use case is for [neuron.nvim](https://github.com/oberblastmeister/neuron.nvim) where the user can query for notes. If the user has typed in something that does not match any entry, we want to create a new note, kind of like Notational Velocity. I would need to be able to get the current line for that to work.