### PR TITLE
finders: added assert for finder executable

### DIFF
--- a/lua/telescope/finders.lua
+++ b/lua/telescope/finders.lua
@@ -303,6 +303,8 @@ end
 finders.new_oneshot_job = function(command_list, opts)
   opts = opts or {}
 
+  assert(1 == vim.fn.executable(command_list[1]), command_list[1]..": command not found.")
+
   command_list = vim.deepcopy(command_list)
 
   local command = table.remove(command_list, 1)


### PR DESCRIPTION
fixed #369 

added an assert to the beginning of the new_oneshot_job function in finders.lua to check whether the executable in config variable: vimgrep_arguments exists or not.

Expected behavior: if ripgrep or any finder specified in vimgrep_arguments does not exist, an error will be raised:
"rg: command not found"