### PR TITLE
Use valid paths to preview considering cwd

### DIFF
--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -258,14 +258,15 @@ previewers.vimgrep = defaulter(function(opts)
       local win_id = status.preview_win
       local height = vim.api.nvim_win_get_height(win_id)
 
-      local filename = entry.filename
+      local p = from_entry.path(entry, true)
+      if p == nil or p == '' then return end
       local lnum = entry.lnum or 0
 
       local context = math.floor(height / 2)
       local start = math.max(0, lnum - context)
       local finish = lnum + context
 
-      return maker(filename, lnum, start, finish)
+      return maker(p, lnum, start, finish)
     end,
   }
 end, {})
@@ -280,7 +281,8 @@ previewers.qflist = defaulter(function(opts)
       local win_id = status.preview_win
       local height = vim.api.nvim_win_get_height(win_id)
 
-      local filename = entry.filename
+      local p = from_entry.path(entry, true)
+      if p == nil or p == '' then return end
       local lnum = entry.lnum
 
       local start, finish
@@ -293,7 +295,7 @@ previewers.qflist = defaulter(function(opts)
         finish = lnum + context
       end
 
-      return maker(filename, lnum, start, finish)
+      return maker(p, lnum, start, finish)
     end
   }
 end, {})

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -3,6 +3,7 @@ local utils = require('telescope.utils')
 local putils = require('telescope.previewers.utils')
 local from_entry = require('telescope.from_entry')
 local Previewer = require('telescope.previewers.previewer')
+local path = require('telescope.path')
 
 local flatten = vim.tbl_flatten
 local buf_delete = utils.buf_delete
@@ -258,7 +259,13 @@ previewers.vimgrep = defaulter(function(opts)
       local win_id = status.preview_win
       local height = vim.api.nvim_win_get_height(win_id)
 
-      local dir = opts.cwd and vim.fn.expand(opts.cwd)..'/' or ''
+      local dir = ''
+      if opts.cwd then
+        dir = vim.fn.expand(opts.cwd)
+        if dir:sub(-1) ~= path.separator then
+          dir = dir..path.separator
+        end
+      end
       local filename = dir..entry.filename
       local lnum = entry.lnum or 0
 

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -258,7 +258,8 @@ previewers.vimgrep = defaulter(function(opts)
       local win_id = status.preview_win
       local height = vim.api.nvim_win_get_height(win_id)
 
-      local filename = entry.filename
+      local dir = opts.cwd and vim.fn.expand(opts.cwd)..'/' or ''
+      local filename = dir..entry.filename
       local lnum = entry.lnum or 0
 
       local context = math.floor(height / 2)

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -3,7 +3,6 @@ local utils = require('telescope.utils')
 local putils = require('telescope.previewers.utils')
 local from_entry = require('telescope.from_entry')
 local Previewer = require('telescope.previewers.previewer')
-local path = require('telescope.path')
 
 local flatten = vim.tbl_flatten
 local buf_delete = utils.buf_delete
@@ -259,13 +258,7 @@ previewers.vimgrep = defaulter(function(opts)
       local win_id = status.preview_win
       local height = vim.api.nvim_win_get_height(win_id)
 
-      local dir = ''
-      if opts.cwd then
-        dir = vim.fn.expand(opts.cwd)
-        if dir:sub(-1) ~= path.separator then
-          dir = dir..path.separator
-        end
-      end
+      local dir = opts.cwd and vim.fn.expand(opts.cwd)..'/' or ''
       local filename = dir..entry.filename
       local lnum = entry.lnum or 0
 

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -258,8 +258,7 @@ previewers.vimgrep = defaulter(function(opts)
       local win_id = status.preview_win
       local height = vim.api.nvim_win_get_height(win_id)
 
-      local dir = opts.cwd and vim.fn.expand(opts.cwd)..'/' or ''
-      local filename = dir..entry.filename
+      local filename = entry.filename
       local lnum = entry.lnum or 0
 
       local context = math.floor(height / 2)


### PR DESCRIPTION
I found `live_grep` picker shows corrupted previews when `cwd` option is used.

```vim
lua require'telescope.builtin'.live_grep{cwd = '/foofoo/barbar'}
```

When this command is executed in `/foo/bar`, and it founds `some-file/found.txt`, preview window will be corrupted because `/foo/bar/some-file/found.txt` does not exist.

### TODO

* [x] I added Unix path separator `/` to join. For Windows, I should use `\` for this? (sry, I do not have Windows)