### PR TITLE
fix bug with custom extensions opts

### DIFF
--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -41,11 +41,9 @@ local function convert_user_opts(user_opts)
   setmetatable(_switch,_switch_metatable)
 
   for key,val in pairs(user_opts) do
-    if default_opts[key]  == nil then
-      print('[Telescope] argument not exists in default options')
-      return
+    if default_opts[key]  ~= nil then
+      _switch[type(default_opts[key])](key,val)
     end
-    _switch[type(default_opts[key])](key,val)
   end
 end
 


### PR DESCRIPTION
 if the user options does not exist in default options but need in extensions. just covert the user options that in default options.