### PR TITLE
WIP: Switchable window attempt

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -55,6 +55,14 @@ function actions.preview_scrolling_down(prompt_bufnr)
   actions.get_current_picker(prompt_bufnr).previewer:scroll_fn(30)
 end
 
+function actions.preview_switch_window_left(prompt_bufnr)
+  actions.get_current_picker(prompt_bufnr).previewer:switch_window(state.get_status(prompt_bufnr).prompt_win)
+end
+
+function actions.preview_switch_window_right(prompt_bufnr)
+  actions.get_current_picker(prompt_bufnr).previewer:switch_window(state.get_status(prompt_bufnr).preview_win)
+end
+
 -- TODO: It seems sometimes we get bad styling.
 function actions._goto_file_selection(prompt_bufnr, command)
   local entry = actions.get_selected_entry(prompt_bufnr)

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -44,6 +44,9 @@ mappings.default_mappings = config.values.default_mappings or {
 
       ["<C-u>"] = actions.preview_scrolling_up,
       ["<C-d>"] = actions.preview_scrolling_down,
+
+      -- ["<C-w>h"] = actions.preview_switch_window_left,
+      ["<C-w>l"] = actions.preview_switch_window_right,
     },
   }
 

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -159,6 +159,12 @@ previewers.new_buffer_previewer = function(opts)
     end
   end
 
+  if not opts.switch_window then
+    function opts.switch_window(_, winid)
+      vim.cmd(string.format("noautocmd call nvim_set_current_win(%s)", winid))
+    end
+  end
+
   return Previewer:new(opts)
 end
 

--- a/lua/telescope/previewers/previewer.lua
+++ b/lua/telescope/previewers/previewer.lua
@@ -10,6 +10,7 @@ function Previewer:new(opts)
     _teardown_func = opts.teardown,
     _send_input = opts.send_input,
     _scroll_fn = opts.scroll_fn,
+    _switch_window = opts.switch_window,
     preview_fn = opts.preview_fn,
   }, Previewer)
 end
@@ -49,6 +50,14 @@ function Previewer:scroll_fn(direction)
     self:_scroll_fn(direction)
   else
     vim.api.nvim_err_writeln("scroll_fn is not defined for this previewer")
+  end
+end
+
+function Previewer:switch_window(winid)
+  if self._switch_window then
+    self:_switch_window(winid)
+  else
+    vim.api.nvim_err_writeln("switch_window is not defined for this previewer")
   end
 end
 


### PR DESCRIPTION
New:
- Switch to buffer_previewer with `<C-w>l` in normal mode (we can talk about more mappings, for insert mode as well)

~~Fixes:~~
~~- Buffer previewer scrolling. Now we can do something like smooth scrolling @tami5~~ doing this somewhere else

Missing:
- [ ] Switch back from previewer. We have to inject a mappings so that is possible
- [ ] Handle edits with interface so that each `buffer_previewer` has to write a save function so we can realize that stuff @sunjon suggested
- [ ] We have to noop a lot of commands and mappings in previewer so the user doesn't close that window or does other unpredictable things. We can also map `:q` to `actions.close` so we close telescope correctly.

CC @hoob3rt