### PR TITLE
Set valid commands for apropos in macOS

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -418,14 +418,15 @@ internal.man_pages = function(opts)
     attach_mappings = function(prompt_bufnr)
       actions._goto_file_selection:replace(function(_, cmd)
         local selection = actions.get_selected_entry()
+        local args = selection.section .. ' ' .. selection.value
 
         actions.close(prompt_bufnr)
         if cmd == 'edit' or cmd == 'new' then
-          vim.cmd('Man ' .. selection.value)
+          vim.cmd('Man ' .. args)
         elseif cmd == 'vnew' then
-          vim.cmd('vert bo Man ' .. selection.value)
+          vim.cmd('vert bo Man ' .. args)
         elseif cmd == 'tabedit' then
-          vim.cmd('tab Man ' .. selection.value)
+          vim.cmd('tab Man ' .. args)
         end
       end)
 

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -408,30 +408,11 @@ internal.man_pages = function(opts)
     opts.man_cmd,
     vim.fn.has'mac' and {'apropos', ' '} or {'apropos', ''}
   )
-
-  local sections = {}
-  for _, section in ipairs(vim.split(opts.sections, ',', true)) do
-    sections[section] = true
-  end
-  local pages = utils.get_os_command_output(opts.man_cmd)
-  local results = {}
-  for _, page in ipairs(pages) do
-    local cmd, section, desc = page:match'^(.+)%s*%((.+)%)%s*%-%s*(.*)$'
-    if sections[section] then
-      table.insert(results, {
-        cmd = cmd,
-        section = section,
-        desc = desc,
-      })
-    end
-  end
+  opts.entry_maker = opts.entry_maker or make_entry.gen_from_apropos(opts)
 
   pickers.new(opts, {
     prompt_title = 'Man',
-    finder    = finders.new_table {
-      results = results,
-      entry_maker = opts.entry_maker or make_entry.gen_from_apropos(opts),
-    },
+    finder    = finders.new_oneshot_job(opts.man_cmd, opts),
     previewer = previewers.man.new(opts),
     sorter = conf.generic_sorter(opts),
     attach_mappings = function(prompt_bufnr)

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -404,7 +404,10 @@ end
 
 internal.man_pages = function(opts)
   opts.sections = utils.get_default(opts.sections, '1')
-  opts.man_cmd = utils.get_default(opts.man_cmd, {'apropos', ''})
+  opts.man_cmd = utils.get_default(
+    opts.man_cmd,
+    vim.fn.has'mac' and {'apropos', ' '} or {'apropos', ''}
+  )
 
   local sections = {}
   for _, section in ipairs(vim.split(opts.sections, ',', true)) do

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -403,7 +403,8 @@ internal.help_tags = function(opts)
 end
 
 internal.man_pages = function(opts)
-  opts.sections = utils.get_default(opts.sections, '1')
+  opts.sections = utils.get_default(opts.sections, {'1'})
+  assert(vim.tbl_islist(opts.sections), 'sections should be a list')
   opts.man_cmd = utils.get_lazy_default(opts.man_cmd, function()
     return vim.fn.has'mac' and {'apropos', ' '} or {'apropos', ''}
   end)

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -409,9 +409,6 @@ internal.man_pages = function(opts)
     return vim.fn.has'mac' and {'apropos', ' '} or {'apropos', ''}
   end)
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_apropos(opts)
-  opts.PAGER = utils.get_lazy_default(opts.PAGER, function()
-    return vim.fn.executable('col') and 'col -bx' or ''
-  end)
 
   pickers.new(opts, {
     prompt_title = 'Man',

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -408,6 +408,9 @@ internal.man_pages = function(opts)
     return vim.fn.has'mac' and {'apropos', ' '} or {'apropos', ''}
   end)
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_apropos(opts)
+  opts.PAGER = utils.get_lazy_default(opts.PAGER, function()
+    return vim.fn.executable('col') and 'col -bx' or ''
+  end)
 
   pickers.new(opts, {
     prompt_title = 'Man',

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -404,10 +404,9 @@ end
 
 internal.man_pages = function(opts)
   opts.sections = utils.get_default(opts.sections, '1')
-  opts.man_cmd = utils.get_default(
-    opts.man_cmd,
-    vim.fn.has'mac' and {'apropos', ' '} or {'apropos', ''}
-  )
+  opts.man_cmd = utils.get_lazy_default(opts.man_cmd, function()
+    return vim.fn.has'mac' and {'apropos', ' '} or {'apropos', ''}
+  end)
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_apropos(opts)
 
   pickers.new(opts, {

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -406,7 +406,8 @@ internal.man_pages = function(opts)
   opts.sections = utils.get_default(opts.sections, {'1'})
   assert(vim.tbl_islist(opts.sections), 'sections should be a list')
   opts.man_cmd = utils.get_lazy_default(opts.man_cmd, function()
-    return vim.fn.has'mac' and {'apropos', ' '} or {'apropos', ''}
+    local is_darwin = vim.loop.os_uname().sysname == 'Darwin'
+    return is_darwin and {'apropos', ' '} or {'apropos', ''}
   end)
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_apropos(opts)
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -623,28 +623,29 @@ function make_entry.gen_from_apropos(opts)
     items = {
       {},
       {},
-      {},
     },
   }
 
   local make_display = function(entry)
     -- Stopgap measure to set `width` for this field. See #414
-    local formatted = ('%-30s'):format(entry.value)
+    local formatted = ('%-30s'):format(entry.keyword)
     return displayer {
       {formatted, 'TelescopeResultsFunction'},
-      {'('..entry.section..')', 'TelescopeResultsVariable'},
       entry.description
     }
   end
 
   return function(line)
-    local cmd, section, desc = line:match'^(.+)%s*%((.+)%)%s*%-%s*(.*)$'
+    local keyword, desc = line:match'^(.+)%s+%-%s+(.*)$'
+    local section = keyword and keyword:match'%(([^)])%)' or nil
+    local cmd = keyword and keyword:match'(%S+)%(' or nil
     return sections[section] and {
       value = cmd,
       description = desc,
       ordinal = cmd,
       display = make_display,
       section = section,
+      keyword = keyword,
     } or nil
   end
 end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -637,7 +637,7 @@ function make_entry.gen_from_apropos(opts)
   return function(line)
     local keyword, desc = line:match'^(.+)%s+%-%s+(.*)$'
     local section = keyword and keyword:match'%(([^)]+)%)' or nil
-    local cmd = keyword and keyword:match'(%S+)%(' or nil
+    local cmd = keyword and keyword:match'(%S+)%s*%(' or nil
     return sections[section] and {
       value = cmd,
       description = desc,

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -623,7 +623,7 @@ function make_entry.gen_from_apropos(opts)
     separator = ' ',
     items = {
       { width = 30 },
-      {},
+      { remaining = true },
     },
   }
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -612,29 +612,40 @@ function make_entry.gen_from_packages(opts)
   end
 end
 
-function make_entry.gen_from_apropos()
+function make_entry.gen_from_apropos(opts)
+  local sections = {}
+  for _, section in ipairs(vim.split(opts.sections, ',', true)) do
+    sections[section] = true
+  end
+
   local displayer = entry_display.create {
-    separator = "",
+    separator = ' ',
     items = {
-      { width = 30 },
-      { remaining = true },
+      {},
+      {},
+      {},
     },
   }
 
   local make_display = function(entry)
+    -- Stopgap measure to set `width` for this field. See #414
+    local formatted = ('%-30s'):format(entry.value)
     return displayer {
-      entry.value,
+      {formatted, 'TelescopeResultsFunction'},
+      {'('..entry.section..')', 'TelescopeResultsVariable'},
       entry.description
     }
   end
 
-  return function(result)
-    return {
-      value = result.cmd,
-      description = result.desc,
-      ordinal = result.cmd,
+  return function(line)
+    local cmd, section, desc = line:match'^(.+)%s*%((.+)%)%s*%-%s*(.*)$'
+    return sections[section] and {
+      value = cmd,
+      description = desc,
+      ordinal = cmd,
       display = make_display,
-    }
+      section = section,
+    } or nil
   end
 end
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -628,13 +628,11 @@ function make_entry.gen_from_apropos()
     }
   end
 
-  return function(line)
-    local cmd, _, desc = line:match("^(.*)%s+%((.*)%)%s+%-%s(.*)$")
-
+  return function(result)
     return {
-      value = cmd,
-      description = desc,
-      ordinal = cmd,
+      value = result.cmd,
+      description = result.desc,
+      ordinal = result.cmd,
       display = make_display,
     }
   end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -635,10 +635,8 @@ function make_entry.gen_from_apropos(opts)
   end
 
   return function(line)
-    local keyword, desc = line:match'^(.-)%s+%-%s+(.*)$'
-    local section = keyword and keyword:match'%(([^)]+)%)' or nil
-    local cmd = keyword and keyword:match'(%S+)%s*%(' or nil
-    return sections[section] and {
+    local keyword, cmd, section, desc = line:match'^((.-)%s*%(([^)]+)%).-)%s+%-%s+(.*)$'
+    return keyword and sections[section] and {
       value = cmd,
       description = desc,
       ordinal = cmd,

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -622,16 +622,14 @@ function make_entry.gen_from_apropos(opts)
   local displayer = entry_display.create {
     separator = ' ',
     items = {
-      {},
+      { width = 30 },
       {},
     },
   }
 
   local make_display = function(entry)
-    -- Stopgap measure to set `width` for this field. See #414
-    local formatted = ('%-30s'):format(entry.keyword)
     return displayer {
-      {formatted, 'TelescopeResultsFunction'},
+      { entry.keyword, 'TelescopeResultsFunction' },
       entry.description
     }
   end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -635,7 +635,7 @@ function make_entry.gen_from_apropos(opts)
   end
 
   return function(line)
-    local keyword, desc = line:match'^(.+)%s+%-%s+(.*)$'
+    local keyword, desc = line:match'^(.-)%s+%-%s+(.*)$'
     local section = keyword and keyword:match'%(([^)]+)%)' or nil
     local cmd = keyword and keyword:match'(%S+)%s*%(' or nil
     return sections[section] and {

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -614,7 +614,7 @@ end
 
 function make_entry.gen_from_apropos(opts)
   local sections = {}
-  for _, section in ipairs(vim.split(opts.sections, ',', true)) do
+  for _, section in ipairs(opts.sections) do
     sections[section] = true
   end
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -637,7 +637,7 @@ function make_entry.gen_from_apropos(opts)
 
   return function(line)
     local keyword, desc = line:match'^(.+)%s+%-%s+(.*)$'
-    local section = keyword and keyword:match'%(([^)])%)' or nil
+    local section = keyword and keyword:match'%(([^)]+)%)' or nil
     local cmd = keyword and keyword:match'(%S+)%(' or nil
     return sections[section] and {
       value = cmd,

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -358,6 +358,9 @@ previewers.help = defaulter(function(_)
 end, {})
 
 previewers.man = defaulter(function(opts)
+  local pager = utils.get_lazy_default(opts.PAGER, function()
+    return vim.fn.executable('col') == 1 and 'col -bx' or ''
+  end)
   return previewers.new_buffer_previewer {
     get_buffer_by_name = function(_, entry)
       return entry.value
@@ -366,14 +369,14 @@ previewers.man = defaulter(function(opts)
     define_preview = function(self, entry, status)
       local win_width = vim.api.nvim_win_get_width(self.state.winid)
       putils.job_maker({'man', entry.value}, self.state.bufnr, {
-        env = { ["PAGER"] = opts.PAGER, ["MANWIDTH"] = win_width },
+        env = { ["PAGER"] = pager, ["MANWIDTH"] = win_width },
         value = entry.value,
         bufname = self.state.bufname
       })
       putils.regex_highlighter(self.state.bufnr, 'man')
     end
   }
-end, { ["PAGER"] = '' })
+end)
 
 previewers.git_branch_log = defaulter(function(_)
   local highlight_buffer = function(bufnr, content)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -383,7 +383,7 @@ previewers.man = defaulter(function(opts)
 
     define_preview = function(self, entry, status)
       local win_width = vim.api.nvim_win_get_width(self.state.winid)
-      putils.job_maker({'man', entry.value}, self.state.bufnr, {
+      putils.job_maker({'man', entry.section, entry.value}, self.state.bufnr, {
         env = { ["PAGER"] = pager, ["MANWIDTH"] = win_width },
         value = entry.value,
         bufname = self.state.bufname

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -357,7 +357,7 @@ previewers.help = defaulter(function(_)
   }
 end, {})
 
-previewers.man = defaulter(function(_)
+previewers.man = defaulter(function(opts)
   return previewers.new_buffer_previewer {
     get_buffer_by_name = function(_, entry)
       return entry.value
@@ -365,15 +365,15 @@ previewers.man = defaulter(function(_)
 
     define_preview = function(self, entry, status)
       local win_width = vim.api.nvim_win_get_width(self.state.winid)
-      putils.job_maker({'man', '-P', 'cat', entry.value}, self.state.bufnr, {
-        env = { ["MANWIDTH"] = win_width },
+      putils.job_maker({'man', entry.value}, self.state.bufnr, {
+        env = { ["PAGER"] = opts.PAGER, ["MANWIDTH"] = win_width },
         value = entry.value,
         bufname = self.state.bufname
       })
       putils.regex_highlighter(self.state.bufnr, 'man')
     end
   }
-end)
+end, { ["PAGER"] = '' })
 
 previewers.git_branch_log = defaulter(function(_)
   local highlight_buffer = function(bufnr, content)


### PR DESCRIPTION
In maacOS apropos needs args and outputs differently.