### PR TITLE
Do not remove a part of branch names

### DIFF
--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -74,7 +74,7 @@ git.branches = function(opts)
   for _, v in ipairs(output) do
     if not string.match(v, 'HEAD') and v ~= '' then
       v = string.gsub(v, '.* ', '')
-      v = string.gsub(v, '^remotes/.*/', '')
+      v = string.gsub(v, '^remotes/[^/]*/', '')
       tmp_results[v] = true
     end
   end


### PR DESCRIPTION
Before this, branch names such as `feature/foo` became `foo`. Fix it.