### PR TITLE
fix: escape filename before opening it

### DIFF
--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -11,7 +11,7 @@ This will provide standard mechanism for accessing information from an entry.
 local from_entry = {}
 
 function from_entry.path(entry, validate)
-  local path = entry.path
+  local path = vim.fn.fnameescape(entry.path)
   if path == nil then path = entry.filename end
   if path == nil then path = entry.value end
   if path == nil then print("Invalid entry", vim.inspect(entry)); return end


### PR DESCRIPTION
I have a weird case where I need to open a file with `$` in its filename so we need to escape it.