### PR TITLE
hotfix: fnameescape in from_entry

### DIFF
--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -11,7 +11,7 @@ This will provide standard mechanism for accessing information from an entry.
 local from_entry = {}
 
 function from_entry.path(entry, validate)
-  local path = vim.fn.fnameescape(entry.path)
+  local path = entry.path and vim.fn.fnameescape(entry.path) or nil
   if path == nil then path = entry.filename end
   if path == nil then path = entry.value end
   if path == nil then print("Invalid entry", vim.inspect(entry)); return end


### PR DESCRIPTION
if `entry.path` is nil `vim.fn.fnameescape` will return null which results
in all other option no longer being checked