### PR TITLE
[WIP] async pickers take 2 using libuv uv_idle_t

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -185,6 +185,23 @@ local function prepare_match(entry, kind)
   return entries
 end
 
+files.scan_dir = function(opts)
+
+  local scan = require'plenary.scandir'
+
+  local results = scan.scan_dir('/home/brian', { hidden = true })
+
+  pickers.new(opts, {
+    prompt_title = 'Files',
+    finder = finders.new_table {
+      results = results,
+      entry_maker = make_entry.gen_from_file(opts),
+    },
+    sorter = conf.generic_sorter(opts),
+    previewer = conf.file_previewer(opts),
+  }):find()
+end
+
 files.treesitter = function(opts)
   opts.show_line = utils.get_default(opts.show_line, true)
 

--- a/lua/telescope/finders.lua
+++ b/lua/telescope/finders.lua
@@ -19,7 +19,9 @@ end
 
 local static_find
 do
-  local exe = Executor.new {}
+  local exe = Executor.new {
+    -- run_task_amount = 2000,
+  }
   static_find = function(results, process_result, process_complete)
     if #exe.tasks ~= 0 then
       exe:close()
@@ -49,7 +51,13 @@ end
 
 local job_find
 do
-  local exe = Executor.new {}
+  local exe = Executor.new {
+    -- kind of like fps
+
+    -- run_task_amount = 1000,
+    -- run_task_amount = 3000,
+    -- run_task_amount = 1,
+  }
   job_find = function(results, process_result, process_complete, current_count, completed)
     if #exe.tasks ~= 0 then
       exe:close()

--- a/lua/telescope/finders.lua
+++ b/lua/telescope/finders.lua
@@ -36,6 +36,17 @@ do
   end
 end
 
+local static_find_no_cancel = function(results, process_result, process_complete)
+  local exe = Executor.new {}
+  exe:add(co.create(function()
+    for _, v in ipairs(results) do
+      process_result(v)
+      co.yield()
+    end
+    process_complete()
+  end))
+end
+
 --[[ =============================================================
 
     JobFinder
@@ -215,21 +226,21 @@ function OneshotJobFinder:new(opts)
       finder, _, process_result, process_complete = coroutine.yield()
       num_execution = num_execution + 1
 
-      static_find(results, process_result, process_complete)
-      -- local current_count = num_results
-      -- job_find(results, process_result, process_complete, current_count, completed)
-      -- local exe = Executor.new {}
-      -- exe:add(co.create(function()
-      --   for index = 1, current_count do
-      --     process_result(results[index])
-      --     co.yield()
-      --   end
+      -- static_find(results, process_result, process_complete)
+      -- static_find_no_cancel(results, process_result, process_complete)
+      local current_count = num_results
+      local exe = Executor.new {}
+      exe:add(co.create(function()
+        for index = 1, current_count do
+          process_result(results[index])
+          co.yield()
+        end
 
-      --   if completed then
-      --     process_complete()
-      --   end
-      -- end))
-      -- exe:run()
+        if completed then
+          process_complete()
+        end
+      end))
+      exe:run()
     end
   end)
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1,4 +1,5 @@
 local a = vim.api
+local co = coroutine
 local popup = require('popup')
 
 require('telescope')

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -216,6 +216,7 @@ function Executor.new(opts)
   self.tasks = opts.tasks or {}
   self.mode = opts.mode or "next"
   self.index = opts.start_idx or 1
+  self.run_task_amount = opts.run_task_amount or 1
   self.idle = uv.new_idle()
 
   return self
@@ -228,10 +229,12 @@ function Executor:run()
       return
     end
 
-    if self.mode == "finish" then
-      self:step_finish()
-    else
-      self:step()
+    for _ = 1, self.run_task_amount do
+      if self.mode == "finish" then
+        self:step_finish()
+      else
+        self:step()
+      end
     end
   end))
 end
@@ -333,7 +336,7 @@ end
 
 utils.List = List
 
-function successive_async(f)
+function utils.successive_async(f)
   local list = List.new()
 
   local function wrapped(...)

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -290,66 +290,66 @@ end
 
 utils.Executor = Executor
 
-List = {}
+VecDeque = {}
+VecDeque.__index = VecDeque
 
-function List.new()
-  return {first = 0, last = -1}
+function VecDeque.new()
+  return setmetatable({first = 0, last = -1}, VecDeque)
 end
 
-function List.pushleft(list, value)
-  local first = list.first - 1
-  list.first = first
-  list[first] = value
+function VecDeque:pushleft(value)
+  local first = self.first - 1
+  self.first = first
+  self[first] = value
 end
 
-function List.pushright (list, value)
-  local last = list.last + 1
-  list.last = last
-  list[last] = value
+function VecDeque:pushright(value)
+  local last = self.last + 1
+  self.last = last
+  self[last] = value
 end
 
-function List.popleft (list)
-  local first = list.first
-  if first > list.last then return nil end
-  local value = list[first]
-  list[first] = nil        -- to allow garbage collection
-  list.first = first + 1
+function VecDeque:popleft()
+  local first = self.first
+  if first > self.last then return nil end
+  local value = self[first]
+  self[first] = nil        -- to allow garbage collection
+  self.first = first + 1
   return value
 end
 
-function List.is_empty(list)
-  return list.first > list.last
+function VecDeque:is_empty()
+  return self.first > self.last
 end
 
-function List.popright (list)
-  local last = list.last
-  if list.first > last then return nil end
-  local value = list[last]
-  list[last] = nil         -- to allow garbage collection
-  list.last = last - 1
+function VecDeque:popright()
+  local last = self.last
+  if self.first > last then return nil end
+  local value = self[last]
+  self[last] = nil         -- to allow garbage collection
+  self.last = last - 1
   return value
 end
 
-function List.len(list)
-  return list.last - list.first
+function VecDeque:len()
+  return self.last - self.first
 end
 
-utils.List = List
+utils.VecDeque = VecDeque
 
 function utils.successive_async(f)
-  local list = List.new()
+  local vecdeque = VecDeque.new()
 
   local function wrapped(...)
-    if list == nil then return end
-    -- if List.is_empty(list) or list == nil then return end
+    if vecdeque == nil then return end
 
-    List.pushleft(list, {...})
-    local curr = List.popright(list)
+    vecdeque:pushleft({...})
+    local curr = vecdeque:popright()
     f(unpack(curr))
   end
 
   local function finish()
-    list = nil 
+    vecdeque = nil 
   end
 
   return wrapped

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -352,4 +352,19 @@ function successive_async(f)
   return wrapped
 end
 
+function utils.exe_cancel_wrap(fn)
+  local exe = Executor.new {}
+  exe:add(fn)
+
+  local function wrapped(...)
+    print(#{...})
+    exe.idle:stop()
+    exe.tasks[1][1] = fn
+    exe.tasks[1][2] = {...}
+    exe:run()
+  end
+
+  return wrapped
+end
+
 return utils


### PR DESCRIPTION
**note**: This is a big work in progress. This is my second take to make telescope fully async. This time I am using coroutines and a coroutine scheduler that uses `uv_idle_t`. `uv_idle_t` runs something once on each iteration for the libuv event loop. This means we can kind of imitate threads and things will be fully async. It is kind of like telescope has it's own event loop. This is not usable yet as the highlighting doesn't work but otherwise there is great performance, this finally fixes the blocking on find files in my home directory! To fix the highlighting issue we can have a separate 'thread' running that only does highlights, so it doesn't flicker and will highlight correctly. Also, this still doesn't solve the problem of blocking on `grep_string` in my home directory. I think I have found that the bottleneck is the `on_stdout` function. The picker will lag when opening because of the sheer amount of entries and `on_stdout` calls. I am not sure how to address that as this pr is only for the lagging while typing, not the lagging when adding all the entries when opening the picker.