### PR TITLE
Use native logic for strdisplaywidth()

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -463,7 +463,8 @@ function make_entry.gen_from_buffer(opts)
 
   local icon_width = 0
   if not disable_devicons then
-    icon_width = vim.fn.strdisplaywidth(get_devicons('fname', disable_devicons))
+    local icon, _ = get_devicons('fname', disable_devicons)
+    icon_width = utils.strdisplaywidth(icon)
   end
 
   local displayer = entry_display.create {

--- a/lua/telescope/pickers/entry_display.lua
+++ b/lua/telescope/pickers/entry_display.lua
@@ -1,9 +1,11 @@
+local utils = require('telescope.utils')
+
 local entry_display = {}
 
 local function truncate(str, len)
   str = tostring(str) -- We need to make sure its an actually a string and not a number
   -- TODO: This doesn't handle multi byte chars...
-  if vim.fn.strdisplaywidth(str) > len then
+  if utils.strdisplaywidth(str) > len then
     str = str:sub(1, len - 1)
     str = str .. "…"
   end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -202,4 +202,25 @@ function utils.get_os_command_output(cmd)
   return Job:new({ command = command, args = cmd }):sync()
 end
 
+utils.strdisplaywidth = (function()
+  if jit then
+    local ffi = require('ffi')
+    ffi.cdef[[
+      typedef unsigned char char_u;
+      int linetabsize_col(int startcol, char_u *s);
+    ]]
+
+    return function(str, col)
+      local startcol = col or 0
+      local s = ffi.new('char[?]', #str + 1)
+      ffi.copy(s, str)
+      return ffi.C.linetabsize_col(startcol, s) - startcol
+    end
+  else
+    return function(str, col)
+      return #str - (col or 0)
+    end
+  end
+end)()
+
 return utils


### PR DESCRIPTION
Fix #414
Ref #413
Ref https://github.com/nvim-telescope/telescope.nvim/pull/274#discussion_r528363826

Use C binding with `ffi` to use `strdisplaywidth()` from Lua loop.

NOTE: `truncate()` logic still have problems that it returns wrong result from multi-byte strings. I think it should be solved by implementing `strcharpart()` in Lua...
