### PR TITLE
Fix: error when repo has a lot of branches, forks and merges

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -403,7 +403,9 @@ previewers.git_branch_log = defaulter(function(_)
       local _, cstart = line:find('- %(')
       if cstart then
         local cend = string.find(line, '%) ')
-        vim.api.nvim_buf_add_highlight(bufnr, ns_previewer, "TelescopeResultsConstant", i - 1, cstart - 1, cend)
+        if cend then
+          vim.api.nvim_buf_add_highlight(bufnr, ns_previewer, "TelescopeResultsConstant", i - 1, cstart - 1, cend)
+        end
       end
       local dstart, _ = line:find(' %(%d')
       if dstart then


### PR DESCRIPTION
This PR simply checks if `cend` evaluates to false, if it doesn't, it will add the highlight to the line.
Unfortunately, I don't have steps to reproduce or any more information like screenshots as I was only able to reproduce this on my current work repo.