### PR TITLE
Remove env workaround for term_previewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ require('telescope').setup{
     borderchars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰'},
     color_devicons = true,
     use_less = true,
-    set_env = { ['COLORTERM'] = 'truecolor' }, -- default { }, currently unsupported for shells like cmd.exe / powershell.exe
+    set_env = { ['COLORTERM'] = 'truecolor' }, -- default = nil,
     file_previewer = require'telescope.previewers'.cat.new, -- For buffer previewer use `require'telescope.previewers'.vim_buffer_cat.new`
     grep_previewer = require'telescope.previewers'.vimgrep.new, -- For buffer previewer use `require'telescope.previewers'.vim_buffer_vimgrep.new`
     qflist_previewer = require'telescope.previewers'.qflist.new, -- For buffer previewer use `require'telescope.previewers'.vim_buffer_qflist.new`

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -67,7 +67,7 @@ function config.set_defaults(defaults)
   set("use_less", true)
   set("color_devicons", true)
 
-  set("set_env", {})
+  set("set_env", nil)
 
   -- TODO: Add motions to keybindings
 


### PR DESCRIPTION
Fix #484

Remove workaround for https://github.com/neovim/neovim/issues/11751 because https://github.com/neovim/neovim/pull/12937 was merged.

I tested it and it still works. I will merge that in 2 or 3 days