### PR TITLE
Open quickfix list on it's own action

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -304,7 +304,6 @@ actions.send_selected_to_qflist = function(prompt_bufnr)
   actions.close(prompt_bufnr)
 
   vim.fn.setqflist(qf_entries, 'r')
-  vim.cmd [[copen]]
 end
 
 actions.send_to_qflist = function(prompt_bufnr)
@@ -319,6 +318,9 @@ actions.send_to_qflist = function(prompt_bufnr)
   actions.close(prompt_bufnr)
 
   vim.fn.setqflist(qf_entries, 'r')
+end
+
+actions.open_qflist = function(_)
   vim.cmd [[copen]]
 end
 


### PR DESCRIPTION
Given that Telescope has a picker for quickfix items, opening its window automatically isn't that useful, so this commit removes the call from send_to_qflist and send_selected_to_qflist. Some users may prefer the old behaviour though so a new action open_qflist was created.