### PR TITLE
add builtin.git_recents picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Built-in functions. Ready to be bound to any key you like. :smile:
 | `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and checkouts it out on enter.                 |
 | `builtin.git_branches`              | Lists all branches with log preview and checkout action.                                    |
 | `builtin.git_status`                | Lists current changes per file with diff preview and add action. (Multiselection still WIP) |
+| `builtin.git_recents`               | Lists files which is changed recently and edit it on enter.                                 |
 | ..................................  | Your next awesome picker function here :D                                                   |
 
 ### Treesitter Picker

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -137,6 +137,26 @@ git.status = function(opts)
   }):find()
 end
 
+git.recents = function(opts)
+  local depth = utils.get_default(opts.depth, 5)
+
+  if opts.cwd then
+    opts.cwd = vim.fn.expand(opts.cwd)
+  end
+
+  opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)
+
+  pickers.new(opts, {
+    prompt_title = 'Git Recents',
+    finder = finders.new_oneshot_job(
+      {'git', 'diff', '--name-only', depth and 'HEAD~' .. depth or 'HEAD'},
+      opts
+    ),
+    previewer = conf.file_previewer(opts),
+    sorter = conf.file_sorter(opts),
+  }):find()
+end
+
 local set_opts_cwd = function(opts)
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -33,6 +33,7 @@ builtin.git_commits = require('telescope.builtin.git').commits
 builtin.git_bcommits = require('telescope.builtin.git').bcommits
 builtin.git_branches = require('telescope.builtin.git').branches
 builtin.git_status = require('telescope.builtin.git').status
+builtin.git_recents = require('telescope.builtin.git').recents
 
 builtin.builtin = require('telescope.builtin.internal').builtin
 builtin.planets = require('telescope.builtin.internal').planets


### PR DESCRIPTION
for: #509

EDIT: With `git diff HEAD~n --name-only`, git_recents picks files which changed in recent n-commits.