### PR TITLE
Enable to show all sections in man_pages

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -615,8 +615,14 @@ end
 
 function make_entry.gen_from_apropos(opts)
   local sections = {}
-  for _, section in ipairs(opts.sections) do
-    sections[section] = true
+  if #opts.sections == 1 and opts.sections[1] == 'ALL' then
+    setmetatable(sections, {
+      __index = function() return true end,
+    })
+  else
+    for _, section in ipairs(opts.sections) do
+      sections[section] = true
+    end
   end
 
   local displayer = entry_display.create {


### PR DESCRIPTION
I want to show all sections in `:Telescope man_pages` some time, but it cannot be achieved with the current `sections` option. I introduced a syntax for this.

```vim
" Show all sections in man pages
:Telescope man_pages sections=ALL
```

```lua
-- for the same purpose
require'telescope'.builtin.man_pages{sections={'ALL'}}
```

I'm worrying that some man pages have odd sections in macOS at least, such as `3tiff`, `n` and `ntcl`.

```
apropos ' ' 2> /dev/null | perl -nle '/\([^)]+\)/; $sections{$&}++; END { print for sort keys %sections }'
(1)
(1m)
(1tcl)
(3)
(3tiff)
(4)
(5)
(6)
(7)
(8)
(9)
(n)
(ntcl)
```

So possibly any page have `ALL` section, and we cannot see it with `:Telescope sections=ALL`. (We can see it with `:Telescope sections=ALL,` (the last comma), then)

I think it rarely occurs and we can ignore them.
