### PR TITLE
docs: update outdated gif + more demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Community driven built-in [pickers](#pickers), [sorters](#sorters) and [previewe
 - [Treesitter](#treesitter-picker)
 
 ![Preview](https://i.imgur.com/TTTja6t.gif)
+<sub>For more showcases of Telescope, please visit the [Showcase section](https://github.com/nvim-telescope/telescope.nvim/wiki/Showcase) in the Telescope Wiki</sub>
 
 
 <!-- You can read this documentation from start to finish, or you can look at the -->

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Community driven built-in [pickers](#pickers), [sorters](#sorters) and [previewe
 - [LSP](#lsp-pickers)
 - [Treesitter](#treesitter-picker)
 
-![by @glepnir](https://user-images.githubusercontent.com/41671631/100819597-6f737900-3487-11eb-8621-37ec1ffabe4b.gif)
+![Preview](https://i.imgur.com/TTTja6t.gif)
 
 
 <!-- You can read this documentation from start to finish, or you can look at the -->


### PR DESCRIPTION
We now use buffer previewer as the default, might as well update the readme demo. Also, I'll add the rest of the builtins demo for the wiki later