### PR TITLE
Modified horizontal layout to allow mirroring of the default layout, added new config value to toggle behavior on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,12 @@ require('telescope').setup{
     sorting_strategy = "descending",
     layout_strategy = "horizontal",
     layout_defaults = {
-      -- TODO add builtin options.
+      horizontal = {
+        mirror = false,
+      },
+      vertical = {
+        mirror = false,
+      },
     },
     file_sorter =  require'telescope.sorters'.get_fuzzy_file,
     file_ignore_patterns = {},
@@ -199,7 +204,7 @@ EOF
 | `sorting_strategy`     | Where first selection should be located.              | descending/ascending       |
 | `layout_strategy`      | How the telescope is drawn.                           | [supported layouts](https://github.com/nvim-telescope/telescope.nvim/wiki/Layouts) |
 | `winblend`             | How transparent is the telescope window should be.    | NUM                        |
-| `layout_defaults`      | Layout specific configuration ........ TODO           | TODO                       |
+| `layout_defaults`      | Extra settings for fine-tuning how your layout looks  | [supported settings](https://github.com/nvim-telescope/telescope.nvim/wiki/Layouts#layout-defaults) |
 | `width`                | TODO                                                  | NUM                        |
 | `preview_cutoff`       | TODO                                                  | NUM                        |
 | `results_height`       | TODO                                                  | NUM                        |

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -248,6 +248,21 @@ Available layout strategies include:
   flex:
   - See |layout_strategies.flex|
 
+Available tweaks to the settings in layout defaults include (can be applied to both horizontal and vertical layouts):
+  mirror (default is `false`): 
+  - Flip the view of the current layout:
+    - If using horizontal: setting mirror to `true` will swap the location of the results/prompt window and preview window
+    - If using vertical: setting mirror to `true` will swap the location of the results and prompt windows
+  
+  width_padding:
+  - How many cells to pad the width of Telescope's layout window
+
+  height_padding:
+  - How many cells to pad the height of Telescope's layout window
+
+  preview_width:
+  - Change the width of Telescope's preview window
+
 
 layout_strategies.center()                        *layout_strategies.center()*
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -255,7 +255,7 @@ Available tweaks to the settings in layout defaults include
   - Flip the view of the current layout:
     - If using horizontal: if `true`, swaps the location of the
       results/prompt window and preview window
-    - If using vertical: if `true, swaps the location of the results and
+    - If using vertical: if `true`, swaps the location of the results and
       prompt windows
 
   width_padding:

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -248,12 +248,12 @@ Available layout strategies include:
   flex:
   - See |layout_strategies.flex|
 
-Available tweaks to the settings in layout defaults include (can be applied to both horizontal and vertical layouts):
-  mirror (default is `false`): 
+Available tweaks to the settings in layout defaults include (can be applied to horizontal and vertical layouts):
+  mirror (default is `false`):
   - Flip the view of the current layout:
-    - If using horizontal: setting mirror to `true` will swap the location of the results/prompt window and preview window
-    - If using vertical: setting mirror to `true` will swap the location of the results and prompt windows
-  
+    - If using horizontal: if `true`, swaps the location of the results/prompt window and preview window
+    - If using vertical: if `true, swaps the location of the results and prompt windows
+
   width_padding:
   - How many cells to pad the width of Telescope's layout window
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -236,7 +236,8 @@ All layout strategies are functions with the following signature: >
         - columns : number Columns in the vim window
         - lines   : number Lines in the vim window
 
-TODO: I would like to make these link to `telescope.layout_strategies.*`, but it's not yet possible.
+TODO: I would like to make these link to `telescope.layout_strategies.*`,
+but it's not yet possible.
 
 Available layout strategies include:
   horizontal:
@@ -248,11 +249,14 @@ Available layout strategies include:
   flex:
   - See |layout_strategies.flex|
 
-Available tweaks to the settings in layout defaults include (can be applied to horizontal and vertical layouts):
+Available tweaks to the settings in layout defaults include
+(can be applied to horizontal and vertical layouts):
   mirror (default is `false`):
   - Flip the view of the current layout:
-    - If using horizontal: if `true`, swaps the location of the results/prompt window and preview window
-    - If using vertical: if `true, swaps the location of the results and prompt windows
+    - If using horizontal: if `true`, swaps the location of the
+      results/prompt window and preview window
+    - If using vertical: if `true, swaps the location of the results and
+      prompt windows
 
   width_padding:
   - How many cells to pad the width of Telescope's layout window

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -65,15 +65,7 @@ function config.set_defaults(defaults)
   ]])
 
   set("layout_strategy", "horizontal")
-  local layout_defaults_table = {
-    horizontal = {
-      mirror = false,
-    },
-    vertical = {
-      mirror = false,
-    },
-  }
-  set("layout_defaults", { layout_defaults_table })
+  set("layout_defaults", {})
 
   set("width", 0.75)
   set("winblend", 0)

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -65,8 +65,15 @@ function config.set_defaults(defaults)
   ]])
 
   set("layout_strategy", "horizontal")
-  set("layout_mirror_horizontal", false)
-  set("layout_defaults", {})
+  local layout_defaults_table = {
+    horizontal = {
+      mirror = false,
+    },
+    vertical = {
+      mirror = false,
+    },
+  }
+  set("layout_defaults", { layout_defaults_table })
 
   set("width", 0.75)
   set("winblend", 0)

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -65,6 +65,7 @@ function config.set_defaults(defaults)
   ]])
 
   set("layout_strategy", "horizontal")
+  set("layout_mirror_horizontal", false)
   set("layout_defaults", {})
 
   set("width", 0.75)

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -32,22 +32,22 @@
 ---
 ---   flex:
 ---   - See |layout_strategies.flex|
---- 
---- Available tweaks to the settings in layout defaults include (can be applied to both horizontal and vertical layouts):
----   mirror (default is `false`): 
+---
+--- Available tweaks to the settings in layout defaults include (can be applied to horizontal and vertical layouts):
+---   mirror (default is `false`):
 ---   - Flip the view of the current layout:
----     - If using horizontal: setting mirror to `true` will swap the location of the results/prompt window and preview window
----     - If using vertical: setting mirror to `true` will swap the location of the results and prompt windows
----   
+---     - If using horizontal: if `true`, swaps the location of the results/prompt window and preview window
+---     - If using vertical: if `true, swaps the location of the results and prompt windows
+---
 ---   width_padding:
 ---   - How many cells to pad the width of Telescope's layout window
---- 
+---
 ---   height_padding:
 ---   - How many cells to pad the height of Telescope's layout window
 ---
 ---   preview_width:
 ---   - Change the width of Telescope's preview window
---- 
+---
 ---@brief ]]
 
 local config = require('telescope.config')

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -76,7 +76,7 @@ layout_strategies.horizontal = function(self, max_columns, max_lines)
     width_padding = "How many cells to pad the width",
     height_padding = "How many cells to pad the height",
     preview_width = "(Resolvable): Determine preview width",
-    mirror = "For a horizontal layout, flip the location of the results/prompt and preview windows. For a vertical layout, flip the orientation of the results and prompt windows",
+    mirror = "Flip the location of the results/prompt and preview windows", 
   })
 
   local initial_options = self:_get_initial_window_options()
@@ -237,7 +237,12 @@ end
 ---    +-----------------+
 ---
 layout_strategies.vertical = function(self, max_columns, max_lines)
-  local layout_config = self.layout_config or {}
+  local layout_config = validate_layout_config(self.layout_config or {}, {
+    width_padding = "How many cells to pad the width",
+    height_padding = "How many cells to pad the height",
+    preview_width = "(Resolvable): Determine preview width",
+    mirror = "Flip the locations of the results and prompt windows", 
+  })
   local initial_options = self:_get_initial_window_options()
 
   local preview = initial_options.preview

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -76,7 +76,7 @@ layout_strategies.horizontal = function(self, max_columns, max_lines)
     width_padding = "How many cells to pad the width",
     height_padding = "How many cells to pad the height",
     preview_width = "(Resolvable): Determine preview width",
-    mirror = "Flip the location of the results/prompt and preview windows", 
+    mirror = "Flip the location of the results/prompt and preview windows",
   })
 
   local initial_options = self:_get_initial_window_options()
@@ -241,7 +241,7 @@ layout_strategies.vertical = function(self, max_columns, max_lines)
     width_padding = "How many cells to pad the width",
     height_padding = "How many cells to pad the height",
     preview_width = "(Resolvable): Determine preview width",
-    mirror = "Flip the locations of the results and prompt windows", 
+    mirror = "Flip the locations of the results and prompt windows",
   })
   local initial_options = self:_get_initial_window_options()
 

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -135,7 +135,7 @@ layout_strategies.horizontal = function(self, max_columns, max_lines)
   end
 
   -- Default value is false, to use the normal horizontal layout
-    if not config.values.layout_defaults.horizontal.mirror then
+  if not config.values.layout_defaults.horizontal.mirror then
     results.col = width_padding
     prompt.col = width_padding
     preview.col = results.col + results.width + 2

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -240,11 +240,11 @@ layout_strategies.vertical = function(self, max_columns, max_lines)
   local layout_config = validate_layout_config(self.layout_config or {}, {
     width_padding = "How many cells to pad the width",
     height_padding = "How many cells to pad the height",
-    preview_width = "(Resolvable): Determine preview width",
+    preview_height = "(Resolvable): Determine preview height",
     mirror = "Flip the locations of the results and prompt windows",
   })
-  local initial_options = self:_get_initial_window_options()
 
+  local initial_options = self:_get_initial_window_options()
   local preview = initial_options.preview
   local results = initial_options.results
   local prompt = initial_options.prompt

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -21,7 +21,8 @@
 ---         - columns : number Columns in the vim window
 ---         - lines   : number Lines in the vim window
 ---
---- TODO: I would like to make these link to `telescope.layout_strategies.*`, but it's not yet possible.
+--- TODO: I would like to make these link to `telescope.layout_strategies.*`,
+--- but it's not yet possible.
 ---
 --- Available layout strategies include:
 ---   horizontal:
@@ -33,11 +34,14 @@
 ---   flex:
 ---   - See |layout_strategies.flex|
 ---
---- Available tweaks to the settings in layout defaults include (can be applied to horizontal and vertical layouts):
+--- Available tweaks to the settings in layout defaults include
+--- (can be applied to horizontal and vertical layouts):
 ---   mirror (default is `false`):
 ---   - Flip the view of the current layout:
----     - If using horizontal: if `true`, swaps the location of the results/prompt window and preview window
----     - If using vertical: if `true, swaps the location of the results and prompt windows
+---     - If using horizontal: if `true`, swaps the location of the
+---       results/prompt window and preview window
+---     - If using vertical: if `true, swaps the location of the results and
+---       prompt windows
 ---
 ---   width_padding:
 ---   - How many cells to pad the width of Telescope's layout window

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -32,7 +32,22 @@
 ---
 ---   flex:
 ---   - See |layout_strategies.flex|
+--- 
+--- Available tweaks to the settings in layout defaults include (can be applied to both horizontal and vertical layouts):
+---   mirror (default is `false`): 
+---   - Flip the view of the current layout:
+---     - If using horizontal: setting mirror to `true` will swap the location of the results/prompt window and preview window
+---     - If using vertical: setting mirror to `true` will swap the location of the results and prompt windows
+---   
+---   width_padding:
+---   - How many cells to pad the width of Telescope's layout window
+--- 
+---   height_padding:
+---   - How many cells to pad the height of Telescope's layout window
 ---
+---   preview_width:
+---   - Change the width of Telescope's preview window
+--- 
 ---@brief ]]
 
 local config = require('telescope.config')

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -135,7 +135,7 @@ layout_strategies.horizontal = function(self, max_columns, max_lines)
   end
 
   -- Default value is false, to use the normal horizontal layout
-  if not config.values.layout_defaults.horizontal.mirror then
+  if not layout_config.mirror then
     results.col = width_padding
     prompt.col = width_padding
     preview.col = results.col + results.width + 2
@@ -285,7 +285,7 @@ layout_strategies.vertical = function(self, max_columns, max_lines)
   results.col, preview.col, prompt.col = width_padding, width_padding, width_padding
 
   if self.previewer then
-    if not config.values.layout_defaults.vertical.mirror then
+    if not layout_config.mirror then
       preview.line = height_padding
       results.line = preview.line + preview.height + 2
       prompt.line = results.line + results.height + 2

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -133,9 +133,16 @@ layout_strategies.horizontal = function(self, max_columns, max_lines)
     preview.height = 0
   end
 
-  results.col = width_padding
-  prompt.col = width_padding
-  preview.col = results.col + results.width + 2
+  -- Default value is false, to use the normal horizontal layout
+  if not layout_config.layout_mirror_horizontal then
+    results.col = width_padding
+    prompt.col = width_padding
+    preview.col = results.col + results.width + 2
+  else
+    preview.col = width_padding
+    prompt.col = preview.col + preview.width + 2
+    results.col = preview.col + preview.width + 2
+  end
 
   preview.line = height_padding
   if self.window.prompt_position == "top" then

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -76,6 +76,7 @@ layout_strategies.horizontal = function(self, max_columns, max_lines)
     width_padding = "How many cells to pad the width",
     height_padding = "How many cells to pad the height",
     preview_width = "(Resolvable): Determine preview width",
+    mirror = "For a horizontal layout, flip the location of the results/prompt and preview windows. For a vertical layout, flip the orientation of the results and prompt windows",
   })
 
   local initial_options = self:_get_initial_window_options()
@@ -134,7 +135,7 @@ layout_strategies.horizontal = function(self, max_columns, max_lines)
   end
 
   -- Default value is false, to use the normal horizontal layout
-  if not config.values.layout_mirror_horizontal then
+    if not config.values.layout_defaults.horizontal.mirror then
     results.col = width_padding
     prompt.col = width_padding
     preview.col = results.col + results.width + 2
@@ -279,9 +280,15 @@ layout_strategies.vertical = function(self, max_columns, max_lines)
   results.col, preview.col, prompt.col = width_padding, width_padding, width_padding
 
   if self.previewer then
-    preview.line = height_padding
-    results.line = preview.line + preview.height + 2
-    prompt.line = results.line + results.height + 2
+    if not config.values.layout_defaults.vertical.mirror then
+      preview.line = height_padding
+      results.line = preview.line + preview.height + 2
+      prompt.line = results.line + results.height + 2
+    else
+      prompt.line = height_padding
+      results.line = prompt.line + prompt.height + 2
+      preview.line = results.line + results.height + 2
+    end
   else
     results.line = height_padding
     prompt.line = results.line + results.height + 2

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -40,7 +40,7 @@
 ---   - Flip the view of the current layout:
 ---     - If using horizontal: if `true`, swaps the location of the
 ---       results/prompt window and preview window
----     - If using vertical: if `true, swaps the location of the results and
+---     - If using vertical: if `true`, swaps the location of the results and
 ---       prompt windows
 ---
 ---   width_padding:

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -134,7 +134,7 @@ layout_strategies.horizontal = function(self, max_columns, max_lines)
   end
 
   -- Default value is false, to use the normal horizontal layout
-  if not layout_config.layout_mirror_horizontal then
+  if not config.values.layout_mirror_horizontal then
     results.col = width_padding
     prompt.col = width_padding
     preview.col = results.col + results.width + 2


### PR DESCRIPTION
This is a feature that I have been wanting for a while now in Telescope, but never really got around to opening an issue for it for whatever reason. Finally decided I might as well see if I can figure out how to do it myself by poking around the codebase 🙂. I would love if the horizontal layout allowed for a config option to let you mirror the default horizontal layout. Here's a visual:

Current horizontal layout (new config option would be set to `false`):
```
   +-----------------+---------------------+
   |                 |                     |
   |     Results     |                     |
   |                 |       Preview       |
   |                 |                     |
   +-----------------|                     |
   |     Prompt      |                     |
   +-----------------+---------------------+
```
Horizontal layout with the new config option set to `true`:
```
   +-------------------+-------------------+
   |                   |                   |
   |                   |       Results     |
   |      Preview      |                   |
   |                   |                   |
   +                   |------------------ |
   |                   |       Prompt      |
   +-------------------+-------------------+
```

I am by no means tied to the name that I chose for this config option, nor tied to the way that I implemented this. I just would love if this was a possibility in telescope, as I'd prefer to see the `prompt` and `results` windows on the right side instead of the left. Thanks for all your hard work on Telescope, it's such an invaluable tool to my current workflow!