### PR TITLE
Change git -P to --no-pager

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -476,7 +476,7 @@ previewers.git_branch_log = defaulter(function(opts)
       local current_remote = 1
 
       local gen_cmd = function(v)
-        return { 'git', '-P', 'log', '--graph', '--pretty=format:%h -%d %s (%cr)',
+        return { 'git', '--no-pager', 'log', '--graph', '--pretty=format:%h -%d %s (%cr)',
         '--abbrev-commit', '--date=relative', v }
       end
 
@@ -512,7 +512,7 @@ previewers.git_commit_diff = defaulter(function(opts)
     end,
 
     define_preview = function(self, entry, status)
-      putils.job_maker({ 'git', '-P', 'diff', entry.value .. '^!' }, self.state.bufnr, {
+      putils.job_maker({ 'git', '--no-pager', 'diff', entry.value .. '^!' }, self.state.bufnr, {
         value = entry.value,
         bufname = self.state.bufname,
         cwd = opts.cwd
@@ -536,7 +536,7 @@ previewers.git_file_diff = defaulter(function(opts)
           bufname = self.state.bufname
         })
       else
-        putils.job_maker({ 'git', '-P', 'diff', entry.value }, self.state.bufnr, {
+        putils.job_maker({ 'git', '--no-pager', 'diff', entry.value }, self.state.bufnr, {
           value = entry.value,
           bufname = self.state.bufname,
           cwd = opts.cwd


### PR DESCRIPTION
This pull request changes the `-P` option given to `git` to `--no-pager` in git commit/file/branch previewers because the latter is more backwards compatible.

The `-P` option was added to `git` around three years ago as a shorthand for `--no-pager` (relavant commit: https://github.com/git/git/commit/7213c288187bd9ef1e32e4f86c20c55436f1ae90). My lab server (remarkably) uses `git 2.17.1` and the preview window for git commits displayed nothing. This patch fixed the problem.

Thank you for the great plugin!