### PR TITLE
fix: proper multibytes chars alignment

### DIFF
--- a/lua/telescope/pickers/entry_display.lua
+++ b/lua/telescope/pickers/entry_display.lua
@@ -28,13 +28,12 @@ entry_display.create = function(configuration)
   local generator = {}
   for _, v in ipairs(configuration.items) do
     if v.width then
-      local justify = not v.right_justify and "-" or ""
-      local format_str = "%" .. justify .. v.width .. "s"
+      local justify = v.right_justify
       table.insert(generator, function(item)
         if type(item) == 'table' then
-          return string.format(format_str, entry_display.truncate(item[1], v.width)), item[2]
+          return utils.align_str(entry_display.truncate(item[1], v.width), v.width, justify), item[2]
         else
-          return string.format(format_str, entry_display.truncate(item, v.width))
+          return utils.align_str(entry_display.truncate(item, v.width), v.width, justify)
         end
       end)
     else

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -284,4 +284,11 @@ function utils.strcharpart(str, nchar, charlen)
   return str:sub(nbyte + 1, nbyte + len)
 end
 
+utils.align_str = function(string, width, right_justify)
+  local str_len = utils.strdisplaywidth(string)
+  return right_justify
+    and string.rep(" ", width - str_len)..string
+    or string..string.rep(" ", width - str_len)
+end
+
 return utils


### PR DESCRIPTION
Use `utils.strdisplaywidth` to count the displayed width instead of using Lua `string.format`. 

Before
![Shot-2021-02-26_5](https://user-images.githubusercontent.com/51877647/109303273-26a44400-786d-11eb-95c4-f8bdbc14e036.png)

After
![Shot-2021-02-26_4](https://user-images.githubusercontent.com/51877647/109303265-25731700-786d-11eb-9111-158dbc7f346c.png)
