### PR TITLE
Allowed git_files to use vim pwd over git root

### DIFF
--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -154,11 +154,14 @@ local set_opts_cwd = function(opts)
 
   -- Find root of git directory and remove trailing newline characters
   local git_root = vim.fn.systemlist("git -C " .. opts.cwd .. " rev-parse --show-toplevel")[1]
+  local use_git_root = utils.get_default(opts.use_git_root, true)
 
   if vim.v.shell_error ~= 0 then
     error(opts.cwd .. ' is not a git directory')
   else
-    opts.cwd = git_root
+    if use_git_root then
+      opts.cwd = git_root
+    end
   end
 end
 

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -37,7 +37,9 @@ git.files = function(opts)
 end
 
 git.commits = function(opts)
-  local results = utils.get_os_command_output({ 'git', 'log', '--pretty=oneline', '--abbrev-commit' }, opts.cwd)
+  local results = utils.get_os_command_output({
+    'git', 'log', '--pretty=oneline', '--abbrev-commit', '--', '.'
+  }, opts.cwd)
 
   pickers.new(opts, {
     prompt_title = 'Git Commits',
@@ -110,7 +112,7 @@ end
 
 git.status = function(opts)
   local gen_new_finder = function()
-    local output = utils.get_os_command_output({ 'git', 'status', '-s' }, opts.cwd)
+    local output = utils.get_os_command_output({ 'git', 'status', '-s', '--', '.' }, opts.cwd)
 
     if table.getn(output) == 0 then
       print('No changes found')


### PR DESCRIPTION
Hi, thanks for the amazing work!

I work in a pretty large git repo and spend my time in a nested folder. What I wanted was an option for `git_files` to only show the git files from my cwd - not the whole project.

I _think_ the only other `git_*` command this might be relevant to is `git_commits` (maybe `git_status`?). I'm not too bothered about those but happy to add it to them.