### PR TITLE
fix: entry_prefix if caret > prefix

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -707,7 +707,7 @@ function Picker:set_selection(row)
       a.nvim_buf_set_text(
         results_bufnr,
         self._selection_row, 0,
-        self._selection_row, #self.entry_prefix,
+        self._selection_row, #self.selection_caret,
         { self.entry_prefix }
       )
       self.highlighter:hi_multiselect(


### PR DESCRIPTION
Fix this issue. I just got the length of the wrong string. Bad rebase by me.
![image](https://user-images.githubusercontent.com/15233006/109412830-7d636800-79aa-11eb-9002-61cf5ab3bc0e.png)

CC @weilbith
