### PR TITLE
Add ability to select in reverse direction

### DIFF
--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -25,6 +25,7 @@ mappings.default_mappings = config.values.default_mappings or {
       ["<C-d>"] = actions.preview_scrolling_down,
 
       ["<Tab>"] = actions.toggle_selection + actions.move_selection_worse,
+      ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
     },
@@ -37,6 +38,7 @@ mappings.default_mappings = config.values.default_mappings or {
       ["<C-t>"] = actions.select_tab,
 
       ["<Tab>"] = actions.toggle_selection + actions.move_selection_worse,
+      ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
 


### PR DESCRIPTION
Use Shift+Tab to match fzf's keymappings.

Seems like a reasonable functionality, which will also make it easier for people coming from fzf.vim.