### PR TITLE
feat: add expand_dir opts for git_status

### DIFF
--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -127,7 +127,10 @@ end
 
 git.status = function(opts)
   local gen_new_finder = function()
-    local output = utils.get_os_command_output({ 'git', 'status', '-s', '--', '.' }, opts.cwd)
+    local git_cmd = {'git', 'status', '-s', '--', '.'}
+    if opts.expand_dir then table.insert(git_cmd, #git_cmd - 1, '-u') end
+
+    local output = utils.get_os_command_output(git_cmd, opts.cwd)
 
     if table.getn(output) == 0 then
       print('No changes found')

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -127,8 +127,12 @@ end
 
 git.status = function(opts)
   local gen_new_finder = function()
+    local expand_dir = utils.if_nil(opts.expand_dir, true, opts.expand_dir)
     local git_cmd = {'git', 'status', '-s', '--', '.'}
-    if opts.expand_dir then table.insert(git_cmd, #git_cmd - 1, '-u') end
+
+    if expand_dir then
+      table.insert(git_cmd, table.getn(git_cmd) - 1, '-u')
+    end
 
     local output = utils.get_os_command_output(git_cmd, opts.cwd)
 


### PR DESCRIPTION
close #579 

do we want to provide a flag just for this option or do we want to make the entire `cmd` overridable? and I'm not sure if this should be the default or not, I like this better but idk about what other people opinion about it.

also, is there any reason why we use `table.getn(tbl)` instead of just `#tbl`? [This thread](https://stackoverflow.com/questions/31452871/table-getn-is-deprecated-how-can-i-get-the-length-of-an-array) said it's deprecated so I tested them both and they have the same result.

cc @Conni2461 @kristijanhusak