### PR TITLE
feat: use IncSearch to highlight TelescopeMatching

### DIFF
--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -18,7 +18,7 @@ highlight default link TelescopeResultsBorder TelescopeBorder
 highlight default link TelescopePreviewBorder TelescopeBorder
 
 " Used for highlighting characters that you match.
-highlight default link TelescopeMatching Special
+highlight default link TelescopeMatching IncSearch
 
 " Used for the prompt prefix
 highlight default link TelescopePromptPrefix Identifier


### PR DESCRIPTION
In the two colorschemes that I tried, papercolor and nord, `Special` highlighting doesn't look good - it either doesn't highlight the search term (nord) or it's impossible to read (papercolor). IncSearch feels like the natural match for TelescopeMatching highlighting.