### PR TITLE
fix: subcommand completion for each extension

### DIFF
--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -104,16 +104,17 @@ end
 -- @Summary get extensions sub command
 -- register extensions dap gh etc.
 -- input in command line `Telescope gh <TAB>`
--- It will show a list that all extensions sub command list
--- ['commands','list_breakpoints','variables','issues','gist','pull_request']
+-- Returns a list for each extension.
 function command.get_extensions_subcommand()
   local exts = require('telescope._extensions').manager
   local complete_ext_table = {}
-  for _,value in pairs(exts) do
+  for cmd,value in pairs(exts) do
     if type(value) == "table" then
+      local subcmds = {}
       for key,_ in pairs(value) do
-        table.insert(complete_ext_table,key)
+        table.insert(subcmds, key)
       end
+      complete_ext_table[cmd] = subcmds
     end
   end
   return complete_ext_table

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -77,7 +77,7 @@ function! s:telescope_complete(arg,line,pos)
   let l:builtin_list = luaeval('vim.tbl_keys(require("telescope.builtin"))')
   let l:extensions_list = luaeval('vim.tbl_keys(require("telescope._extensions").manager)')
   let l:options_list = luaeval('vim.tbl_keys(require("telescope.config").values)')
-  let l:extensions_subcommand_list = luaeval('require("telescope.command").get_extensions_subcommand()')
+  let l:extensions_subcommand_dict = luaeval('require("telescope.command").get_extensions_subcommand()')
 
   let list = [extend(l:builtin_list,l:extensions_list),l:options_list]
   let l = split(a:line[:a:pos-1], '\%(\%(\%(^\|[^\\]\)\\\)\@<!\s\)\+', 1)
@@ -89,7 +89,7 @@ function! s:telescope_complete(arg,line,pos)
 
   if n == 1
     if index(l:extensions_list,l[1]) >= 0
-      return join(l:extensions_subcommand_list,"\n")
+      return join(get(l:extensions_subcommand_dict, l[1], []),"\n")
     endif
     return join(list[1],"\n")
   endif


### PR DESCRIPTION
Fixed subcommand completion for each extension.

@glepnir If there is a reason why the subcommands for all extensions are being completed, I would appreciate it if you could let me know.

## Before

https://user-images.githubusercontent.com/16581287/109809572-c85fd280-7c6b-11eb-8398-062ba1827eca.mp4

## After

https://user-images.githubusercontent.com/16581287/109809677-f0e7cc80-7c6b-11eb-80bb-db6359856bb6.mp4

