### PR TITLE
Add loading guard

### DIFF
--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -1,3 +1,8 @@
+if exists('g:loaded_telescope')
+  finish
+endif
+let g:loaded_telescope = 1
+
 " Sets the highlight for selected items within the picker.
 highlight default link TelescopeSelection Visual
 highlight default link TelescopeSelectionCaret TelescopeSelection


### PR DESCRIPTION
Motivation:
Sometimes it's nice to use "g:loaded_<smth>"-flags to check if plugin is installed/used.

Implementation examples:
- https://github.com/tpope/vim-fugitive/blob/9cba97f4db4e0af4275f802c2de977f553d26ec6/plugin/fugitive.vim#L6-L9
- https://github.com/mhinz/vim-startify/blob/f2fc11844b234479d37bef37faa7ceb2aade788b/plugin/startify.vim#L7
- https://github.com/neovim/nvim-lspconfig/blob/470b0cf45a7e60243e97628c21b05804088dfbf5/plugin/lspconfig.vim#L1