### PR TITLE
Add ability to show hidden files in file_browser

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -206,6 +206,7 @@ files.file_browser = function(opts)
     local data = {}
 
     scan.scan_dir(path, {
+      hidden = opts.hidden or false,
       add_dirs = true,
       depth = 1,
       on_insert = function(entry, typ)


### PR DESCRIPTION
Hoping to be able to see hidden files in `file_browser`, disabled by default