### PR TITLE
feat: add completion to pre-filtering

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -420,29 +420,46 @@ actions.smart_send_to_qflist = function(prompt_bufnr)
   end
 end
 
-actions.complete = function(prompt_bufnr)
-  local tags = action_state.get_current_picker(prompt_bufnr).sorter.tags
-  local delimiter = action_state.get_current_picker(prompt_bufnr).sorter._delimiter
+actions.complete_tag = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local tags = utils.get_default(current_picker.sorter.tags, {})
+  local delimiter = current_picker.sorter._delimiter
 
-  if not tags then return end
-
-  local symbols = {}
-  local line = action_state.get_current_line()
-  for t, _ in pairs(tags) do
-    table.insert(symbols, string.format('%s%s%s ', delimiter, t:lower(), delimiter))
+  if vim.tbl_isempty(tags) then
+    print('No tags found or associated with picker.')
+    return
   end
 
-  local filtered_symbols
+  -- format tags to match filter_function
+  local prefilter_tags = {}
+  for tag, _ in pairs(tags) do
+    table.insert(prefilter_tags, string.format('%s%s%s ', delimiter, tag:lower(), delimiter))
+  end
+
+  local line = action_state.get_current_line()
+  local filtered_tags = {}
   -- retrigger completion with already selected tag anew
   -- trim and add space since we can match [[:pattern: ]]  with or without space at the end
-  if vim.tbl_contains(symbols, vim.trim(line) .. " ") then
-    filtered_symbols = symbols
+  if vim.tbl_contains(prefilter_tags, vim.trim(line) .. " ") then
+    filtered_tags = prefilter_tags
   else
-    filtered_symbols = utils.filter_completion(line, symbols)
+    -- match tag by substring
+    for _, tag in pairs(prefilter_tags) do
+      local start, _ = tag:find(line)
+      if start then
+        table.insert(filtered_tags, tag)
+      end
+    end
   end
-  local col = vim.api.nvim_win_get_cursor(0)[2] + 1
 
-  vim.fn.complete(col - #line, filtered_symbols)
+  if vim.tbl_isempty(filtered_tags) then
+    print('No matches found.')
+    return
+  end
+
+  -- col - #line bytes are replaced by accepted match
+  local col = vim.api.nvim_win_get_cursor(0)[2] + 1
+  vim.fn.complete(col - #line, filtered_tags)
 
 end
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -457,7 +457,7 @@ actions.complete_tag = function(prompt_bufnr)
     return
   end
 
-  -- col - #line bytes are replaced by accepted match
+  -- incremental completion by substituting string starting from col - #line byte offset
   local col = vim.api.nvim_win_get_cursor(0)[2] + 1
   vim.fn.complete(col - #line, filtered_tags)
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -422,11 +422,11 @@ end
 
 actions.complete_tag = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local tags = utils.get_default(current_picker.sorter.tags, {})
+  local tags = current_picker.sorter.tags
   local delimiter = current_picker.sorter._delimiter
 
-  if vim.tbl_isempty(tags) then
-    print('No tags found or associated with picker.')
+  if not tags then
+    print('No tag pre-filtering set for this picker')
     return
   end
 
@@ -453,7 +453,7 @@ actions.complete_tag = function(prompt_bufnr)
   end
 
   if vim.tbl_isempty(filtered_tags) then
-    print('No matches found.')
+    print('No matches found')
     return
   end
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -420,6 +420,33 @@ actions.smart_send_to_qflist = function(prompt_bufnr)
   end
 end
 
+actions.complete = function(prompt_bufnr)
+  local tags = action_state.get_current_picker(prompt_bufnr).sorter.tags
+  local delimiter = action_state.get_current_picker(prompt_bufnr).sorter._delimiter
+
+  if not tags then return end
+
+  local symbols = {}
+  -- :sub(2, -1): remove preceding ">"
+  local line = vim.api.nvim_buf_get_lines(prompt_bufnr, 0, 1, false)[1]:sub(2,-1) or ""
+  for t, _ in pairs(tags) do
+    table.insert(symbols, string.format('%s%s%s ', delimiter, t:lower(), delimiter))
+  end
+
+  local filtered_symbols
+  -- retrigger completion with already selected tag anew
+  -- trim and add space since we can match [[:pattern: ]]  with or without space at the end
+  if vim.tbl_contains(symbols, vim.trim(line) .. " ") then
+    filtered_symbols = symbols
+  else
+    filtered_symbols = utils.filter_completion(line, symbols)
+  end
+  local col = vim.api.nvim_win_get_cursor(0)[2] + 1
+
+  vim.fn.complete(col - #line, filtered_symbols)
+
+end
+
 --- Open the quickfix list
 actions.open_qflist = function(_)
   vim.cmd [[copen]]

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -427,8 +427,7 @@ actions.complete = function(prompt_bufnr)
   if not tags then return end
 
   local symbols = {}
-  -- :sub(2, -1): remove preceding ">"
-  local line = vim.api.nvim_buf_get_lines(prompt_bufnr, 0, 1, false)[1]:sub(2,-1) or ""
+  local line = action_state.get_current_line()
   for t, _ in pairs(tags) do
     table.insert(symbols, string.format('%s%s%s ', delimiter, t:lower(), delimiter))
   end

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -28,7 +28,7 @@ mappings.default_mappings = config.values.default_mappings or {
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
-      ["<C-l>"] = actions.complete_tag,
+      ["<C-l>"] = actions.complete_tag
     },
 
     n = {

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -28,7 +28,7 @@ mappings.default_mappings = config.values.default_mappings or {
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
-      ["<C-l>"] = actions.complete,
+      ["<C-l>"] = actions.complete_tag,
     },
 
     n = {

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -28,6 +28,7 @@ mappings.default_mappings = config.values.default_mappings or {
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
+      ["<C-l>"] = actions.complete,
     },
 
     n = {

--- a/lua/telescope/sorters.lua
+++ b/lua/telescope/sorters.lua
@@ -39,6 +39,7 @@ function Sorter:new(opts)
 
   return setmetatable({
     state = {},
+    tags = opts.tags,
     filter_function = opts.filter_function,
     scoring_function = opts.scoring_function,
     highlighter = opts.highlighter,
@@ -87,6 +88,7 @@ function Sorter:score(prompt, entry)
 
   local filter_score
   if self.filter_function ~= nil then
+    if self.tags then self.tags:insert(entry) end
     filter_score, prompt = self:filter_function(prompt, entry)
   end
 
@@ -510,6 +512,8 @@ end
 
 sorters.prefilter = function(opts)
   local sorter = opts.sorter
+  sorter.tags = util.create_set(opts.tag)
+  sorter._delimiter = vim.F.if_nil(opts.delimiter, ':')
   sorter.filter_function = filter_function(opts)
   sorter._was_discarded = function() return false end
   return sorter

--- a/lua/telescope/sorters.lua
+++ b/lua/telescope/sorters.lua
@@ -509,11 +509,24 @@ local filter_function = function(opts)
   end
 end
 
+local function create_tag_set(tag)
+  tag = vim.F.if_nil(tag, 'ordinal')
+  local set = {}
+  return setmetatable(set, {
+    __index = {
+      insert = function(set_, entry)
+        local value = entry[tag]
+        if not set_[value] then set_[value] = true end
+      end
+    }
+  })
+end
+
 sorters.prefilter = function(opts)
   local sorter = opts.sorter
   opts.delimiter = util.get_default(opts.delimiter, ':')
   sorter._delimiter = opts.delimiter
-  sorter.tags = util.create_tag_set(opts.tag)
+  sorter.tags = create_tag_set(opts.tag)
   sorter.filter_function = filter_function(opts)
   sorter._was_discarded = function() return false end
   return sorter

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -392,17 +392,5 @@ utils.get_devicons = (function()
   end
 end)()
 
-function utils.create_tag_set(tag)
-  tag = vim.F.if_nil(tag, 'ordinal')
-  local set = {}
-  return setmetatable(set, {
-    __index = {
-      insert = function(set_, entry)
-        local value = entry[tag]
-        if not set_[value] then set_[value] = true end
-      end
-    }
-  })
-end
 
 return utils

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -392,7 +392,7 @@ utils.get_devicons = (function()
   end
 end)()
 
-function utils.create_set(tag)
+function utils.create_tag_set(tag)
   tag = vim.F.if_nil(tag, 'ordinal')
   local set = {}
   return setmetatable(set, {
@@ -403,18 +403,6 @@ function utils.create_set(tag)
       end
     }
   })
-end
-
-function utils.filter_completion(line, symbols)
-  -- match residuals
-  local matches = {}
-  for _, val in pairs(symbols) do
-    local start, _ = val:find(line)
-    if start then
-      table.insert(matches, val)
-    end
-  end
-  return matches
 end
 
 return utils

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -392,5 +392,4 @@ utils.get_devicons = (function()
   end
 end)()
 
-
 return utils

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -392,4 +392,29 @@ utils.get_devicons = (function()
   end
 end)()
 
+function utils.create_set(tag)
+  tag = vim.F.if_nil(tag, 'ordinal')
+  local set = {}
+  return setmetatable(set, {
+    __index = {
+      insert = function(set_, entry)
+        local value = entry[tag]
+        if not set_[value] then set_[value] = true end
+      end
+    }
+  })
+end
+
+function utils.filter_completion(line, symbols)
+  -- match residuals
+  local matches = {}
+  for _, val in pairs(symbols) do
+    local start, _ = val:find(line)
+    if start then
+      table.insert(matches, val)
+    end
+  end
+  return matches
+end
+
 return utils


### PR DESCRIPTION
This PR adds simple insert mode completion to `tag` prefiltering to both (a) cycle through (in e.g. empty prompt or prompt merely comprises a tag) or (b) incrementally complete `tags` by

1. Collecting `tags` in a set table during scoring
2. Trigger `action` to set insert completion for prompt with `complete` **

https://user-images.githubusercontent.com/39233597/110256294-57385c00-7f98-11eb-86e9-9f647bb2a659.mp4

Accepting a match currently is done via (a)`<C-y>` (standard vim binding), (b) continue typing with open menu or (c) `ESC` as `<CR>` is of course bound to jumping to line of entry. 

Known issue:

- Backspace freezes after going into normal mode (e: i.e. accepting completion with `ESC`): one can still cycle through but only delete prompt from normal mode (i.e. `cc`) which I guess is related to #261 

** Unlike `:help complete` suggests, it works without `<C-R>` as evident by mapping set to `<C-l>` :)