### PR TITLE
Update actions.open_qflist to use cwindow

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -465,7 +465,7 @@ end
 
 --- Open the quickfix list
 actions.open_qflist = function(_)
-  vim.cmd [[copen]]
+  vim.cmd [[cwindow]]
 end
 
 -- ==================================================


### PR DESCRIPTION
`:cwindow` will only open the quickfix window if it has been populated.