### PR TITLE
Add change directory functionality to file browser

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -244,6 +244,12 @@ files.file_browser = function(opts)
         current_picker:refresh(gen_new_finder(new_cwd), { reset_prompt = true })
       end)
 
+      local change_working_directory = function(prompt_bufnr)
+	local dir = actions.get_selected_entry(prompt_bufnr).value
+      	vim.fn.execute("cd " .. dir, "silent")
+      end
+      map('n', 'C', change_working_directory)
+
       local create_new_file = function()
         local current_picker = action_state.get_current_picker(prompt_bufnr)
         local file = action_state.get_current_line()


### PR DESCRIPTION
Just a small piece of lua code to change nvim's pwd while using the builtin file_browser
Navigate to the directory and type (capitol) C in normal mode
