### PR TITLE
Improve oldfiles finder

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -231,6 +231,8 @@ internal.loclist = function(opts)
 end
 
 internal.oldfiles = function(opts)
+  opts.include_current_session = utils.get_default(opts.include_current_session, true)
+
   local results = {}
 
   if opts.include_current_session then

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -234,7 +234,7 @@ internal.oldfiles = function(opts)
   local results = {}
 
   if opts.include_current_session then
-    for k,buffer in ipairs(vim.split(vim.fn.execute(':buffers! t'), "\n")) do
+    for _, buffer in ipairs(vim.split(vim.fn.execute(':buffers! t'), "\n")) do
       local match = string.match(buffer, '%s*(%d+)')
       if match then
         local file = vim.api.nvim_buf_get_name(match)
@@ -245,7 +245,7 @@ internal.oldfiles = function(opts)
     end
   end
 
-  for k,file in ipairs(vim.v.oldfiles) do
+  for _, file in ipairs(vim.v.oldfiles) do
     if vim.loop.fs_lstat(file) and vim.fn.index(results, file) == -1 then
       table.insert(results, file)
     end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -231,9 +231,26 @@ internal.loclist = function(opts)
 end
 
 internal.oldfiles = function(opts)
-  local results = vim.tbl_filter(function(val)
-    return 0 ~= vim.fn.filereadable(val)
-  end, vim.v.oldfiles)
+  local results = {}
+
+  if opts.include_current_session then
+    for k,buffer in ipairs(vim.split(vim.fn.execute(':buffers! t'), "\n")) do
+      local match = string.match(buffer, '%s*(%d+)')
+      if match then
+        local file = vim.api.nvim_buf_get_name(match)
+        if vim.fn.filereadable(file) == 1 then
+          table.insert(results, file)
+        end
+      end
+    end
+  end
+
+  for k,file in ipairs(vim.v.oldfiles) do
+    if vim.fn.filereadable(file) == 1 and vim.fn.index(results, file) == -1 then
+      table.insert(results, file)
+    end
+  end
+
   pickers.new(opts, {
     prompt_title = 'Oldfiles',
     finder = finders.new_table{

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -251,6 +251,12 @@ internal.oldfiles = function(opts)
     end
   end
 
+  if opts.cwd_only then
+    results = vim.tbl_filter(function(file)
+      return vim.fn.matchstrpos(file, vim.fn.getcwd())[2] ~= -1
+    end, results)
+  end
+
   pickers.new(opts, {
     prompt_title = 'Oldfiles',
     finder = finders.new_table{

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -248,7 +248,7 @@ internal.oldfiles = function(opts)
   end
 
   for _, file in ipairs(vim.v.oldfiles) do
-    if vim.loop.fs_stat(file) and vim.fn.index(results, file) == -1 then
+    if vim.loop.fs_stat(file) and not vim.tbl_contains(results, file) then
       table.insert(results, file)
     end
   end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -237,10 +237,10 @@ internal.oldfiles = function(opts)
 
   if opts.include_current_session then
     for _, buffer in ipairs(vim.split(vim.fn.execute(':buffers! t'), "\n")) do
-      local match = string.match(buffer, '%s*(%d+)')
+      local match = tonumber(string.match(buffer, '%s*(%d+)'))
       if match then
         local file = vim.api.nvim_buf_get_name(match)
-        if vim.loop.fs_stat(file) then
+        if vim.loop.fs_stat(file) and match ~= vim.api.nvim_get_current_buf() then
           table.insert(results, file)
         end
       end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -238,7 +238,7 @@ internal.oldfiles = function(opts)
       local match = string.match(buffer, '%s*(%d+)')
       if match then
         local file = vim.api.nvim_buf_get_name(match)
-        if vim.fn.filereadable(file) == 1 then
+        if vim.loop.fs_lstat(file) then
           table.insert(results, file)
         end
       end
@@ -246,14 +246,15 @@ internal.oldfiles = function(opts)
   end
 
   for k,file in ipairs(vim.v.oldfiles) do
-    if vim.fn.filereadable(file) == 1 and vim.fn.index(results, file) == -1 then
+    if vim.loop.fs_lstat(file) and vim.fn.index(results, file) == -1 then
       table.insert(results, file)
     end
   end
 
   if opts.cwd_only then
+    local cwd = vim.loop.cwd()
     results = vim.tbl_filter(function(file)
-      return vim.fn.matchstrpos(file, vim.fn.getcwd())[2] ~= -1
+      return vim.fn.matchstrpos(file, cwd)[2] ~= -1
     end, results)
   end
 

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -233,10 +233,11 @@ end
 internal.oldfiles = function(opts)
   opts.include_current_session = utils.get_default(opts.include_current_session, true)
 
+  local current_buffer = vim.api.nvim_get_current_buf()
+  local current_file = vim.api.nvim_buf_get_name(current_buffer)
   local results = {}
 
   if opts.include_current_session then
-    local current_buffer = vim.api.nvim_get_current_buf()
     for _, buffer in ipairs(vim.split(vim.fn.execute(':buffers! t'), "\n")) do
       local match = tonumber(string.match(buffer, '%s*(%d+)'))
       if match then
@@ -249,7 +250,7 @@ internal.oldfiles = function(opts)
   end
 
   for _, file in ipairs(vim.v.oldfiles) do
-    if vim.loop.fs_stat(file) and not vim.tbl_contains(results, file) then
+    if vim.loop.fs_stat(file) and not vim.tbl_contains(results, file) and file ~= current_file then
       table.insert(results, file)
     end
   end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -236,11 +236,12 @@ internal.oldfiles = function(opts)
   local results = {}
 
   if opts.include_current_session then
+    local current_buffer = vim.api.nvim_get_current_buf()
     for _, buffer in ipairs(vim.split(vim.fn.execute(':buffers! t'), "\n")) do
       local match = tonumber(string.match(buffer, '%s*(%d+)'))
       if match then
         local file = vim.api.nvim_buf_get_name(match)
-        if vim.loop.fs_stat(file) and match ~= vim.api.nvim_get_current_buf() then
+        if vim.loop.fs_stat(file) and match ~= current_buffer then
           table.insert(results, file)
         end
       end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -240,7 +240,7 @@ internal.oldfiles = function(opts)
       local match = string.match(buffer, '%s*(%d+)')
       if match then
         local file = vim.api.nvim_buf_get_name(match)
-        if vim.loop.fs_lstat(file) then
+        if vim.loop.fs_stat(file) then
           table.insert(results, file)
         end
       end
@@ -248,7 +248,7 @@ internal.oldfiles = function(opts)
   end
 
   for _, file in ipairs(vim.v.oldfiles) do
-    if vim.loop.fs_lstat(file) and vim.fn.index(results, file) == -1 then
+    if vim.loop.fs_stat(file) and vim.fn.index(results, file) == -1 then
       table.insert(results, file)
     end
   end


### PR DESCRIPTION
This adds options to the `oldfiles` finder to make it optionally more useful as a MRU (most recently used) finder.

- `include_current_session`
    - Normally `v:oldfiles` only lists files from past vim sessions. This option will include recently accessed files in the current vim session using `:buffers! t` (the `!` bang shows unlisted buffers after they are closed, and the `t` modifier sorts the list by MRU).
- `cwd_only`
    - This option filters the results to only show files within the cwd. This makes for a nice project-specific-MRU finder.
    
At the moment both options don't change default `oldfiles` finder behaviour, as they are both opt-in. I might argue making `include_current_session=true` a default, having to restart vim to see new entries populated into `v:oldfiles` is kind of weird. Either way though, it'd just be nice to have the option!

---

PS. I know there was an issue/discussion at #433 around MRU pickers that was closed because of the (very cool) [frecency extension](https://github.com/nvim-telescope/telescope-frecency.nvim), but I'd argue that MRU and frecency are different things:

- **Frecency** = Frequency + Recency
- **MRU** = Recency only