### PR TITLE
Add option to display in external window

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -25,6 +25,15 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Default: '  '
 
+                                           *telescope.defaults.externalize*
+    externalize: ~
+        Displays the prompt, result, and preview windows as external windows if set to true.
+        Only available when using an UI with ui-multigrid support.
+
+        Available options are:
+        - "false" (default)
+        - "true"
+
                                          *telescope.defaults.prompt_prefix*
     prompt_prefix: ~
         Will be shown in front of the prompt.

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -88,7 +88,14 @@ function config.set_defaults(defaults)
   set("layout_strategy", "horizontal")
   set("layout_defaults", {})
 
-  set("externalize", false)
+  set("externalize", false, [[
+    Displays the prompt, result, and preview windows as external windows if set to true.
+    Only available when using an UI with ui-multigrid support.
+
+    Available options are:
+    - "false" (default)
+    - "true"]])
+
   set("width", 0.75)
   set("winblend", 0)
   set("prompt_position", "bottom")

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -88,6 +88,7 @@ function config.set_defaults(defaults)
   set("layout_strategy", "horizontal")
   set("layout_defaults", {})
 
+  set("externalize", false)
   set("width", 0.75)
   set("winblend", 0)
   set("prompt_position", "bottom")

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -548,14 +548,12 @@ function Picker:find()
   end
 end
 
-
-
 function Picker:hide_preview()
   -- 1. Hide the window (and border)
   -- 2. Resize prompt & results windows accordingly
 end
 
-function Picker.close_windows(self, status)
+function Picker:close_windows(status)
   local prompt_win = status.prompt_win
   local results_win = status.results_win
   local preview_win = status.preview_win
@@ -1132,7 +1130,7 @@ function pickers.on_close_prompt(prompt_bufnr)
   -- TODO: This is an attempt to clear all the memory stuff we may have left.
   -- vim.api.nvim_buf_detach(prompt_bufnr)
 
-  picker.close_windows(picker, status)
+  picker:close_windows(status)
 end
 
 function Picker:_get_prompt()


### PR DESCRIPTION
This PR is the first step in the features to display the windows that make up the telescope in neovim external window.

![telescope-with-ext-windows](https://user-images.githubusercontent.com/8478977/111626663-a2bcf680-8831-11eb-9579-ab197aae1366.gif)

In this first PR implementation, external windows are not given any valid positional information, so many GUIs will display the prompt, result, and preview windows in strange positions. This is because, in the current neovim specification, external windows generally do not have positional information (See [Multigrid Events](https://neovim.io/doc/user/ui.html#ui-multigrid)), and their position depends on the implementation of the GUI front-end.
In [Goneovim](https://github.com/akiyosi/goneovim), which I am developing, I have implemented a process that layout these external windows appropriately according to their size.

One idea to give positional information to the external windows is to display them as normal float windows beforehand, and then externalize them. However, I am not familiar with the project architecture and have not been able to implement this workaround.

I would appreciate any feedback or advice on this PR.