### PR TITLE
live_grep_raw

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -96,13 +96,19 @@ files.live_grep_raw = function(opts)
 
     if single_quoted or double_quoted then
       local before_args = prompt:match("(.-)['\"]")
-      -- local after_args = prompt:match("['\"](.-)")
-      for arg in before_args:gmatch("%S+") do
-        table.insert(args, arg)
+      local after_args = prompt:match(".*['\"](.*)")
+      local all_args = before_args .. ' ' .. after_args
+      for arg in all_args:gmatch("%S+") do
+        if arg:match('^-') then
+          table.insert(args, arg)
+        else
+          -- Show graceful grep error
+          -- Path cannot come before query
+        end
       end
     end
 
-    return vim.tbl_flatten { args, query, path }
+    return vim.tbl_flatten { args, '--', query, path }
   end
 
   pickers.new(opts, {

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -5,6 +5,7 @@ local finders = require('telescope.finders')
 local make_entry = require('telescope.make_entry')
 local pickers = require('telescope.pickers')
 local previewers = require('telescope.previewers')
+local sorters = require('telescope.sorters')
 local utils = require('telescope.utils')
 local conf = require('telescope.config').values
 
@@ -128,6 +129,7 @@ files.live_grep_raw = function(opts)
     prompt_title = 'Live Grep Raw',
     finder = finders.new_job(cmd_generator, opts.entry_maker, opts.max_results, opts.cwd),
     previewer = conf.grep_previewer(opts),
+    sorter = sorters.grep_highlighter_only(opts),
   }):find()
 end
 

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -86,7 +86,7 @@ files.live_grep_raw = function(opts)
     local args = tbl_clone(opts.vimgrep_arguments)
     local single_quoted = prompt:match("'(.*)'")
     local double_quoted = prompt:match('"(.*)"')
-    local path = '.'
+    local paths = {}
 
     if single_quoted then
       query = single_quoted
@@ -106,9 +106,14 @@ files.live_grep_raw = function(opts)
           -- Path cannot come before query
         end
       end
+      for path in after_args:gmatch("%S+") do
+        if not path:match('^-') then
+          table.insert(paths, path)
+        end
+      end
     end
 
-    return vim.tbl_flatten { args, '--', query, path }
+    return vim.tbl_flatten { args, '--', query, paths }
   end
 
   pickers.new(opts, {

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -23,6 +23,7 @@ local builtin = {}
 
 --- Live grep means grep as you type.
 builtin.live_grep = require('telescope.builtin.files').live_grep
+builtin.live_grep_raw = require('telescope.builtin.files').live_grep_raw
 
 builtin.grep_string = require('telescope.builtin.files').grep_string
 builtin.find_files = require('telescope.builtin.files').find_files

--- a/lua/telescope/sorters.lua
+++ b/lua/telescope/sorters.lua
@@ -440,6 +440,18 @@ sorters.highlighter_only = function(opts)
   }
 end
 
+sorters.grep_highlighter_only = function(opts)
+  opts = opts or {}
+
+  return Sorter:new {
+    scoring_function = function() return 0 end,
+
+    highlighter = function(_, prompt, display)
+      return {}
+    end,
+  }
+end
+
 -- Bad & Dumb Sorter
 sorters.get_levenshtein_sorter = function()
   return Sorter:new {


### PR DESCRIPTION
I proposed this idea on the Telescope Gitter, and there seemed to be interest from fearless leader @tjdevries, among others. The idea is to port [vim-agriculture](https://github.com/jesseleite/vim-agriculture)'s functionality into a ` live_grep_raw` Telescope finder.

### Behaviour

- It would behave like the `live_grep` finder, but would not escape user input, allowing regex search by default:
    - `func.*someFunc`
- It would also allow the user to pass CLI flags and/or a path argument, right into the Telescope prompt:
    - `-u "func.*someFunc" vendor`
- If the command returns without errors, show a typical result count (ie. `2 / 6` or `0 / 0`) at the right side of the prompt.
- We should gracefully handle errors (due to incomplete regex, etc):
    - Replace the `0 / 0` result count with an `Error` string
    - Return all of rg's error output in the preview window
- We should set default max result count to 1000 or something, to minimize chaos.

### Example

![CleanShot 2021-03-19 at 01 59 43](https://user-images.githubusercontent.com/5187394/111737914-d0686680-8856-11eb-87f1-8d744a26cadd.png)

### Todo

- [x] Support both `rg` and `ag` by default.
    - Telescope already uses `rg` by default.
    - Configure `vimgrep_arguments = {'ag', '--nogroup', '--column'}` to use `ag`.
- [x] Accept params before a quoted query string.
- [x] Accept params after a quoted query string.
- [x] Accept path(s) after a quoted query string.
- [ ] Highlight/colour matching query output on each result line.
    - Build custom sorter that highlights regex?
    - Or find a way to render highlights from rg directly?
- [ ] Gracefully handle errors.
- [ ] Handle max result chaos.
    - @tjdevries said he might already have something for limiting max results?