### PR TITLE
fix: properly set default_text if prompt_prefix exists

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -401,9 +401,8 @@ files.tags = function(opts)
 end
 
 files.current_buffer_tags = function(opts)
-  return files.tags(vim.tbl_extend("force", {only_current_file = true, hide_filename = true}, opts))
+  return files.tags(vim.tbl_extend("force", {prompt_title = 'Current Buffer Tags', only_current_file = true, hide_filename = true}, opts))
 end
-
 
 local function apply_checks(mod)
   for k, v in pairs(mod) do

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -22,7 +22,7 @@ git.files = function(opts)
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)
 
   pickers.new(opts, {
-    prompt_title = 'Git File',
+    prompt_title = 'Git Files',
     finder = finders.new_oneshot_job(
       vim.tbl_flatten( {
         "git", "ls-files", "--exclude-standard", "--cached",

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -499,7 +499,8 @@ function Picker:find()
   pcall(a.nvim_buf_set_option, prompt_bufnr, 'filetype', 'TelescopePrompt')
 
   if self.default_text then
-    vim.api.nvim_buf_set_lines(prompt_bufnr, 0, 1, false, {self.default_text})
+    local default_text = string.format('%s%s', self.prompt_prefix, self.default_text)
+    vim.api.nvim_buf_set_lines(prompt_bufnr, 0, 1, false, {default_text})
   end
 
   if self.initial_mode == "insert" then


### PR DESCRIPTION
Currently, `default_text` will only be properly set if it starts with the `prompt_prefix`.

For example, `lua require'telescope.builtin'.lsp_document_symbols{default_text='>:class:'`} would have to be passed to set the line to ':class' (which in turn triggers class prefiltering) to properly set the line, assuming the prompt_prefix is >.

See also: https://www.reddit.com/r/neovim/comments/m9vwy2/search_for_class_using_telescope_and_native_lsp/

e: why does this PR of a freshly rebased fork drag on some unrelated commits? :disappointed: 