### PR TITLE
Support for preprocessing of line in finders

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,30 @@ require('telescope').setup{
   }
 }
 ```
+Example of finder processing json result.
+```lua
+local function do_preprocess(line)
+  local result = {}
+  local pJson = json.decode(line)
+  for _, v in ipairs(pJson) do
+    -- optionally pick only fields you are interested in.
+    table.insert(result, v)
+  end
+  return result
+end
+```
+Usage
+```lua
+Finder:new{
+  entry_maker     = function(line) end,
+  fn_command      = function() { command = "", args  = { "ls-files" } } end,
+  fn_preprocess   = do_preprocess,
+  static          = false,
+  maximum_results = false
+}
+```
+ 
+
 
 Themes should work with every `telescope.builtin` function. If you wish to make
 a theme, check out `lua/telescope/themes.lua`.

--- a/lua/telescope/finders.lua
+++ b/lua/telescope/finders.lua
@@ -37,6 +37,8 @@ local JobFinder = _callable_obj()
 ---
 ---@param opts table Keys:
 --     fn_command function The function to call
+--     fn_preprocess function The optional function to be called for each line before calling entry_maker.
+--       Allows for creating multiple entries (table) from single line.
 function JobFinder:new(opts)
   opts = opts or {}
 
@@ -70,7 +72,8 @@ function JobFinder:_find(prompt, process_result, process_complete)
     if not line or line == "" then
       return
     end
-    -- If fn_preprocess is available use on the line, afterwards run entry_maker on each of the result.
+    -- If fn_preprocess is defined, call it for each line producing multiple results.
+    -- Call entry_maker on each result.
     if self.fn_preprocess ~= nil then
       local lines = self.fn_preprocess(line)
       for _, item in ipairs (lines) do
@@ -180,8 +183,9 @@ end
 --- One shot job
 ---@param command_list string[]: Command list to execute.
 ---@param opts table: stuff
---         @key entry_maker function Optional: function(line: string) => table
---         @key cwd string
+---        @key entry_maker function Optional: function(line: string) => table
+---        @key cwd string
+---        @key fn_preprocess function Optional: function(line: string) => table
 finders.new_oneshot_job = function(command_list, opts)
   opts = opts or {}
 


### PR DESCRIPTION
Rationale: Different command line tools outputs single line of json as
result of operation (hoogle - https://github.com/ndmitchell/hoogle) or
(neuron - https://github.com/srid/neuron). Currently there is no way to
create multiple results from one line

Solution: If fn_preprocess function from line to {item} is provided (is
not nil) then run it and call entry_maker and process_result for each
item in this result.
If not provided behave as before.

Example:
Given the program which outputs single json line for single invocation we can use following preprocess function
```lua
local function do_preprocess(line)
  local result = {}
  local t = string.sub(line, 1, 1)
  -- Filter out non json lines
  if t ~= '[' and t ~= '{' then
    return {}
  end
  local pJson = json.decode(line)
  for _, v in ipairs(pJson) do
    table.insert(result, v)
  end
  return result
end
```
In this case entry maker and process result will be called for each result.
