### PR TITLE
Better relative path output in `live_grep` finder

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -49,7 +49,7 @@ files.live_grep = function(opts)
 
       prompt = escape_chars(prompt)
 
-      return flatten { vimgrep_arguments, prompt, opts.search_dirs or '.' }
+      return flatten { vimgrep_arguments, prompt, opts.search_dirs or nil }
     end,
     opts.entry_maker or make_entry.gen_from_vimgrep(opts),
     opts.max_results,


### PR DESCRIPTION
Default to nil path, for better relative path output.  It's subtle, but notice the `./` in the path results, which is unnecessary.

## Before

![CleanShot 2021-03-22 at 23 31 02](https://user-images.githubusercontent.com/5187394/112088921-0d8a6c80-8b67-11eb-8fd5-7b76c9661a4c.png)

## After

![CleanShot 2021-03-22 at 23 31 44](https://user-images.githubusercontent.com/5187394/112088936-124f2080-8b67-11eb-8631-a683ea26ea72.png)