### PR TITLE
Add option to display buffers which are in cwd 

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -544,6 +544,9 @@ internal.buffers = function(opts)
     if opts.ignore_current_buffer and b == vim.api.nvim_get_current_buf() then
       return false
     end
+    if opts.only_cwd and not string.find(vim.api.nvim_buf_get_name(b), vim.loop.cwd()) then
+      return false
+    end
     return true
   end, vim.api.nvim_list_bufs())
   if not next(bufnrs) then return end


### PR DESCRIPTION
This PR is the implementation for a new option in `buffers listing` which allows viewing of `buffers` which are in the `current working directory` which resolves #733 

@tami5 Could you kindly give me some feedback :)
