### PR TITLE
Fix: open files with the same name (#697)

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -108,11 +108,11 @@ set.edit = function(prompt_bufnr, command)
   if entry_bufnr then
     edit_buffer(command, entry_bufnr)
   else
-    filename = path.normalize(vim.fn.fnameescape(filename), vim.loop.cwd())
 
     -- check if we didn't pick a different buffer
     -- prevents restarting lsp server
-    if vim.api.nvim_get_current_buf() ~= vim.fn.bufnr(filename) then
+    if vim.api.nvim_buf_get_name(0) ~= filename then
+      filename = path.normalize(vim.fn.fnameescape(filename), vim.loop.cwd())
       vim.cmd(string.format("%s %s", command, filename))
     end
 

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -111,7 +111,7 @@ set.edit = function(prompt_bufnr, command)
 
     -- check if we didn't pick a different buffer
     -- prevents restarting lsp server
-    if vim.api.nvim_buf_get_name(0) ~= filename then
+    if vim.api.nvim_buf_get_name(0) ~= filename or command ~= "edit" then
       filename = path.normalize(vim.fn.fnameescape(filename), vim.loop.cwd())
       vim.cmd(string.format("%s %s", command, filename))
     end


### PR DESCRIPTION
Fixes a bug where files with the same name could not be opened. This PR implements the change as discussed in the related issue #697.