### PR TITLE
feat: Add ability to choose window to edit

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -658,6 +658,15 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Default: nil
 
+                                  *telescope.defaults.get_selection_window*
+    get_selection_window: ~
+          Function that takes function(picker, entry) and returns a window id.
+          The window ID will be used to decide what window the chosen file will
+          be opened in and the cursor placed in upon leaving the picker.
+
+          Default: `function() return 0 end`
+
+
                                         *telescope.defaults.file_previewer*
     file_previewer: ~
         Function pointer to the default file_previewer. It is mostly used

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -130,8 +130,12 @@ action_set.edit = function(prompt_bufnr, command)
 
   local entry_bufnr = entry.bufnr
 
-  local picker = action_state.get_current_picker(prompt_bufnr)
   require("telescope.actions").close(prompt_bufnr)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+  local win_id = picker.get_selection_window(picker, entry)
+  if win_id ~= 0 and a.nvim_get_current_win() ~= win_id then
+    vim.api.nvim_set_current_win(win_id)
+  end
 
   if picker.push_cursor_on_edit then
     vim.cmd "normal! m'"

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -788,6 +788,20 @@ append(
 )
 
 append(
+  "get_selection_window",
+  function()
+    return 0
+  end,
+  [[
+    Function that takes function(picker, entry) and returns a window id.
+    The window ID will be used to decide what window the chosen file will
+    be opened in and the cursor placed in upon leaving the picker.
+
+    Default: `function() return 0 end`
+  ]]
+)
+
+append(
   "file_previewer",
   function(...)
     return require("telescope.previewers").vim_buffer_cat.new(...)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -94,6 +94,8 @@ function Picker:new(opts)
 
     default_selection_index = opts.default_selection_index,
 
+    get_selection_window = get_default(opts.get_selection_window, config.values.get_selection_window),
+
     cwd = opts.cwd,
 
     _find_id = 0,


### PR DESCRIPTION
TODO:
- Add utility function or something that can make this easy to pass in "editting_win" only.

When we do that, we can probably close: https://github.com/nvim-telescope/telescope.nvim/pull/531/

And then users can configure how they desire :)