### PR TITLE
git action for creating and checking out a new branch

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -297,6 +297,31 @@ actions.insert_value = function(prompt_bufnr)
   return entry.value
 end
 
+--- Create and checkout a new git branch if it doesn't already exist
+---@param prompt_bufnr number: The prompt bufnr
+actions.git_create_branch = function(prompt_bufnr)
+  local cwd = action_state.get_current_picker(prompt_bufnr).cwd
+  local new_branch = action_state.get_current_line()
+
+  if new_branch == "" then
+    print('Please enter the name of the new branch to create')
+  else
+    actions.close(prompt_bufnr)
+    local _, ret, stderr = utils.get_os_command_output({ 'git', 'checkout', '-b', new_branch }, cwd)
+    if ret == 0 then
+      print(string.format('Switched to a new branch: "%s"', new_branch))
+    else
+      print(string.format(
+        'Error when creating new branch: %s Git returned "%s"',
+        new_branch,
+        table.concat(stderr, '  ')
+      ))
+    end
+  end
+end
+
+--- Checkout an existing git branch
+---@param prompt_bufnr number: The prompt bufnr
 actions.git_checkout = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
@@ -313,6 +338,8 @@ actions.git_checkout = function(prompt_bufnr)
   end
 end
 
+--- Tell git to track the currently selected remote branch in Telescope
+---@param prompt_bufnr number: The prompt bufnr
 actions.git_track_branch = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
@@ -329,6 +356,8 @@ actions.git_track_branch = function(prompt_bufnr)
   end
 end
 
+--- Delete the currently selected branch
+---@param prompt_bufnr number: The prompt bufnr
 actions.git_delete_branch = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
@@ -349,6 +378,8 @@ actions.git_delete_branch = function(prompt_bufnr)
   end
 end
 
+--- Rebase to selected git branch
+---@param prompt_bufnr number: The prompt bufnr
 actions.git_rebase_branch = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
@@ -369,6 +400,8 @@ actions.git_rebase_branch = function(prompt_bufnr)
   end
 end
 
+--- Stage/unstage selected file
+---@param prompt_bufnr number: The prompt bufnr
 actions.git_staging_toggle = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -306,10 +306,17 @@ actions.git_create_branch = function(prompt_bufnr)
   if new_branch == "" then
     print('Please enter the name of the new branch to create')
   else
+    local confirmation = vim.fn.input(string.format('Create new branch "%s"? [y/n]: ', new_branch))
+    if string.len(confirmation) == 0 or string.sub(string.lower(confirmation), 0, 1) ~= 'y' then
+      print(string.format('Didn\'t create branch "%s"', new_branch))
+      return
+    end
+
     actions.close(prompt_bufnr)
+
     local _, ret, stderr = utils.get_os_command_output({ 'git', 'checkout', '-b', new_branch }, cwd)
     if ret == 0 then
-      print(string.format('Switched to a new branch: "%s"', new_branch))
+      print(string.format('Switched to a new branch: %s', new_branch))
     else
       print(string.format(
         'Error when creating new branch: %s Git returned "%s"',

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -177,8 +177,8 @@ git.branches = function(opts)
       map('i', '<c-r>', actions.git_rebase_branch)
       map('n', '<c-r>', actions.git_rebase_branch)
 
-      map('i', '<c-u>', actions.git_create_branch)
-      map('n', '<c-u>', actions.git_create_branch)
+      map('i', '<c-a>', actions.git_create_branch)
+      map('n', '<c-a>', actions.git_create_branch)
 
       map('i', '<c-d>', actions.git_delete_branch)
       map('n', '<c-d>', actions.git_delete_branch)

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -177,14 +177,12 @@ git.branches = function(opts)
       map('i', '<c-r>', actions.git_rebase_branch)
       map('n', '<c-r>', actions.git_rebase_branch)
 
-      map('i', '<c-a>', actions.git_create_branch)
-      map('n', '<c-a>', actions.git_create_branch)
+      map('i', '<c-u>', actions.git_create_branch)
+      map('n', '<c-u>', actions.git_create_branch)
 
       map('i', '<c-d>', actions.git_delete_branch)
       map('n', '<c-d>', actions.git_delete_branch)
 
-      map('i', '<c-u>', false)
-      map('n', '<c-u>', false)
       return true
     end
   }):find()

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -177,6 +177,9 @@ git.branches = function(opts)
       map('i', '<c-r>', actions.git_rebase_branch)
       map('n', '<c-r>', actions.git_rebase_branch)
 
+      map('i', '<c-a>', actions.git_create_branch)
+      map('n', '<c-a>', actions.git_create_branch)
+
       map('i', '<c-d>', actions.git_delete_branch)
       map('n', '<c-d>', actions.git_delete_branch)
 


### PR DESCRIPTION
- Added a new action called `actions.git_create_branch` that will allow the user to create and checkout a new branch if it doesn't already exist
- Added some basic docstrings for the other git actions

I set the default binding to `<C-a>` to trigger this action when using the `git_branches` picker, but am happy to change that if people don't like it. The best mnemonic keymapping I could think of was `<C-c>` as in **checkout** or **create**, but that obviously will not work as a binding lol. I'm very much open to suggestion on the binding, my thought process was `<C-a>` could be thought of as **add new branch**, even if that doesn't really match the git command itself (since I used `git checkout -b [new-branch]`). 