### PR TITLE
fix: live_grep prepending cwd to paths that are already absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,10 +376,10 @@ Built-in functions. Ready to be bound to any key you like. :smile:
 
 #### Options for builtin.live_grep
 
-| Keys                   | Description                                           | Options      |
-|------------------------|-------------------------------------------------------|--------------|
-| `grep_open_files`      | Restrict live_grep to currently open files.           | boolean      |
-| `search_dirs`          | List of directories to search in.                     | list         |
+| Keys                   | Description                                                                        | Options      |
+|------------------------|------------------------------------------------------------------------------------|--------------|
+| `grep_open_files`      | Restrict live_grep to currently open files, mutually exclusive with `search_dirs`  | boolean      |
+| `search_dirs`          | List of directories to search in, mutually exclusive with `grep_open_files`        | list         |
 
 
 ### Vim Pickers

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -51,9 +51,7 @@ files.live_grep = function(opts)
       local file = vim.api.nvim_buf_get_name(bufnr)
       table.insert(filelist, tele_path.make_relative(file, opts.cwd))
     end
-  end
-
-  if search_dirs then
+  elseif search_dirs then
     for i, path in ipairs(search_dirs) do
       search_dirs[i] = vim.fn.expand(path)
     end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -2,6 +2,8 @@ local entry_display = require('telescope.pickers.entry_display')
 local path = require('telescope.path')
 local utils = require('telescope.utils')
 
+local Path = require('plenary.path')
+
 local get_default = utils.get_default
 
 local treesitter_type_highlight = {
@@ -155,7 +157,11 @@ do
 
     local execute_keys = {
       path = function(t)
-        return t.cwd .. path.separator .. t.filename, false
+        if Path:new(t.filename):is_absolute() then
+          return t.filename, false
+        else
+          return t.cwd .. path.separator .. t.filename, false
+        end
       end,
 
       filename = function(t)


### PR DESCRIPTION
I noticed that as part of #666 (coincidence???) that sometimes we end up with entries that include the current working directory concatenated with an already absolute path. This would break passing `search_dirs` to `live_grep` as of that commit due to the change in how we were calling `flatten`, which would now mean the search directories weren't a table of their own, but included in the returned arguments. Regardless, this broke something downstream of that picker where the entries would have a path like:

```
/home/amasquelier/.local/share/nvim/site/pack/packer/start/telescope.nvim/lua/telescope/state.lua
```

and we'd prepend them with the `cwd`, resulting in:

```
/home/amasquelier/.local/share/nvim/site/pack/packer/start/telescope.nvim/lua/telescope//home/amasquelier/.local/share/nvim/site/pack/packer/start/telescope.nvim/lua/telescope/state.lua
```

which breaks a number of things.

This PR fixes three things:

1. The case mentioned above, where if a path is already absolute, we do not try to prepend the current working directory to it.
2. The previewer for `live_grep` when passing `grep_open_files` as an option now works as well.
3. Make `grep_open_files` and `search_dirs` mutually exclusive, as we are either doing one of the other. It doesn't make a ton of sense to do both.

I'm not sure how kosher it is to use `plenary.path`, as it is already a dependency, but there seems to be a general trend of using `telescope.path` instead. Let me know if this is an issue.