### PR TITLE
feat: add search history picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Built-in functions. Ready to be bound to any key you like. :smile:
 | `builtin.commands`                  | Lists Available plugin/user commands and run it.                                            |
 | `builtin.tags`                      | Lists Tags in current directory with preview (ctags -R)                                     |
 | `builtin.command_history`           | Lists Commands previously ran and run it on enter.                                          |
+| `builtin.search_history`            | Lists Searches previously ran and run it on enter.                                          |
 | `builtin.help_tags`                 | Lists Available help tags and open help document.                                           |
 | `builtin.man_pages`                 | Lists Man entries.                                                                          |
 | `builtin.marks`                     | Lists Markers and their value.                                                              |

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -234,6 +234,19 @@ actions.set_command_line = function(prompt_bufnr)
   vim.cmd(entry.value)
 end
 
+actions.edit_search_line = function(prompt_bufnr)
+  local entry = action_state.get_selected_entry(prompt_bufnr)
+  actions.close(prompt_bufnr)
+  a.nvim_feedkeys(a.nvim_replace_termcodes("/" .. entry.value , true, false, true), "t", true)
+end
+
+actions.set_search_line = function(prompt_bufnr)
+  local entry = action_state.get_selected_entry(prompt_bufnr)
+
+  actions.close(prompt_bufnr)
+  a.nvim_feedkeys(a.nvim_replace_termcodes("/" .. entry.value .. "<CR>", true, false, true), "t", true)
+end
+
 actions.edit_register = function(prompt_bufnr)
   local entry = action_state.get_selected_entry(prompt_bufnr)
   local picker = action_state.get_current_picker(prompt_bufnr)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -48,6 +48,7 @@ builtin.quickfix = require('telescope.builtin.internal').quickfix
 builtin.loclist = require('telescope.builtin.internal').loclist
 builtin.oldfiles = require('telescope.builtin.internal').oldfiles
 builtin.command_history = require('telescope.builtin.internal').command_history
+builtin.search_history = require('telescope.builtin.internal').search_history
 builtin.vim_options = require('telescope.builtin.internal').vim_options
 builtin.help_tags = require('telescope.builtin.internal').help_tags
 builtin.man_pages = require('telescope.builtin.internal').man_pages

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -297,6 +297,36 @@ internal.command_history = function(opts)
   }):find()
 end
 
+internal.search_history = function(opts)
+  local search_string = vim.fn.execute('history search')
+  local search_list = vim.split(search_string, "\n")
+
+  local results = {}
+  for i = #search_list, 3, -1 do
+    local item = search_list[i]
+    local _, finish = string.find(item, "%d+ +")
+    table.insert(results, string.sub(item, finish + 1))
+  end
+
+  pickers.new(opts, {
+    prompt_title = 'Search History',
+    finder = finders.new_table(results),
+    sorter = conf.generic_sorter(opts),
+
+    attach_mappings = function(_, map)
+      map('i', '<CR>', actions.set_search_line)
+      map('n', '<CR>', actions.set_search_line)
+      map('n', '<C-e>', actions.edit_search_line)
+      map('i', '<C-e>', actions.edit_search_line)
+
+      -- TODO: Find a way to insert the text... it seems hard.
+      -- map('i', '<C-i>', actions.insert_value, { expr = true })
+
+      return true
+    end,
+  }):find()
+end
+
 internal.vim_options = function(opts)
   -- Load vim options.
   local vim_opts = loadfile(utils.data_directory() .. path.separator .. 'options' ..

--- a/lua/tests/manual/all_defaults.lua
+++ b/lua/tests/manual/all_defaults.lua
@@ -11,6 +11,7 @@ require('telescope.builtin').lsp_references()
 require('telescope.builtin').builtin()
 require('telescope.builtin').fd()
 require('telescope.builtin').command_history()
+require('telescope.builtin').search_history()
 require('telescope.builtin').live_grep()
 require('telescope.builtin').loclist()
 


### PR DESCRIPTION
Adding a history picker analogous to fzf.vim's `History/`. There is no Lua api like `vim.search` as far as I can tell, so I just send the keys a la `/foo<CR>` when selecting a row. Is that the best/acceptable way to do that? I also have not found any tests for command history so haven't wrote any of my own, I am missing something here?