### PR TITLE
feat: file browser navigate to parent directory

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -247,7 +247,7 @@ files.file_browser = function(opts)
         table.insert(data, typ == 'directory' and (entry .. os_sep) or entry)
       end
     })
-    table.insert(data, 1, '..\\')
+    table.insert(data, 1, '..' .. os_sep)
 
     return finders.new_table {
       results = data,

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -247,7 +247,7 @@ files.file_browser = function(opts)
         table.insert(data, typ == 'directory' and (entry .. os_sep) or entry)
       end
     })
-    table.insert(data, 1, '../')
+    table.insert(data, 1, '..\\')
 
     return finders.new_table {
       results = data,


### PR DESCRIPTION
File Browser: Instead of adding the parent directory as `../` we could add it as `..\\`.
This tiny change would allow us to navigate to the parent directory.
Otherwise, it would open the parent direcotry in netrw.