### PR TITLE
Git actions docs fix

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -148,6 +148,22 @@ action_set.scroll_previewer({prompt_bufnr}, {direction})*action_set.scroll_previ
 
 Actions functions that are useful for people creating their own mappings.
 
+actions.move_selection_next({prompt_bufnr})    *actions.move_selection_next()*
+    Move the selection to the next entry
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.move_selection_previous({prompt_bufnr})*actions.move_selection_previous()*
+    Move the selection to the previous entry
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
 actions.move_selection_worse({prompt_bufnr})  *actions.move_selection_worse()*
     Move the selection to the entry that has a worse score
 
@@ -226,7 +242,6 @@ actions.git_checkout({prompt_bufnr})                  *actions.git_checkout()*
 
     Parameters: ~
         {prompt_bufnr} (number)  The prompt bufnr
-
 
 
 actions.git_delete_branch({prompt_bufnr})        *actions.git_delete_branch()*

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -244,8 +244,8 @@ actions.git_checkout({prompt_bufnr})                  *actions.git_checkout()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_delete_branch({prompt_bufnr})        *actions.git_delete_branch()*
-    Delete the currently selected branch
+actions.git_track_branch({prompt_bufnr})          *actions.git_track_branch()*
+    Tell git to track the currently selected remote branch in Telescope
 
 
     Parameters: ~

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -196,6 +196,30 @@ actions.toggle_selection({prompt_bufnr})          *actions.toggle_selection()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
+actions.git_create_branch({prompt_bufnr})        *actions.git_create_branch()*
+    Create and checkout a new git branch if it doesn't already exist
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.git_checkout({prompt_bufnr})                  *actions.git_checkout()*
+    Checkout an existing git branch
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.git_delete_branch({prompt_bufnr})        *actions.git_delete_branch()*
+    Delete the currently selected branch
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
 actions.open_qflist()                                  *actions.open_qflist()*
     Open the quickfix list
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -345,6 +345,8 @@ actions.git_checkout = function(prompt_bufnr)
   end
 end
 
+--- Tell git to track the currently selected remote branch in Telescope
+---@param prompt_bufnr number: The prompt bufnr
 actions.git_track_branch = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
@@ -361,8 +363,9 @@ actions.git_track_branch = function(prompt_bufnr)
   end
 end
 
---- Delete the currently selected branch
----@param prompt_bufnr number: The prompt bufnr
+-- TODO: add this function header back once the treesitter max-query bug is resolved
+-- Delete the currently selected branch
+-- @param prompt_bufnr number: The prompt bufnr
 actions.git_delete_branch = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
@@ -383,6 +386,9 @@ actions.git_delete_branch = function(prompt_bufnr)
   end
 end
 
+-- TODO: add this function header back once the treesitter max-query bug is resolved
+-- Rebase to selected git branch
+-- @param prompt_bufnr number: The prompt bufnr
 actions.git_rebase_branch = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
@@ -403,6 +409,9 @@ actions.git_rebase_branch = function(prompt_bufnr)
   end
 end
 
+-- TODO: add this function header back once the treesitter max-query bug is resolved
+-- Stage/unstage selected file
+-- @param prompt_bufnr number: The prompt bufnr
 actions.git_staging_toggle = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -345,8 +345,6 @@ actions.git_checkout = function(prompt_bufnr)
   end
 end
 
---- Tell git to track the currently selected remote branch in Telescope
----@param prompt_bufnr number: The prompt bufnr
 actions.git_track_branch = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
@@ -385,8 +383,6 @@ actions.git_delete_branch = function(prompt_bufnr)
   end
 end
 
---- Rebase to selected git branch
----@param prompt_bufnr number: The prompt bufnr
 actions.git_rebase_branch = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
@@ -407,8 +403,6 @@ actions.git_rebase_branch = function(prompt_bufnr)
   end
 end
 
---- Stage/unstage selected file
----@param prompt_bufnr number: The prompt bufnr
 actions.git_staging_toggle = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()


### PR DESCRIPTION
This fixes the max-query treesitter issue in the actions documentation that was caused by #755's docs additions, and is replacing #759 as that PR got messy quickly. @Conni2461 I think the diff looks correct now.