### PR TITLE
prevent fouc on the first preview loading

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -184,8 +184,10 @@ previewers.new_buffer_previewer = function(opts)
     else
       local bufnr = vim.api.nvim_create_buf(false, true)
       set_bufnr(self, bufnr)
-
-      vim.api.nvim_win_set_buf(status.preview_win, bufnr)
+      
+      vim.schedule(function()
+        vim.api.nvim_win_set_buf(status.preview_win, bufnr)
+      end)
 
       -- TODO(conni2461): We only have to set options once. Right?
       vim.api.nvim_win_set_option(status.preview_win, 'winhl', 'Normal:TelescopePreviewNormal')

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -184,7 +184,7 @@ previewers.new_buffer_previewer = function(opts)
     else
       local bufnr = vim.api.nvim_create_buf(false, true)
       set_bufnr(self, bufnr)
-      
+
       vim.schedule(function()
         vim.api.nvim_win_set_buf(status.preview_win, bufnr)
       end)


### PR DESCRIPTION
There's a slight lag on the first preview loading (during preview buffer creation).
It is not visible the next time a user chooses a file for preview because a scratch buffer
for the file already exists. This lag *and* setting preview window to display the newly
created buffer before its fully initialized causes a brief flash of a blank terminal background.

This change delays setting preview window to display the new preview buffer and consequently
eliminates the flash. It should improve user experience since flickering can be distracting.