### PR TITLE
fix: use treesitter language name instead of ft if available

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -368,6 +368,11 @@ files.current_buffer_fuzzy_find = function(opts)
     })
   end
 
+  local ts_ok, ts_parsers = pcall(require, 'nvim-treesitter.parsers')
+  if ts_ok then
+    filetype = ts_parsers.ft_to_lang(filetype)
+  end
+
   local ok, parser = pcall(vim.treesitter.get_parser, bufnr, filetype)
   if ok then
     local query = vim.treesitter.get_query(filetype, "highlights")

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -373,9 +373,9 @@ files.current_buffer_fuzzy_find = function(opts)
     filetype = ts_parsers.ft_to_lang(filetype)
   end
 
-  local ok, parser = pcall(vim.treesitter.get_parser, bufnr, filetype)
+  local parser_ok, parser = pcall(vim.treesitter.get_parser, bufnr, filetype)
   local query_ok, query = pcall(vim.treesitter.get_query, filetype, "highlights")
-  if ok and query_ok then
+  if parser_ok and query_ok then
     local root = parser:parse()[1]:root()
 
     local highlighter = vim.treesitter.highlighter.new(parser)

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -374,9 +374,8 @@ files.current_buffer_fuzzy_find = function(opts)
   end
 
   local ok, parser = pcall(vim.treesitter.get_parser, bufnr, filetype)
-  if ok then
-    local query = vim.treesitter.get_query(filetype, "highlights")
-
+  local query_ok, query = pcall(vim.treesitter.get_query, filetype, "highlights")
+  if ok and query_ok then
     local root = parser:parse()[1]:root()
 
     local highlighter = vim.treesitter.highlighter.new(parser)


### PR DESCRIPTION
This will fix the problem where the filetype is different than the treesitter lang name. Eg., filetype -> "sh", language name -> "bash"

Ref:
- https://github.com/nvim-telescope/telescope.nvim/issues/795#issuecomment-826043348
- https://github.com/nvim-telescope/telescope.nvim/issues/795#issuecomment-826086757

Fix suggestion by @Conni2461: https://github.com/nvim-telescope/telescope.nvim/issues/795#issuecomment-826769060