### PR TITLE
feat: Add delete_buffer action and mappings

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -560,13 +560,12 @@ end
 actions.delete_buffer = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local multi_selection = current_picker:get_multi_selection()
+  actions.close(prompt_bufnr)
 
   if vim.tbl_isempty(multi_selection) then
     local selection = action_state.get_selected_entry()
-    actions.close(prompt_bufnr)
     vim.api.nvim_buf_delete(selection.bufnr, {force = true})
   else
-    actions.close(prompt_bufnr)
     for _, selection in ipairs(multi_selection) do
       vim.api.nvim_buf_delete(selection.bufnr, {force = true})
     end

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -554,8 +554,9 @@ actions.open_qflist = function(_)
   vim.cmd [[copen]]
 end
 
---- Delete the selected buffer or all the buffers selected using multi selection.
----@param prompt_bufnr number: The prompt bufnr
+-- TODO: add this function header back once the treesitter max-query bug is resolved
+-- Delete the selected buffer or all the buffers selected using multi selection.
+-- @param prompt_bufnr number: The prompt bufnr
 actions.delete_buffer = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local multi_selection = current_picker:get_multi_selection()

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -554,6 +554,24 @@ actions.open_qflist = function(_)
   vim.cmd [[copen]]
 end
 
+--- Delete the selected buffer or all the buffers selected using multi selection.
+---@param prompt_bufnr number: The prompt bufnr
+actions.delete_buffer = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local multi_selection = current_picker:get_multi_selection()
+
+  if vim.tbl_isempty(multi_selection) then
+    local selection = action_state.get_selected_entry()
+    actions.close(prompt_bufnr)
+    vim.api.nvim_buf_delete(selection.bufnr, {force = true})
+  else
+    actions.close(prompt_bufnr)
+    for _, selection in ipairs(multi_selection) do
+      vim.api.nvim_buf_delete(selection.bufnr, {force = true})
+    end
+  end
+end
+
 -- ==================================================
 -- Transforms modules and sets the corect metatables.
 -- ==================================================

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -615,6 +615,7 @@ internal.buffers = function(opts)
     attach_mappings = function(_, map)
       map('i', '<M-w>', actions.delete_buffer)
       map('n', '<M-w>', actions.delete_buffer)
+      return true
     end,
   }):find()
 end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -612,26 +612,6 @@ internal.buffers = function(opts)
     previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
     default_selection_index = default_selection_idx,
-    attach_mappings = function(prompt_bufnr, map)
-      local delete_buf = function()
-        local current_picker = action_state.get_current_picker(prompt_bufnr)
-        local multi_selection = current_picker:get_multi_selection()
-
-        if vim.tbl_isempty(multi_selection) then
-          local selection = action_state.get_selected_entry()
-          actions.close(prompt_bufnr)
-          vim.api.nvim_buf_delete(selection.bufnr, {force = true})
-        else
-          actions.close(prompt_bufnr)
-          for _, selection in ipairs(multi_selection) do
-            vim.api.nvim_buf_delete(selection.bufnr, {force = true})
-          end
-        end
-      end
-      map('i', '<C-r>', delete_buf)
-      map('n', '<C-r>', delete_buf)
-      return true
-    end
   }):find()
 end
 

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -612,6 +612,26 @@ internal.buffers = function(opts)
     previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
     default_selection_index = default_selection_idx,
+    attach_mappings = function(prompt_bufnr, map)
+      local delete_buf = function()
+        local current_picker = action_state.get_current_picker(prompt_bufnr)
+        local multi_selection = current_picker:get_multi_selection()
+
+        if vim.tbl_isempty(multi_selection) then
+          local selection = action_state.get_selected_entry()
+          actions.close(prompt_bufnr)
+          vim.api.nvim_buf_delete(selection.bufnr, {force = true})
+        else
+          actions.close(prompt_bufnr)
+          for _, selection in ipairs(multi_selection) do
+            vim.api.nvim_buf_delete(selection.bufnr, {force = true})
+          end
+        end
+      end
+      map('i', '<C-r>', delete_buf)
+      map('n', '<C-r>', delete_buf)
+      return true
+    end
   }):find()
 end
 

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -612,6 +612,10 @@ internal.buffers = function(opts)
     previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
     default_selection_index = default_selection_idx,
+    attach_mappings = function(_, map)
+      map('i', '<M-w>', actions.delete_buffer)
+      map('n', '<M-w>', actions.delete_buffer)
+    end,
   }):find()
 end
 

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -28,9 +28,7 @@ mappings.default_mappings = config.values.default_mappings or {
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
-      ["<C-l>"] = actions.complete_tag,
-
-      ["<M-w>"] = actions.delete_buffer,
+      ["<C-l>"] = actions.complete_tag
     },
 
     n = {
@@ -57,8 +55,6 @@ mappings.default_mappings = config.values.default_mappings or {
 
       ["<C-u>"] = actions.preview_scrolling_up,
       ["<C-d>"] = actions.preview_scrolling_down,
-
-      ["<M-w>"] = actions.delete_buffer,
     },
   }
 

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -28,7 +28,9 @@ mappings.default_mappings = config.values.default_mappings or {
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
-      ["<C-l>"] = actions.complete_tag
+      ["<C-l>"] = actions.complete_tag,
+
+      ["<M-w>"] = actions.delete_buffer,
     },
 
     n = {
@@ -55,6 +57,8 @@ mappings.default_mappings = config.values.default_mappings or {
 
       ["<C-u>"] = actions.preview_scrolling_up,
       ["<C-d>"] = actions.preview_scrolling_down,
+
+      ["<M-w>"] = actions.delete_buffer,
     },
   }
 


### PR DESCRIPTION
This can delete the currently selected entry as well as the selections done using multi-select.

Question: Should this be included in the buffers picker or should it be implemented as an action with a default mapping? Currently, I have implemented in the picker itself but that would hard code the mappings for the action. Although this action is only useful in the buffers picker so it might make sense :)

fixes: #689 

Other mappings which sounds good for this action: `<C-x>` (taken by `select_horizontal`), `<C-d>` (taken by `preview_scrolling_down`)

Maybe provide an option (`delete_buf_mapping`) for the user to choose the mappings? That way they can override other mappings which they don't use.