### PR TITLE
feat: actions to create a new qflist

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -481,12 +481,20 @@ actions.add_selected_to_qflist = function(prompt_bufnr)
   send_selected_to_qf(prompt_bufnr, 'a')
 end
 
+actions.send_selected_to_new_qflist = function(prompt_bufnr)
+  send_selected_to_qf(prompt_bufnr, ' ')
+end
+
 actions.send_to_qflist = function(prompt_bufnr)
   send_all_to_qf(prompt_bufnr, 'r')
 end
 
 actions.add_to_qflist = function(prompt_bufnr)
   send_all_to_qf(prompt_bufnr, 'a')
+end
+
+actions.send_to_new_qflist = function(prompt_bufnr)
+  send_all_to_qf(prompt_bufnr, ' ')
 end
 
 local smart_send = function(prompt_bufnr, mode)


### PR DESCRIPTION
Little something to accompany the current actions for quickfix lists that support the `"r"` and `"a"` `{action}` on `setqflist({list} [, {action}[, {what}]])`. These two new actions call `setqflist` with the `" "` empty `{action}` in order to create a new list instead of acting on the current one.
