### PR TITLE
Jumplist picker and jump to row/col on existing buffers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,8 @@ Built-in functions. Ready to be bound to any key you like. :smile:
 | `builtin.buffers`                   | Lists Open buffers in the current vim instance.                                             |
 | `builtin.oldfiles`                  | Lists Previously open files.                                                                |
 | `builtin.commands`                  | Lists Available plugin/user commands and run it.                                            |
-| `builtin.tags`                      | Lists Tags in current directory with preview (ctags -R)                                     |
+| `builtin.tags`                      | Lists Tags in current directory with preview (ctags -R).                                    |
+| `builtin.tagstack`                  | Lists Tagstack entries.                                                                     |
 | `builtin.command_history`           | Lists Commands previously ran and run it on enter.                                          |
 | `builtin.search_history`            | Lists Searches previously ran and run it on enter.                                          |
 | `builtin.help_tags`                 | Lists Available help tags and open help document.                                           |
@@ -398,6 +399,7 @@ Built-in functions. Ready to be bound to any key you like. :smile:
 | `builtin.colorscheme`               | Lists Colorscheme and switch to it on enter.                                                |
 | `builtin.quickfix`                  | Lists items from quickfix.                                                                  |
 | `builtin.loclist`                   | Lists items from current window's location list.                                            |
+| `builtin.jumplist`                  | Lists Jump List entries.                                                                    |
 | `builtin.vim_options`               | Lists vim options and on enter edit the options value.                                      |
 | `builtin.registers`                 | Lists vim registers and edit or paste selection.                                            |
 | `builtin.autocommands`              | Lists vim autocommands and go to their declaration.                                         |

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -113,19 +113,18 @@ action_set.edit = function(prompt_bufnr, command)
   if entry_bufnr then
     edit_buffer(command, entry_bufnr)
   else
-
     -- check if we didn't pick a different buffer
     -- prevents restarting lsp server
     if vim.api.nvim_buf_get_name(0) ~= filename or command ~= "edit" then
       filename = path.normalize(vim.fn.fnameescape(filename), vim.loop.cwd())
       vim.cmd(string.format("%s %s", command, filename))
     end
+  end
 
-    if row and col then
-      local ok, err_msg = pcall(a.nvim_win_set_cursor, 0, {row, col})
-      if not ok then
-        log.debug("Failed to move to cursor:", err_msg, row, col)
-      end
+  if row and col then
+    local ok, err_msg = pcall(a.nvim_win_set_cursor, 0, {row, col})
+    if not ok then
+      log.debug("Failed to move to cursor:", err_msg, row, col)
     end
   end
 end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -63,6 +63,7 @@ builtin.highlights = require('telescope.builtin.internal').highlights
 builtin.autocommands = require('telescope.builtin.internal').autocommands
 builtin.spell_suggest = require('telescope.builtin.internal').spell_suggest
 builtin.tagstack = require('telescope.builtin.internal').tagstack
+builtin.jumplist = require('telescope.builtin.internal').jumplist
 
 builtin.lsp_references = require('telescope.builtin.lsp').references
 builtin.lsp_definitions = require('telescope.builtin.lsp').definitions

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -926,6 +926,30 @@ internal.tagstack = function(opts)
     }):find()
 end
 
+internal.jumplist = function(opts)
+  opts = opts or {}
+  local jumplist = vim.api.nvim_eval('getjumplist()')[1]
+
+  for _, value in ipairs(jumplist) do
+    value.text = ''
+  end
+
+  -- reverse the list
+  local sorted_jumplist = {}
+  for i = #jumplist, 1, -1 do
+    sorted_jumplist[#sorted_jumplist+1] = jumplist[i]
+  end
+
+  pickers.new(opts, {
+      prompt_title = 'Jumplist',
+      finder = finders.new_table {
+        results = sorted_jumplist,
+        entry_maker = make_entry.gen_from_jumplist(opts),
+      },
+      previewer = previewers.vim_buffer_qflist.new(opts),
+      sorter = conf.generic_sorter(opts),
+    }):find()
+end
 
 local function apply_checks(mod)
   for k, v in pairs(mod) do

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -928,7 +928,7 @@ end
 
 internal.jumplist = function(opts)
   opts = opts or {}
-  local jumplist = vim.api.nvim_eval('getjumplist()')[1]
+  local jumplist = vim.fn.getjumplist()[1]
 
   for _, value in ipairs(jumplist) do
     value.text = ''
@@ -937,7 +937,7 @@ internal.jumplist = function(opts)
   -- reverse the list
   local sorted_jumplist = {}
   for i = #jumplist, 1, -1 do
-    sorted_jumplist[#sorted_jumplist+1] = jumplist[i]
+    table.insert(sorted_jumplist, jumplist[i])
   end
 
   pickers.new(opts, {

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -916,39 +916,36 @@ internal.tagstack = function(opts)
   end
 
   pickers.new(opts, {
-      prompt_title = 'TagStack',
-      finder = finders.new_table {
-        results = tags,
-        entry_maker = make_entry.gen_from_quickfix(opts),
-      },
-      previewer = previewers.vim_buffer_qflist.new(opts),
-      sorter = conf.generic_sorter(opts),
-    }):find()
+    prompt_title = 'TagStack',
+    finder = finders.new_table {
+      results = tags,
+      entry_maker = make_entry.gen_from_quickfix(opts),
+    },
+    previewer = conf.qflist_previewer(opts),
+    sorter = conf.generic_sorter(opts),
+  }):find()
 end
 
 internal.jumplist = function(opts)
   opts = opts or {}
   local jumplist = vim.fn.getjumplist()[1]
 
-  for _, value in ipairs(jumplist) do
-    value.text = ''
-  end
-
   -- reverse the list
   local sorted_jumplist = {}
   for i = #jumplist, 1, -1 do
+    jumplist[i].text = ''
     table.insert(sorted_jumplist, jumplist[i])
   end
 
   pickers.new(opts, {
-      prompt_title = 'Jumplist',
-      finder = finders.new_table {
-        results = sorted_jumplist,
-        entry_maker = make_entry.gen_from_jumplist(opts),
-      },
-      previewer = previewers.vim_buffer_qflist.new(opts),
-      sorter = conf.generic_sorter(opts),
-    }):find()
+    prompt_title = 'Jumplist',
+    finder = finders.new_table {
+      results = sorted_jumplist,
+      entry_maker = make_entry.gen_from_jumplist(opts),
+    },
+    previewer = conf.qflist_previewer(opts),
+    sorter = conf.generic_sorter(opts),
+  }):find()
 end
 
 local function apply_checks(mod)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1130,5 +1130,57 @@ function make_entry.gen_from_git_status(opts)
   end
 end
 
+function make_entry.gen_from_jumplist(opts)
+  opts = opts or {}
+  opts.tail_path = get_default(opts.tail_path, true)
+
+  local displayer = entry_display.create {
+    separator = "▏",
+    items = {
+      { width = 10 },
+      { remaining = true },
+    }
+  }
+
+  local make_display = function(entry)
+    local filename
+    if not opts.hide_filename then
+      filename = entry.filename
+      if opts.tail_path then
+        filename = utils.path_tail(filename)
+      elseif opts.shorten_path then
+        filename = utils.path_shorten(filename)
+      end
+    end
+
+    local line_info = {table.concat({entry.lnum, entry.col}, ":"), "TelescopeResultsLineNr"}
+
+    return displayer {
+      line_info,
+      filename,
+    }
+  end
+
+  return function(entry)
+    local filename = entry.filename or vim.api.nvim_buf_get_name(entry.bufnr)
+
+    return {
+      valid = true,
+
+      value = entry,
+      ordinal = (
+        not opts.ignore_filename and filename
+        or ''
+        ) .. ' ' .. entry.text,
+      display = make_display,
+
+      bufnr = entry.bufnr,
+      filename = filename,
+      lnum = entry.lnum,
+      col = entry.col,
+    }
+  end
+end
+
 
 return make_entry

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1162,6 +1162,10 @@ function make_entry.gen_from_jumplist(opts)
   end
 
   return function(entry)
+    if not vim.api.nvim_buf_is_valid(entry.bufnr) then
+      return
+    end
+
     local filename = entry.filename or vim.api.nvim_buf_get_name(entry.bufnr)
 
     return {


### PR DESCRIPTION
First time developer for lua, neovim plugin, and open source. Please help me in this learning experience.

Partially address #715 

1. Create a `jumplist` picker
2. Jump to row/col on existing buffers (helps for jumplist and also some existing pickers ie. quickfix)

The major limitation right now is that vim `getjumplist()` does not include file text. `vim.api.nvim_buf_get_lines()` does not work because some jump targets are in unloaded buffers. I decided to only include the filename and row/col in the entries, and rely on the previewer to view contents. Open to any suggestions here.