### PR TITLE
fix(lsp): handle errors from buf_request_sync calls

### DIFF
--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -19,7 +19,12 @@ lsp.references = function(opts)
   local params = vim.lsp.util.make_position_params()
   params.context = { includeDeclaration = true }
 
-  local results_lsp = vim.lsp.buf_request_sync(0, "textDocument/references", params, opts.timeout or 10000)
+  local results_lsp, err = vim.lsp.buf_request_sync(0, "textDocument/references", params, opts.timeout or 10000)
+  if err then
+    vim.api.nvim_err_writeln("Error when finding references: " .. err)
+    return
+  end
+
   local locations = {}
   for _, server_results in pairs(results_lsp) do
     if server_results.result then
@@ -46,7 +51,11 @@ local function list_or_jump(action, title, opts)
   opts = opts or {}
 
   local params = vim.lsp.util.make_position_params()
-  local result = vim.lsp.buf_request_sync(0, action, params, opts.timeout or 10000)
+  local result, err = vim.lsp.buf_request_sync(0, action, params, opts.timeout or 10000)
+  if err then
+    vim.api.nvim_err_writeln("Error when executing " .. action .. " : " .. err)
+    return
+  end
   local flattened_results = {}
   for _, server_results in pairs(result) do
     if server_results.result then
@@ -82,7 +91,11 @@ end
 
 lsp.document_symbols = function(opts)
   local params = vim.lsp.util.make_position_params()
-  local results_lsp = vim.lsp.buf_request_sync(0, "textDocument/documentSymbol", params, opts.timeout or 10000)
+  local results_lsp, err = vim.lsp.buf_request_sync(0, "textDocument/documentSymbol", params, opts.timeout or 10000)
+  if err then
+    vim.api.nvim_err_writeln("Error when finding document symbols: " .. err)
+    return
+  end
 
   if not results_lsp or vim.tbl_isempty(results_lsp) then
     print("No results from textDocument/documentSymbol")
@@ -233,7 +246,11 @@ lsp.workspace_symbols = function(opts)
   opts.shorten_path = utils.get_default(opts.shorten_path, true)
 
   local params = {query = opts.query or ''}
-  local results_lsp = vim.lsp.buf_request_sync(0, "workspace/symbol", params, opts.timeout or 10000)
+  local results_lsp, err = vim.lsp.buf_request_sync(0, "workspace/symbol", params, opts.timeout or 10000)
+  if err then
+    vim.api.nvim_err_writeln("Error when finding workspace symbols: " .. err)
+    return
+  end
 
   local locations = {}
 

--- a/scratch/clason_finders.lua
+++ b/scratch/clason_finders.lua
@@ -60,7 +60,11 @@ finders.lsp_references = function(opts)
   local params = vim.lsp.util.make_position_params()
   params.context = { includeDeclaration = false }
 
-  local results_lsp = vim.lsp.buf_request_sync(0, "textDocument/references", params)
+  local results_lsp, err = vim.lsp.buf_request_sync(0, "textDocument/references", params)
+  if err then
+    vim.api.nvim_err_writeln("Error when finding references: " .. err)
+    return
+  end
   local locations = {}
   for _, server_results in pairs(results_lsp) do
     vim.list_extend(locations, vim.lsp.util.locations_to_items(server_results.result) or {})
@@ -83,7 +87,11 @@ end
 -- fuzzy find in document symbols
 finders.lsp_document_symbols = function(opts)
   local params = vim.lsp.util.make_position_params()
-  local results_lsp = vim.lsp.buf_request_sync(0, "textDocument/documentSymbol", params)
+  local results_lsp, err = vim.lsp.buf_request_sync(0, "textDocument/documentSymbol", params)
+  if err then
+    vim.api.nvim_err_writeln("Error when finding document symbols: " .. err)
+    return
+  end
   local locations = {}
   for _, server_results in pairs(results_lsp) do
     vim.list_extend(locations, vim.lsp.util.symbols_to_items(server_results.result, 0) or {})
@@ -106,7 +114,11 @@ end
 -- fuzzy find in all workspace symbols (may need longer timeout!)
 finders.lsp_workspace_symbols = function(opts)
   local params = {query = ''}
-  local results_lsp = vim.lsp.buf_request_sync(0, "workspace/symbol", params, 1000)
+  local results_lsp, err = vim.lsp.buf_request_sync(0, "workspace/symbol", params, 1000)
+  if err then
+    vim.api.nvim_err_writeln("Error when finding symbols: " .. err)
+    return
+  end
   local locations = {}
   for _, server_results in pairs(results_lsp) do
     vim.list_extend(locations, vim.lsp.util.symbols_to_items(server_results.result, 0) or {})


### PR DESCRIPTION
If `buf_request_sync` runs into an error, or timeout, it'll return `(nil, err)`.