### PR TITLE
Fix oldfiles cwd_only that include backslashes

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -251,6 +251,7 @@ internal.oldfiles = function(opts)
 
   if opts.cwd_only then
     local cwd = vim.loop.cwd()
+    cwd = cwd:gsub([[\]],[[\\]])
     results = vim.tbl_filter(function(file)
       return vim.fn.matchstrpos(file, cwd)[2] ~= -1
     end, results)


### PR DESCRIPTION
Fixes an issue that stops the `cwd_only` option working for `oldfiles` when the `cwd` includes backslashes.

---

The results table has filenames with double escaped backslashes, but the cwd has only single escaped backslashes.
This problem stopped this option from working at all on Windows.