### PR TITLE
Flex layout scrolling bug

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -137,7 +137,12 @@ end
 action_set.scroll_previewer = function (prompt_bufnr, direction)
   local status = state.get_status(prompt_bufnr)
   local default_speed = vim.api.nvim_win_get_height(status.preview_win) / 2
-  local speed = status.picker.layout_config.scroll_speed or default_speed
+  local speed
+  if status.picker.layout_config then
+    speed = status.picker.layout_config.scroll_speed or default_speed
+  else
+    speed = default_speed
+  end
 
   action_state.get_current_picker(prompt_bufnr).previewer:scroll_fn(math.floor(speed * direction))
 end


### PR DESCRIPTION
This contains a fix for #796. However, I'm opening this PR as I think there might be a bit to discuss about the `flex` layout, as I'm having a bit of trouble figuring out the real culprit. As far as I can see, I don't know how `layout_config` could end up being a nil value, every occurrence I see of it in Telescope has it fallback to an empty table at the very least, so I'm not sure how it ever becomes a nil value. I could possibly use a hand in debugging this further. 

What I have here feels more like a temporary workaround than actually fixing the real problem though. I'll be continuing to work on figuring out the real underlying issue here the coming day or two. 