### PR TITLE
feat: delete entry from the picker without closing telescope

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -369,6 +369,15 @@ actions.open_loclist()                                *actions.open_loclist()*
 
 
 
+actions.delete_buffer({prompt_bufnr})                *actions.delete_buffer()*
+    Delete the selected buffer or all the buffers selected using multi
+    selection.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
 
 ================================================================================
                                                              *telescope.builtin*
@@ -1011,13 +1020,13 @@ previewers.Previewer()                                *previewers.Previewer()*
     - `:scroll_fn(direction)`
 
     `Previewer:new()` expects a table as input with following keys:
-      - `setup` function(self): Will be called the first time preview will be 
+      - `setup` function(self): Will be called the first time preview will be
         called.
       - `teardown` function(self): Will be called on cleanup.
       - `preview_fn` function(self, entry, status): Will be called each time a
         new entry was selected.
-      - `send_input` function(self, input): This is meant for 
-        `termopen_previewer` and it can be used to send input to the terminal 
+      - `send_input` function(self, input): This is meant for
+        `termopen_previewer` and it can be used to send input to the terminal
         application, like less.
       - `scroll_fn` function(self, direction): Used to make scrolling work.
 
@@ -1122,7 +1131,7 @@ previewers.new_buffer_previewer()          *previewers.new_buffer_previewer()*
       - `keep_last_buf = true` (optional) Will not delete the last selected
         buffer. This would allow you to reuse that buffer in the select action.
         For example, that buffer can be opened in a new split, rather than
-        recreating that buffer in an action. To access the last buffer number: 
+        recreating that buffer in an action. To access the last buffer number:
         `require('telescope.state').get_global_key("last_preview_bufnr")`
       - `get_buffer_by_name = function(self, entry)` Allows you to set a unique
         name for each buffer. This is used for caching purpose.
@@ -1144,7 +1153,7 @@ previewers.new_buffer_previewer()          *previewers.new_buffer_previewer()*
         never loaded or when `get_buffer_by_name` is not set.
 
     Tips:
-      - If you want to display content of a terminal job, use: 
+      - If you want to display content of a terminal job, use:
         `require('telescope.previewers.utils').job_maker(cmd, bufnr, opts)`
           - `cmd` table: for example { 'git', 'diff', entry.value }
           - `bufnr` number: in which the content will be written
@@ -1163,18 +1172,18 @@ previewers.new_buffer_previewer()          *previewers.new_buffer_previewer()*
               in time.
       - If you want to attach a highlighter use:
         - `require('telescope.previewers.utils').highlighter(bufnr, ft)`
-          - This will prioritize tree sitter highlighting if available for 
+          - This will prioritize tree sitter highlighting if available for
             environment and language.
         - `require('telescope.previewers.utils').regex_highlighter(bufnr, ft)`
         - `require('telescope.previewers.utils').ts_highlighter(bufnr, ft)`
-      - If you want to use `vim.fn.search` or similar you need to run it in 
+      - If you want to use `vim.fn.search` or similar you need to run it in
         that specific buffer context. Do
           vim.api.nvim_buf_call(bufnr, function()
             -- for example `search` and `matchadd`
           end)
         to achieve that.
-      - If you want to read a file into the buffer it's best to use 
-        `buffer_previewer_maker`. But access this function with 
+      - If you want to read a file into the buffer it's best to use
+        `buffer_previewer_maker`. But access this function with
         `require('telescope.config').values.buffer_previewer_maker` because it
         can be redefined by users.
 
@@ -1275,9 +1284,9 @@ Available tweaks to the settings in layout defaults include (can be applied to
 horizontal and vertical layouts):
   - mirror (default is `false`):
     - Flip the view of the current layout:
-      - If using horizontal: if `true`, swaps the location of the 
+      - If using horizontal: if `true`, swaps the location of the
         results/prompt window and preview window
-      - If using vertical: if `true`, swaps the location of the results and 
+      - If using vertical: if `true`, swaps the location of the results and
         prompt windows
 
   - width_padding:

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1020,13 +1020,13 @@ previewers.Previewer()                                *previewers.Previewer()*
     - `:scroll_fn(direction)`
 
     `Previewer:new()` expects a table as input with following keys:
-      - `setup` function(self): Will be called the first time preview will be
+      - `setup` function(self): Will be called the first time preview will be 
         called.
       - `teardown` function(self): Will be called on cleanup.
       - `preview_fn` function(self, entry, status): Will be called each time a
         new entry was selected.
-      - `send_input` function(self, input): This is meant for
-        `termopen_previewer` and it can be used to send input to the terminal
+      - `send_input` function(self, input): This is meant for 
+        `termopen_previewer` and it can be used to send input to the terminal 
         application, like less.
       - `scroll_fn` function(self, direction): Used to make scrolling work.
 
@@ -1131,7 +1131,7 @@ previewers.new_buffer_previewer()          *previewers.new_buffer_previewer()*
       - `keep_last_buf = true` (optional) Will not delete the last selected
         buffer. This would allow you to reuse that buffer in the select action.
         For example, that buffer can be opened in a new split, rather than
-        recreating that buffer in an action. To access the last buffer number:
+        recreating that buffer in an action. To access the last buffer number: 
         `require('telescope.state').get_global_key("last_preview_bufnr")`
       - `get_buffer_by_name = function(self, entry)` Allows you to set a unique
         name for each buffer. This is used for caching purpose.
@@ -1153,7 +1153,7 @@ previewers.new_buffer_previewer()          *previewers.new_buffer_previewer()*
         never loaded or when `get_buffer_by_name` is not set.
 
     Tips:
-      - If you want to display content of a terminal job, use:
+      - If you want to display content of a terminal job, use: 
         `require('telescope.previewers.utils').job_maker(cmd, bufnr, opts)`
           - `cmd` table: for example { 'git', 'diff', entry.value }
           - `bufnr` number: in which the content will be written
@@ -1172,18 +1172,18 @@ previewers.new_buffer_previewer()          *previewers.new_buffer_previewer()*
               in time.
       - If you want to attach a highlighter use:
         - `require('telescope.previewers.utils').highlighter(bufnr, ft)`
-          - This will prioritize tree sitter highlighting if available for
+          - This will prioritize tree sitter highlighting if available for 
             environment and language.
         - `require('telescope.previewers.utils').regex_highlighter(bufnr, ft)`
         - `require('telescope.previewers.utils').ts_highlighter(bufnr, ft)`
-      - If you want to use `vim.fn.search` or similar you need to run it in
+      - If you want to use `vim.fn.search` or similar you need to run it in 
         that specific buffer context. Do
           vim.api.nvim_buf_call(bufnr, function()
             -- for example `search` and `matchadd`
           end)
         to achieve that.
-      - If you want to read a file into the buffer it's best to use
-        `buffer_previewer_maker`. But access this function with
+      - If you want to read a file into the buffer it's best to use 
+        `buffer_previewer_maker`. But access this function with 
         `require('telescope.config').values.buffer_previewer_maker` because it
         can be redefined by users.
 
@@ -1284,9 +1284,9 @@ Available tweaks to the settings in layout defaults include (can be applied to
 horizontal and vertical layouts):
   - mirror (default is `false`):
     - Flip the view of the current layout:
-      - If using horizontal: if `true`, swaps the location of the
+      - If using horizontal: if `true`, swaps the location of the 
         results/prompt window and preview window
-      - If using vertical: if `true`, swaps the location of the results and
+      - If using vertical: if `true`, swaps the location of the results and 
         prompt windows
 
   - width_padding:

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -650,6 +650,15 @@ actions.open_loclist = function(_)
   vim.cmd [[lopen]]
 end
 
+--- Delete the selected buffer or all the buffers selected using multi selection.
+---@param prompt_bufnr number: The prompt bufnr
+actions.delete_buffer = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  current_picker:delete_selection(function(selection)
+    vim.api.nvim_buf_delete(selection.bufnr, { force = true })
+  end)
+end
+
 -- ==================================================
 -- Transforms modules and sets the corect metatables.
 -- ==================================================

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -497,7 +497,7 @@ end
 --- selections made using multi-select. It can be used to define actions
 --- such as deleting buffers or files.
 ---
---- Example usage: >
+--- Example usage:
 --- <pre>
 --- actions.delete_something = function(prompt_bufnr)
 ---    local current_picker = action_state.get_current_picker(prompt_bufnr)
@@ -506,7 +506,9 @@ end
 ---    end)
 --- end
 --- </pre>
---- <
+---
+--- Example usage in telescope:
+---   - `actions.delete_buffer()`
 ---@param delete_cb function: called with each deleted selection
 function Picker:delete_selection(delete_cb)
   vim.validate { delete_cb = { delete_cb, "f" } }

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -491,17 +491,19 @@ function Picker:hide_preview()
   -- 2. Resize prompt & results windows accordingly
 end
 
--- A simple interface to remove an entry from the results window without closing
--- telescope.
--- @param delete_cb function
+---A simple interface to remove an entry from the results window without closing
+---telescope. The `delete_cb` function will be called with each deleted selection.
+---@param delete_cb function
 function Picker:delete_selection(delete_cb)
+  vim.validate { delete_cb = { delete_cb, "f" } }
   local original_selection_strategy = self.selection_strategy
   self.selection_strategy = "row"
-  delete_cb = (delete_cb and type(delete_cb) == "function") and delete_cb or function() end
 
   local delete_selections = self._multi:get()
+  local used_multi_select = true
   if vim.tbl_isempty(delete_selections) then
     table.insert(delete_selections, self:get_selection())
+    used_multi_select = false
   end
 
   local selection_index = {}
@@ -519,7 +521,7 @@ function Picker:delete_selection(delete_cb)
     delete_cb(selection)
   end
 
-  if #delete_selections > 1 then
+  if used_multi_select then
     self._multi = MultiSelect:new()
   end
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -498,9 +498,8 @@ function Picker:delete_selection()
   local original_selection_strategy = self.selection_strategy
   self.selection_strategy = "row"
 
-  local row = self:get_selection_row()
-  local index = self:get_index(row)
-  table.remove(self.finder.results, index)
+  local selection = self:get_selection()
+  table.remove(self.finder.results, selection.index)
   self:__on_lines(nil, nil, nil, 0, 1)
 
   vim.schedule(function()

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -491,9 +491,23 @@ function Picker:hide_preview()
   -- 2. Resize prompt & results windows accordingly
 end
 
----A simple interface to remove an entry from the results window without closing
----telescope. The `delete_cb` function will be called with each deleted selection.
----@param delete_cb function
+-- TODO: update multi-select with the correct tag name when available
+--- A simple interface to remove an entry from the results window without
+--- closing telescope. This either deletes the current selection or all the
+--- selections made using multi-select. It can be used to define actions
+--- such as deleting buffers or files.
+---
+--- Example usage: >
+--- <pre>
+--- actions.delete_something = function(prompt_bufnr)
+---    local current_picker = action_state.get_current_picker(prompt_bufnr)
+---    current_picker:delete_selection(function(selection)
+---      -- delete the selection outside of telescope
+---    end)
+--- end
+--- </pre>
+--- <
+---@param delete_cb function: called with each deleted selection
 function Picker:delete_selection(delete_cb)
   vim.validate { delete_cb = { delete_cb, "f" } }
   local original_selection_strategy = self.selection_strategy

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -491,24 +491,28 @@ function Picker:hide_preview()
   -- 2. Resize prompt & results windows accordingly
 end
 
--- WIP
--- TODO(dhruvmanila): update the selection when we're at the last row or the
--- first depending on the sorting_strategy
-function Picker:delete_selection()
+-- A simple interface to remove an entry from the results window without closing
+-- telescope.
+-- @param delete_cb function
+function Picker:delete_selection(delete_cb)
   local original_selection_strategy = self.selection_strategy
   self.selection_strategy = "row"
 
-  local actual_index
+  local selection_index
   local selection = self:get_selection()
   for index, entry in ipairs(self.finder.results) do
-    if entry.index == selection.index then
-      actual_index = index
+    if entry == selection then
+      selection_index = index
       break
     end
   end
 
-  table.remove(self.finder.results, actual_index)
+  table.remove(self.finder.results, selection_index)
   self:__on_lines(nil, nil, nil, 0, 1)
+
+  if delete_cb and type(delete_cb) == "function" then
+    delete_cb(selection)
+  end
 
   vim.schedule(function()
     self.selection_strategy = original_selection_strategy

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -508,7 +508,7 @@ function Picker:delete_selection(delete_cb)
   end
 
   table.remove(self.finder.results, selection_index)
-  self:__on_lines(nil, nil, nil, 0, 1)
+  self:refresh()
 
   if delete_cb and type(delete_cb) == "function" then
     delete_cb(selection)
@@ -667,10 +667,10 @@ function Picker:refresh(finder, opts)
   end
   if opts.reset_prompt then self:reset_prompt() end
 
-  self.finder:close()
   if finder then
-      self.finder = finder
-      self._multi = MultiSelect:new()
+    self.finder:close()
+    self.finder = finder
+    self._multi = MultiSelect:new()
   end
 
   self.__on_lines(nil, nil, nil, 0, 1)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -498,8 +498,16 @@ function Picker:delete_selection()
   local original_selection_strategy = self.selection_strategy
   self.selection_strategy = "row"
 
+  local actual_index
   local selection = self:get_selection()
-  table.remove(self.finder.results, selection.index)
+  for index, entry in ipairs(self.finder.results) do
+    if entry.index == selection.index then
+      actual_index = index
+      break
+    end
+  end
+
+  table.remove(self.finder.results, actual_index)
   self:__on_lines(nil, nil, nil, 0, 1)
 
   vim.schedule(function()

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -491,6 +491,23 @@ function Picker:hide_preview()
   -- 2. Resize prompt & results windows accordingly
 end
 
+-- WIP
+-- TODO(dhruvmanila): update the selection when we're at the last row or the
+-- first depending on the sorting_strategy
+function Picker:delete_selection()
+  local original_selection_strategy = self.selection_strategy
+  self.selection_strategy = "row"
+
+  local row = self:get_selection_row()
+  local index = self:get_index(row)
+  table.remove(self.finder.results, index)
+  self:__on_lines(nil, nil, nil, 0, 1)
+
+  vim.schedule(function()
+    self.selection_strategy = original_selection_strategy
+  end)
+end
+
 
 function Picker.close_windows(status)
   local prompt_win = status.prompt_win


### PR DESCRIPTION
This will allow users to delete entries  from the picker without closing telescope.

Discussion ref: https://github.com/nvim-telescope/telescope.nvim/pull/803#pullrequestreview-654985978
fixes: #689 
fixes: #621 
fixes: #672  

This function in and of itself will just remove the entry, what I'm proposing next is:
Idea: Should we provide a callback parameter which will be called with the removed entry, so that the user or the specific picker can do exactly what needs to be done outside of telescope? Eg., delete the buffer, delete the file, etc.

The selection strategy is temporarily set to "row" as that will help keep the selection in the same position instead of resetting to the top. If there is any other way to achieve this, do suggest :)

Thanks @Conni2461 for helping!

https://user-images.githubusercontent.com/67177269/117562588-a9434e00-b0bd-11eb-9181-275e82cce317.mov
