### PR TITLE
fix: Reset multi-selection in Picker:refresh()

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -640,7 +640,10 @@ function Picker:refresh(finder, opts)
   if opts.reset_prompt then self:reset_prompt() end
 
   self.finder:close()
-  if finder then self.finder = finder end
+  if finder then
+      self.finder = finder
+      self._multi = MultiSelect:new()
+  end
 
   self.__on_lines(nil, nil, nil, 0, 1)
 end


### PR DESCRIPTION
When providing the current Picker with a new finder in Picker:refresh(), the Picker's MultiSelect would still contain the entries from the old finder. This would lead to unexpected behavior when multi-selecting new items after the refresh. To fix this, let's just reset the MultiSelect when the finder is switched out.