### PR TITLE
fix: Cleanup on picker close

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -502,7 +502,7 @@ function Picker.close_windows(status)
   local preview_border_win = status.preview_border_win
 
   local function del_win(name, win_id, force, bdelete)
-    if not vim.api.nvim_win_is_valid(win_id) then
+    if win_id == nil or not vim.api.nvim_win_is_valid(win_id) then
       return
     end
 


### PR DESCRIPTION
I think this fixes #822 and other related cleanup issues.
_(Note: I haven't tested all the setups in the related issues, but it seems to fix all the issues I have encountered.)_

---

**What I think the problem was:**
- On closing the picker, the autocommand defined [here](https://github.com/nvim-telescope/telescope.nvim/blob/e2907fc0f225a7bf33ace6915bc6b55ed1e10b31/lua/telescope/pickers.lua#L451) would be activated.
- This calls `pickers.on_close_prompt`, which calls `Picker.close_windows`
- In layouts without a preview, `status.preview_win` would be nil.
- `del_win` would be called for the preview window, using the nil `win_id`.
- The check for valid win_id [here](https://github.com/nvim-telescope/telescope.nvim/blob/e2907fc0f225a7bf33ace6915bc6b55ed1e10b31/lua/telescope/pickers.lua#L505) would still pass (not really sure why it's set up this way).
- `bufnr` would then be set to the current buffer number (the one that telescope was opened from), and this buffer would be deleted.

 