### PR TITLE
add git_stash field to builtin

### DIFF
--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -38,6 +38,7 @@ builtin.git_commits = require('telescope.builtin.git').commits
 builtin.git_bcommits = require('telescope.builtin.git').bcommits
 builtin.git_branches = require('telescope.builtin.git').branches
 builtin.git_status = require('telescope.builtin.git').status
+builtin.git_stash = require('telescope.builtin.git').stash
 
 builtin.builtin = require('telescope.builtin.internal').builtin
 


### PR DESCRIPTION
PR #800 add git\_stash picker. However, it's not added as a field in builtin.
