### PR TITLE
Consistent filepath display and code cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ require('telescope').setup{
     file_sorter =  require'telescope.sorters'.get_fuzzy_file,
     file_ignore_patterns = {},
     generic_sorter =  require'telescope.sorters'.get_generic_fuzzy_sorter,
-    shorten_path = true,
     winblend = 0,
     border = {},
     borderchars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
     color_devicons = true,
     use_less = true,
+    path_display = {},
     set_env = { ['COLORTERM'] = 'truecolor' }, -- default = nil,
     file_previewer = require'telescope.previewers'.vim_buffer_cat.new,
     grep_previewer = require'telescope.previewers'.vim_buffer_vimgrep.new,
@@ -204,6 +204,7 @@ EOF
 | `color_devicons`       | Whether to color devicons or not                      | boolean                    |
 | `use_less`             | Whether to use less with bat or less/cat if bat not installed | boolean            |
 | `set_env`              | Set environment variables for previewer               | dict                       |
+| `path_display`         | How file paths are displayed                          | [supported settings](https://github.com/nvim-telescope/telescope.nvim/wiki/Path-Display-Configuration) |
 | `file_previewer`       | What telescope previewer to use for files.            | [Previewers](#previewers)  |
 | `grep_previewer`       | What telescope previewer to use for grep and similar  | [Previewers](#previewers)  |
 | `qflist_previewer`     | What telescope previewer to use for qflist            | [Previewers](#previewers)  |
@@ -223,7 +224,6 @@ EOF
 | `vimgrep_arguments`    | The command line argument for grep search ... TODO.   | dict                       |
 | `selection_strategy`   | What happens to the selection if the list changes.    | follow/reset/row/closest   |
 | `file_ignore_patterns` | Pattern to be ignored `{ "scratch/.*", "%.env" }`      | dict                       |
-| `shorten_path`         | Whether to shorten paths or not.                      | boolean                    |
 
 ### Customize Default Builtin behavior
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -114,13 +114,15 @@ telescope.setup({opts})                                    *telescope.setup()*
           Into your config.
 
 
-        otherwise, just set the mapping to the function that you want it to be.
+        otherwise, just set the mapping to the function that you want it to
+        be.
 
             ...,
             ["<C-i>"] = require('telescope.actions').select_default,
             ...,
 
-        If the function you want is part of `telescope.actions`, then you can simply give a string.
+        If the function you want is part of `telescope.actions`, then you can
+        simply give a string.
           For example, the previous option is equivalent to:
 
             ...,
@@ -135,6 +137,21 @@ telescope.setup({opts})                                    *telescope.setup()*
             ["kk"] = { "<cmd>echo \"Hello, World!\"<cr>", type = "command" },)
             ...,
 
+
+                                          *telescope.defaults.path_display*
+    path_display: ~
+        Determines how file paths are displayed
+
+        path_display can be set to an array with a combination of:
+        - "hidden"    hide file names
+        - "tail"      only display the file name, and not the path
+        - "absolute"  display absolute paths
+        - "shorten"   only display the first character of each directory in
+                      the path
+
+        path_display can also be set to 'hidden' string to hide file names
+
+        Default: {}
 
                                          *telescope.defaults.prompt_prefix*
     prompt_prefix: ~
@@ -728,14 +745,9 @@ builtin.tags({opts})                                          *builtin.tags()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {ctags_file}    (string)   specify a particular ctags file to use
-        {show_line}     (boolean)  if true, shows the content of the line the
-                                   tag is found on in the picker (default is
-                                   true)
-        {shorten_path}  (boolean)  if true, makes file paths shown in picker
-                                   use one letter for folders (default is true)
-        {hide_filename} (boolean)  if true, hides the name of the file in the
-                                   current picker (default is false)
+        {ctags_file} (string)   specify a particular ctags file to use
+        {show_line}  (boolean)  if true, shows the content of the line the tag
+                                is found on in the picker (default is true)
 
 
 builtin.current_buffer_tags({opts})            *builtin.current_buffer_tags()*
@@ -1045,12 +1057,6 @@ builtin.tagstack({opts})                                  *builtin.tagstack()*
     Parameters: ~
         {opts} (table)  options to pass to the picker
 
-    Fields: ~
-        {shorten_path}  (boolean)  if true, makes file paths shown in picker
-                                   use one letter for folders (default is true)
-        {hide_filename} (boolean)  if true, hides the name of the file in the
-                                   current picker (default is true)
-
 
 builtin.jumplist({opts})                                  *builtin.jumplist()*
     Lists items from Vim's jumplist, jumps to location on `<cr>`
@@ -1067,10 +1073,6 @@ builtin.lsp_references({opts})                      *builtin.lsp_references()*
 
     Parameters: ~
         {opts} (table)  options to pass to the picker
-
-    Fields: ~
-        {shorten_path} (boolean)  if true, makes file paths shown in picker use
-                                  one letter for folders (default is false)
 
 
 builtin.lsp_definitions({opts})                    *builtin.lsp_definitions()*
@@ -1134,13 +1136,7 @@ builtin.lsp_workspace_symbols({opts})        *builtin.lsp_workspace_symbols()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {shorten_path}    (boolean)       if true, makes file paths shown in
-                                          picker use one letter for folders
-                                          (default is false)
         {ignore_filename} (string)        file(s) to ignore
-        {hide_filename}   (boolean)       if true, hides the name of the file
-                                          in the current picker (default is
-                                          false)
         {symbols}         (string|table)  filter results by symbol kind(s)
 
 
@@ -1153,10 +1149,6 @@ builtin.lsp_dynamic_workspace_symbols({opts})*builtin.lsp_dynamic_workspace_symb
 
     Parameters: ~
         {opts} (table)  options to pass to the picker
-
-    Fields: ~
-        {hide_filename} (boolean)  if true, hides the name of the file in the
-                                   current picker (default is false)
 
 
 builtin.lsp_document_diagnostics({opts})  *builtin.lsp_document_diagnostics()*
@@ -1173,9 +1165,6 @@ builtin.lsp_document_diagnostics({opts})  *builtin.lsp_document_diagnostics()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {hide_filename}  (boolean)        if true, hides the name of the file
-                                          in the current picker (default is
-                                          false)
         {severity}       (string|number)  filter diagnostics by severity name
                                           (string) or id (number)
         {severity_limit} (string|number)  keep diagnostics equal or more severe
@@ -1205,9 +1194,6 @@ builtin.lsp_workspace_diagnostics({opts})*builtin.lsp_workspace_diagnostics()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {hide_filename}  (boolean)        if true, hides the name of the file
-                                          in the current picker (default is
-                                          false)
         {severity}       (string|number)  filter diagnostics by severity name
                                           (string) or id (number)
         {severity_limit} (string|number)  keep diagnostics equal or more severe

--- a/doc/telescope_changelog.txt
+++ b/doc/telescope_changelog.txt
@@ -47,5 +47,43 @@ better.
 
     You should get error messages when you try and use any of the above keys now.
 
+                                                     *telescope.changelog-839*
+
+Date: July 7, 2021
+PR: https://github.com/nvim-telescope/telescope.nvim/pull/839
+
+Small breaking change regarding `shorten_path` and `hide_filename`.
+This allows to configure path displays on a global level and offers a way for
+extension developers to make use of the same configuration, offering a better
+overall experience.
+
+The new way to configure to configure path displays is with:
+    `path_display`: It is a table and accepts multiple values:
+        - "hidden"    hide file names
+        - "tail"      only display the file name, and not the path
+        - "absolute"  display absolute paths
+        - "shorten"   only display the first character of each directory in
+                      the path
+    see |telescope.defaults.path_display|
+
+Example would be for a global configuration:
+  require("telescope").setup{
+    defaults = {
+      path_display = {
+        "shorten_path",
+        "absolute",
+      },
+    }
+  }
+
+You can also still pass this to a single builtin call:
+    require("telescope.builtin").find_files {
+      path_display = { "shorten_path" }
+    }
+
+For extension developers there is a new util function that can be used to
+display a path:
+    local filename = utils.transform_path(opts, entry.filename)
+
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -492,7 +492,7 @@ files.current_buffer_tags = function(opts)
   return files.tags(vim.tbl_extend("force", {
     prompt_title = 'Current Buffer Tags',
     only_current_file = true,
-    hide_filename = true,
+    path_display = 'hidden',
   }, opts))
 end
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -118,8 +118,6 @@ builtin.current_buffer_fuzzy_find = require('telescope.builtin.files').current_b
 ---@param opts table: options to pass to the picker
 ---@field ctags_file string: specify a particular ctags file to use
 ---@field show_line boolean: if true, shows the content of the line the tag is found on in the picker (default is true)
----@field shorten_path boolean: if true, makes file paths shown in picker use one letter for folders (default is true)
----@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
 builtin.tags = require('telescope.builtin.files').tags
 
 --- Lists all of the tags for the currently open buffer, with a preview
@@ -289,8 +287,6 @@ builtin.spell_suggest = require('telescope.builtin.internal').spell_suggest
 
 --- Lists the tag stack for the current window, jumps to tag on `<cr>`
 ---@param opts table: options to pass to the picker
----@field shorten_path boolean: if true, makes file paths shown in picker use one letter for folders (default is true)
----@field hide_filename boolean: if true, hides the name of the file in the current picker (default is true)
 builtin.tagstack = require('telescope.builtin.internal').tagstack
 
 --- Lists items from Vim's jumplist, jumps to location on `<cr>`
@@ -305,7 +301,6 @@ builtin.jumplist = require('telescope.builtin.internal').jumplist
 
 --- Lists LSP references for word under the cursor, jumps to reference on `<cr>`
 ---@param opts table: options to pass to the picker
----@field shorten_path boolean: if true, makes file paths shown in picker use one letter for folders (default is false)
 builtin.lsp_references = require('telescope.builtin.lsp').references
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
@@ -336,9 +331,7 @@ builtin.lsp_document_symbols = require('telescope.builtin.lsp').document_symbols
 --- - Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
 ---@param opts table: options to pass to the picker
----@field shorten_path boolean: if true, makes file paths shown in picker use one letter for folders (default is false)
 ---@field ignore_filename string: file(s) to ignore
----@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
 ---@field symbols string|table: filter results by symbol kind(s)
 builtin.lsp_workspace_symbols = require('telescope.builtin.lsp').workspace_symbols
 
@@ -346,7 +339,6 @@ builtin.lsp_workspace_symbols = require('telescope.builtin.lsp').workspace_symbo
 --- - Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
 ---@param opts table: options to pass to the picker
----@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
 builtin.lsp_dynamic_workspace_symbols = require('telescope.builtin.lsp').dynamic_workspace_symbols
 
 --- Lists LSP diagnostics for the current buffer
@@ -355,7 +347,6 @@ builtin.lsp_dynamic_workspace_symbols = require('telescope.builtin.lsp').dynamic
 --- - Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
 ---@param opts table: options to pass to the picker
----@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
 ---@field severity string|number: filter diagnostics by severity name (string) or id (number)
 ---@field severity_limit string|number: keep diagnostics equal or more severe wrt severity name (string) or id (number)
 ---@field severity_bound string|number: keep diagnostics equal or less severe wrt severity name (string) or id (number)
@@ -369,7 +360,6 @@ builtin.lsp_document_diagnostics = require('telescope.builtin.lsp').diagnostics
 --- - Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
 ---@param opts table: options to pass to the picker
----@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
 ---@field severity string|number: filter diagnostics by severity name (string) or id (number)
 ---@field severity_limit string|number: keep diagnostics equal or more severe wrt severity name (string) or id (number)
 ---@field severity_bound string|number: keep diagnostics equal or less severe wrt severity name (string) or id (number)

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -19,7 +19,7 @@ local internal = {}
 --  vim.fn.setreg("+", "nnoremap $TODO :lua require('telescope.builtin').<whatever>()<CR>")
 -- TODO: Can we just do the names instead?
 internal.builtin = function(opts)
-  opts.hide_filename = utils.get_default(opts.hide_filename, true)
+  opts.path_display = utils.get_default(opts.path_display, "hidden")
   opts.ignore_filename = utils.get_default(opts.ignore_filename, true)
   opts.include_extensions = utils.get_default(opts.include_extensions, false)
 

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -15,8 +15,6 @@ local conf = require('telescope.config').values
 local lsp = {}
 
 lsp.references = function(opts)
-  opts.shorten_path = utils.get_default(opts.shorten_path, true)
-
   local params = vim.lsp.util.make_position_params()
   params.context = { includeDeclaration = true }
 
@@ -250,8 +248,6 @@ lsp.range_code_actions = function(opts)
 end
 
 lsp.workspace_symbols = function(opts)
-  opts.shorten_path = utils.get_default(opts.shorten_path, true)
-
   local params = {query = opts.query or ''}
   local results_lsp, err = vim.lsp.buf_request_sync(0, "workspace/symbol", params, opts.timeout or 10000)
   if err then
@@ -283,7 +279,6 @@ lsp.workspace_symbols = function(opts)
   end
 
   opts.ignore_filename = utils.get_default(opts.ignore_filename, false)
-  opts.hide_filename = utils.get_default(opts.hide_filename, false)
 
   pickers.new(opts, {
     prompt_title = 'LSP Workspace Symbols',
@@ -337,7 +332,7 @@ lsp.diagnostics = function(opts)
     return
   end
 
-  opts.hide_filename = utils.get_default(opts.hide_filename, true)
+  opts.path_display = utils.get_default(opts.path_display, 'hidden')
   pickers.new(opts, {
     prompt_title = 'LSP Document Diagnostics',
     finder = finders.new_table {
@@ -354,7 +349,7 @@ end
 
 lsp.workspace_diagnostics = function(opts)
   opts = utils.get_default(opts, {})
-  opts.hide_filename = utils.get_default(opts.hide_filename, false)
+  opts.path_display = utils.get_default(opts.path_display, {})
   opts.prompt_title = 'LSP Workspace Diagnostics'
   opts.get_all = true
   lsp.diagnostics(opts)

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -177,6 +177,20 @@ local telescope_defaults = {
     Default: true]]
   },
 
+  path_display = { {}, [[
+    Determines how file paths are displayed
+
+    path_display can be set to an array with a combination of:
+    - "hidden"    hide file names
+    - "tail"      only display the file name, and not the path
+    - "absolute"  display absolute paths
+    - "shorten"   only display the first character of each directory in the path
+
+    path_display can also be set to 'hidden' string to hide file names
+
+    Default: {}]]
+  },
+
   borderchars = { { "─", "│", "─", "│", "╭", "╮", "╯", "╰" } },
 
   get_status_text = {

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -184,7 +184,8 @@ local telescope_defaults = {
     - "hidden"    hide file names
     - "tail"      only display the file name, and not the path
     - "absolute"  display absolute paths
-    - "shorten"   only display the first character of each directory in the path
+    - "shorten"   only display the first character of each directory in
+                  the path
 
     path_display can also be set to 'hidden' string to hide file names
 
@@ -261,13 +262,15 @@ local telescope_defaults = {
       Into your config.
 
 
-    otherwise, just set the mapping to the function that you want it to be.
+    otherwise, just set the mapping to the function that you want it to
+    be.
 
         ...,
         ["<C-i>"] = require('telescope.actions').select_default,
         ...,
 
-    If the function you want is part of `telescope.actions`, then you can simply give a string.
+    If the function you want is part of `telescope.actions`, then you can
+    simply give a string.
       For example, the previous option is equivalent to:
 
         ...,

--- a/lua/telescope/deprecated.lua
+++ b/lua/telescope/deprecated.lua
@@ -8,6 +8,20 @@ deprecated.picker_window_options = function(opts)
   -- Deprecated: PR:922, 2021/06/25
   -- Can be removed in a few weeks.
 
+  if opts.shorten_path then
+    table.insert(messages,
+      "'opts.shorten_path' is no longer valid. Please use 'opts.path_display' instead. " ..
+      "Please See ':help telescope.changelog-839'"
+    )
+  end
+
+  if opts.hide_filename then
+    table.insert(messages,
+      "'opts.hide_filename' is no longer valid. Please use 'opts.path_display' instead. " ..
+      "Please See ':help telescope.changelog-839'"
+    )
+  end
+
   if opts.width then
     table.insert(messages, "'opts.width' is no longer valid. Please use 'layout_config.width' instead")
   end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -5,8 +5,6 @@ local strings = require('plenary.strings')
 
 local Path = require('plenary.path')
 
-local get_default = utils.get_default
-
 local treesitter_type_highlight = {
   ["associated"] = "TSConstant",
   ["constant"]   = "TSConstant",
@@ -68,17 +66,13 @@ do
     local cwd = vim.fn.expand(opts.cwd or vim.fn.getcwd())
 
     local disable_devicons = opts.disable_devicons
-    local shorten_path = opts.shorten_path
 
     local mt_file_entry = {}
 
     mt_file_entry.cwd = cwd
     mt_file_entry.display = function(entry)
       local hl_group
-      local display = path.make_relative(entry.value, cwd)
-      if shorten_path then
-        display = utils.path_shorten(display)
-      end
+      local display = utils.transform_path(opts, entry.value)
 
       display, hl_group = utils.transform_devicons(entry.value, display, disable_devicons)
 
@@ -136,7 +130,6 @@ do
   end
 
   --- Special options:
-  ---  - shorten_path: make the path appear short
   ---  - disable_coordinates: Don't show the line & row numbers
   ---  - only_sort_text: Only sort via the text. Ignore filename and other items
   function make_entry.gen_from_vimgrep(opts)
@@ -145,7 +138,6 @@ do
     opts = opts or {}
 
     local disable_devicons = opts.disable_devicons
-    local shorten_path = opts.shorten_path
     local disable_coordinates = opts.disable_coordinates
     local only_sort_text = opts.only_sort_text
 
@@ -188,12 +180,7 @@ do
       cwd = vim.fn.expand(opts.cwd or vim.fn.getcwd()),
 
       display = function(entry)
-        local display_filename
-        if shorten_path then
-          display_filename = utils.path_shorten(entry.filename)
-        else
-          display_filename = entry.filename
-        end
+        local display_filename = utils.transform_path(opts, entry.filename)
 
         local coordinates = ""
         if not disable_coordinates then
@@ -290,7 +277,6 @@ end
 
 function make_entry.gen_from_quickfix(opts)
   opts = opts or {}
-  opts.tail_path = get_default(opts.tail_path, true)
 
   local displayer = entry_display.create {
     separator = "▏",
@@ -302,15 +288,7 @@ function make_entry.gen_from_quickfix(opts)
   }
 
   local make_display = function(entry)
-    local filename
-    if not opts.hide_filename then
-      filename = entry.filename
-      if opts.tail_path then
-        filename = utils.path_tail(filename)
-      elseif opts.shorten_path then
-        filename = utils.path_shorten(filename)
-      end
-    end
+    local filename = utils.transform_path(opts, entry.filename)
 
     local line_info = {table.concat({entry.lnum, entry.col}, ":"), "TelescopeResultsLineNr"}
 
@@ -379,17 +357,7 @@ function make_entry.gen_from_lsp_symbols(opts)
         )[1] or ''
       msg = vim.trim(msg)
     else
-      local filename = ""
-      opts.tail_path = get_default(opts.tail_path, true)
-
-      if not opts.hide_filename then -- hide the filename entirely
-        filename = entry.filename
-        if opts.tail_path then
-          filename = utils.path_tail(filename)
-        elseif opts.shorten_path then
-          filename = utils.path_shorten(filename)
-        end
-      end
+      local filename = utils.transform_path(opts, entry.filename)
 
       if opts.show_line then -- show inline line info
         filename = filename .. " [" ..entry.lnum .. ":" .. entry.col .. "]"
@@ -463,12 +431,7 @@ function make_entry.gen_from_buffer(opts)
   local cwd = vim.fn.expand(opts.cwd or vim.fn.getcwd())
 
   local make_display = function(entry)
-    local display_bufname
-    if opts.shorten_path then
-      display_bufname = path.shorten(entry.filename)
-    else
-      display_bufname = entry.filename
-    end
+    local display_bufname = utils.transform_path(opts, entry.filename)
 
     local icon, hl_group = utils.get_devicons(entry.filename, disable_devicons)
 
@@ -869,14 +832,7 @@ function make_entry.gen_from_ctags(opts)
   }
 
   local make_display = function(entry)
-    local filename
-    if not opts.hide_filename then
-      if opts.shorten_path then
-        filename = path.shorten(entry.filename)
-      else
-        filename = entry.filename
-      end
-    end
+    local filename = utils.transform_path(opts, entry.filename)
 
     local scode
     if opts.show_line then
@@ -932,7 +888,6 @@ end
 
 function make_entry.gen_from_lsp_diagnostics(opts)
   opts = opts or {}
-  opts.tail_path = utils.get_default(opts.tail_path, true)
   local lsp_type_diagnostic = vim.lsp.protocol.DiagnosticSeverity
 
   local signs
@@ -956,22 +911,14 @@ function make_entry.gen_from_lsp_diagnostics(opts)
     { remaining = true }
   }
   local line_width = utils.get_default(opts.line_width, 45)
-  if not opts.hide_filename then table.insert(layout, 2, {width = line_width}) end
+  if not utils.is_path_hidden(opts) then table.insert(layout, 2, {width = line_width}) end
   local displayer = entry_display.create {
     separator = "▏",
     items = layout
   }
 
   local make_display = function(entry)
-    local filename
-    if not opts.hide_filename then
-      filename = entry.filename
-      if opts.tail_path then
-        filename = utils.path_tail(filename)
-      elseif opts.shorten_path then
-        filename = utils.path_shorten(filename)
-      end
-    end
+    local filename = utils.transform_path(opts, entry.filename)
 
     -- add styling of entries
     local pos = string.format("%4d:%2d", entry.lnum, entry.col)
@@ -1156,7 +1103,6 @@ end
 
 function make_entry.gen_from_jumplist(opts)
   opts = opts or {}
-  opts.tail_path = get_default(opts.tail_path, true)
 
   local displayer = entry_display.create {
     separator = "▏",
@@ -1167,15 +1113,7 @@ function make_entry.gen_from_jumplist(opts)
   }
 
   local make_display = function(entry)
-    local filename
-    if not opts.hide_filename then
-      filename = entry.filename
-      if opts.tail_path then
-        filename = utils.path_tail(filename)
-      elseif opts.shorten_path then
-        filename = utils.path_shorten(filename)
-      end
-    end
+    local filename = utils.transform_path(opts, entry.filename)
 
     local line_info = {table.concat({entry.lnum, entry.col}, ":"), "TelescopeResultsLineNr"}
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -818,12 +818,15 @@ function make_entry.gen_from_ctags(opts)
   local current_file = path.normalize(vim.fn.expand('%'), cwd)
 
   local display_items = {
-    { width = 30 },
     { remaining = true },
   }
+  local hidden = utils.is_path_hidden(opts)
+  if not hidden then
+    table.insert(display_items, 1, { width = 30 })
+  end
 
   if opts.show_line then
-    table.insert(display_items, 2, { width = 30 })
+    table.insert(display_items, 1, { width = 30 })
   end
 
   local displayer = entry_display.create {
@@ -839,11 +842,18 @@ function make_entry.gen_from_ctags(opts)
       scode = entry.scode
     end
 
-    return displayer {
-      filename,
-      entry.tag,
-      scode,
-    }
+    if hidden then
+      return displayer {
+        entry.tag,
+        scode,
+      }
+    else
+      return displayer {
+        filename,
+        entry.tag,
+        scode,
+      }
+    end
   end
 
   return function(line)


### PR DESCRIPTION
## Changes
1. Default overridable values for `hide_filename`, `shorten_path`, and `tail_path`
2. Consistent use of aforementioned values across entry makers
3. extract copy pasted path transformations into a common utility function

### Caveats
* This will probably change filepath display for some pickers for many users.
* I tried some basic manual testing for many of the affected pickers, but may have missed some

### Open Questions
* I am not sure how to deal with some of the existing pickers that have default values for `shorten_path` and `tail_path`
  * ie. lsp references sets `shorten_path` to true by default
  * IMO, these pickers should instead follow global values, and the user can just pass in options to override defaults as needed