### PR TITLE
Change default behavior of git_files to be the same as git ls-files' default and fzf.vim's GFiles

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -977,7 +977,7 @@ builtin.git_files({opts})                      *telescope.builtin.git_files()*
                                         (default: true)
         {show_untracked}     (boolean)  if true, adds `--others` flag to
                                         command and shows untracked files
-                                        (default: true)
+                                        (default: false)
         {recurse_submodules} (boolean)  if true, adds the
                                         `--recurse-submodules` flag to command
                                         (default: false)

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -22,7 +22,7 @@ git.files = function(opts)
     return
   end
 
-  local show_untracked = utils.get_default(opts.show_untracked, true)
+  local show_untracked = utils.get_default(opts.show_untracked, false)
   local recurse_submodules = utils.get_default(opts.recurse_submodules, false)
   if show_untracked and recurse_submodules then
     utils.notify("builtin.git_files", {

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -132,7 +132,7 @@ builtin.current_buffer_tags = require_on_exported_call("telescope.builtin.files"
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
----@field show_untracked boolean: if true, adds `--others` flag to command and shows untracked files (default: true)
+---@field show_untracked boolean: if true, adds `--others` flag to command and shows untracked files (default: false)
 ---@field recurse_submodules boolean: if true, adds the `--recurse-submodules` flag to command (default: false)
 ---@field git_command table: command that will be exectued. {"git","ls-files","--exclude-standard","--cached"}
 builtin.git_files = require_on_exported_call("telescope.builtin.git").files


### PR DESCRIPTION
This closes #826, just wanted to put up this PR as a way for us to discuss this. While I don't personally ever have a use case that I _don't_ want to see untracked files by git when fuzzy searching in my projects, I do think that this default does make more sense, considering how fzf.vim's `:GFiles` command and `git ls-files` work by default. We do have a lot of people transitioning from fzf who may find this default confusing. Perhaps it could be documented in more detail as well if we feel that's necessary, I'd be happy to make that happen. 

cc @mhinz @kaddkaka @clason 