### PR TITLE
Fix string.find() matching for only_cwd option

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -569,7 +569,7 @@ internal.buffers = function(opts)
     if opts.ignore_current_buffer and b == vim.api.nvim_get_current_buf() then
       return false
     end
-    if opts.only_cwd and not string.find(vim.api.nvim_buf_get_name(b), vim.loop.cwd()) then
+    if opts.only_cwd and not string.find(vim.api.nvim_buf_get_name(b), vim.loop.cwd(), 1, true) then
       return false
     end
     return true


### PR DESCRIPTION
This fixes an issue with the `builtin.buffers` `only_cwd` option that occurs when the `cwd` has an `-` in the name (or any other character that triggers pattern matching).

`string.find()` defaults to _pattern_ matching (rather than string literal matching).

This fix asks `string.find()` to interpret the arguments as literal strings rather than patterns.

Reference: https://stackoverflow.com/a/15258515/181902