### PR TITLE
fix: attempt to concatenate when entry.kind == nil or symbol_type == nil

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -424,7 +424,7 @@ function make_entry.gen_from_lsp_symbols(opts)
     if not opts.ignore_filename and filename then
       ordinal = filename .. " "
     end
-    ordinal = ordinal ..  symbol_name .. " " .. symbol_type
+    ordinal = ordinal ..  symbol_name .. " " .. (symbol_type or "unknown")
     return {
       valid = true,
 
@@ -562,7 +562,7 @@ function make_entry.gen_from_treesitter(opts)
 
       value = entry.node,
       kind = entry.kind,
-      ordinal = node_text .. " " .. entry.kind,
+      ordinal = node_text .. " " .. (entry.kind or "unknown"),
       display = make_display,
 
       node_text = node_text,


### PR DESCRIPTION
Fix #763 #874. I'm also hitting the same error when I attempt to `:Telescope treesitter` in .c files.