### PR TITLE
Change the `show_all_buffers` option to true by default for `buffers` picker

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -630,13 +630,15 @@ builtin.reloader({opts})                                  *builtin.reloader()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.buffers({opts}, {show_all_buffers}, {ignore_current_buffer}, {only_cwd})*builtin.buffers()*
+builtin.buffers({opts})                                    *builtin.buffers()*
     Lists open buffers in current neovim instance, opens selected buffer on
     `<cr>`
 
 
     Parameters: ~
-        {opts}                  (table)    options to pass to the picker
+        {opts} (table)  options to pass to the picker
+
+    Fields: ~
         {show_all_buffers}      (boolean)  if true, show all buffers, including
                                            unloaded buffers (default true)
         {ignore_current_buffer} (boolean)  if true, don't show the current

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -630,13 +630,20 @@ builtin.reloader({opts})                                  *builtin.reloader()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.buffers({opts})                                    *builtin.buffers()*
+builtin.buffers({opts}, {show_all_buffers}, {ignore_current_buffer}, {only_cwd})*builtin.buffers()*
     Lists open buffers in current neovim instance, opens selected buffer on
     `<cr>`
 
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+        {opts}                  (table)    options to pass to the picker
+        {show_all_buffers}      (boolean)  if true, show all buffers, including
+                                           unloaded buffers (default true)
+        {ignore_current_buffer} (boolean)  if true, don't show the current
+                                           buffer in the list (default false)
+        {only_cwd}              (boolean)  if true, only show buffers in the
+                                           current working directory (default
+                                           false)
 
 
 builtin.colorscheme({opts})                            *builtin.colorscheme()*

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -207,6 +207,9 @@ builtin.reloader = require('telescope.builtin.internal').reloader
 
 --- Lists open buffers in current neovim instance, opens selected buffer on `<cr>`
 ---@param opts table: options to pass to the picker
+---@param show_all_buffers boolean: if true, show all buffers, including unloaded buffers (default true)
+---@param ignore_current_buffer boolean: if true, don't show the current buffer in the list (default false)
+---@param only_cwd boolean: if true, only show buffers in the current working directory (default false)
 builtin.buffers = require('telescope.builtin.internal').buffers
 
 --- Lists available colorschemes and applies them on `<cr>`

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -207,9 +207,9 @@ builtin.reloader = require('telescope.builtin.internal').reloader
 
 --- Lists open buffers in current neovim instance, opens selected buffer on `<cr>`
 ---@param opts table: options to pass to the picker
----@param show_all_buffers boolean: if true, show all buffers, including unloaded buffers (default true)
----@param ignore_current_buffer boolean: if true, don't show the current buffer in the list (default false)
----@param only_cwd boolean: if true, only show buffers in the current working directory (default false)
+---@field show_all_buffers boolean: if true, show all buffers, including unloaded buffers (default true)
+---@field ignore_current_buffer boolean: if true, don't show the current buffer in the list (default false)
+---@field only_cwd boolean: if true, only show buffers in the current working directory (default false)
 builtin.buffers = require('telescope.builtin.internal').buffers
 
 --- Lists available colorschemes and applies them on `<cr>`

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -563,7 +563,8 @@ internal.buffers = function(opts)
     if 1 ~= vim.fn.buflisted(b) then
         return false
     end
-    if not opts.show_all_buffers and not vim.api.nvim_buf_is_loaded(b) then
+    -- only hide unloaded buffers if opts.show_all_buffers is false, keep them listed if true or nil
+    if opts.show_all_buffers == false and not vim.api.nvim_buf_is_loaded(b) then
       return false
     end
     if opts.ignore_current_buffer and b == vim.api.nvim_get_current_buf() then


### PR DESCRIPTION
We've had several people open issues with this problem recently, I figured we should probably just change this as it's a pretty trivial adjustment. Also added some more docs about the `buffers` picker's specific options. I'll be adding more docs for the rest of the pickers too where I missed their specific options soon now that I have a better idea of where to check. I know that we were going to add this to #415 but I figured we might consider just adjusting this one now with all the recent issues regarding it.

Closes #368 

@Conni2461 thoughts on just making this default, as you and I have responded to several issues lately with people requesting this?