### PR TITLE
fix: abort picker set_selection if no manager

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -649,6 +649,8 @@ function Picker:refresh(finder, opts)
 end
 
 function Picker:set_selection(row)
+  if not self.manager then return end
+
   row = self.scroller(self.max_results, self.manager:num_results(), row)
 
   if not self:can_select_row(row) then


### PR DESCRIPTION
When the finder is slow to populate the list of items, I noticed that clicking <up> or <down> quickly after opening a Telescope would error because self.manager wasn't available yet.

`E5108: Error executing lua ...im/pack/mse/opt/telescope.nvim/lua/telescope/pickers.lua:652: attempt to index field 'manager' (a nil value)`