### PR TITLE
feat: improved configuration and sorting of lsp_{document,workspace}_diagnostics

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -827,6 +827,9 @@ builtin.lsp_dynamic_workspace_symbols({opts})*builtin.lsp_dynamic_workspace_symb
 
 builtin.lsp_document_diagnostics({opts})  *builtin.lsp_document_diagnostics()*
     Lists LSP diagnostics for the current buffer
+    - Fields:
+      - `All severity flags can be passed as `string` or `number` as per
+        `:vim.lsp.protocol.DiagnosticSeverity:`
     - Default keymaps:
       - `<C-l>`: show autocompletion menu to prefilter your query with the
         diagnostic you want to see (i.e. `:warning:`)
@@ -836,13 +839,26 @@ builtin.lsp_document_diagnostics({opts})  *builtin.lsp_document_diagnostics()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {hide_filename} (boolean)  if true, hides the name of the file in the
-                                   current picker (default is false)
+        {hide_filename}  (boolean)  if true, hides the name of the file in the
+                                    current picker (default is false)
+        {severity}       (string)   filter diagnostics by severity name
+                                    (string) or id (number)
+        {severity_limit} (string)   filter for diagnostics equal or more severe
+                                    wrt severity name (string) or id (number)
+        {severity_bound} (string)   filter for diagnostics equal or less severe
+                                    wrt severity name (string) or id (number)
+        {no_sign}        (bool)     hide LspDiagnosticSigns from Results
+                                    (default is false)
+        {line_width}     (number)   set length of diagnostic entry text in
+                                    Results
 
 
 builtin.lsp_workspace_diagnostics({opts})*builtin.lsp_workspace_diagnostics()*
     Lists LSP diagnostics for the current workspace if supported, otherwise
     searches in all open buffers
+    - Fields:
+      - `All severity flags can be passed as `string` or `number` as per
+        `:vim.lsp.protocol.DiagnosticSeverity:`
     - Default keymaps:
       - `<C-l>`: show autocompletion menu to prefilter your query with the
         diagnostic you want to see (i.e. `:warning:`)
@@ -852,8 +868,18 @@ builtin.lsp_workspace_diagnostics({opts})*builtin.lsp_workspace_diagnostics()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {hide_filename} (boolean)  if true, hides the name of the file in the
-                                   current picker (default is false)
+        {hide_filename}  (boolean)  if true, hides the name of the file in the
+                                    current picker (default is false)
+        {severity}       (string)   filter diagnostics by severity name
+                                    (string) or id (number)
+        {severity_limit} (string)   filter for diagnostics equal or more severe
+                                    wrt severity name (string) or id (number)
+        {severity_bound} (string)   filter for diagnostics equal or less severe
+                                    wrt severity name (string) or id (number)
+        {no_sign}        (bool)     hide LspDiagnosticSigns from Results
+                                    (default is false)
+        {line_width}     (number)   set length of diagnostic entry text in
+                                    Results
 
 
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -839,18 +839,21 @@ builtin.lsp_document_diagnostics({opts})  *builtin.lsp_document_diagnostics()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {hide_filename}  (boolean)  if true, hides the name of the file in the
-                                    current picker (default is false)
-        {severity}       (string)   filter diagnostics by severity name
-                                    (string) or id (number)
-        {severity_limit} (string)   filter for diagnostics equal or more severe
-                                    wrt severity name (string) or id (number)
-        {severity_bound} (string)   filter for diagnostics equal or less severe
-                                    wrt severity name (string) or id (number)
-        {no_sign}        (bool)     hide LspDiagnosticSigns from Results
-                                    (default is false)
-        {line_width}     (number)   set length of diagnostic entry text in
-                                    Results
+        {hide_filename}  (boolean)        if true, hides the name of the file
+                                          in the current picker (default is
+                                          false)
+        {severity}       (string|number)  filter diagnostics by severity name
+                                          (string) or id (number)
+        {severity_limit} (string|number)  filter for diagnostics equal or more
+                                          severe wrt severity name (string) or
+                                          id (number)
+        {severity_bound} (string|number)  filter for diagnostics equal or less
+                                          severe wrt severity name (string) or
+                                          id (number)
+        {no_sign}        (bool)           hide LspDiagnosticSigns from Results
+                                          (default is false)
+        {line_width}     (number)         set length of diagnostic entry text
+                                          in Results
 
 
 builtin.lsp_workspace_diagnostics({opts})*builtin.lsp_workspace_diagnostics()*
@@ -868,18 +871,21 @@ builtin.lsp_workspace_diagnostics({opts})*builtin.lsp_workspace_diagnostics()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {hide_filename}  (boolean)  if true, hides the name of the file in the
-                                    current picker (default is false)
-        {severity}       (string)   filter diagnostics by severity name
-                                    (string) or id (number)
-        {severity_limit} (string)   filter for diagnostics equal or more severe
-                                    wrt severity name (string) or id (number)
-        {severity_bound} (string)   filter for diagnostics equal or less severe
-                                    wrt severity name (string) or id (number)
-        {no_sign}        (bool)     hide LspDiagnosticSigns from Results
-                                    (default is false)
-        {line_width}     (number)   set length of diagnostic entry text in
-                                    Results
+        {hide_filename}  (boolean)        if true, hides the name of the file
+                                          in the current picker (default is
+                                          false)
+        {severity}       (string|number)  filter diagnostics by severity name
+                                          (string) or id (number)
+        {severity_limit} (string|number)  filter for diagnostics equal or more
+                                          severe wrt severity name (string) or
+                                          id (number)
+        {severity_bound} (string|number)  filter for diagnostics equal or less
+                                          severe wrt severity name (string) or
+                                          id (number)
+        {no_sign}        (bool)           hide LspDiagnosticSigns from Results
+                                          (default is false)
+        {line_width}     (number)         set length of diagnostic entry text
+                                          in Results
 
 
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -310,9 +310,9 @@ builtin.lsp_dynamic_workspace_symbols = require('telescope.builtin.lsp').dynamic
 ---   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
 ---@param opts table: options to pass to the picker
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
----@field severity string: filter diagnostics by severity name (string) or id (number)
----@field severity_limit string: filter for diagnostics equal or more severe wrt severity name (string) or id (number)
----@field severity_bound string: filter for diagnostics equal or less severe wrt severity name (string) or id (number)
+---@field severity string|number: filter diagnostics by severity name (string) or id (number)
+---@field severity_limit string|number: filter for diagnostics equal or more severe wrt severity name (string) or id (number)
+---@field severity_bound string|number: filter for diagnostics equal or less severe wrt severity name (string) or id (number)
 ---@field no_sign bool: hide LspDiagnosticSigns from Results (default is false)
 ---@field line_width number: set length of diagnostic entry text in Results
 builtin.lsp_document_diagnostics = require('telescope.builtin.lsp').diagnostics
@@ -324,9 +324,9 @@ builtin.lsp_document_diagnostics = require('telescope.builtin.lsp').diagnostics
 ---   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
 ---@param opts table: options to pass to the picker
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
----@field severity string: filter diagnostics by severity name (string) or id (number)
----@field severity_limit string: filter for diagnostics equal or more severe wrt severity name (string) or id (number)
----@field severity_bound string: filter for diagnostics equal or less severe wrt severity name (string) or id (number)
+---@field severity string|number: filter diagnostics by severity name (string) or id (number)
+---@field severity_limit string|number: filter for diagnostics equal or more severe wrt severity name (string) or id (number)
+---@field severity_bound string|number: filter for diagnostics equal or less severe wrt severity name (string) or id (number)
 ---@field no_sign bool: hide LspDiagnosticSigns from Results (default is false)
 ---@field line_width number: set length of diagnostic entry text in Results
 builtin.lsp_workspace_diagnostics = require('telescope.builtin.lsp').workspace_diagnostics

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -309,8 +309,8 @@ builtin.lsp_dynamic_workspace_symbols = require('telescope.builtin.lsp').dynamic
 ---@param opts table: options to pass to the picker
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
 ---@field severity string or number: filter diagnostics by severity name or id (i.e. 'error' or 1)
----@field severity_threshold string or number: filter for diagnostics equal or more severe wrt severity name or id
----@field severity_bound string or number: filter for diagnostics equal or less severe relative to severity name or id
+---@field severity_limit string or number: filter for diagnostics equal or more severe wrt severity name or id
+---@field severity_bound string or number: filter for diagnostics equal or less severe wrt severity name or id
 ---@field no_sign bool: hide LspDiagnosticSigns from Results (default is false)
 ---@field line_width number: set length of diagnostic entry text in Results
 builtin.lsp_document_diagnostics = require('telescope.builtin.lsp').diagnostics
@@ -321,8 +321,8 @@ builtin.lsp_document_diagnostics = require('telescope.builtin.lsp').diagnostics
 ---@param opts table: options to pass to the picker
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
 ---@field severity string or number: filter diagnostics by severity name or id (i.e. 'error' or 1)
----@field severity_threshold string or number: filter for diagnostics equal or more severe wrt severity name or id
----@field severity_bound string or number: filter for diagnostics equal or less severe relative to severity name or id
+---@field severity_limit string or number: filter for diagnostics equal or more severe wrt severity name or id
+---@field severity_bound string or number: filter for diagnostics equal or less severe wrt severity name or id
 ---@field no_sign bool: hide LspDiagnosticSigns from Results (default is false)
 ---@field line_width number: set length of diagnostic entry text in Results
 builtin.lsp_workspace_diagnostics = require('telescope.builtin.lsp').workspace_diagnostics

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -308,6 +308,11 @@ builtin.lsp_dynamic_workspace_symbols = require('telescope.builtin.lsp').dynamic
 ---   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
 ---@param opts table: options to pass to the picker
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
+---@field severity string or number: filter diagnostics by severity name or id (i.e. 'error' or 1)
+---@field severity_threshold string or number: filter for diagnostics equal or more severe wrt severity name or id
+---@field severity_bound string or number: filter for diagnostics equal or less severe relative to severity name or id
+---@field no_sign bool: hide LspDiagnosticSigns from Results (default is false)
+---@field line_width number: set length of diagnostic entry text in Results
 builtin.lsp_document_diagnostics = require('telescope.builtin.lsp').diagnostics
 
 --- Lists LSP diagnostics for the current workspace if supported, otherwise searches in all open buffers
@@ -315,6 +320,11 @@ builtin.lsp_document_diagnostics = require('telescope.builtin.lsp').diagnostics
 ---   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
 ---@param opts table: options to pass to the picker
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
+---@field severity string or number: filter diagnostics by severity name or id (i.e. 'error' or 1)
+---@field severity_threshold string or number: filter for diagnostics equal or more severe wrt severity name or id
+---@field severity_bound string or number: filter for diagnostics equal or less severe relative to severity name or id
+---@field no_sign bool: hide LspDiagnosticSigns from Results (default is false)
+---@field line_width number: set length of diagnostic entry text in Results
 builtin.lsp_workspace_diagnostics = require('telescope.builtin.lsp').workspace_diagnostics
 
 return builtin

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -304,25 +304,29 @@ builtin.lsp_workspace_symbols = require('telescope.builtin.lsp').workspace_symbo
 builtin.lsp_dynamic_workspace_symbols = require('telescope.builtin.lsp').dynamic_workspace_symbols
 
 --- Lists LSP diagnostics for the current buffer
+--- - Fields:
+---   - `All severity flags can be passed as `string` or `number` as per `:vim.lsp.protocol.DiagnosticSeverity:`
 --- - Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
 ---@param opts table: options to pass to the picker
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
----@field severity string or number: filter diagnostics by severity name or id (i.e. 'error' or 1)
----@field severity_limit string or number: filter for diagnostics equal or more severe wrt severity name or id
----@field severity_bound string or number: filter for diagnostics equal or less severe wrt severity name or id
+---@field severity string: filter diagnostics by severity name (string) or id (number)
+---@field severity_limit string: filter for diagnostics equal or more severe wrt severity name (string) or id (number)
+---@field severity_bound string: filter for diagnostics equal or less severe wrt severity name (string) or id (number)
 ---@field no_sign bool: hide LspDiagnosticSigns from Results (default is false)
 ---@field line_width number: set length of diagnostic entry text in Results
 builtin.lsp_document_diagnostics = require('telescope.builtin.lsp').diagnostics
 
 --- Lists LSP diagnostics for the current workspace if supported, otherwise searches in all open buffers
+--- - Fields:
+---   - `All severity flags can be passed as `string` or `number` as per `:vim.lsp.protocol.DiagnosticSeverity:`
 --- - Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
 ---@param opts table: options to pass to the picker
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
----@field severity string or number: filter diagnostics by severity name or id (i.e. 'error' or 1)
----@field severity_limit string or number: filter for diagnostics equal or more severe wrt severity name or id
----@field severity_bound string or number: filter for diagnostics equal or less severe wrt severity name or id
+---@field severity string: filter diagnostics by severity name (string) or id (number)
+---@field severity_limit string: filter for diagnostics equal or more severe wrt severity name (string) or id (number)
+---@field severity_bound string: filter for diagnostics equal or less severe wrt severity name (string) or id (number)
 ---@field no_sign bool: hide LspDiagnosticSigns from Results (default is false)
 ---@field line_width number: set length of diagnostic entry text in Results
 builtin.lsp_workspace_diagnostics = require('telescope.builtin.lsp').workspace_diagnostics

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -29,13 +29,6 @@ local lsp_type_highlight = {
   ["Variable"] = "TelescopeResultsVariable",
 }
 
-local lsp_type_diagnostic = {
-  [1] = "Error",
-  [2] = "Warning",
-  [3] = "Information",
-  [4] = "Hint"
-}
-
 local make_entry = {}
 
 do
@@ -936,18 +929,21 @@ end
 function make_entry.gen_from_lsp_diagnostics(opts)
   opts = opts or {}
   opts.tail_path = utils.get_default(opts.tail_path, true)
+  local lsp_type_diagnostic = vim.lsp.protocol.DiagnosticSeverity
 
   local signs
   if not opts.no_sign then
     signs = {}
-    for _, v in pairs(lsp_type_diagnostic) do
+    for severity, _ in pairs(lsp_type_diagnostic) do
       -- pcall to catch entirely unbound or cleared out sign hl group
-      local status, sign = pcall(
-        function() return vim.trim(vim.fn.sign_getdefined("LspDiagnosticsSign" .. v)[1].text) end)
-      if not status then
-        sign = v:sub(1,1)
+      if type(severity) == 'string' then
+        local status, sign = pcall(
+          function() return vim.trim(vim.fn.sign_getdefined("LspDiagnosticsSign" .. severity)[1].text) end)
+        if not status then
+          sign = severity:sub(1,1)
+        end
+        signs[severity] = sign
       end
-      signs[v] = sign
     end
   end
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -177,8 +177,7 @@ utils.diagnostics_to_tbl = function(opts)
       end
       return a.bufnr < b.bufnr
     end
-    end
-  )
+  end)
 
   return items
 end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -82,11 +82,48 @@ utils.quickfix_items_to_entries = function(locations)
   return results
 end
 
+local convert_diagnostic_type = function(severity)
+  -- convert from string to int
+  if type(severity) == 'string' then
+    -- make sure that e.g. error is uppercased to Error
+    return vim.lsp.protocol.DiagnosticSeverity[severity:gsub("^%l", string.upper)]
+  end
+  -- otherwise keep original value, incl. nil
+  return severity
+end
+
+local filter_diag_severity = function(opts, severity)
+  if opts.severity ~= nil then
+    return opts.severity == severity
+  elseif opts.severity_threshold ~= nil then
+    return severity <= opts.severity_threshold
+  elseif opts.severity_bound ~= nil then
+    return severity >= opts.severity_bound
+  else
+    return true
+  end
+end
+
 utils.diagnostics_to_tbl = function(opts)
   opts = opts or {}
   local items = {}
+  local lsp_type_diagnostic = vim.lsp.protocol.DiagnosticSeverity
   local current_buf = vim.api.nvim_get_current_buf()
-  local lsp_type_diagnostic = {[1] = "Error", [2] = "Warning", [3] = "Information", [4] = "Hint"}
+
+  opts.severity = convert_diagnostic_type(opts.severity)
+  opts.severity_threshold = convert_diagnostic_type(opts.severity_threshold)
+  opts.severity_bound = convert_diagnostic_type(opts.severity_bound)
+
+  local validate_severity = 0
+  for _, v in pairs({opts.severity, opts.severity_threshold, opts.severity_bound}) do
+    if v ~= nil then
+      validate_severity = validate_severity + 1
+    end
+    if validate_severity > 1 then
+      print('Please pass valid severity parameters')
+      return {}
+    end
+  end
 
   local preprocess_diag = function(diag, bufnr)
     local filename = vim.api.nvim_buf_get_name(bufnr)
@@ -102,11 +139,10 @@ utils.diagnostics_to_tbl = function(opts)
       col = col + 1,
       start = start,
       finish = finish,
-    -- remove line break to avoid display issues
+      -- remove line break to avoid display issues
       text = vim.trim(diag.message:gsub("[\n]", "")),
       type = lsp_type_diagnostic[diag.severity] or lsp_type_diagnostic[1]
     }
-    table.sort(buffer_diag, function(a, b) return a.lnum < b.lnum end)
     return buffer_diag
   end
 
@@ -116,10 +152,34 @@ utils.diagnostics_to_tbl = function(opts)
     for _, diag in pairs(diags) do
       -- workspace diagnostics may include empty tables for unused bufnr
       if not vim.tbl_isempty(diag) then
-        table.insert(items, preprocess_diag(diag, bufnr))
+        if filter_diag_severity(opts, diag.severity) then
+          table.insert(items, preprocess_diag(diag, bufnr))
+        end
       end
     end
   end
+
+  -- sort results by bufnr (prioritize cur buf), severity, lnum
+  table.sort(items, function(a, b)
+    if a.bufnr == b.bufnr then
+      if a.type == b.type then
+        return a.lnum < b.lnum
+      else
+        return a.type < b.type
+      end
+    else
+      -- prioritize for current bufnr
+      if a.bufnr == current_buf then
+        return true
+      end
+      if b.bufnr == current_buf then
+        return false
+      end
+      return a.bufnr < b.bufnr
+    end
+    end
+  )
+
   return items
 end
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -95,8 +95,8 @@ end
 local filter_diag_severity = function(opts, severity)
   if opts.severity ~= nil then
     return opts.severity == severity
-  elseif opts.severity_threshold ~= nil then
-    return severity <= opts.severity_threshold
+  elseif opts.severity_limit ~= nil then
+    return severity <= opts.severity_limit
   elseif opts.severity_bound ~= nil then
     return severity >= opts.severity_bound
   else
@@ -111,11 +111,11 @@ utils.diagnostics_to_tbl = function(opts)
   local current_buf = vim.api.nvim_get_current_buf()
 
   opts.severity = convert_diagnostic_type(opts.severity)
-  opts.severity_threshold = convert_diagnostic_type(opts.severity_threshold)
+  opts.severity_limit = convert_diagnostic_type(opts.severity_limit)
   opts.severity_bound = convert_diagnostic_type(opts.severity_bound)
 
   local validate_severity = 0
-  for _, v in pairs({opts.severity, opts.severity_threshold, opts.severity_bound}) do
+  for _, v in pairs({opts.severity, opts.severity_limit, opts.severity_bound}) do
     if v ~= nil then
       validate_severity = validate_severity + 1
     end


### PR DESCRIPTION
Closes #846 

This PR adds various flags to enable explicit selection of diagnostics by severity. This preferred over passing `default_text` as the flag is buggy (see issue) and does not allow to group diagnostics.

For instance, you can now filter for "Error" with

`lua require 'telescope.builtin'.lsp_workspace_diagnostics{severity='error'}` or `lua require 'telescope.builtin'.lsp_workspace_diagnostics{severity=1}` 

and limit the search to `Error` and `Warning` with `lua require 'telescope.builtin'.lsp_workspace_diagnostics{severity_threshold='warning'}`

Further, the PR
* Improves sorting: by bufnr (incl. prioritize current buffer), severity, and line number -- bufnr corresponds to hierarchical file tree of project with highest level files having lowest bufnr (though the initially opened file will have the lowest bufnr, though hunch is this is still preferred over alphabetical file name sorting)
* Link severity definition to `vim.lsp.protocol.DiagnosticSeverity`, just a tiny bit cleaner and more future-proof I suppose
* Completed documentation for `no_sign` and `line_width`