### PR TITLE
Make comment match with config

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ require('telescope').setup{
       i = {
         -- To disable a keymap, put [map] = false
         -- So, to not map "<C-n>", just put
-        ["<c-x>"] = false,
+        ["<C-n>"] = false,
 
         -- Otherwise, just set the mapping to the function that you want it to be.
         ["<C-i>"] = actions.select_horizontal,


### PR DESCRIPTION
This is tiny commit; I was setting up the plugin and noticed this discrepancy between the comment in the config and the actual config. 