### PR TITLE
feat: set defaults for each picker in telescope setup

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19,6 +19,7 @@ globals = {
   "TelescopeCachedTails",
   "TelescopeCachedNgrams",
   "_TelescopeConfigurationValues",
+  "_TelescopeConfigurationPickers",
   "__TelescopeKeymapStore",
 }
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,43 @@ EOF
 | `file_ignore_patterns` | Pattern to be ignored `{ "scratch/.*", "%.env" }`      | dict                       |
 | `shorten_path`         | Whether to shorten paths or not.                      | boolean                    |
 
+### Customize Default Builtin behavior
+
+You can customize each default builtin behavior by adding the prefered options
+into the table that is passed into `require("telescope").setup()`.
+
+Example:
+
+```lua
+require("telescope").setup {
+  defaults = {
+    -- Your defaults config goes in here
+  },
+  pickers = {
+    -- Your special builtin config goes in here
+    buffers = {
+      sort_lastused = true,
+      theme = "dropdown",
+      previewer = false,
+      mappings = {
+        i = {
+          ["<c-d>"] = require("telescope.actions").delete_buffer,
+        },
+        n = {
+          ["<c-d>"] = require("telescope.actions").delete_buffer,
+        }
+      }
+    },
+    find_files = {
+      theme = "dropdown"
+    }
+  },
+  extensions = {
+    -- your extension config goes in here
+  }
+}
+```
+
 ## Mappings
 
 Mappings are fully customizable.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ require("telescope").setup {
       mappings = {
         i = {
           ["<c-d>"] = require("telescope.actions").delete_buffer,
+          -- or right hand side can also be a the name of the action as string
+          ["<c-d>"] = "delete_buffer",
         },
         n = {
           ["<c-d>"] = require("telescope.actions").delete_buffer,

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -387,9 +387,37 @@ your desired picker by passing a lua table to the picker with all of the
 options you want to use. Here's an example with the live_grep picker:
 
 :lua require('telescope.builtin').live_grep({
-   prompt_title = 'find string in open buffers...',
-   grep_open_files = true
- })
+  prompt_title = 'find string in open buffers...',
+  grep_open_files = true
+})
+-- or with dropdown theme
+:lua require('telescope.builtin').find_files(require('telescope.themes').get_dropdown{
+  previewer = false
+})
+
+You can also pass default configurations to builtin pickers. These options will
+also be added if the picker is executed with `Telescope find_files`.
+
+require("telescope").setup {
+  pickers = {
+    buffers = {
+      show_all_buffers = true,
+      sort_lastused = true,
+      theme = "dropdown",
+      previewer = false,
+      mappings = {
+        i = {
+          ["<c-d>"] = require("telescope.actions").delete_buffer,
+          -- or right hand side can also be a the name of the action as string
+          ["<c-d>"] = "delete_buffer",
+        },
+        n = {
+          ["<c-d>"] = require("telescope.actions").delete_buffer,
+        }
+      }
+    }
+  }
+}
 
 This will use the default configuration options. Other configuration options
 are still in flux at the moment

--- a/lua/telescope/actions/mt.lua
+++ b/lua/telescope/actions/mt.lua
@@ -60,7 +60,6 @@ action_mt.create = function(mod)
     _post = {},
   }
 
-  mt.type = "action"
   mt.__index = mt
 
   mt.clear = function()

--- a/lua/telescope/actions/mt.lua
+++ b/lua/telescope/actions/mt.lua
@@ -60,6 +60,7 @@ action_mt.create = function(mod)
     _post = {},
   }
 
+  mt.type = "action"
   mt.__index = mt
 
   mt.clear = function()

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -37,6 +37,8 @@
 ---       mappings = {
 ---         i = {
 ---           ["<c-d>"] = require("telescope.actions").delete_buffer,
+---           -- or right hand side can also be a the name of the action as string
+---           ["<c-d>"] = "delete_buffer",
 ---         },
 ---         n = {
 ---           ["<c-d>"] = require("telescope.actions").delete_buffer,

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -14,9 +14,37 @@
 ---
 --- <pre>
 --- :lua require('telescope.builtin').live_grep({
----    prompt_title = 'find string in open buffers...',
----    grep_open_files = true
----  })
+---   prompt_title = 'find string in open buffers...',
+---   grep_open_files = true
+--- })
+--- -- or with dropdown theme
+--- :lua require('telescope.builtin').find_files(require('telescope.themes').get_dropdown{
+---   previewer = false
+--- })
+--- </pre>
+---
+--- You can also pass default configurations to builtin pickers. These options will also be added if
+--- the picker is executed with `Telescope find_files`.
+---
+--- <pre>
+--- require("telescope").setup {
+---   pickers = {
+---     buffers = {
+---       show_all_buffers = true,
+---       sort_lastused = true,
+---       theme = "dropdown",
+---       previewer = false,
+---       mappings = {
+---         i = {
+---           ["<c-d>"] = require("telescope.actions").delete_buffer,
+---         },
+---         n = {
+---           ["<c-d>"] = require("telescope.actions").delete_buffer,
+---         }
+---       }
+---     }
+---   }
+--- }
 --- </pre>
 ---
 --- This will use the default configuration options. Other configuration options are still in flux at the moment
@@ -325,4 +353,46 @@ builtin.lsp_document_diagnostics = require('telescope.builtin.lsp').diagnostics
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
 builtin.lsp_workspace_diagnostics = require('telescope.builtin.lsp').workspace_diagnostics
 
+local apply_config = function(mod)
+  local pickers_conf = require('telescope.config').pickers
+  for k, v in pairs(mod) do
+    local pconf = vim.deepcopy(pickers_conf[k] or {})
+    if pconf.theme then
+      local theme = pconf.theme
+      pconf.theme = nil
+      pconf = require("telescope.themes")["get_" .. theme](pconf)
+    end
+    if pconf.mappings then
+      local mappings = pconf.mappings
+      pconf.mappings = nil
+      pconf.attach_mappings = function(_, map)
+        for mode, tbl in pairs(mappings) do
+          for key, action in pairs(tbl) do
+            map(mode, key, action)
+          end
+        end
+        return true
+      end
+    end
+    mod[k] = function(opts)
+      opts = opts or {}
+      if pconf.attach_mappings and opts.attach_mappings then
+        local attach_mappings = pconf.attach_mappings
+        pconf.attach_mappings = nil
+        local opts_attach = opts.attach_mappings
+        opts.attach_mappings = function(prompt_bufnr, map)
+          attach_mappings(prompt_bufnr, map)
+          return opts_attach(prompt_bufnr, map)
+        end
+      end
+
+      v(vim.tbl_extend("force", pconf, opts))
+    end
+  end
+
+  return mod
+end
+
+-- We can't do this in one statement because tree-sitter-lua docgen gets confused if we do
+builtin = apply_config(builtin)
 return builtin

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -1,5 +1,6 @@
 -- Keep the values around between reloads
 _TelescopeConfigurationValues = _TelescopeConfigurationValues or {}
+_TelescopeConfigurationPickers = _TelescopeConfigurationPickers or {}
 
 local function first_non_null(...)
   local n = select('#', ...)
@@ -45,6 +46,15 @@ local config = {}
 
 config.values = _TelescopeConfigurationValues
 config.descriptions = {}
+config.pickers = _TelescopeConfigurationPickers
+
+function config.set_pickers(pickers)
+  pickers = pickers or {}
+
+  for k, v in pairs(pickers) do
+    config.pickers[k] = v
+  end
+end
 
 function config.set_defaults(defaults)
   defaults = defaults or {}

--- a/lua/telescope/init.lua
+++ b/lua/telescope/init.lua
@@ -37,6 +37,7 @@ function telescope.setup(opts)
   end
 
   require('telescope.config').set_defaults(opts.defaults)
+  require('telescope.config').set_pickers(opts.pickers)
   _extensions.set_config(opts.extensions)
 end
 

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -126,6 +126,8 @@ local telescope_map = function(prompt_bufnr, mode, key_bind, key_func, opts)
       return
     elseif key_func.type == "action_key" then
       key_func = actions[key_func[1]]
+    elseif key_func.type == "action" then
+      key_func = key_func[1]
     end
   end
 

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -111,51 +111,58 @@ local telescope_map = function(prompt_bufnr, mode, key_bind, key_func, opts)
   if opts.silent == nil then opts.silent = true end
 
   if type(key_func) == "string" then
-    a.nvim_buf_set_keymap(
+    key_func = actions[key_func]
+  elseif type(key_func) == "table" then
+    if key_func.type == "command" then
+      a.nvim_buf_set_keymap(
+        prompt_bufnr,
+        mode,
+        key_bind,
+        key_func[1],
+        opts or {
+          silent = true
+        }
+      )
+      return
+    elseif key_func.type == "action_key" then
+      key_func = actions[key_func[1]]
+    end
+  end
+
+  local key_id = assign_function(prompt_bufnr, key_func)
+  local prefix
+
+  local map_string
+  if opts.expr then
+    map_string = string.format(
+      [[luaeval("require('telescope.mappings').execute_keymap(%s, %s)")]],
       prompt_bufnr,
-      mode,
-      key_bind,
-      key_func,
-      opts or {
-        silent = true
-      }
+      key_id
     )
   else
-    local key_id = assign_function(prompt_bufnr, key_func)
-    local prefix
-
-    local map_string
-    if opts.expr then
-      map_string = string.format(
-        [[luaeval("require('telescope.mappings').execute_keymap(%s, %s)")]],
-        prompt_bufnr,
-        key_id
-      )
+    if mode == "i" and not opts.expr then
+      prefix = "<cmd>"
+    elseif mode == "n" then
+      prefix = ":<C-U>"
     else
-      if mode == "i" and not opts.expr then
-        prefix = "<cmd>"
-      elseif mode == "n" then
-        prefix = ":<C-U>"
-      else
-        prefix = ":"
-      end
-
-      map_string = string.format(
-        "%slua require('telescope.mappings').execute_keymap(%s, %s)<CR>",
-        prefix,
-        prompt_bufnr,
-        key_id
-      )
+      prefix = ":"
     end
 
-    a.nvim_buf_set_keymap(
+    map_string = string.format(
+      "%slua require('telescope.mappings').execute_keymap(%s, %s)<CR>",
+      prefix,
       prompt_bufnr,
-      mode,
-      key_bind,
-      map_string,
-      opts
+      key_id
     )
   end
+
+  a.nvim_buf_set_keymap(
+    prompt_bufnr,
+    mode,
+    key_bind,
+    map_string,
+    opts
+  )
 end
 
 mappings.apply_keymap = function(prompt_bufnr, attach_mappings, buffer_keymap)


### PR DESCRIPTION
Close https://github.com/nvim-telescope/telescope.nvim/issues/582

Its so long that i wrote telescope code. LUL 

I don't like the idea of custom pickers, the one that @tami5 proposed. I think for that people should just continue to go with own wrapper functions. But this helps clean up other things. Like this e.g.

```lua
local actions = require('telescope.actions')

require("telescope").setup {
  pickers = {
    buffers = {
      show_all_buffers = true,
      sort_lastused = true,
      theme = "dropdown",
      previewer = false,
      mappings = {
        i = {
          ["<c-d>"] = actions.delete_buffer,
        },
        n = {
          ["<c-d>"] = actions.delete_buffer,
        }
      }
    }
  }
}
```

I am not sure if this is the best way to implement this feature