### PR TITLE
feat: `selection_strategy` closest

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ EOF
 | `file_sorter`          | The sorter for file lists.                            | [Sorters](#sorters)        |
 | `generic_sorter`       | The sorter for everything else.                       | [Sorters](#sorters)        |
 | `vimgrep_arguments`    | The command line argument for grep search ... TODO.   | dict                       |
-| `selection_strategy`   | What happens to the selection if the list changes.    | follow/reset/row           |
+| `selection_strategy`   | What happens to the selection if the list changes.    | follow/reset/row/closest   |
 | `file_ignore_patterns` | Pattern to be ignored `{ "scratch/.*", "%.env" }`      | dict                       |
 | `shorten_path`         | Whether to shorten paths or not.                      | boolean                    |
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -164,6 +164,7 @@ telescope.setup({opts})                                    *telescope.setup()*
         - "reset" (default)
         - "follow"
         - "row"
+        - "closest"
 
                                       *telescope.defaults.sorting_strategy*
     sorting_strategy: ~

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -124,7 +124,8 @@ local telescope_defaults = {
     Available options are:
     - "reset" (default)
     - "follow"
-    - "row"]],
+    - "row"
+    - "closest"]],
   },
 
   scroll_strategy = {

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1069,6 +1069,12 @@ function Picker:get_result_completor(results_bufnr, find_id, prompt, status_upda
       else
         self:set_selection(self:get_reset_row())
       end
+    elseif selection_strategy == 'closest' then
+      if prompt == "" and self.default_selection_index ~= nil then
+        self:set_selection(self:get_row(self.default_selection_index))
+      else
+        self:set_selection(self:get_reset_row())
+      end
     else
       error('Unknown selection strategy: ' .. selection_strategy)
     end


### PR DESCRIPTION
I use the builtin buffers command a lot to switch between buffers. I like it to preselect the previous buffer but when I start typing it'd be nice to have it select the closest match over `default_selection_index`

```lua
require('telescope.builtin').buffers {
    sort_lastused = true,
    show_all_buffers = true,
    selection_strategy = "closest"
}
```

This is perhaps what I'd expect `"reset"` to do but I don't want to mess up anyone's experience.