### PR TITLE
feat: Add length option for `shorten_path`

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -222,6 +222,21 @@ telescope.setup({opts})                                    *telescope.setup()*
         - "row"
         - "closest"
 
+                                           *telescope.defaults.shorten_len*
+    shorten_len: ~
+        Determines the length of the shortened portions of a filepath.
+
+        e.g. for a path like
+          `alpha/beta/gamma/delta.txt`
+        setting `shorten_len = 1` will give a path like:
+          `a/b/g/delta.txt`
+        when "shorten" is present in `path_display`.
+        Similarly, `shorten_len = 2` will give a path like:
+          `al/be/ga/delta.txt`
+        when "shorten" is present in `path_display`.
+
+        Default: 1
+
                                       *telescope.defaults.sorting_strategy*
     sorting_strategy: ~
         Determines the direction "better" results are sorted towards.

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -179,6 +179,15 @@ telescope.setup({opts})                                    *telescope.setup()*
         - "shorten"   only display the first character of each directory in
                       the path
 
+        You can also specify the number of characters of each directory name
+        to keep by setting `path_display.shorten = num`.
+          e.g. for a path like
+            `alpha/beta/gamma/delta.txt`
+          setting `path_display.shorten = 1` will give a path like:
+            `a/b/g/delta.txt`
+          Similarly, `path_display.shorten = 2` will give a path like:
+            `al/be/ga/delta.txt`
+
         path_display can also be set to 'hidden' string to hide file names
 
         path_display can also be set to a function for custom formatting of
@@ -221,21 +230,6 @@ telescope.setup({opts})                                    *telescope.setup()*
         - "follow"
         - "row"
         - "closest"
-
-                                           *telescope.defaults.shorten_len*
-    shorten_len: ~
-        Determines the length of the shortened portions of a filepath.
-
-        e.g. for a path like
-          `alpha/beta/gamma/delta.txt`
-        setting `shorten_len = 1` will give a path like:
-          `a/b/g/delta.txt`
-        when "shorten" is present in `path_display`.
-        Similarly, `shorten_len = 2` will give a path like:
-          `al/be/ga/delta.txt`
-        when "shorten" is present in `path_display`.
-
-        Default: 1
 
                                       *telescope.defaults.sorting_strategy*
     sorting_strategy: ~

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -202,6 +202,21 @@ local telescope_defaults = {
     Default: {}]]
   },
 
+  shorten_len = { 1, [[
+    Determines the length of the shortened portions of a filepath.
+
+    e.g. for a path like
+      `alpha/beta/gamma/delta.txt`
+    setting `shorten_len = 1` will give a path like:
+      `a/b/g/delta.txt`
+    when "shorten" is present in `path_display`.
+    Similarly, `shorten_len = 2` will give a path like:
+      `al/be/ga/delta.txt`
+    when "shorten" is present in `path_display`.
+
+    Default: 1]]
+  },
+
   borderchars = { { "─", "│", "─", "│", "╭", "╮", "╯", "╰" } },
 
   get_status_text = {

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -188,6 +188,15 @@ local telescope_defaults = {
     - "shorten"   only display the first character of each directory in
                   the path
 
+    You can also specify the number of characters of each directory name
+    to keep by setting `path_display.shorten = num`.
+      e.g. for a path like
+        `alpha/beta/gamma/delta.txt`
+      setting `path_display.shorten = 1` will give a path like:
+        `a/b/g/delta.txt`
+      Similarly, `path_display.shorten = 2` will give a path like:
+        `al/be/ga/delta.txt`
+
     path_display can also be set to 'hidden' string to hide file names
 
     path_display can also be set to a function for custom formatting of
@@ -202,20 +211,6 @@ local telescope_defaults = {
     Default: {}]]
   },
 
-  shorten_len = { 1, [[
-    Determines the length of the shortened portions of a filepath.
-
-    e.g. for a path like
-      `alpha/beta/gamma/delta.txt`
-    setting `shorten_len = 1` will give a path like:
-      `a/b/g/delta.txt`
-    when "shorten" is present in `path_display`.
-    Similarly, `shorten_len = 2` will give a path like:
-      `al/be/ga/delta.txt`
-    when "shorten" is present in `path_display`.
-
-    Default: 1]]
-  },
 
   borderchars = { { "─", "│", "─", "│", "╭", "╮", "╯", "╰" } },
 

--- a/lua/telescope/path.lua
+++ b/lua/telescope/path.lua
@@ -21,29 +21,12 @@ path.make_relative = function(filepath, cwd)
   return filepath
 end
 
-path.shorten = (function()
-  if jit then
-    local ffi = require('ffi')
-    ffi.cdef [[
-    typedef unsigned char char_u;
-    char_u *shorten_dir(char_u *str);
-    ]]
-
-    return function(filepath)
-      if not filepath then
-        return filepath
-      end
-
-      local c_str = ffi.new("char[?]", #filepath + 1)
-      ffi.copy(c_str, filepath)
-      return ffi.string(ffi.C.shorten_dir(c_str))
-    end
-  else
-    return function(filepath)
-      return filepath
-    end
-  end
-end)()
+-- In most cases it is better to use `utils.path_shorten`
+-- as it handles cases for `len` being things other than
+-- a positive integer.
+path.shorten = function(filepath,len)
+  return require'plenary.path'.new(filepath):shorten(len)
+end
 
 path.normalize = function(filepath, cwd)
   filepath = path.make_relative(filepath, cwd)

--- a/lua/telescope/path.lua
+++ b/lua/telescope/path.lua
@@ -21,12 +21,29 @@ path.make_relative = function(filepath, cwd)
   return filepath
 end
 
--- In most cases it is better to use `utils.path_shorten`
--- as it handles cases for `len` being things other than
--- a positive integer.
-path.shorten = function(filepath,len)
-  return require'plenary.path'.new(filepath):shorten(len)
-end
+path.shorten = (function()
+  if jit then
+    local ffi = require('ffi')
+    ffi.cdef [[
+    typedef unsigned char char_u;
+    char_u *shorten_dir(char_u *str);
+    ]]
+
+    return function(filepath)
+      if not filepath then
+        return filepath
+      end
+
+      local c_str = ffi.new("char[?]", #filepath + 1)
+      ffi.copy(c_str, filepath)
+      return ffi.string(ffi.C.shorten_dir(c_str))
+    end
+  else
+    return function(filepath)
+      return filepath
+    end
+  end
+end)()
 
 path.normalize = function(filepath, cwd)
   filepath = path.make_relative(filepath, cwd)

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -3,6 +3,8 @@ local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
 local Path = require('plenary.path')
 local Job  = require('plenary.job')
 
+local log = require('telescope.log')
+
 local utils = {}
 
 utils.get_separator = function()
@@ -252,13 +254,8 @@ utils.diagnostics_to_tbl = function(opts)
 end
 
 utils.path_shorten = function(filename,len)
-  if len == nil or len == true then
-    return Path:new(filename):shorten(1)
-  elseif tonumber(len) > 0 then
-    return Path:new(filename):shorten(tonumber(len))
-  else
-    error('Invalid value for `len`. Acceptable values are `nil`, `true` and positive integers.')
-  end
+  log.warn("`utils.path_shorten` is deprecated. Use `require('plenary.path').shorten`.")
+  return Path:new(filename):shorten(len)
 end
 
 utils.path_tail = (function()
@@ -279,7 +276,6 @@ end
 
 utils.transform_path = function(opts, path)
   local path_display = utils.get_default(opts.path_display, require('telescope.config').values.path_display)
-  local shorten_len = utils.get_default(opts.shorten_len, require('telescope.config').values.shorten_len)
 
   local transformed_path = path
 
@@ -307,8 +303,8 @@ utils.transform_path = function(opts, path)
       transformed_path = Path:new(transformed_path):make_relative(cwd)
     end
 
-    if vim.tbl_contains(path_display, "shorten") then
-      transformed_path = utils.path_shorten(transformed_path, shorten_len)
+    if vim.tbl_contains(path_display, "shorten") or path_display["shorten"] ~= nil then
+      transformed_path = Path:new(transformed_path):shorten(path_display["shorten"])
     end
   end
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -271,7 +271,7 @@ utils.is_path_hidden = function(opts, path_display)
   path_display = path_display or utils.get_default(opts.path_display, require('telescope.config').values.path_display)
 
   return path_display == nil or path_display == "hidden" or
-    type(path_display) ~= "table" or vim.tbl_contains(path_display, "hidden")
+    type(path_display) ~= "table" or vim.tbl_contains(path_display, "hidden") or path_display.hidden
 end
 
 utils.transform_path = function(opts, path)
@@ -287,10 +287,10 @@ utils.transform_path = function(opts, path)
     return ''
   end
 
-  if vim.tbl_contains(path_display, "tail") then
+  if vim.tbl_contains(path_display, "tail") or path_display.tail then
     transformed_path = utils.path_tail(transformed_path)
   else
-    if not vim.tbl_contains(path_display, "absolute") then
+    if not vim.tbl_contains(path_display, "absolute") or path_display.absolute == false then
       local cwd
       if opts.cwd then
         cwd = opts.cwd

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -251,8 +251,14 @@ utils.diagnostics_to_tbl = function(opts)
   return items
 end
 
-utils.path_shorten = function(file)
-  return Path:new(file):shorten()
+utils.path_shorten = function(filename,len)
+  if len == nil or len == true then
+    return Path:new(filename):shorten(1)
+  elseif tonumber(len) > 0 then
+    return Path:new(filename):shorten(tonumber(len))
+  else
+    error('Invalid value for `len`. Acceptable values are `nil`, `true` and positive integers.')
+  end
 end
 
 utils.path_tail = (function()
@@ -273,6 +279,7 @@ end
 
 utils.transform_path = function(opts, path)
   local path_display = utils.get_default(opts.path_display, require('telescope.config').values.path_display)
+  local shorten_len = utils.get_default(opts.shorten_len, require('telescope.config').values.shorten_len)
 
   local transformed_path = path
 
@@ -301,7 +308,7 @@ utils.transform_path = function(opts, path)
     end
 
     if vim.tbl_contains(path_display, "shorten") then
-      transformed_path = Path:new(transformed_path):shorten()
+      transformed_path = utils.path_shorten(transformed_path, shorten_len)
     end
   end
 
@@ -439,7 +446,7 @@ utils.transform_devicons = (function()
       end
 
       local icon, icon_highlight = devicons.get_icon(filename, string.match(filename, '%a+$'), { default = true })
-      local icon_display = (icon or ' ') .. ' ' .. display
+      local icon_display = (icon or ' ') .. ' ' .. (display or '')
 
       if conf.color_devicons then
         return icon_display, icon_highlight


### PR DESCRIPTION
WIP

Adding option to provide a length for `shorten_path`, not just a boolean, as suggested in #880.
Implemented using `Path:shorten` from plenary as the function in telescope had gotten out of date in comparison.

Todo:
- [x]  Update documentation

---

Feedback welcome 🙂