### PR TITLE
docs: update builtin.file_browser options

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -465,7 +465,8 @@ builtin.file_browser({opts})                          *builtin.file_browser()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {search_dirs} (table)  directory/directories to search in
+        {cwd}   (string)  directory path to browse (default is cwd)
+        {depth} (number)  file tree depth to display (default is 1)
 
 
 builtin.treesitter()                                    *builtin.treesitter()*

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -69,7 +69,8 @@ builtin.fd = builtin.find_files
 ---       create the file `init.lua` inside of `lua/telescope` and will create the necessary folders (similar to how
 ---       `mkdir -p` would work) if they do not already exist
 ---@param opts table: options to pass to the picker
----@field search_dirs table: directory/directories to search in
+---@field cwd string: directory path to browse (default is cwd)
+---@field depth number: file tree depth to display (default is 1)
 builtin.file_browser = require('telescope.builtin.files').file_browser
 
 --- Lists function names, variables, and other symbols from treesitter queries


### PR DESCRIPTION
Removes the unsued `search_dirs` option, and adds `cwd` and `depth`.