### PR TITLE
feat: add utility for fetching buffer directory

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -231,13 +231,7 @@ files.file_browser = function(opts)
   opts = opts or {}
 
   opts.depth = opts.depth or 1
-  opts.relative = opts.relative or false
   opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
-
-  if opts.relative then
-    opts.cwd = utils.get_current_buffer_dir()
-  end
-
   opts.new_finder = opts.new_finder or function(path)
     opts.cwd = path
     local data = {}

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -231,7 +231,10 @@ files.file_browser = function(opts)
   opts = opts or {}
 
   opts.depth = opts.depth or 1
-  opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
+	opts.relative = opts.relative or false
+	opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
+	opts.cwd = utils.get_current_buffer_dir() and opts.relative or opts.cwd
+
   opts.new_finder = opts.new_finder or function(path)
     opts.cwd = path
     local data = {}

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -233,7 +233,10 @@ files.file_browser = function(opts)
   opts.depth = opts.depth or 1
 	opts.relative = opts.relative or false
 	opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
-	opts.cwd = utils.get_current_buffer_dir() and opts.relative or opts.cwd
+
+	if opts.relative then
+		opts.cwd = utils.get_current_buffer_dir()
+	end
 
   opts.new_finder = opts.new_finder or function(path)
     opts.cwd = path

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -231,12 +231,12 @@ files.file_browser = function(opts)
   opts = opts or {}
 
   opts.depth = opts.depth or 1
-	opts.relative = opts.relative or false
-	opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
+  opts.relative = opts.relative or false
+  opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
 
-	if opts.relative then
-		opts.cwd = utils.get_current_buffer_dir()
-	end
+  if opts.relative then
+    opts.cwd = utils.get_current_buffer_dir()
+  end
 
   opts.new_finder = opts.new_finder or function(path)
     opts.cwd = path

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -71,7 +71,7 @@ builtin.fd = builtin.find_files
 ---@param opts table: options to pass to the picker
 ---@field cwd string: directory path to browse (default is cwd)
 ---@field depth number: file tree depth to display (default is 1)
----@field relative boolean: file tree at open buffer location (default is false)
+---@field relative boolean: browse directory of currently opened buffer (default is false)
 builtin.file_browser = require('telescope.builtin.files').file_browser
 
 --- Lists function names, variables, and other symbols from treesitter queries

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -71,6 +71,7 @@ builtin.fd = builtin.find_files
 ---@param opts table: options to pass to the picker
 ---@field cwd string: directory path to browse (default is cwd)
 ---@field depth number: file tree depth to display (default is 1)
+---@field relative boolean: file tree at open buffer location (default is false)
 builtin.file_browser = require('telescope.builtin.files').file_browser
 
 --- Lists function names, variables, and other symbols from treesitter queries

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -36,21 +36,24 @@ local builtin = {}
 --
 --
 
---- Search for a string in your current working directory and get results live as you type (respecting .gitignore)
+--- Search for a string and get results live as you type (respecting .gitignore)
 ---@param opts table: options to pass to the picker
+---@field cwd string: directory path to search from (default is cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
 ---@field search_dirs table: directory/directories to search in, mutually exclusive with `grep_open_files`
 builtin.live_grep = require('telescope.builtin.files').live_grep
 
 --- Searches for the string under your cursor in your current working directory
 ---@param opts table: options to pass to the picker
+---@field cwd string: directory path to search from (default is cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field search string: the query to search
 ---@field search_dirs table: directory/directories to search in
 ---@field use_regex boolean: if true, special characters won't be escaped, allows for using regex (default is false)
 builtin.grep_string = require('telescope.builtin.files').grep_string
 
---- Lists files in your current working directory, respects .gitignore
+--- Search for files (respecting .gitignore)
 ---@param opts table: options to pass to the picker
+---@field cwd string: directory path to search from (default is cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field find_command table: command line arguments for `find_files` to use for the search, overrides default config
 ---@field follow boolean: if true, follows symlinks (i.e. uses `-L` flag for the `find` command)
 ---@field hidden boolean: determines whether to show hidden files or not (default is false)
@@ -69,9 +72,8 @@ builtin.fd = builtin.find_files
 ---       create the file `init.lua` inside of `lua/telescope` and will create the necessary folders (similar to how
 ---       `mkdir -p` would work) if they do not already exist
 ---@param opts table: options to pass to the picker
----@field cwd string: directory path to browse (default is cwd)
+---@field cwd string: directory path to browse (default is cwd, use utils.buffer_dir() to browse relative to open buffer)
 ---@field depth number: file tree depth to display (default is 1)
----@field relative boolean: browse directory of currently opened buffer (default is false)
 builtin.file_browser = require('telescope.builtin.files').file_browser
 
 --- Lists function names, variables, and other symbols from treesitter queries

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -233,7 +233,7 @@ function utils.data_directory()
 end
 
 function utils.get_current_buffer_dir()
-	return vim.fn.expand('%:p:h')
+  return vim.fn.expand('%:p:h')
 end
 
 function utils.display_termcodes(str)

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -232,6 +232,10 @@ function utils.data_directory()
   return base_directory .. pathlib.separator .. 'data' .. pathlib.separator
 end
 
+function utils.get_current_buffer_dir()
+	return vim.fn.expand('%:p:h')
+end
+
 function utils.display_termcodes(str)
   return str:gsub(string.char(9), "<TAB>"):gsub("", "<C-F>"):gsub(" ", "<Space>")
 end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -232,7 +232,7 @@ function utils.data_directory()
   return base_directory .. pathlib.separator .. 'data' .. pathlib.separator
 end
 
-function utils.get_current_buffer_dir()
+function utils.buffer_dir()
   return vim.fn.expand('%:p:h')
 end
 


### PR DESCRIPTION
# Motivation

The [tpope/vim-vinegar plugin](https://github.com/tpope/vim-vinegar) offers great file/directory navigation and creation features. This is particularly helpful when you want to make edits to files in close proximity to your open buffer. 

It accomplishes this using the builtin `netrw` vim script. Telescope's `builtin.file_browser` does basically all I want in regards to file manipulation and navigation. The only thing that is missing is that it does not have the option of opening up in a *relative* location to your open buffer.

# Initial Solution

Add a `relative (boolean)` option to `builtin.file_browser` function. So when `true`, the file browser will open at current buffer's directory (overriding `cwd` option):

```lua
require('telescope.builtin').file_browser({ relative = true })
```

# Updated Solution

Add `buffer_dir()` utility function that fetches the directory of your current buffer, which can then be passed  to the `cwd` field in a picker. That way you can get this functionality anywhere `cwd` is supported.

```lua
require('telescope.builtin').file_browser({ cwd = require'telescope.utils'.buffer_dir() })
require('telescope.builtin').find_files({ cwd = require'telescope.utils'.buffer_dir() })
require('telescope.builtin').grep_string({ cwd = require'telescope.utils'.buffer_dir() }
-- etc
```