### PR TITLE
feat: add filtering by symbol(s) to lsp_{document,workspace}_symbols

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -916,7 +916,8 @@ builtin.lsp_document_symbols({opts})          *builtin.lsp_document_symbols()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {ignore_filename} (type)  string with file to ignore
+        {ignore_filename} (type)          string with file to ignore
+        {symbols}         (string|table)  filter results by symbol kind(s)
 
 
 builtin.lsp_workspace_symbols({opts})        *builtin.lsp_workspace_symbols()*
@@ -930,12 +931,14 @@ builtin.lsp_workspace_symbols({opts})        *builtin.lsp_workspace_symbols()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {shorten_path}    (boolean)  if true, makes file paths shown in picker
-                                     use one letter for folders (default is
-                                     false)
-        {ignore_filename} (string)   file(s) to ignore
-        {hide_filename}   (boolean)  if true, hides the name of the file in the
-                                     current picker (default is false)
+        {shorten_path}    (boolean)       if true, makes file paths shown in
+                                          picker use one letter for folders
+                                          (default is false)
+        {ignore_filename} (string)        file(s) to ignore
+        {hide_filename}   (boolean)       if true, hides the name of the file
+                                          in the current picker (default is
+                                          false)
+        {symbols}         (string|table)  filter results by symbol kind(s)
 
 
 builtin.lsp_dynamic_workspace_symbols({opts})*builtin.lsp_dynamic_workspace_symbols()*
@@ -972,12 +975,12 @@ builtin.lsp_document_diagnostics({opts})  *builtin.lsp_document_diagnostics()*
                                           false)
         {severity}       (string|number)  filter diagnostics by severity name
                                           (string) or id (number)
-        {severity_limit} (string|number)  filter for diagnostics equal or more
-                                          severe wrt severity name (string) or
-                                          id (number)
-        {severity_bound} (string|number)  filter for diagnostics equal or less
-                                          severe wrt severity name (string) or
-                                          id (number)
+        {severity_limit} (string|number)  keep diagnostics equal or more severe
+                                          wrt severity name (string) or id
+                                          (number)
+        {severity_bound} (string|number)  keep diagnostics equal or less severe
+                                          wrt severity name (string) or id
+                                          (number)
         {no_sign}        (bool)           hide LspDiagnosticSigns from Results
                                           (default is false)
         {line_width}     (number)         set length of diagnostic entry text
@@ -1004,12 +1007,12 @@ builtin.lsp_workspace_diagnostics({opts})*builtin.lsp_workspace_diagnostics()*
                                           false)
         {severity}       (string|number)  filter diagnostics by severity name
                                           (string) or id (number)
-        {severity_limit} (string|number)  filter for diagnostics equal or more
-                                          severe wrt severity name (string) or
-                                          id (number)
-        {severity_bound} (string|number)  filter for diagnostics equal or less
-                                          severe wrt severity name (string) or
-                                          id (number)
+        {severity_limit} (string|number)  keep diagnostics equal or more severe
+                                          wrt severity name (string) or id
+                                          (number)
+        {severity_bound} (string|number)  keep diagnostics equal or less severe
+                                          wrt severity name (string) or id
+                                          (number)
         {no_sign}        (bool)           hide LspDiagnosticSigns from Results
                                           (default is false)
         {line_width}     (number)         set length of diagnostic entry text

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -323,6 +323,7 @@ builtin.lsp_range_code_actions = require('telescope.builtin.lsp').range_code_act
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
 ---@param opts table: options to pass to the picker
 ---@field ignore_filename type: string with file to ignore
+---@field symbols string|table: filter results by symbol kind(s)
 builtin.lsp_document_symbols = require('telescope.builtin.lsp').document_symbols
 
 --- Lists LSP document symbols in the current workspace
@@ -332,6 +333,7 @@ builtin.lsp_document_symbols = require('telescope.builtin.lsp').document_symbols
 ---@field shorten_path boolean: if true, makes file paths shown in picker use one letter for folders (default is false)
 ---@field ignore_filename string: file(s) to ignore
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
+---@field symbols string|table: filter results by symbol kind(s)
 builtin.lsp_workspace_symbols = require('telescope.builtin.lsp').workspace_symbols
 
 --- Dynamically lists LSP for all workspace symbols
@@ -349,8 +351,8 @@ builtin.lsp_dynamic_workspace_symbols = require('telescope.builtin.lsp').dynamic
 ---@param opts table: options to pass to the picker
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
 ---@field severity string|number: filter diagnostics by severity name (string) or id (number)
----@field severity_limit string|number: filter for diagnostics equal or more severe wrt severity name (string) or id (number)
----@field severity_bound string|number: filter for diagnostics equal or less severe wrt severity name (string) or id (number)
+---@field severity_limit string|number: keep diagnostics equal or more severe wrt severity name (string) or id (number)
+---@field severity_bound string|number: keep diagnostics equal or less severe wrt severity name (string) or id (number)
 ---@field no_sign bool: hide LspDiagnosticSigns from Results (default is false)
 ---@field line_width number: set length of diagnostic entry text in Results
 builtin.lsp_document_diagnostics = require('telescope.builtin.lsp').diagnostics
@@ -363,8 +365,8 @@ builtin.lsp_document_diagnostics = require('telescope.builtin.lsp').diagnostics
 ---@param opts table: options to pass to the picker
 ---@field hide_filename boolean: if true, hides the name of the file in the current picker (default is false)
 ---@field severity string|number: filter diagnostics by severity name (string) or id (number)
----@field severity_limit string|number: filter for diagnostics equal or more severe wrt severity name (string) or id (number)
----@field severity_bound string|number: filter for diagnostics equal or less severe wrt severity name (string) or id (number)
+---@field severity_limit string|number: keep diagnostics equal or more severe wrt severity name (string) or id (number)
+---@field severity_bound string|number: keep diagnostics equal or less severe wrt severity name (string) or id (number)
 ---@field no_sign bool: hide LspDiagnosticSigns from Results (default is false)
 ---@field line_width number: set length of diagnostic entry text in Results
 builtin.lsp_workspace_diagnostics = require('telescope.builtin.lsp').workspace_diagnostics

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -107,7 +107,11 @@ lsp.document_symbols = function(opts)
     vim.list_extend(locations, vim.lsp.util.symbols_to_items(server_results.result, 0) or {})
   end
 
-  locations = utils.filter_symbols(opts, locations)
+  locations = utils.filter_symbols(locations, opts)
+  if locations == nil then
+    -- error message already printed in `utils.filter_symbols`
+    return
+  end
 
   if vim.tbl_isempty(locations) then
     return
@@ -265,7 +269,11 @@ lsp.workspace_symbols = function(opts)
     end
   end
 
-  locations = utils.filter_symbols(opts, locations)
+  locations = utils.filter_symbols(locations, opts)
+  if locations == nil then
+    -- error message already printed in `utils.filter_symbols`
+    return
+  end
 
   if vim.tbl_isempty(locations) then
     print("No results from workspace/symbol. Maybe try a different query: " ..

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -107,6 +107,8 @@ lsp.document_symbols = function(opts)
     vim.list_extend(locations, vim.lsp.util.symbols_to_items(server_results.result, 0) or {})
   end
 
+  locations = utils.filter_symbols(opts, locations)
+
   if vim.tbl_isempty(locations) then
     return
   end
@@ -262,6 +264,8 @@ lsp.workspace_symbols = function(opts)
       end
     end
   end
+
+  locations = utils.filter_symbols(opts, locations)
 
   if vim.tbl_isempty(locations) then
     print("No results from workspace/symbol. Maybe try a different query: " ..

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -92,7 +92,7 @@ utils.filter_symbols = function(results, opts)
   if type(opts.symbols) == "string" then
     opts.symbols = string.lower(opts.symbols)
     if vim.tbl_contains(valid_symbols, opts.symbols) then
-      for _, result in pairs(results) do
+      for _, result in ipairs(results) do
         if string.lower(result.kind) == opts.symbols then
           table.insert(filtered_symbols, result)
         end
@@ -103,9 +103,9 @@ utils.filter_symbols = function(results, opts)
   elseif type(opts.symbols) == "table" then
     opts.symbols = vim.tbl_map(string.lower, opts.symbols)
     local mismatched_symbols = {}
-    for _, symbol in pairs(opts.symbols) do
+    for _, symbol in ipairs(opts.symbols) do
       if vim.tbl_contains(valid_symbols, symbol) then
-        for _, result in pairs(results) do
+        for _, result in ipairs(results) do
           if string.lower(result.kind) == symbol then
             table.insert(filtered_symbols, result)
           end
@@ -125,7 +125,7 @@ utils.filter_symbols = function(results, opts)
   if not vim.tbl_isempty(filtered_symbols) then
     -- filter adequately for workspace symbols
     local filename_to_bufnr = {}
-    for _, symbol in pairs(filtered_symbols) do
+    for _, symbol in ipairs(filtered_symbols) do
       if filename_to_bufnr[symbol.filename] == nil then
         filename_to_bufnr[symbol.filename] = vim.uri_to_bufnr(vim.uri_from_fname(symbol.filename))
       end
@@ -184,7 +184,7 @@ utils.diagnostics_to_tbl = function(opts)
   opts.severity_bound = convert_diagnostic_type(opts.severity_bound)
 
   local validate_severity = 0
-  for _, v in pairs({opts.severity, opts.severity_limit, opts.severity_bound}) do
+  for _, v in ipairs({opts.severity, opts.severity_limit, opts.severity_bound}) do
     if v ~= nil then
       validate_severity = validate_severity + 1
     end
@@ -218,7 +218,7 @@ utils.diagnostics_to_tbl = function(opts)
   local buffer_diags = opts.get_all and vim.lsp.diagnostic.get_all() or
     {[current_buf] = vim.lsp.diagnostic.get(current_buf, opts.client_id)}
   for bufnr, diags in pairs(buffer_diags) do
-    for _, diag in pairs(diags) do
+    for _, diag in ipairs(diags) do
       -- workspace diagnostics may include empty tables for unused bufnr
       if not vim.tbl_isempty(diag) then
         if filter_diag_severity(opts, diag.severity) then


### PR DESCRIPTION
Closes #901 

If we have something like this for diagnostics eventually, might as well have it for lsp symbols I suppose.

e: thanks @Conni2461  -- docgen for multiple types seems to work nicely :)