### PR TITLE
fix: make_relative doesn't check path sep

### DIFF
--- a/lua/telescope/path.lua
+++ b/lua/telescope/path.lua
@@ -7,17 +7,11 @@ path.home = vim.fn.expand("~")
 path.make_relative = function(filepath, cwd)
   if not cwd or not filepath then return filepath end
 
+  if cwd:sub(#cwd, #cwd) ~= path.separator then
+    cwd = cwd .. path.separator
+  end
   if filepath:sub(1, #cwd) == cwd  then
-    local offset =  0
-    -- if  cwd does ends in the os separator, we need to take it off
-    if cwd:sub(#cwd, #cwd) ~= path.separator then
-      offset = 1
-    end
-
-    -- only cut of cwd if filepath actually contains a path separator after cwd
-    if filepath:sub(#cwd + 1, #cwd + 1) == path.separator then
-      filepath = filepath:sub(#cwd + 1 + offset, #filepath)
-    end
+    filepath = filepath:sub(#cwd + 1, #filepath)
   end
 
   return filepath

--- a/lua/telescope/path.lua
+++ b/lua/telescope/path.lua
@@ -14,7 +14,10 @@ path.make_relative = function(filepath, cwd)
       offset = 1
     end
 
-    filepath = filepath:sub(#cwd + 1 + offset, #filepath)
+    -- only cut of cwd if filepath actually contains a path separator after cwd
+    if filepath:sub(#cwd + 1, #cwd + 1) == path.separator then
+      filepath = filepath:sub(#cwd + 1 + offset, #filepath)
+    end
   end
 
   return filepath


### PR DESCRIPTION
A while ago I noticed a bug with find_file with a cwd argument set:

If you're editing `/tmp/foo/a`
and call `:Telescope find_files cwd /tmp/foo_bar` and select a file from that folder, it will edit that file as `bar/file`.

I've tracked it down to make_relative not checking for the path separator after the cwd properly:

```
:lua print(require'telescope.path'.make_relative("/tmp/foo_bar/b", "/tmp/foo"))
```
prints `bar/b`, while it should not find a relative path. The issue is that a path can only be made relative if the character at the `_` is a path separator.

Out of curiosity, i checked `plenary.path`, and it seems to have the same bug:

```
:lua print(require'plenary.path':new("/tmp/foo_bar/b"):make_relative("/tmp/foo/"))
```

prints `bar/b`