### PR TITLE
feat: syntactic sugar to map funcs over entries & selections

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -370,6 +370,34 @@ actions.toggle_selection({prompt_bufnr})          *actions.toggle_selection()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
+actions.select_all({prompt_bufnr})                      *actions.select_all()*
+    Multi select all entries.
+    - Note: selected entries may include results not visible in the results
+      popup.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.drop_all({prompt_bufnr})                          *actions.drop_all()*
+    Drop all entries from the current multi selection.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.toggle_all({prompt_bufnr})                      *actions.toggle_all()*
+    Toggle multi selection for all entries.
+    - Note: toggled entries may include results not visible in the results
+      popup.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
 actions.git_create_branch({prompt_bufnr})        *actions.git_create_branch()*
     Create and checkout a new git branch if it doesn't already exist
 
@@ -428,7 +456,7 @@ actions.git_rebase_branch({prompt_bufnr})        *actions.git_rebase_branch()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_checkout_current_buffer({prompt_bufnr})*actions.git_checkout_current_buffer()*
+actions.git_staging_toggle({prompt_bufnr})      *actions.git_staging_toggle()*
     Stage/unstage selected file
 
 
@@ -1191,6 +1219,70 @@ builtin.lsp_workspace_diagnostics({opts})*builtin.lsp_workspace_diagnostics()*
                                           (default is false)
         {line_width}     (number)         set length of diagnostic entry text
                                           in Results
+
+
+
+================================================================================
+                                                       *telescope.actions.utils*
+
+Utilities to wrap functions around picker selections and entries.
+
+Generally used from within other |telescope.actions|
+
+utils.map_entries({prompt_bufnr}, {f})                   *utils.map_entries()*
+    Apply `f` to the entries of the current picker.
+    - Notes:
+      - Mapped entries may include results not visible in the results popup.
+      - Indices are 1-indexed, whereas rows are 0-indexed.
+    - Warning: `map_entries` has no return value.
+      - The below example showcases how to collect results
+    Usage:
+        local action_state = require "telescope.actions.state"
+        local action_utils = require "telescope.actions.utils"
+        function entry_value_by_row()
+          local prompt_bufnr = vim.api.nvim_get_current_buf()
+          local current_picker = action_state.get_current_picker(prompt_bufnr)
+          local results = {}
+            action_utils.map_entries(prompt_bufnr, function(entry, index, row)
+            results[row] = entry.value
+          end)
+          return results
+        end
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)    The prompt bufnr
+        {f}            (function)  Function to map onto entries of picker that
+                                   takes (entry, index, row) as viable
+                                   arguments
+
+
+utils.map_selections({prompt_bufnr}, {f})             *utils.map_selections()*
+    Apply `f` to the multi selections of the current picker and return a table
+    of mapped selections.
+    - Notes:
+      - Mapped selections may include results not visible in the results popup.
+      - Selected entries are returned in order of their selection.
+    - Warning: `map_selections` has no return value.
+      - The below example showcases how to collect results
+    Usage:
+        local action_state = require "telescope.actions.state"
+        local action_utils = require "telescope.actions.utils"
+        function selection_by_index()
+          local prompt_bufnr = vim.api.nvim_get_current_buf()
+          local current_picker = action_state.get_current_picker(prompt_bufnr)
+          local results = {}
+            action_utils.map_selections(prompt_bufnr, function(entry, index)
+            results[index] = entry.value
+          end)
+          return results
+        end
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)    The prompt bufnr
+        {f}            (function)  Function to map onto selection of picker
+                                   that takes (selection) as a viable argument
 
 
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -144,45 +144,6 @@ function actions.toggle_selection(prompt_bufnr)
   current_picker:toggle_selection(current_picker:get_selection_row())
 end
 
---- Apply `f` to entries of current picker and returns list of mapped entries
---- `f` takes (entry, index, row) as viable arguments in order
----@param prompt_bufnr number: The prompt bufnr
----@param f function: function to apply on entries of picker
----@return table: result from mapped entries
-function actions.map_entries(prompt_bufnr, f)
-  local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local results = {}
-  local index = 1
-  local row, result
-    -- indices are 1-indexed, rows are 0-indexed
-  for entry in current_picker.manager:iter() do
-    row = current_picker:get_row(index)
-    -- assign result to variable as function w/o return value
-    -- results in error upon table.insert as it's not technically nil but 'empty'
-    result = f(entry, index, row)
-    results[index] = result
-    index = index + 1
-  end
-  return results
-end
-
---- Apply `f` to multi selections of current picker and returns list of mapped selections.
----@param prompt_bufnr number: The prompt bufnr
----@param f function: function to apply on multi selection of picker
----@return table: result from `f` applied to multi selections
-function actions.map_selections(prompt_bufnr, f)
-  local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local results = {}
-  local result
-  for _, selection in ipairs(current_picker:get_multi_selection()) do
-    result = f(selection)
-    -- assign result to variable as function w/o return value
-    -- results in error upon table.insert as it's not technically nil but 'empty'
-    table.insert(results, result)
-  end
-  return results
-end
-
 --- Multi select all entries, possibly including entries not visible in results popup.
 ---@param prompt_bufnr number: The prompt bufnr
 function actions.select_all(prompt_bufnr)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -15,6 +15,7 @@ local utils = require('telescope.utils')
 local p_scroller = require('telescope.pickers.scroller')
 
 local action_state = require('telescope.actions.state')
+local action_utils = require('telescope.actions.utils')
 local action_set = require('telescope.actions.set')
 
 local transform_mod = require('telescope.actions.mt').transform_mod
@@ -159,7 +160,7 @@ function actions.map_entries(prompt_bufnr, f)
     -- assign result to variable as function w/o return value
     -- results in error upon table.insert as it's not technically nil but 'empty'
     result = f(entry, index, row)
-    table.insert(results, result)
+    results[index] = result
     index = index + 1
   end
   return results
@@ -195,33 +196,33 @@ function actions.select_all(prompt_bufnr)
       end
     end
   end
-  actions.map_entries(prompt_bufnr, select_all)
+  action_utils.map_entries(prompt_bufnr, select_all)
 end
 
 --- Drop all entries from multi selection.
 ---@param prompt_bufnr number: The prompt bufnr
 function actions.drop_all(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local drop_all = function(entry, idx, row)
+  local drop_all = function(entry, _, row)
     current_picker._multi:drop(entry)
     if current_picker:can_select_row(row) then
       current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))
     end
   end
-  actions.map_entries(prompt_bufnr, drop_all)
+  action_utils.map_entries(prompt_bufnr, drop_all)
 end
 
 --- Toggle multi selection for all entries.
 ---@param prompt_bufnr number: The prompt bufnr
 function actions.toggle_all(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local toggle_all = function(entry, idx, row)
+  local toggle_all = function(entry, _, row)
     current_picker._multi:toggle(entry)
     if current_picker:can_select_row(row) then
       current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))
     end
   end
-  actions.map_entries(prompt_bufnr, toggle_all)
+  action_utils.map_entries(prompt_bufnr, toggle_all)
 end
 
 function actions.preview_scrolling_up(prompt_bufnr)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -149,29 +149,26 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 function actions.select_all(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  -- indices are 1-indexed, rows are 0-indexed
-  local select_all = function(entry, _, row)
+  action_utils.map_entries(prompt_bufnr, function(entry, _, row)
     if not current_picker._multi:is_selected(entry) then
       current_picker._multi:add(entry)
       if current_picker:can_select_row(row) then
         current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))
       end
     end
-  end
-  action_utils.map_entries(prompt_bufnr, select_all)
+  end)
 end
 
 --- Drop all entries from the current multi selection.
 ---@param prompt_bufnr number: The prompt bufnr
 function actions.drop_all(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local drop_all = function(entry, _, row)
+  action_utils.map_entries(prompt_bufnr, function(entry, _, row)
     current_picker._multi:drop(entry)
     if current_picker:can_select_row(row) then
       current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))
     end
-  end
-  action_utils.map_entries(prompt_bufnr, drop_all)
+  end)
 end
 
 --- Toggle multi selection for all entries.
@@ -179,13 +176,12 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 function actions.toggle_all(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local toggle_all = function(entry, _, row)
+  action_utils.map_entries(prompt_bufnr, function(entry, _, row)
     current_picker._multi:toggle(entry)
     if current_picker:can_select_row(row) then
       current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))
     end
-  end
-  action_utils.map_entries(prompt_bufnr, toggle_all)
+  end)
 end
 
 function actions.preview_scrolling_up(prompt_bufnr)

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -10,7 +10,7 @@ local action_state = require('telescope.actions.state')
 
 local utils = {}
 
---- Apply `f` to the entries of the current picker. 
+--- Apply `f` to the entries of the current picker.
 --- - Notes:
 ---   - Mapped entries may include results not visible in the results popup.
 ---   - Indices are 1-indexed, whereas rows are 0-indexed.
@@ -20,7 +20,7 @@ local utils = {}
 --- Usage:
 ---     local action_state = require "telescope.actions.state"
 ---     local action_utils = require "telescope.actions.utils"
----     function value_by_row()
+---     function entry_value_by_row()
 ---       local prompt_bufnr = vim.api.nvim_get_current_buf()
 ---       local current_picker = action_state.get_current_picker(prompt_bufnr)
 ---       local results = {}
@@ -31,7 +31,7 @@ local utils = {}
 ---     end
 --- </pre>
 ---@param prompt_bufnr number: The prompt bufnr
----@param f function: Function to apply on entries of picker that takes (entry, index, row) as possible arguments
+---@param f function: Function to map onto entries of picker that takes (entry, index, row) as viable arguments
 function utils.map_entries(prompt_bufnr, f)
   vim.validate{
     f = {f, "function"}
@@ -49,31 +49,32 @@ end
 --- Apply `f` to the multi selections of the current picker and return a table of mapped selections.
 --- - Notes:
 ---   - Mapped selections may include results not visible in the results popup.
+---   - Selected entries are returned in order of their selection.
 --- - Warning: `map_selections` has no return value.
 ---   - The below example showcases how to collect results
 --- <pre>
 --- Usage:
 ---     local action_state = require "telescope.actions.state"
 ---     local action_utils = require "telescope.actions.utils"
----     function value_by_row()
+---     function selection_by_index()
 ---       local prompt_bufnr = vim.api.nvim_get_current_buf()
 ---       local current_picker = action_state.get_current_picker(prompt_bufnr)
 ---       local results = {}
----         action_utils.map_entries(prompt_bufnr, function(entry, index, row)
----         results[row] = entry.value
+---         action_utils.map_selections(prompt_bufnr, function(entry, index)
+---         results[index] = entry.value
 ---       end)
 ---       return results
 ---     end
 --- </pre>
 ---@param prompt_bufnr number: The prompt bufnr
----@param f function: Function to apply on multi selection of picker that takes (selection, selection index) as possible arguments
+---@param f function: Function to map onto selection of picker that takes (selection) as a viable argument
 function utils.map_selections(prompt_bufnr, f)
   vim.validate{
     f = {f, "function"}
   }
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  for index, selection in ipairs(current_picker:get_multi_selection()) do
-    f(selection, index)
+  for _, selection in ipairs(current_picker:get_multi_selection()) do
+    f(selection)
   end
 end
 

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -10,49 +10,71 @@ local action_state = require('telescope.actions.state')
 
 local utils = {}
 
---- Apply `f` to the entries of the current picker and return a table of mapped entries.
---- - Note: mapped entries may include results not visible in the results popup.
+--- Apply `f` to the entries of the current picker. 
+--- - Notes:
+---   - Mapped entries may include results not visible in the results popup.
+---   - Indices are 1-indexed, whereas rows are 0-indexed.
+--- - Warning: `map_entries` has no return value.
+---   - The below example showcases how to collect results
+--- <pre>
+--- Usage:
+---     local action_state = require "telescope.actions.state"
+---     local action_utils = require "telescope.actions.utils"
+---     function value_by_row()
+---       local prompt_bufnr = vim.api.nvim_get_current_buf()
+---       local current_picker = action_state.get_current_picker(prompt_bufnr)
+---       local results = {}
+---         action_utils.map_entries(prompt_bufnr, function(entry, index, row)
+---         results[row] = entry.value
+---       end)
+---       return results
+---     end
+--- </pre>
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to apply on entries of picker that takes (entry, index, row) as possible arguments
----@return table: Result from `f` applied to entries
 function utils.map_entries(prompt_bufnr, f)
   vim.validate{
     f = {f, "function"}
   }
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local results = {}
   local index = 1
-  local row, result
     -- indices are 1-indexed, rows are 0-indexed
   for entry in current_picker.manager:iter() do
-    row = current_picker:get_row(index)
-    -- assign result to variable as function w/o return value
-    -- results in error upon table.insert as it's not technically nil but 'empty'
-    result = f(entry, index, row)
-    results[index] = result
+    local row = current_picker:get_row(index)
+    f(entry, index, row)
     index = index + 1
   end
-  return results
 end
 
 --- Apply `f` to the multi selections of the current picker and return a table of mapped selections.
+--- - Notes:
+---   - Mapped selections may include results not visible in the results popup.
+--- - Warning: `map_selections` has no return value.
+---   - The below example showcases how to collect results
+--- <pre>
+--- Usage:
+---     local action_state = require "telescope.actions.state"
+---     local action_utils = require "telescope.actions.utils"
+---     function value_by_row()
+---       local prompt_bufnr = vim.api.nvim_get_current_buf()
+---       local current_picker = action_state.get_current_picker(prompt_bufnr)
+---       local results = {}
+---         action_utils.map_entries(prompt_bufnr, function(entry, index, row)
+---         results[row] = entry.value
+---       end)
+---       return results
+---     end
+--- </pre>
 ---@param prompt_bufnr number: The prompt bufnr
----@param f function: Function to apply on multi selection of picker
----@return table: Result from `f` applied to selections
+---@param f function: Function to apply on multi selection of picker that takes (selection, selection index) as possible arguments
 function utils.map_selections(prompt_bufnr, f)
   vim.validate{
     f = {f, "function"}
   }
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local results = {}
-  local result
-  for _, selection in ipairs(current_picker:get_multi_selection()) do
-    result = f(selection)
-    -- assign result to variable as function w/o return value
-    -- results in error upon table.insert as it's not technically nil but 'empty'
-    table.insert(results, result)
+  for index, selection in ipairs(current_picker:get_multi_selection()) do
+    f(selection, index)
   end
-  return results
 end
 
 return utils

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -1,7 +1,7 @@
 ---@tag telescope.actions.utils
 
 ---@brief [[
---- Utilities to wrap functions around picker selection and entries.
+--- Utilities to wrap functions around picker selections and entries.
 ---
 --- Generally used from within other |telescope.actions|
 ---@brief ]]
@@ -10,12 +10,15 @@ local action_state = require('telescope.actions.state')
 
 local utils = {}
 
---- Apply `f` to entries of current picker and returns list of mapped entries
---- `f` takes (entry, index, row) as viable arguments in order
+--- Apply `f` to the entries of the current picker and return a table of mapped entries.
+--- - Note: mapped entries may include results not visible in the results popup.
 ---@param prompt_bufnr number: The prompt bufnr
----@param f function: function to apply on entries of picker
----@return table: result from mapped entries
+---@param f function: Function to apply on entries of picker that takes (entry, index, row) as possible arguments
+---@return table: Result from `f` applied to entries
 function utils.map_entries(prompt_bufnr, f)
+  vim.validate{
+    f = {f, "function"}
+  }
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local results = {}
   local index = 1
@@ -32,11 +35,14 @@ function utils.map_entries(prompt_bufnr, f)
   return results
 end
 
---- Apply `f` to multi selections of current picker and returns list of mapped selections.
+--- Apply `f` to the multi selections of the current picker and return a table of mapped selections.
 ---@param prompt_bufnr number: The prompt bufnr
----@param f function: function to apply on multi selection of picker
----@return table: result from `f` applied to multi selections
+---@param f function: Function to apply on multi selection of picker
+---@return table: Result from `f` applied to selections
 function utils.map_selections(prompt_bufnr, f)
+  vim.validate{
+    f = {f, "function"}
+  }
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local results = {}
   local result

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -1,0 +1,52 @@
+---@tag telescope.actions.utils
+
+---@brief [[
+--- Utilities to wrap functions around picker selection and entries.
+---
+--- Generally used from within other |telescope.actions|
+---@brief ]]
+
+local action_state = require('telescope.actions.state')
+
+local utils = {}
+
+--- Apply `f` to entries of current picker and returns list of mapped entries
+--- `f` takes (entry, index, row) as viable arguments in order
+---@param prompt_bufnr number: The prompt bufnr
+---@param f function: function to apply on entries of picker
+---@return table: result from mapped entries
+function utils.map_entries(prompt_bufnr, f)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local results = {}
+  local index = 1
+  local row, result
+    -- indices are 1-indexed, rows are 0-indexed
+  for entry in current_picker.manager:iter() do
+    row = current_picker:get_row(index)
+    -- assign result to variable as function w/o return value
+    -- results in error upon table.insert as it's not technically nil but 'empty'
+    result = f(entry, index, row)
+    results[index] = result
+    index = index + 1
+  end
+  return results
+end
+
+--- Apply `f` to multi selections of current picker and returns list of mapped selections.
+---@param prompt_bufnr number: The prompt bufnr
+---@param f function: function to apply on multi selection of picker
+---@return table: result from `f` applied to multi selections
+function utils.map_selections(prompt_bufnr, f)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local results = {}
+  local result
+  for _, selection in ipairs(current_picker:get_multi_selection()) do
+    result = f(selection)
+    -- assign result to variable as function w/o return value
+    -- results in error upon table.insert as it's not technically nil but 'empty'
+    table.insert(results, result)
+  end
+  return results
+end
+
+return utils

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -26,7 +26,6 @@ mappings.default_mappings = config.values.default_mappings or {
 
       ["<Tab>"] = actions.toggle_selection + actions.move_selection_worse,
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
-      ["<M-Tab>"] = actions.toggle_all,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
       ["<C-l>"] = actions.complete_tag
@@ -41,7 +40,6 @@ mappings.default_mappings = config.values.default_mappings or {
 
       ["<Tab>"] = actions.toggle_selection + actions.move_selection_worse,
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
-      ["<M-Tab>"] = actions.toggle_all,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
 

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -26,6 +26,7 @@ mappings.default_mappings = config.values.default_mappings or {
 
       ["<Tab>"] = actions.toggle_selection + actions.move_selection_worse,
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
+      ["<M-Tab>"] = actions.toggle_all,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
       ["<C-l>"] = actions.complete_tag
@@ -40,6 +41,7 @@ mappings.default_mappings = config.values.default_mappings or {
 
       ["<Tab>"] = actions.toggle_selection + actions.move_selection_worse,
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
+      ["<M-Tab>"] = actions.toggle_all,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -264,7 +264,7 @@ function Picker:can_select_row(row)
   if self.sorting_strategy == 'ascending' then
     return row <= self.manager:num_results()
   else
-    return row <= self.max_results and row >= self.max_results - self.manager:num_results()
+    return row >= 0 and row <= self.max_results and row >= self.max_results - self.manager:num_results()
   end
 end
 

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -15,6 +15,7 @@ docs.test = function()
     "./lua/telescope/actions/init.lua",
     "./lua/telescope/actions/state.lua",
     "./lua/telescope/actions/set.lua",
+    "./lua/telescope/actions/utils.lua",
     "./lua/telescope/previewers/init.lua",
     "./lua/telescope/config/resolve.lua",
     "./lua/telescope/themes.lua",


### PR DESCRIPTION
This PR closes #900 and implements
* toggling, selecting, and dropping all entries from multi selection
* carves out sugar to apply functions (and collect the result) on entries and multi-selections
* furthermore includes `vim-bbye` action from #906 