### PR TITLE
fix: display issues in `:Telescope registers`

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -666,7 +666,7 @@ function make_entry.gen_from_registers(_)
     local content = entry.content
     return displayer {
       {'[' .. entry.value .. ']', "TelescopeResultsNumber"},
-      type(content) == 'string' and content:gsub('\n',' | ') or content,
+      type(content) == 'string' and content:gsub('\n','\\n') or content,
     }
   end
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -663,9 +663,10 @@ function make_entry.gen_from_registers(_)
   }
 
   local make_display = function(entry)
+    local content = entry.content
     return displayer {
       {'[' .. entry.value .. ']', "TelescopeResultsNumber"},
-      entry.content,
+      type(content) == 'string' and content:gsub('\n',' | ') or content,
     }
   end
 


### PR DESCRIPTION
- Problems occured when a register contained newlines
- Caused issues in `Picker:set_selection`
- Couldn't move selection when a register with newlines was selected

I think that this problem wasn't noticed due to the clean-up for entries with newlines in `Picker:entry_adder`.