### PR TITLE
Fix/table number option extend

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -35,7 +35,13 @@ local smarter_depth_2_extend = function(priority, base)
       end
     end
   end
-  result = vim.tbl_deep_extend("keep", priority, result)
+  for key, val in pairs(priority) do
+    if type(val) ~= "table" then
+      result[key] = first_non_null(val,result[key])
+    else
+      result[key] = vim.tbl_extend("keep",val,result[key] or {})
+    end
+  end
   return result
 end
 
@@ -43,6 +49,7 @@ end
 -- selection_strategy
 
 local config = {}
+config.smarter_depth_2_extend = smarter_depth_2_extend
 
 config.values = _TelescopeConfigurationValues
 config.descriptions = {}

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -99,7 +99,7 @@ function Picker:new(opts)
     selection_strategy = get_default(opts.selection_strategy, config.values.selection_strategy),
 
     layout_strategy = layout_strategy,
-    layout_config = vim.tbl_deep_extend("keep", opts.layout_config or {}, config.values.layout_config or {}),
+    layout_config = config.smarter_depth_2_extend(opts.layout_config or {}, config.values.layout_config or {}),
 
     window = {
       winblend = get_default(opts.winblend, config.values.winblend),

--- a/lua/tests/automated/layout_strategies_spec.lua
+++ b/lua/tests/automated/layout_strategies_spec.lua
@@ -89,4 +89,14 @@ describe('layout_strategies', function()
     {horizontal={height=50}}, {horizontal={height=100}}, {height=120}
   )
 
+  test_defaults_key("should handle user config overriding a table with a number",
+    'height','horizontal',120,
+    {height={padding=5}},{height=120},{}
+  )
+
+  test_defaults_key("should handle user oneshot overriding a table with a number",
+    'height','horizontal',120,
+    {},{height={padding=5}},{height=120}
+  )
+
 end)


### PR DESCRIPTION
Fixes #944

- refactor `smarter_depth_2_extend` in `config.lua`
- use `config.smarter_depth_2_extend` for setting `layout_config` in `Picker:new`
- add tests to avoid us breaking things the same way in the future