### PR TITLE
feat: option to `include_extensions` in `builtin` picker

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -332,8 +332,17 @@ end
 actions.run_builtin = function(prompt_bufnr)
   local entry = action_state.get_selected_entry(prompt_bufnr)
 
-actions._close(prompt_bufnr, true)
-  require('telescope.builtin')[entry.text]()
+  actions._close(prompt_bufnr, true)
+  if string.match(entry.text," : ") then
+    -- Call appropriate function from extensions
+    local split_string = vim.split(entry.text," : ")
+    local ext = split_string[1]
+    local func = split_string[2]
+    require('telescope').extensions[ext][func]()
+  else
+    -- Call appropriate telescope builtin
+    require('telescope.builtin')[entry.text]()
+  end
 end
 
 actions.insert_symbol = function(prompt_bufnr)

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -21,6 +21,7 @@ local internal = {}
 internal.builtin = function(opts)
   opts.hide_filename = utils.get_default(opts.hide_filename, true)
   opts.ignore_filename = utils.get_default(opts.ignore_filename, true)
+  opts.include_extensions = utils.get_default(opts.include_extensions, false)
 
   local objs = {}
 
@@ -32,8 +33,23 @@ internal.builtin = function(opts)
     })
   end
 
+  local title = 'Telescope Builtin'
+
+  if opts.include_extensions then
+    title = 'Telescope Pickers'
+    for ext, funcs in pairs(require'telescope'.extensions) do
+      for func_name, func_obj in pairs(funcs) do
+        local debug_info = debug.getinfo(func_obj)
+        table.insert(objs, {
+          filename = string.sub(debug_info.source, 2),
+          text = string.format("%s : %s", ext, func_name),
+        })
+      end
+    end
+  end
+
   pickers.new(opts, {
-    prompt_title = 'Telescope Builtin',
+    prompt_title = title,
     finder    = finders.new_table {
       results = objs,
       entry_maker = function(entry)


### PR DESCRIPTION
Provide option to `include_extensions` in the `builtin.builtin` picker
- add option `include_extensions` which defaults to `false`
- if `include_extensions` is `true` then add functions from extensions to results
- update `actions.run_builtin` to check if extension function provided

---

Resolves #925