### PR TITLE
find_files: accept search_dirs from command line with opts.path.

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -137,6 +137,10 @@ files.find_files = function(opts)
   local follow = opts.follow
   local search_dirs = opts.search_dirs
 
+  if opts.path then
+    search_dirs = {opts.path}
+  end
+
   if search_dirs then
     for k,v in pairs(search_dirs) do
       search_dirs[k] = vim.fn.expand(v)


### PR DESCRIPTION
This allows the Telescope command to specify a path to search in...
The nvim command line won't allow us to pass a table.