### PR TITLE
WIP: recalculate picker layout on `VimResized`

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -441,9 +441,13 @@ function Picker:find()
     [[  autocmd BufLeave <buffer> ++nested ++once :silent lua require('telescope.pickers').on_close_prompt(%s)]],
     prompt_bufnr)
 
+  local on_vim_resize = string.format(
+    [[  autocmd VimResized <buffer> ++nested :silent lua require('telescope.pickers').on_resize_window(%s)]],
+    prompt_bufnr)
   vim.cmd([[augroup PickerInsert]])
   vim.cmd([[  au!]])
   vim.cmd(    on_buf_leave)
+  vim.cmd(    on_vim_resize)
   vim.cmd([[augroup END]])
 
   self.prompt_bufnr = prompt_bufnr
@@ -481,6 +485,39 @@ function Picker:find()
   elseif self.initial_mode ~= "normal" then
     error("Invalid setting for initial_mode: " .. self.initial_mode)
   end
+end
+
+function Picker:recalculate_layout()
+  local line_count = vim.o.lines - vim.o.cmdheight
+  if vim.o.laststatus ~= 0 then
+    line_count = line_count - 1
+  end
+
+  local popup_opts = self:get_window_options(vim.o.columns, line_count)
+  -- `popup.nvim` massaging so people don't have to remember minheight shenanigans
+  popup_opts.results.minheight = popup_opts.results.height
+  popup_opts.prompt.minheight = popup_opts.prompt.height
+  if popup_opts.preview then
+    popup_opts.preview.minheight = popup_opts.preview.height
+  end
+
+  local status = state.get_status(self.prompt_bufnr)
+  local prompt_win = status.prompt_win
+  local results_win = status.results_win
+  local preview_win = status.preview_win
+  popup.resize(results_win, popup_opts.results)
+
+
+  if popup_opts.preview then
+    popup.resize(preview_win, popup_opts.preview)
+  end
+
+  popup.resize(prompt_win, popup_opts.prompt)
+
+  -- Temporarily disabled: Draw the screen ASAP. This makes things feel speedier.
+  -- vim.cmd [[redraw]]
+
+  self.max_results = popup_opts.results.height
 end
 
 function Picker:hide_preview()
@@ -1135,6 +1172,22 @@ function pickers.on_close_prompt(prompt_bufnr)
   end
 
   picker.close_windows(status)
+end
+
+function pickers.on_resize_window(prompt_bufnr)
+  print('resizing'..prompt_bufnr)
+  local status = state.get_status(prompt_bufnr)
+  local picker = status.picker
+
+  -- if picker.sorter then
+  --   picker.sorter:_destroy()
+  -- end
+
+  -- if picker.previewer then
+  --   picker.previewer:teardown()
+  -- end
+
+  picker:recalculate_layout()
 end
 
 --- Get the prompt text without the prompt prefix.


### PR DESCRIPTION
- implements `Picker:recalculate_layout` function
- adds an autocommand to call this function on the `VimResized` event
- relies on nvim-lua/plenary.nvim#180 and nvim-lua/popup.nvim#15

Currently has issues when the results window changes in height.

Demo:
![telescope-resize](https://user-images.githubusercontent.com/35707277/124515434-5d6c0700-ddd7-11eb-8087-dea9d0045097.gif)

As shown in the demo, the picker still works fine when the results window is the same height, but when the height increases, you can no longer change the selection. In other tests, when the height decreases, you can change the selection but the displayed list is in the wrong position and updates as you select each one.

I will have a go at fixing the results window issues, but thought it would be good to get feedback on what is done so far 🙂 