### PR TITLE
Empty string text for closed buffer in tagstack picker.

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -924,7 +924,7 @@ internal.tagstack = function(opts)
       value.lnum - 1,
       value.lnum,
       false
-    )[1]
+    )[1] or ''
   end
 
   -- reverse the list

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -906,31 +906,30 @@ end
 
 internal.tagstack = function(opts)
   opts = opts or {}
-  local tagstack = vim.fn.gettagstack()
-  if vim.tbl_isempty(tagstack.items) then
+  local tagstack = vim.fn.gettagstack().items
+
+  local tags = {}
+  for i = #tagstack, 1, -1 do
+    local tag = tagstack[i]
+    tag.bufnr = tag.from[1]
+    if vim.api.nvim_buf_is_valid(tag.bufnr) then
+      tags[#tags + 1] = tag
+      tag.filename = vim.fn.bufname(tag.bufnr)
+      tag.lnum = tag.from[2]
+      tag.col = tag.from[3]
+
+      tag.text = vim.api.nvim_buf_get_lines(
+        tag.bufnr,
+        tag.lnum - 1,
+        tag.lnum,
+        false
+      )[1] or ''
+    end
+  end
+
+  if vim.tbl_isempty(tags) then
     print("No tagstack available")
     return
-  end
-
-  for _, value in pairs(tagstack.items) do
-    value.valid = true
-    value.bufnr = value.from[1]
-    value.lnum = value.from[2]
-    value.col = value.from[3]
-    value.filename = vim.fn.bufname(value.from[1])
-
-    value.text = vim.api.nvim_buf_get_lines(
-      value.bufnr,
-      value.lnum - 1,
-      value.lnum,
-      false
-    )[1] or ''
-  end
-
-  -- reverse the list
-  local tags = {}
-  for i = #tagstack.items, 1, -1 do
-    tags[#tags+1] = tagstack.items[i]
   end
 
   pickers.new(opts, {


### PR DESCRIPTION
When there is an tagstack entry for a closed buffer, there is a `nil` error in [make_entry.lua#L312](https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/make_entry.lua#L312) because entry.text is nil. 

```
ordinal = (
        not opts.ignore_filename and filename
        or ''
        ) .. ' ' .. entry.text,
```

This fix enters empty text for entries with closed buffers. I think it makes sense, because most people are not regularly closing buffers, especially recently open ones, during their workflow. Therefore, people are unlikely to see entries for closed buffers high up on their Telescope list. So we use empty text as a way to avoid nil errors, but don't expect the empty text to be surfaced to the user often.

Steps to repro:
1. open buffer `A`
2. create a tagstack entry in `A` ie. builtin LSP jump to reference does so
3. close buffer `A`
4. `:Telescope tagstack`