### PR TITLE
Jumplist picker uses quickfix entry maker. Delete jumplist entry maker.

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -951,9 +951,11 @@ internal.jumplist = function(opts)
   -- reverse the list
   local sorted_jumplist = {}
   for i = #jumplist, 1, -1 do
-    jumplist[i].text = vim.api.nvim_buf_get_lines(jumplist[i].bufnr, jumplist[i].lnum, jumplist[i].lnum+1,
-      false)[1] or ''
-    table.insert(sorted_jumplist, jumplist[i])
+    if vim.api.nvim_buf_is_valid(jumplist[i].bufnr) then
+      jumplist[i].text = vim.api.nvim_buf_get_lines(jumplist[i].bufnr, jumplist[i].lnum, jumplist[i].lnum+1,
+        false)[1] or ''
+      table.insert(sorted_jumplist, jumplist[i])
+    end
   end
 
   pickers.new(opts, {

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -951,7 +951,8 @@ internal.jumplist = function(opts)
   -- reverse the list
   local sorted_jumplist = {}
   for i = #jumplist, 1, -1 do
-    jumplist[i].text = vim.api.nvim_buf_get_lines(jumplist[i].bufnr, jumplist[i].lnum, jumplist[i].lnum+1, false)[1] or ''
+    jumplist[i].text = vim.api.nvim_buf_get_lines(jumplist[i].bufnr, jumplist[i].lnum, jumplist[i].lnum+1,
+      false)[1] or ''
     table.insert(sorted_jumplist, jumplist[i])
   end
 

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -951,7 +951,7 @@ internal.jumplist = function(opts)
   -- reverse the list
   local sorted_jumplist = {}
   for i = #jumplist, 1, -1 do
-    jumplist[i].text = ''
+    jumplist[i].text = vim.api.nvim_buf_get_lines(jumplist[i].bufnr, jumplist[i].lnum, jumplist[i].lnum+1, false)[1] or ''
     table.insert(sorted_jumplist, jumplist[i])
   end
 
@@ -959,7 +959,7 @@ internal.jumplist = function(opts)
     prompt_title = 'Jumplist',
     finder = finders.new_table {
       results = sorted_jumplist,
-      entry_maker = make_entry.gen_from_jumplist(opts),
+      entry_maker = make_entry.gen_from_quickfix(opts),
     },
     previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1111,52 +1111,5 @@ function make_entry.gen_from_git_status(opts)
   end
 end
 
-function make_entry.gen_from_jumplist(opts)
-  opts = opts or {}
-
-  local displayer = entry_display.create {
-    separator = "▏",
-    items = {
-      { width = 10 },
-      { remaining = true },
-    }
-  }
-
-  local make_display = function(entry)
-    local filename = utils.transform_path(opts, entry.filename)
-
-    local line_info = {table.concat({entry.lnum, entry.col}, ":"), "TelescopeResultsLineNr"}
-
-    return displayer {
-      line_info,
-      filename,
-    }
-  end
-
-  return function(entry)
-    if not vim.api.nvim_buf_is_valid(entry.bufnr) then
-      return
-    end
-
-    local filename = entry.filename or vim.api.nvim_buf_get_name(entry.bufnr)
-
-    return {
-      valid = true,
-
-      value = entry,
-      ordinal = (
-        not opts.ignore_filename and filename
-        or ''
-        ) .. ' ' .. entry.text,
-      display = make_display,
-
-      bufnr = entry.bufnr,
-      filename = filename,
-      lnum = entry.lnum,
-      col = entry.col,
-    }
-  end
-end
-
 
 return make_entry


### PR DESCRIPTION
When I authored #839, I didn't include the jumplist text because we wouldn't be able to get text for closed buffers. This is a non-issue because I've found in my workflow that that recent entries on the jumplist are always open in a buffer. I think that having the buffer text feels a little better when going through the jumplist picker. For entries that aren't open in a buffer, we include empty text, but we expect it to not be surfaced to the user very often.

Another benefit is that the jumplist picker now reuses the quickfix entry maker, as many other pickers already do. This means we can delete the jumplist entry maker.

This is all opinionated. Open to ideas.