### PR TITLE
Remove center action after select_default action in default mappings.

### DIFF
--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -16,7 +16,7 @@ mappings.default_mappings = config.values.default_mappings or {
       ["<Down>"] = actions.move_selection_next,
       ["<Up>"] = actions.move_selection_previous,
 
-      ["<CR>"] = actions.select_default + actions.center,
+      ["<CR>"] = actions.select_default,
       ["<C-x>"] = actions.select_horizontal,
       ["<C-v>"] = actions.select_vertical,
       ["<C-t>"] = actions.select_tab,
@@ -33,7 +33,7 @@ mappings.default_mappings = config.values.default_mappings or {
 
     n = {
       ["<esc>"] = actions.close,
-      ["<CR>"] = actions.select_default + actions.center,
+      ["<CR>"] = actions.select_default,
       ["<C-x>"] = actions.select_horizontal,
       ["<C-v>"] = actions.select_vertical,
       ["<C-t>"] = actions.select_tab,
@@ -205,7 +205,7 @@ mappings.apply_keymap = function(prompt_bufnr, attach_mappings, buffer_keymap)
     end
   end
 
-  -- TODO: Probalby should not overwrite any keymaps
+  -- TODO: Probably should not overwrite any keymaps
   for mode, mode_map in pairs(mappings.default_mappings) do
     mode = string.lower(mode)
 


### PR DESCRIPTION
Partially fixes https://github.com/nvim-telescope/telescope.nvim/issues/429

default mapping change: `["<CR>"] = actions.select_default + actions.center` -> `["<CR>"] = actions.select_default`

When selecting to edit an empty entry, the telescope floating window does not close. Then, `actions.center` changes the prompt buffer to normal mode triggering prompt buffer bugs in https://github.com/nvim-telescope/telescope.nvim/issues/429 and https://github.com/nvim-telescope/telescope.nvim/issues/852.

I also think its awkward that by default, `select_default` mapping is followed by `actions.center`, while `select_(horizontal|vertical|tab)` default mappings are not. This change brings some consistency. The `actions.center` action is kept around in case users want to map to it.

If we want, we could add `vim.cmd(':normal! zz')` to the end of the edit function, but I feel its unnecessary.
