### PR TITLE
Fix: Define undefined variable in config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ its `attach_mappings` key to a function, like so:
 ```lua
 local actions = require('telescope.actions')
 local action_set = require('telescope.actions.set')
+local action_state = require('telescope.actions.state')
 -- Picker specific remapping
 ------------------------------
 require('telescope.builtin').fd({ -- or new custom picker's attach_mappings field:


### PR DESCRIPTION
Define the undefined variable “action_state”, which is used in a code
example for replacing picker mappings in the README.

The new definiton is added 7 lines above the usage of that variable:

``` lua
  local entry = action_state.get_selected_entry()
```

I haven't tested this yet. I just stumbled across this, while reading the documentation, and i wondered: “Where does this variable come from?”