### PR TITLE
Show results correctly when sorting_strategy=ascending is set

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -886,6 +886,8 @@ function Picker:entry_adder(index, entry, _, insert)
     if insert then
       if self.sorting_strategy == 'descending' then
         vim.api.nvim_buf_set_lines(self.results_bufnr, 0, 1, false, {})
+      else
+        vim.api.nvim_buf_set_lines(self.results_bufnr, self.max_results - 1, self.max_results, false, {})
       end
     end
 


### PR DESCRIPTION
**Why** is the change needed?

See #840

When setting sorting_strategy to ascending, the wrong line range is
shown in the result making the result impossible to follow.

**How** is the need addressed?

-   Basically adding the [fix](https://github.com/nvim-telescope/telescope.nvim/issues/840#issuecomment-867127533) that @jedrzejboczar suggested in the issue.

What **side-effects** could the change have?

- Can't think of any, are there better ways to do this?

Closes #840
Co-authored-by: yendreij <yendreij@gmail.com>