### PR TITLE
feat: add Windows `where` file finder command

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -187,7 +187,6 @@ files.find_files = function(opts)
         end
       end
     elseif 1 == vim.fn.executable("where") then
-      print('using the `where` function')
       find_command = { 'where', '/r', '.', '*'}
       if hidden then
         print('The `hidden` key is not available for the Windows `where` command in `find_files`.')

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -7,6 +7,7 @@ local pickers = require('telescope.pickers')
 local previewers = require('telescope.previewers')
 local utils = require('telescope.utils')
 local conf = require('telescope.config').values
+local log = require('telescope.log')
 
 local scan = require('plenary.scandir')
 local Path = require('plenary.path')
@@ -188,22 +189,14 @@ files.find_files = function(opts)
       end
     elseif 1 == vim.fn.executable("where") then
       find_command = { 'where', '/r', '.', '*'}
-      if hidden then
-        print('The `hidden` key is not available for the Windows `where` command in `find_files`.')
+      if hidden ~= nil then
+        log.warn('The `hidden` key is not available for the Windows `where` command in `find_files`.')
       end
-      if follow then
-        print('The `follow` key is not available for the Windows `where` command in `find_files`.')
+      if follow ~= nil then
+        log.warn('The `follow` key is not available for the Windows `where` command in `find_files`.')
       end
-      if search_dirs then
-        table.remove(find_command, 3)
-        local dir_num = 1
-        for _,v in pairs(search_dirs) do
-          if dir_num == 1 then
-            table.insert(find_command, 3, v)
-          else
-            print('Multiple `search_dirs` are not available for the Windows `where` command in `find_files`.')
-          end
-        end
+      if search_dirs ~= nil then
+        log.warn('The `search_dirs` key is not available for the Windows `where` command in `find_files`.')
       end
     end
   end

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -173,7 +173,7 @@ files.find_files = function(opts)
           table.insert(find_command, v)
         end
       end
-    elseif 1 == vim.fn.executable("find") then
+    elseif 1 == vim.fn.executable("find") and not vim.fn.has('win32') then
       find_command = { 'find', '.', '-type', 'f' }
       if not hidden then
         table.insert(find_command, { '-not', '-path', "*/.*" })
@@ -184,6 +184,26 @@ files.find_files = function(opts)
         table.remove(find_command, 2)
         for _,v in pairs(search_dirs) do
           table.insert(find_command, 2, v)
+        end
+      end
+    elseif 1 == vim.fn.executable("where") then
+      print('using the `where` function')
+      find_command = { 'where', '/r', '.', '*'}
+      if hidden then
+        print('The `hidden` key is not available for the Windows `where` command in `find_files`.')
+      end
+      if follow then
+        print('The `follow` key is not available for the Windows `where` command in `find_files`.')
+      end
+      if search_dirs then
+        table.remove(find_command, 3)
+        local dir_num = 1
+        for _,v in pairs(search_dirs) do
+          if dir_num == 1 then
+            table.insert(find_command, 3, v)
+          else
+            print('Multiple `search_dirs` are not available for the Windows `where` command in `find_files`.')
+          end
         end
       end
     end


### PR DESCRIPTION
Adds the Windows `where` command as a default file finder.

Note, since `where` doesn't have many options:
- `hidden` and `follow` flags will not change anything
- `search_dirs` only supports a single search directory

I also added an extra check for the `find` command as it is different on Windows and Linux.

---

This allow Windows users to have a usable experience without installing external dependencies that are currently labelled as optional.