### PR TITLE
add `search_dirs` to split_keywords table

### DIFF
--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -123,7 +123,8 @@ end
 local split_keywords = {
   ['find_command'] = true,
   ['vimgrep_arguments'] = true,
-  ['sections'] = true
+  ['sections'] = true,
+  ['search_dirs'] = true
 }
 
 function command.register_keyword(keyword)


### PR DESCRIPTION
Closes #985.

I might need some feedback on if this is the correctly way to deal with a new split keyword since we also have `command.register_keyword` but it isn't being used anywhere. Maybe it's for extensions only and since `search_dirs` is for builtins, it should be in the `split_keywords` table?