### PR TITLE
fix: builtin `find_files`, `find` command `win32` check == 0

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -174,7 +174,7 @@ files.find_files = function(opts)
           table.insert(find_command, v)
         end
       end
-    elseif 1 == vim.fn.executable("find") and not vim.fn.has('win32') then
+    elseif 1 == vim.fn.executable("find") and vim.fn.has('win32') == 0 then
       find_command = { 'find', '.', '-type', 'f' }
       if not hidden then
         table.insert(find_command, { '-not', '-path', "*/.*" })


### PR DESCRIPTION
- changes check for Windows OS, as 0 is truthy, so `not 0` and `not 1` are both `false`

---

Fixes [this](https://github.com/nvim-telescope/telescope.nvim/commit/999fad2ce514d869b736aa5d948d355fad89be8d#commitcomment-53467463)