### PR TITLE
fix: set filetype of preview buffer

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -116,6 +116,8 @@ previewers.file_maker = function(filepath, bufnr, opts)
       end
     end
   end
+
+  pcall(vim.api.nvim_buf_set_option, bufnr, 'filetype', ft)
 end
 
 previewers.new_buffer_previewer = function(opts)


### PR DESCRIPTION
# What does this PR address?

When opening telescope with a preview buffer, I get an `unknown filetype` error message. When opening telescope without the preview buffer showing (for example on a narrow window), I do not get such an error message.

# How does the PR fix this?

I have simply added one line in the buffer preview code to set the filetype of the preview buffer based on the filetype that was detected by plenary. This resolves the issue for me.

I'm not familiar with the code base (or writing vim plugins in general) so do let me know if there's a better way to accomplish this.