### PR TITLE
fix: prevent error if preview scroll is triggered but no preview is available

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -155,7 +155,6 @@ action_set.scroll_previewer = function (prompt_bufnr, direction)
     return
   end
 
-
   local status = state.get_status(prompt_bufnr)
   local default_speed = vim.api.nvim_win_get_height(status.preview_win) / 2
   local speed = status.picker.layout_config.scroll_speed or default_speed

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -148,11 +148,19 @@ end
 ---@param direction number: The direction of the scrolling
 --      Valid directions include: "1", "-1"
 action_set.scroll_previewer = function (prompt_bufnr, direction)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+
+  -- Check if we actually have a previewer
+  if (type(picker['previewer']) ~= "table" or picker.previewer['scroll_fn'] == nil) then
+    return
+  end
+
+
   local status = state.get_status(prompt_bufnr)
   local default_speed = vim.api.nvim_win_get_height(status.preview_win) / 2
   local speed = status.picker.layout_config.scroll_speed or default_speed
 
-  action_state.get_current_picker(prompt_bufnr).previewer:scroll_fn(math.floor(speed * direction))
+  picker.previewer:scroll_fn(math.floor(speed * direction))
 end
 
 -- ==================================================

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -148,10 +148,10 @@ end
 ---@param direction number: The direction of the scrolling
 --      Valid directions include: "1", "-1"
 action_set.scroll_previewer = function (prompt_bufnr, direction)
-  local picker = action_state.get_current_picker(prompt_bufnr)
+  local currenct_picker = action_state.get_current_picker(prompt_bufnr)
 
   -- Check if we actually have a previewer
-  if (type(picker['previewer']) ~= "table" or picker.previewer['scroll_fn'] == nil) then
+  if (type(current_picker['previewer']) ~= "table" or current_picker.previewer['scroll_fn'] == nil) then
     return
   end
 
@@ -159,7 +159,7 @@ action_set.scroll_previewer = function (prompt_bufnr, direction)
   local default_speed = vim.api.nvim_win_get_height(status.preview_win) / 2
   local speed = status.picker.layout_config.scroll_speed or default_speed
 
-  picker.previewer:scroll_fn(math.floor(speed * direction))
+  current_picker.previewer:scroll_fn(math.floor(speed * direction))
 end
 
 -- ==================================================

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -151,7 +151,7 @@ action_set.scroll_previewer = function (prompt_bufnr, direction)
   local currenct_picker = action_state.get_current_picker(prompt_bufnr)
 
   -- Check if we actually have a previewer
-  if (type(current_picker['previewer']) ~= "table" or current_picker.previewer['scroll_fn'] == nil) then
+  if (type(current_picker.previewer) ~= "table" or current_picker.previewer.scroll_fn == nil) then
     return
   end
 

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -148,10 +148,10 @@ end
 ---@param direction number: The direction of the scrolling
 --      Valid directions include: "1", "-1"
 action_set.scroll_previewer = function (prompt_bufnr, direction)
-  local currenct_picker = action_state.get_current_picker(prompt_bufnr)
+  local previewer = action_state.get_current_picker(prompt_bufnr).previewer
 
   -- Check if we actually have a previewer
-  if (type(current_picker.previewer) ~= "table" or current_picker.previewer.scroll_fn == nil) then
+  if (type(previewer) ~= "table" or previewer.scroll_fn == nil) then
     return
   end
 
@@ -159,7 +159,7 @@ action_set.scroll_previewer = function (prompt_bufnr, direction)
   local default_speed = vim.api.nvim_win_get_height(status.preview_win) / 2
   local speed = status.picker.layout_config.scroll_speed or default_speed
 
-  current_picker.previewer:scroll_fn(math.floor(speed * direction))
+  previewer:scroll_fn(math.floor(speed * direction))
 end
 
 -- ==================================================


### PR DESCRIPTION
In some pickers there is no preview buffer available (e.g. symbols). Pressing <C-d> or <C-u> then results in an error.
Adding a check to make sure a previewer is available and it can scroll to prevent the throwing of an error.
