### PR TITLE
feat: add git reset action for git commits picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ document symbols not recognized as methods by treesitter.
 
 | Functions                           | Description                                                                                                |
 |-------------------------------------|------------------------------------------------------------------------------------------------------------|
-| `builtin.git_commits`               | Lists git commits with diff preview and checks them out on `<cr>`                                          |
+| `builtin.git_commits`               | Lists git commits with diff preview, checkout action `<cr>`, reset mixed `<C-r>m`, reset soft `<C-r>s` and reset hard `<C-r>h` |
 | `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and checks them out on `<cr>`                                 |
 | `builtin.git_branches`              | Lists all branches with log preview, checkout action `<cr>`, track action `<C-t>` and rebase action`<C-r>` |
 | `builtin.git_status`                | Lists current changes per file with diff preview and add action. (Multi-selection still WIP)               |

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -542,6 +542,28 @@ actions.git_rebase_branch = function(prompt_bufnr)
   end
 end
 
+--- Reset to selected git commit
+---@param prompt_bufnr number: The prompt bufnr
+actions.git_reset_branch = function(prompt_bufnr)
+  local cwd = action_state.get_current_picker(prompt_bufnr).cwd
+  local selection = action_state.get_selected_entry()
+
+  local confirmation = vim.fn.input('Do you really wanna reset to commit ' .. selection.value .. '? [Y/n] ')
+  if confirmation ~= '' and string.lower(confirmation) ~= 'y' then return end
+
+  actions.close(prompt_bufnr)
+  local _, ret, stderr = utils.get_os_command_output({ 'git', 'reset', selection.value }, cwd)
+  if ret == 0 then
+    print("Reset to: " .. selection.value)
+  else
+    print(string.format(
+      'Error when resetting to: %s. Git returned: "%s"',
+      selection.value,
+      table.concat(stderr, '  ')
+    ))
+  end
+end
+
 actions.git_checkout_current_buffer = function(prompt_bufnr)
   local cwd = actions.get_current_picker(prompt_bufnr).cwd
   local selection = actions.get_selected_entry()

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -542,17 +542,15 @@ actions.git_rebase_branch = function(prompt_bufnr)
   end
 end
 
---- Reset to selected git commit
----@param prompt_bufnr number: The prompt bufnr
-actions.git_reset_branch = function(prompt_bufnr)
+local git_reset_branch = function(prompt_bufnr, mode)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
 
-  local confirmation = vim.fn.input('Do you really wanna reset to commit ' .. selection.value .. '? [Y/n] ')
+  local confirmation = vim.fn.input('Do you really wanna ' .. mode .. ' reset to commit ' .. selection.value .. '? [Y/n] ')
   if confirmation ~= '' and string.lower(confirmation) ~= 'y' then return end
 
   actions.close(prompt_bufnr)
-  local _, ret, stderr = utils.get_os_command_output({ 'git', 'reset', selection.value }, cwd)
+  local _, ret, stderr = utils.get_os_command_output({ 'git', 'reset', mode, selection.value }, cwd)
   if ret == 0 then
     print("Reset to: " .. selection.value)
   else
@@ -562,6 +560,24 @@ actions.git_reset_branch = function(prompt_bufnr)
       table.concat(stderr, '  ')
     ))
   end
+end
+
+--- Reset to selected git commit using mixed mode
+---@param prompt_bufnr number: The prompt bufnr
+actions.git_reset_mixed = function(prompt_bufnr)
+  git_reset_branch(prompt_bufnr, '--mixed')
+end
+
+--- Reset to selected git commit using soft mode
+---@param prompt_bufnr number: The prompt bufnr
+actions.git_reset_soft = function(prompt_bufnr)
+  git_reset_branch(prompt_bufnr, '--soft')
+end
+
+--- Reset to selected git commit using hard mode
+---@param prompt_bufnr number: The prompt bufnr
+actions.git_reset_hard = function(prompt_bufnr)
+  git_reset_branch(prompt_bufnr, '--hard')
 end
 
 actions.git_checkout_current_buffer = function(prompt_bufnr)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -528,38 +528,36 @@ local git_reset_branch = function(prompt_bufnr, mode)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
 
-  local confirmation = vim.fn.input('Do you really wanna ' .. mode .. ' reset to ' .. selection.value .. '? [Y/n] ')
-  if confirmation ~= '' and string.lower(confirmation) ~= 'y' then return end
+  local confirmation = vim.fn.input("Do you really wanna " .. mode .. " reset to " .. selection.value .. "? [Y/n] ")
+  if confirmation ~= "" and string.lower(confirmation) ~= "y" then
+    return
+  end
 
   actions.close(prompt_bufnr)
-  local _, ret, stderr = utils.get_os_command_output({ 'git', 'reset', mode, selection.value }, cwd)
+  local _, ret, stderr = utils.get_os_command_output({ "git", "reset", mode, selection.value }, cwd)
   if ret == 0 then
     print("Reset to: " .. selection.value)
   else
-    print(string.format(
-      'Error when resetting to: %s. Git returned: "%s"',
-      selection.value,
-      table.concat(stderr, '  ')
-    ))
+    print(string.format('Error when resetting to: %s. Git returned: "%s"', selection.value, table.concat(stderr, "  ")))
   end
 end
 
 --- Reset to selected git commit using mixed mode
 ---@param prompt_bufnr number: The prompt bufnr
 actions.git_reset_mixed = function(prompt_bufnr)
-  git_reset_branch(prompt_bufnr, '--mixed')
+  git_reset_branch(prompt_bufnr, "--mixed")
 end
 
 --- Reset to selected git commit using soft mode
 ---@param prompt_bufnr number: The prompt bufnr
 actions.git_reset_soft = function(prompt_bufnr)
-  git_reset_branch(prompt_bufnr, '--soft')
+  git_reset_branch(prompt_bufnr, "--soft")
 end
 
 --- Reset to selected git commit using hard mode
 ---@param prompt_bufnr number: The prompt bufnr
 actions.git_reset_hard = function(prompt_bufnr)
-  git_reset_branch(prompt_bufnr, '--hard')
+  git_reset_branch(prompt_bufnr, "--hard")
 end
 
 actions.git_checkout_current_buffer = function(prompt_bufnr)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -546,7 +546,7 @@ local git_reset_branch = function(prompt_bufnr, mode)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
 
-  local confirmation = vim.fn.input('Do you really wanna ' .. mode .. ' reset to commit ' .. selection.value .. '? [Y/n] ')
+  local confirmation = vim.fn.input('Do you really wanna ' .. mode .. ' reset to ' .. selection.value .. '? [Y/n] ')
   if confirmation ~= '' and string.lower(confirmation) ~= 'y' then return end
 
   actions.close(prompt_bufnr)

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -59,8 +59,12 @@ git.commits = function(opts)
     sorter = conf.file_sorter(opts),
     attach_mappings = function(_, map)
       actions.select_default:replace(actions.git_checkout)
-      map('i', '<c-r>', actions.git_reset_branch)
-      map('n', '<c-r>', actions.git_reset_branch)
+      map('i', '<c-r>m', actions.git_reset_mixed)
+      map('n', '<c-r>m', actions.git_reset_mixed)
+      map('i', '<c-r>s', actions.git_reset_soft)
+      map('n', '<c-r>s', actions.git_reset_soft)
+      map('i', '<c-r>h', actions.git_reset_hard)
+      map('n', '<c-r>h', actions.git_reset_hard)
       return true
     end
   }):find()

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -57,8 +57,10 @@ git.commits = function(opts)
       previewers.git_commit_message.new(opts),
     },
     sorter = conf.file_sorter(opts),
-    attach_mappings = function()
+    attach_mappings = function(_, map)
       actions.select_default:replace(actions.git_checkout)
+      map('i', '<c-r>', actions.git_reset_branch)
+      map('n', '<c-r>', actions.git_reset_branch)
       return true
     end
   }):find()

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -67,12 +67,12 @@ git.commits = function(opts)
     sorter = conf.file_sorter(opts),
     attach_mappings = function(_, map)
       actions.select_default:replace(actions.git_checkout)
-      map('i', '<c-r>m', actions.git_reset_mixed)
-      map('n', '<c-r>m', actions.git_reset_mixed)
-      map('i', '<c-r>s', actions.git_reset_soft)
-      map('n', '<c-r>s', actions.git_reset_soft)
-      map('i', '<c-r>h', actions.git_reset_hard)
-      map('n', '<c-r>h', actions.git_reset_hard)
+      map("i", "<c-r>m", actions.git_reset_mixed)
+      map("n", "<c-r>m", actions.git_reset_mixed)
+      map("i", "<c-r>s", actions.git_reset_soft)
+      map("n", "<c-r>s", actions.git_reset_soft)
+      map("i", "<c-r>h", actions.git_reset_hard)
+      map("n", "<c-r>h", actions.git_reset_hard)
       return true
     end,
   }):find()

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -143,7 +143,9 @@ builtin.git_files = require('telescope.builtin.git').files
 --- Lists commits for current directory with diff preview
 --- - Default keymaps:
 ---   - `<cr>`: checks out the currently selected commit
----   - `<C-r>`: resets current branch to selected commit
+---   - `<C-r>m`: resets current branch to selected commit using mixed mode
+---   - `<C-r>s`: resets current branch to selected commit using soft mode
+---   - `<C-r>h`: resets current branch to selected commit using hard mode
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
 builtin.git_commits = require('telescope.builtin.git').commits

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -143,6 +143,7 @@ builtin.git_files = require('telescope.builtin.git').files
 --- Lists commits for current directory with diff preview
 --- - Default keymaps:
 ---   - `<cr>`: checks out the currently selected commit
+---   - `<C-r>`: resets current branch to selected commit
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
 builtin.git_commits = require('telescope.builtin.git').commits


### PR DESCRIPTION
**Adding a [git reset](https://git-scm.com/docs/git-reset) action and making it available in the `git_commits` picker.** 

This PR:
- Adds a `git_reset` action
- Adds the above action to the `git_commits` picker
- Maps `<c-r>` to call the action in either normal or insert mode

Like similar actions, the `git_reset` action has a confirmation along with handling of the error and success cases and their messages. The default for git reset is [--mixed](https://git-scm.com/docs/git-reset#Documentation/git-reset.txt---mixed). That behavior is continued here. If this PR is accepted, I'd like to follow-up with [--soft](https://git-scm.com/docs/git-reset#Documentation/git-reset.txt---soft) and [--hard](https://git-scm.com/docs/git-reset#Documentation/git-reset.txt---hard) options in a future PR. I personally have my local version hardcoded to `--hard`. But, that would probably surprise and upset many users if it were the default. Git's default is safe and friendly. 😄 

The reason for adding the new action to the `git_commits` picker is because it's Telescope's `git log` picker. It is convenient, intuitive and awesome to `reset` to the selected commit. I've been using it locally for a while and it saves me from having to copy/paste the SHA or count backwards from `HEAD`.  Who has time for all that? Telescope to the rescue as usual. 🔭 

