### PR TITLE
feat: add no_ignore option to find_files

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -160,7 +160,7 @@ files.find_files = function(opts)
         table.insert(find_command, "--hidden")
       end
       if no_ignore then
-        table.insert(find_command, '--no-ignore')
+        table.insert(find_command, "--no-ignore")
       end
       if follow then
         table.insert(find_command, "-L")
@@ -177,7 +177,7 @@ files.find_files = function(opts)
         table.insert(find_command, "--hidden")
       end
       if no_ignore then
-        table.insert(find_command, '--no-ignore')
+        table.insert(find_command, "--no-ignore")
       end
       if follow then
         table.insert(find_command, "-L")
@@ -194,7 +194,7 @@ files.find_files = function(opts)
         table.insert(find_command, "--hidden")
       end
       if no_ignore then
-        table.insert(find_command, '--no-ignore')
+        table.insert(find_command, "--no-ignore")
       end
       if follow then
         table.insert(find_command, "-L")
@@ -211,7 +211,7 @@ files.find_files = function(opts)
         find_command = flatten(find_command)
       end
       if no_ignore ~= nil then
-        log.warn('The `no_ignore` key is not available for the `find` command in `find_files`.')
+        log.warn "The `no_ignore` key is not available for the `find` command in `find_files`."
       end
       if follow then
         table.insert(find_command, "-L")
@@ -228,7 +228,7 @@ files.find_files = function(opts)
         log.warn "The `hidden` key is not available for the Windows `where` command in `find_files`."
       end
       if no_ignore ~= nil then
-        log.warn('The `no_ignore` key is not available for the Windows `where` command in `find_files`.')
+        log.warn "The `no_ignore` key is not available for the Windows `where` command in `find_files`."
       end
       if follow ~= nil then
         log.warn "The `follow` key is not available for the Windows `where` command in `find_files`."

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -134,6 +134,7 @@ end
 files.find_files = function(opts)
   local find_command = opts.find_command
   local hidden = opts.hidden
+  local no_ignore = opts.no_ignore
   local follow = opts.follow
   local search_dirs = opts.search_dirs
 
@@ -147,6 +148,7 @@ files.find_files = function(opts)
     if 1 == vim.fn.executable("fd") then
       find_command = { 'fd', '--type', 'f' }
       if hidden then table.insert(find_command, '--hidden') end
+      if no_ignore then table.insert(find_command, '--no-ignore') end
       if follow then table.insert(find_command, '-L') end
       if search_dirs then
         table.insert(find_command, '.')
@@ -157,6 +159,7 @@ files.find_files = function(opts)
     elseif 1 == vim.fn.executable("fdfind") then
       find_command = { 'fdfind', '--type', 'f' }
       if hidden then table.insert(find_command, '--hidden') end
+      if no_ignore then table.insert(find_command, '--no-ignore') end
       if follow then table.insert(find_command, '-L') end
       if search_dirs then
         table.insert(find_command, '.')
@@ -167,6 +170,7 @@ files.find_files = function(opts)
     elseif 1 == vim.fn.executable("rg") then
       find_command = { 'rg', '--files' }
       if hidden then table.insert(find_command, '--hidden') end
+      if no_ignore then table.insert(find_command, '--no-ignore') end
       if follow then table.insert(find_command, '-L') end
       if search_dirs then
         for _,v in pairs(search_dirs) do
@@ -179,6 +183,9 @@ files.find_files = function(opts)
         table.insert(find_command, { '-not', '-path', "*/.*" })
         find_command = flatten(find_command)
       end
+      if no_ignore ~= nil then
+        log.warn('The `no_ignore` key is not available for the `find` command in `find_files`.')
+      end
       if follow then table.insert(find_command, '-L') end
       if search_dirs then
         table.remove(find_command, 2)
@@ -190,6 +197,9 @@ files.find_files = function(opts)
       find_command = { 'where', '/r', '.', '*'}
       if hidden ~= nil then
         log.warn('The `hidden` key is not available for the Windows `where` command in `find_files`.')
+      end
+      if no_ignore ~= nil then
+        log.warn('The `no_ignore` key is not available for the Windows `where` command in `find_files`.')
       end
       if follow ~= nil then
         log.warn('The `follow` key is not available for the Windows `where` command in `find_files`.')

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -84,6 +84,7 @@ builtin.grep_string = require('telescope.builtin.files').grep_string
 ---@field find_command table: command line arguments for `find_files` to use for the search, overrides default config
 ---@field follow boolean: if true, follows symlinks (i.e. uses `-L` flag for the `find` command)
 ---@field hidden boolean: determines whether to show hidden files or not (default is false)
+---@field no_ignore boolean: show files ignored by .gitignore, .ignore, etc. (default is false)
 ---@field search_dirs table: directory/directories to search in
 builtin.find_files = require('telescope.builtin.files').find_files
 


### PR DESCRIPTION
This will allow find_files to find files ignored by .gitignore
and other ignore files. This is supported by fd, rg, and fdfind.