### PR TITLE
fix: escape newlines in code action title

### DIFF
--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -165,7 +165,7 @@ lsp.code_actions = function(opts)
       for _, result in pairs(response.result) do
         local entry = {
           idx = idx,
-          command_title = result.title,
+          command_title = result.title:gsub("\r\n", "\\r\\n"):gsub("\n", "\\n"),
           client_name = client and client.name or "",
           command = result,
         }


### PR DESCRIPTION
_Logs:_
```
[DEBUG Sat Jul 17 09:36:33 2021] ...pack/packer/opt/telescope.nvim/lua/telescope/pickers.lua:898: Failed to set lines... String cannot contain newlines
[DEBUG Sat Jul 17 09:36:33 2021] ...pack/packer/opt/telescope.nvim/lua/telescope/pickers.lua:898: Failed to set lines... String cannot contain newlines
[DEBUG Sat Jul 17 09:36:33 2021] ...pack/packer/opt/telescope.nvim/lua/telescope/pickers.lua:797: ...pack/packer/opt/telescope.nvim/lua/telescope/pickers.lua:786: String cannot contain newlines
```

_Before:_

<img width="1585" alt="Screenshot 2021-07-17 at 09 52 52" src="https://user-images.githubusercontent.com/67177269/126025418-f5d061d5-78d4-4370-b749-dd1cd5ccbf11.png">

_After:_

<img width="1585" alt="Screenshot 2021-07-17 at 09 53 13" src="https://user-images.githubusercontent.com/67177269/126025421-2b34ac98-2c03-4d23-8341-989e75fd8e17.png">

---
There's also the case where the code action title is very long and the entire Neovim gets frozen and the CPU usage gets high:

<img width="1668" alt="Screenshot 2021-07-17 at 10 12 24" src="https://user-images.githubusercontent.com/67177269/126025879-3e5772fb-2f99-4bd8-973e-cdbe2f9791a2.png">
<img width="1171" alt="Screenshot 2021-07-17 at 10 12 38" src="https://user-images.githubusercontent.com/67177269/126025880-e9e95c7d-951e-4dcd-8317-7a2fb9931807.png">
