### PR TITLE
feat: multi-select style actions

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1482,7 +1482,7 @@ Functions to be used to determine the current state of telescope.
 Generally used from within other |telescope.actions|
 
 action_state.get_selected_entry()          *action_state.get_selected_entry()*
-    Get the current entry
+    Get the user-overriden or current entry
 
 
 
@@ -1555,29 +1555,56 @@ action_set.scroll_previewer({prompt_bufnr}, {direction})*action_set.scroll_previ
 ================================================================================
                                                        *telescope.actions.utils*
 
-Utilities to wrap functions around picker selections and entries.
+Utilities to wrap actions and functions around picker selections and entries.
+Generally used with other |telescope.actions| or custom functions that lever
+entries or selections.
+The functions without the `_` prefix are intended to be mapped at setup,
+whereas `functions` with the `_` prefix are intended to be used in custom
+actions. Refer to the respective function documentation for examples.
+The functions that take `action(s)` as input typically are |telescope.actions|
+that lever the `action_state.selected_entry`. In particular,
+`action_utils.with_{entries, selection, selections}` intermittently override
+the `selected_entry` to perform the |telescope.actions| accordingly. More
+generally, `actions` are functions are akin to the below example
+  local action_state = require "telescope.actions.state"
+  function(prompt_bufnr)
+    local entry = action_state.get_selected_entry()
+    -- lever entry for function
+    ...
+  end
 
-Generally used from within other |telescope.actions|
-
-utils.map_entries({prompt_bufnr}, {f})                   *utils.map_entries()*
-    Apply `f` to the entries of the current picker.
+action_utils._map_entries({prompt_bufnr}, {f})   *action_utils._map_entries()*
+    Apply `f` to the entries of the current picker and prompt.
+    - `f` takes (entry, index, row) as arguments.
     - Notes:
       - Mapped entries may include results not visible in the results popup.
       - Indices are 1-indexed, whereas rows are 0-indexed.
     - Warning: `map_entries` has no return value.
-      - The below example showcases how to collect results
-    Usage:
-        local action_state = require "telescope.actions.state"
-        local action_utils = require "telescope.actions.utils"
-        function entry_value_by_row()
-          local prompt_bufnr = vim.api.nvim_get_current_buf()
-          local current_picker = action_state.get_current_picker(prompt_bufnr)
-          local results = {}
-            action_utils.map_entries(prompt_bufnr, function(entry, index, row)
-            results[row] = entry.value
-          end)
-          return results
-        end
+      - The below example showcase how to collect results.
+    Example Usage: collect entries in key-value table
+      local action_state = require "telescope.actions.state"
+      local action_utils = require "telescope.actions.utils"
+      require("telescope").setup {
+        defaults = {
+          mappings = {
+            i = {
+              -- with `action_utils._map_entries`
+              ['<C-e>'] = function(prompt_bufnr)
+                  local results = {}
+                  action_utils._with_entries(prompt_bufnr, function(entry, entry_index)
+                  results[entry_index] = entry
+                  return results
+                end)
+              end,
+              -- with `action_utils.map_entries`
+              ['<C-e>'] = action_utils.with_entries(function(entry, entry_index)
+                  results[entry_index] = entry
+                  return results
+                end)
+            },
+          },
+        },
+      }
 
 
     Parameters: ~
@@ -1587,32 +1614,173 @@ utils.map_entries({prompt_bufnr}, {f})                   *utils.map_entries()*
                                    arguments
 
 
-utils.map_selections({prompt_bufnr}, {f})             *utils.map_selections()*
+action_utils.map_entries()                        *action_utils.map_entries()*
+    Apply `f` to the entries of the current picker and prompt. See
+    |action_utils._map_entries| for further information.
+    - `f` takes (entry, index, row) as arguments.
+
+
+
+action_utils._map_selections({prompt_bufnr}, {f})*action_utils._map_selections()*
     Apply `f` to the multi selections of the current picker and return a table
     of mapped selections.
+    - `f` takes (selection, selection_index) as arguments
     - Notes:
       - Mapped selections may include results not visible in the results popup.
       - Selected entries are returned in order of their selection.
     - Warning: `map_selections` has no return value.
       - The below example showcases how to collect results
-    Usage:
-        local action_state = require "telescope.actions.state"
-        local action_utils = require "telescope.actions.utils"
-        function selection_by_index()
-          local prompt_bufnr = vim.api.nvim_get_current_buf()
-          local current_picker = action_state.get_current_picker(prompt_bufnr)
-          local results = {}
-            action_utils.map_selections(prompt_bufnr, function(entry, index)
-            results[index] = entry.value
-          end)
-          return results
-        end
+    Example Usage: collect selections in key-value table
+      local actions = require "telescope.actions"
+      local action_utils = require "telescope.actions.utils"
+      require("telescope").setup {
+        defaults = {
+          mappings = {
+            i = {
+            -- Collect selections
+              -- with `action_utils._map_selections`
+              ['<C-m>'] = function(prompt_bufnr)
+                  local results = {}
+                  action_utils._map_selections(prompt_bufnr, function(selection, selection_index)
+                  results[selection_index] = selection
+                  return results
+                  end),
+                end
+              -- with `action_utils.map_selections`
+              ['<C-m>'] = action_utils.with_selections(function(selection, selection_index)
+                  results[selection_index] = selection
+                  return results
+                end),
+            },
+          },
+        },
+      }
 
 
     Parameters: ~
         {prompt_bufnr} (number)    The prompt bufnr
         {f}            (function)  Function to map onto selection of picker
-                                   that takes (selection) as a viable argument
+                                   that takes (selection, selection_index) as
+                                   arguments
+
+
+action_utils.map_selections({f})               *action_utils.map_selections()*
+    Apply `f` to the multi selections of the current picker and return a table
+    of mapped selections. See |action_utils._map_selections| for further
+    information.
+    - `f` takes (selection, selection_index) as arguments
+
+
+    Parameters: ~
+        {f} (function)  Function to map onto selection of picker that takes
+                        (selection, selection_index) as arguments
+
+
+action_utils._with_entries({f})                 *action_utils._with_entries()*
+    Run an `action` from |telescope.actions| on entries of the current picker
+    and prompt.
+    - Notes:
+      - Mapped entries may include results not visible in the results popup.
+      - See |telescope.action.utils| for information on what functions
+        constitute `actions`.
+    Example Usage: git_staging_toggle
+      local actions = require "telescope.actions"
+      local action_utils = require "telescope.actions.utils"
+      require("telescope").setup {
+        defaults = {
+          pickers = {
+            git_status = {
+              mappings = {
+                i = {
+                -- Open selections vertically
+                  -- with `action_utils._with_entries`
+                  ['<S-Tab>'] = function(prompt_bufnr)
+                    action_utils.with_entries(prompt_bufnr, actions.git_staging_toggle)
+                    end,
+                  -- with `action_utils.with_entries`
+                  ['<S-Tab>'] = action_utils.with_entries(actions.git_staging_toggle)
+                },
+              },
+            },
+          },
+        }
+      }
+
+
+    Parameters: ~
+        {f} (function)  apply action onto all results
+
+
+action_utils.with_entries({f})                   *action_utils.with_entries()*
+    Run an `action` from |telescope.actions| on the entries of the current
+    picker and prompt.
+    - Note: see |action_utils._with_entries| for further information.
+
+
+    Parameters: ~
+        {f} (function)  apply action onto all results
+
+
+action_utils._with_selections({prompt_bufnr}, {f})*action_utils._with_selections()*
+    Run an `action` from |telescope.actions| on the multi selection.
+    - Note: see |telescope.action.utils| for information on what functions
+      constitute `actions`.
+    Example Usage: open selections vertically
+      local actions = require "telescope.actions"
+      local action_utils = require "telescope.actions.utils"
+      require("telescope").setup {
+        defaults = {
+          mappings = {
+            i = {
+            -- Open selections vertically
+              -- with `action_utils._with_selections`
+              ['<C-v><C-v>'] = function(prompt_bufnr)
+                action_utils.with_selections(prompt_bufnr, actions.select_vertical)
+                end,
+              -- with `action_utils.with_selections`
+              ['<C-v><C-v>'] = action_utils.with_selections(actions.select_vertical)
+            },
+          },
+        },
+      }
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)    The prompt bufnr
+        {f}            (function)  apply action onto entries of multi selection
+
+
+action_utils.with_selections({f})             *action_utils.with_selections()*
+    Run an `action` from |telescope.actions| on the multi selection.
+    - Note: see |telescope.action.utils| for specification on what functions
+      constitute `actions`.
+
+
+    Parameters: ~
+        {f} (function)  apply action onto entries of multi selection
+
+
+action_utils.cycle({actions})                           *action_utils.cycle()*
+    Apply `actions` to multi selections or entries in cycle, on
+    entry-after-entry basis. Commonly used in combination with
+    `action_utils.with_{selections, entries}`.
+    Example Usage: open selections alternatingly vertically and horizontally
+      local actions = require "telescope.actions"
+      local action_utils = require "telescope.actions.utils"
+      require("telescope").setup {
+        defaults = {
+          mappings = {
+            i = {
+              ['<C-b>'] = action_utils.with_selections(
+                            action_utils.cycle({actions.select_vertical, actions.select_horizontal})
+            },
+          },
+        },
+      }
+
+
+    Parameters: ~
+        {actions} (table)  table of actions to apply iteratively
 
 
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1558,14 +1558,18 @@ action_set.scroll_previewer({prompt_bufnr}, {direction})*action_set.scroll_previ
 Utilities to wrap actions and functions around picker selections and entries.
 Generally used with other |telescope.actions| or custom functions that lever
 entries or selections.
+
 The functions without the `_` prefix are intended to be mapped at setup,
 whereas `functions` with the `_` prefix are intended to be used in custom
-actions. Refer to the respective function documentation for examples.
+actions. Refer to the respective function documentation for example use cases.
+
 The functions that take `action(s)` as input typically are |telescope.actions|
 that lever the `action_state.selected_entry`. In particular,
 `action_utils.with_{entries, selection, selections}` intermittently override
 the `selected_entry` to perform the |telescope.actions| accordingly. More
-generally, `actions` are functions are akin to the below example
+generally, `actions` as referred to in |telescope.actions.utils| are functions
+are akin to the below example:
+
   local action_state = require "telescope.actions.state"
   function(prompt_bufnr)
     local entry = action_state.get_selected_entry()
@@ -1581,6 +1585,7 @@ action_utils._map_entries({prompt_bufnr}, {f})   *action_utils._map_entries()*
       - Indices are 1-indexed, whereas rows are 0-indexed.
     - Warning: `map_entries` has no return value.
       - The below example showcase how to collect results.
+
     Example Usage: collect entries in key-value table
       local action_state = require "telescope.actions.state"
       local action_utils = require "telescope.actions.utils"
@@ -1630,6 +1635,7 @@ action_utils._map_selections({prompt_bufnr}, {f})*action_utils._map_selections()
       - Selected entries are returned in order of their selection.
     - Warning: `map_selections` has no return value.
       - The below example showcases how to collect results
+
     Example Usage: collect selections in key-value table
       local actions = require "telescope.actions"
       local action_utils = require "telescope.actions.utils"
@@ -1683,7 +1689,8 @@ action_utils._with_entries({f})                 *action_utils._with_entries()*
       - Mapped entries may include results not visible in the results popup.
       - See |telescope.action.utils| for information on what functions
         constitute `actions`.
-    Example Usage: git_staging_toggle
+
+    Example Usage: |actions.git_staging_toggle|
       local actions = require "telescope.actions"
       local action_utils = require "telescope.actions.utils"
       require("telescope").setup {
@@ -1725,7 +1732,8 @@ action_utils._with_selections({prompt_bufnr}, {f})*action_utils._with_selections
     Run an `action` from |telescope.actions| on the multi selection.
     - Note: see |telescope.action.utils| for information on what functions
       constitute `actions`.
-    Example Usage: open selections vertically
+
+    Example Usage: |actions.select_vertical|
       local actions = require "telescope.actions"
       local action_utils = require "telescope.actions.utils"
       require("telescope").setup {
@@ -1747,7 +1755,8 @@ action_utils._with_selections({prompt_bufnr}, {f})*action_utils._with_selections
 
     Parameters: ~
         {prompt_bufnr} (number)    The prompt bufnr
-        {f}            (function)  apply action onto entries of multi selection
+        {f}            (function)  apply `action` onto entries of multi
+                                   selection
 
 
 action_utils.with_selections({f})             *action_utils.with_selections()*
@@ -1757,13 +1766,38 @@ action_utils.with_selections({f})             *action_utils.with_selections()*
 
 
     Parameters: ~
-        {f} (function)  apply action onto entries of multi selection
+        {f} (function)  apply `action` onto entries of multi selection
+
+
+action_utils._with_selection({prompt_bufnr}, {f})*action_utils._with_selection()*
+    Run an `action` from |telescope.actions| on an indexed multi selection. The
+    index denotes the order in selection of the entry to run the action on.
+    - Note: see |telescope.action.utils| for specification on what functions
+      constitute `actions`.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)    The prompt bufnr
+        {f}            (function)  apply `action` onto entries of multi
+                                   selection
+
+
+action_utils.with_selection({f})               *action_utils.with_selection()*
+    Run an `action` from |telescope.actions| on an indexed multi selection. The
+    index denotes the order in selection of the entry to run the action on.
+    - Note: see |telescope.action.utils| for specification on what functions
+      constitute `actions`.
+
+
+    Parameters: ~
+        {f} (function)  apply `action` onto entries of multi selection
 
 
 action_utils.cycle({actions})                           *action_utils.cycle()*
     Apply `actions` to multi selections or entries in cycle, on
     entry-after-entry basis. Commonly used in combination with
     `action_utils.with_{selections, entries}`.
+
     Example Usage: open selections alternatingly vertically and horizontally
       local actions = require "telescope.actions"
       local action_utils = require "telescope.actions.utils"

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -60,6 +60,10 @@ function actions.get_current_line()
   return action_state.get_current_line()
 end
 
+function actions.inspect()
+  P(action_state.get_selected_entry())
+end
+
 function actions.get_current_picker(prompt_bufnr)
   -- TODO(1.0): Remove
   action_is_deprecated("get_current_picker")
@@ -784,7 +788,7 @@ actions.cycle_previewers_prev = function(prompt_bufnr)
 end
 
 -- ==================================================
--- Transforms modules and sets the corect metatables.
+-- Transforms modules and sets the correct metatables.
 -- ==================================================
 actions = transform_mod(actions)
 return actions

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -60,10 +60,6 @@ function actions.get_current_line()
   return action_state.get_current_line()
 end
 
-function actions.inspect()
-  P(action_state.get_selected_entry())
-end
-
 function actions.get_current_picker(prompt_bufnr)
   -- TODO(1.0): Remove
   action_is_deprecated("get_current_picker")

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -121,7 +121,7 @@ action_set.edit = function(prompt_bufnr, command)
   end
 
   local entry_bufnr = entry.bufnr
-  
+
   -- multi-style actions may have torn down picker
   if action_state.get_current_picker(prompt_bufnr) ~= nil then
     require('telescope.actions').close(prompt_bufnr)

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -121,8 +121,11 @@ action_set.edit = function(prompt_bufnr, command)
   end
 
   local entry_bufnr = entry.bufnr
-
-  require('telescope.actions').close(prompt_bufnr)
+  
+  -- multi-style actions may have torn down picker
+  if action_state.get_current_picker(prompt_bufnr) ~= nil then
+    require('telescope.actions').close(prompt_bufnr)
+  end
 
   if entry_bufnr then
     edit_buffer(command, entry_bufnr)

--- a/lua/telescope/actions/state.lua
+++ b/lua/telescope/actions/state.lua
@@ -11,9 +11,13 @@ local conf = require('telescope.config').values
 
 local action_state = {}
 
---- Get the current entry
+--- Get the user-overriden or current entry
 function action_state.get_selected_entry()
-  return global_state.get_global_key('selected_entry')
+  local global_entry = global_state.get_and_clear_global_key('set_entry')
+  if global_entry == nil then
+    return global_state.get_global_key('selected_entry')
+  end
+  return global_entry
 end
 
 --- Gets the current line

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -97,6 +97,8 @@ function action_utils._with_selections(prompt_bufnr, action)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   for index, selection in ipairs(current_picker:get_multi_selection()) do
     global_state.set_global_key("set_entry", selection)
+    -- satisfy linter
+    local _ = index
     action(prompt_bufnr)
   end
 end

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -2,13 +2,16 @@
 
 ---@brief [[
 --- Utilities to wrap actions and functions around picker selections and entries.
---- Generally used with other |telescope.actions| or custom functions that lever entries or selections.<br>
+--- Generally used with other |telescope.actions| or custom functions that lever entries or selections.
+---
 --- The functions without the `_` prefix are intended to be mapped at setup, whereas `functions` with the `_` prefix
---- are intended to be used in custom actions. Refer to the respective function documentation for examples.<br>
+--- are intended to be used in custom actions. Refer to the respective function documentation for example use cases.
+---
 --- The functions that take `action(s)` as input typically are |telescope.actions| that lever the
 --- `action_state.selected_entry`. In particular, `action_utils.with_{entries, selection, selections}`
 --- intermittently override the `selected_entry` to perform the |telescope.actions| accordingly.
---- More generally, `actions` are functions are akin to the below example
+--- More generally, `actions` as referred to in |telescope.actions.utils| are functions are akin to the below example:
+---
 --- <pre>
 ---   local action_state = require "telescope.actions.state"
 ---   function(prompt_bufnr)
@@ -31,6 +34,7 @@ local action_utils = {}
 ---   - Indices are 1-indexed, whereas rows are 0-indexed.
 --- - Warning: `map_entries` has no return value.
 ---   - The below example showcase how to collect results.
+---
 --- <pre>
 --- Example Usage: collect entries in key-value table
 ---   local action_state = require "telescope.actions.state"
@@ -89,6 +93,7 @@ end
 ---   - Selected entries are returned in order of their selection.
 --- - Warning: `map_selections` has no return value.
 ---   - The below example showcases how to collect results
+---
 --- <pre>
 --- Example Usage: collect selections in key-value table
 ---   local actions = require "telescope.actions"
@@ -142,8 +147,9 @@ end
 --- - Notes:
 ---   - Mapped entries may include results not visible in the results popup.
 ---   - See |telescope.action.utils| for information on what functions constitute `actions`.
+---
 --- <pre>
---- Example Usage: git_staging_toggle
+--- Example Usage: |actions.git_staging_toggle|
 ---   local actions = require "telescope.actions"
 ---   local action_utils = require "telescope.actions.utils"
 ---   require("telescope").setup {
@@ -188,8 +194,9 @@ end
 
 --- Run an `action` from |telescope.actions| on the multi selection.
 --- - Note: see |telescope.action.utils| for information on what functions constitute `actions`.
+---
 --- <pre>
---- Example Usage: open selections vertically
+--- Example Usage: |actions.select_vertical|
 ---   local actions = require "telescope.actions"
 ---   local action_utils = require "telescope.actions.utils"
 ---   require("telescope").setup {
@@ -209,7 +216,7 @@ end
 ---   }
 --- </pre>
 ---@param prompt_bufnr number: The prompt bufnr
----@param f function: apply action onto entries of multi selection
+---@param f function: apply `action` onto entries of multi selection
 function action_utils._with_selections(prompt_bufnr, action)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   for _, selection in ipairs(current_picker:get_multi_selection()) do
@@ -220,14 +227,18 @@ end
 
 --- Run an `action` from |telescope.actions| on the multi selection.
 --- - Note: see |telescope.action.utils| for specification on what functions constitute `actions`.
----@param f function: apply action onto entries of multi selection
+---@param f function: apply `action` onto entries of multi selection
 function action_utils.with_selections(action)
   return function(prompt_bufnr)
     action_utils._with_selections(prompt_bufnr, action)
   end
 end
 
--- TODO: docs & mapping variant
+--- Run an `action` from |telescope.actions| on an indexed multi selection.
+--- The index denotes the order in selection of the entry to run the action on.
+--- - Note: see |telescope.action.utils| for specification on what functions constitute `actions`.
+---@param prompt_bufnr number: The prompt bufnr
+---@param f function: apply `action` onto entries of multi selection
 function action_utils._with_selection(prompt_bufnr, action, selection_index)
   selection_index = vim.F.if_nil(selection_index, 1)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
@@ -236,6 +247,10 @@ function action_utils._with_selection(prompt_bufnr, action, selection_index)
   action(prompt_bufnr)
 end
 
+--- Run an `action` from |telescope.actions| on an indexed multi selection.
+--- The index denotes the order in selection of the entry to run the action on.
+--- - Note: see |telescope.action.utils| for specification on what functions constitute `actions`.
+---@param f function: apply `action` onto entries of multi selection
 function action_utils.with_selection(action, selection_index)
   return function(prompt_bufnr)
     action_utils._with_selection(prompt_bufnr, action, selection_index)
@@ -244,6 +259,7 @@ end
 
 --- Apply `actions` to multi selections or entries in cycle, on entry-after-entry basis.
 --- Commonly used in combination with `action_utils.with_{selections, entries}`.
+---
 --- <pre>
 --- Example Usage: open selections alternatingly vertically and horizontally
 ---   local actions = require "telescope.actions"

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -1,36 +1,61 @@
 ---@tag telescope.actions.utils
 
 ---@brief [[
---- Utilities to wrap functions around picker selections and entries.
----
---- Generally used from within other |telescope.actions|
+--- Utilities to wrap actions and functions around picker selections and entries.
+--- Generally used with other |telescope.actions| or custom functions that lever entries or selections.<br>
+--- The functions without the `_` prefix are intended to be mapped at setup, whereas `functions` with the `_` prefix
+--- are intended to be used in custom actions. Refer to the respective function documentation for examples.<br>
+--- The functions that take `action(s)` as input typically are |telescope.actions| that lever the
+--- `action_state.selected_entry`. In particular, `action_utils.with_{entries, selection, selections}`
+--- intermittently override the `selected_entry` to perform the |telescope.actions| accordingly.
+--- More generally, `actions` are functions are akin to the below example
+--- <pre>
+---   local action_state = require "telescope.actions.state"
+---   function(prompt_bufnr)
+---     local entry = action_state.get_selected_entry()
+---     -- lever entry for function
+---     ...
+---   end
+--- </pre>
 ---@brief ]]
 
 local action_state = require "telescope.actions.state"
 local global_state = require "telescope.state"
 
-local utils = require "telescope.utils"
 local action_utils = {}
 
---- Apply `f` to the entries of the current picker.
+--- Apply `f` to the entries of the current picker and prompt.
+--- - `f` takes (entry, index, row) as arguments.
 --- - Notes:
 ---   - Mapped entries may include results not visible in the results popup.
 ---   - Indices are 1-indexed, whereas rows are 0-indexed.
 --- - Warning: `map_entries` has no return value.
----   - The below example showcases how to collect results
+---   - The below example showcase how to collect results.
 --- <pre>
---- Usage:
----     local action_state = require "telescope.actions.state"
----     local action_utils = require "telescope.actions.utils"
----     function entry_value_by_row()
----       local prompt_bufnr = vim.api.nvim_get_current_buf()
----       local current_picker = action_state.get_current_picker(prompt_bufnr)
----       local results = {}
----         action_utils.map_entries(prompt_bufnr, function(entry, index, row)
----         results[row] = entry.value
----       end)
----       return results
----     end
+--- Example Usage: collect entries in key-value table
+---   local action_state = require "telescope.actions.state"
+---   local action_utils = require "telescope.actions.utils"
+---   require("telescope").setup {
+---     defaults = {
+---       mappings = {
+---         i = {
+---           -- with `action_utils._map_entries`
+---           ['<C-e>'] = function(prompt_bufnr)
+---               local results = {}
+---               action_utils._with_entries(prompt_bufnr, function(entry, entry_index)
+---               results[entry_index] = entry
+---               return results
+---             end)
+---           end,
+---           -- with `action_utils.map_entries`
+---           ['<C-e>'] = action_utils.with_entries(function(entry, entry_index)
+---               results[entry_index] = entry
+---               return results
+---             end)
+---         },
+---       },
+---     },
+---   }
 --- </pre>
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto entries of picker that takes (entry, index, row) as viable arguments
@@ -48,6 +73,9 @@ function action_utils._map_entries(prompt_bufnr, f)
   end
 end
 
+--- Apply `f` to the entries of the current picker and prompt.
+--- See |action_utils._map_entries| for further information.
+--- - `f` takes (entry, index, row) as arguments.
 function action_utils.map_entries(f)
   return function(prompt_bufnr)
     action_utils._map_entries(prompt_bufnr, f)
@@ -55,87 +83,90 @@ function action_utils.map_entries(f)
 end
 
 --- Apply `f` to the multi selections of the current picker and return a table of mapped selections.
+--- - `f` takes (selection, selection_index) as arguments
 --- - Notes:
 ---   - Mapped selections may include results not visible in the results popup.
 ---   - Selected entries are returned in order of their selection.
 --- - Warning: `map_selections` has no return value.
 ---   - The below example showcases how to collect results
 --- <pre>
---- Usage:
----     local action_state = require "telescope.actions.state"
----     local action_utils = require "telescope.actions.utils"
----     function selection_by_index()
----       local prompt_bufnr = vim.api.nvim_get_current_buf()
----       local current_picker = action_state.get_current_picker(prompt_bufnr)
----       local results = {}
----         action_utils.map_selections(prompt_bufnr, function(entry, index)
----         results[index] = entry.value
----       end)
----       return results
----     end
+--- Example Usage: collect selections in key-value table
+---   local actions = require "telescope.actions"
+---   local action_utils = require "telescope.actions.utils"
+---   require("telescope").setup {
+---     defaults = {
+---       mappings = {
+---         i = {
+---         -- Collect selections
+---           -- with `action_utils._map_selections`
+---           ['<C-m>'] = function(prompt_bufnr)
+---               local results = {}
+---               action_utils._map_selections(prompt_bufnr, function(selection, selection_index)
+---               results[selection_index] = selection
+---               return results
+---               end),
+---             end
+---           -- with `action_utils.map_selections`
+---           ['<C-m>'] = action_utils.with_selections(function(selection, selection_index)
+---               results[selection_index] = selection
+---               return results
+---             end),
+---         },
+---       },
+---     },
+---   }
 --- </pre>
 ---@param prompt_bufnr number: The prompt bufnr
----@param f function: Function to map onto selection of picker that takes (selection) as a viable argument
+---@param f function: Function to map onto selection of picker that takes (selection, selection_index) as arguments
 function action_utils._map_selections(prompt_bufnr, f)
   vim.validate {
     f = { f, "function" },
   }
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  for _, selection in ipairs(current_picker:get_multi_selection()) do
-    f(selection)
+  for selection_index, selection in ipairs(current_picker:get_multi_selection()) do
+    f(selection, selection_index)
   end
 end
 
+--- Apply `f` to the multi selections of the current picker and return a table of mapped selections.
+--- See |action_utils._map_selections| for further information.
+--- - `f` takes (selection, selection_index) as arguments
+---@param f function: Function to map onto selection of picker that takes (selection, selection_index) as arguments
 function action_utils.map_selections(f)
   return function(prompt_bufnr)
     action_utils._map_selections(prompt_bufnr, f)
   end
 end
 
--- TODO more control flow
-function action_utils._with_selections(prompt_bufnr, action)
-  local current_picker = action_state.get_current_picker(prompt_bufnr)
-  for index, selection in ipairs(current_picker:get_multi_selection()) do
-    global_state.set_global_key("set_entry", selection)
-    -- satisfy linter
-    local _ = index
-    action(prompt_bufnr)
-  end
-end
-
-function action_utils.with_selections(action)
-  return function(prompt_bufnr)
-    action_utils._with_selections(prompt_bufnr, action)
-  end
-end
-
-function action_utils.with_selection(action, selection_index)
-  selection_index = vim.F.if_nil(selection_index, 1)
-  return function(prompt_bufnr)
-    local current_picker = action_state.get_current_picker(prompt_bufnr)
-    local selections = current_picker:get_multi_selection()
-    global_state.set_global_key("set_entry", selections[selection_index])
-    action(prompt_bufnr)
-  end
-end
-
-function action_utils.round_robin(actions)
-  local num_actions = #actions
-  local cycle = function(i, n)
-    local result = i % n
-    return result == 0 and n or result
-  end
-  return function(prompt_bufnr)
-    -- level 3 is the calling function
-    local variables = utils.locals(3)
-    if variables.index == nil then
-      print("No index found! Cannot cycle through, attempting to abort safely...")
-      return 
-    end
-    actions[cycle(variables.index, num_actions)](prompt_bufnr)
-  end
-end
-
+--- Run an `action` from |telescope.actions| on entries of the current picker and prompt.
+--- - Notes:
+---   - Mapped entries may include results not visible in the results popup.
+---   - See |telescope.action.utils| for information on what functions constitute `actions`.
+--- <pre>
+--- Example Usage: git_staging_toggle
+---   local actions = require "telescope.actions"
+---   local action_utils = require "telescope.actions.utils"
+---   require("telescope").setup {
+---     defaults = {
+---       pickers = {
+---         git_status = {
+---           mappings = {
+---             i = {
+---             -- Open selections vertically
+---               -- with `action_utils._with_entries`
+---               ['<S-Tab>'] = function(prompt_bufnr)
+---                 action_utils.with_entries(prompt_bufnr, actions.git_staging_toggle)
+---                 end,
+---               -- with `action_utils.with_entries`
+---               ['<S-Tab>'] = action_utils.with_entries(actions.git_staging_toggle)
+---             },
+---           },
+---         },
+---       },
+---     }
+---   }
+--- </pre>
+---@param f function: apply action onto all results
 function action_utils._with_entries(prompt_bufnr, action)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local index = 1
@@ -146,9 +177,99 @@ function action_utils._with_entries(prompt_bufnr, action)
   end
 end
 
+--- Run an `action` from |telescope.actions| on the entries of the current picker and prompt.
+--- - Note: see |action_utils._with_entries| for further information.
+---@param f function: apply action onto all results
 function action_utils.with_entries(action)
   return function(prompt_bufnr)
     action_utils._with_entries(prompt_bufnr, action)
+  end
+end
+
+--- Run an `action` from |telescope.actions| on the multi selection.
+--- - Note: see |telescope.action.utils| for information on what functions constitute `actions`.
+--- <pre>
+--- Example Usage: open selections vertically
+---   local actions = require "telescope.actions"
+---   local action_utils = require "telescope.actions.utils"
+---   require("telescope").setup {
+---     defaults = {
+---       mappings = {
+---         i = {
+---         -- Open selections vertically
+---           -- with `action_utils._with_selections`
+---           ['<C-v><C-v>'] = function(prompt_bufnr)
+---             action_utils.with_selections(prompt_bufnr, actions.select_vertical)
+---             end,
+---           -- with `action_utils.with_selections`
+---           ['<C-v><C-v>'] = action_utils.with_selections(actions.select_vertical)
+---         },
+---       },
+---     },
+---   }
+--- </pre>
+---@param prompt_bufnr number: The prompt bufnr
+---@param f function: apply action onto entries of multi selection
+function action_utils._with_selections(prompt_bufnr, action)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  for _, selection in ipairs(current_picker:get_multi_selection()) do
+    global_state.set_global_key("set_entry", selection)
+    action(prompt_bufnr)
+  end
+end
+
+--- Run an `action` from |telescope.actions| on the multi selection.
+--- - Note: see |telescope.action.utils| for specification on what functions constitute `actions`.
+---@param f function: apply action onto entries of multi selection
+function action_utils.with_selections(action)
+  return function(prompt_bufnr)
+    action_utils._with_selections(prompt_bufnr, action)
+  end
+end
+
+-- TODO: docs & mapping variant
+function action_utils._with_selection(prompt_bufnr, action, selection_index)
+  selection_index = vim.F.if_nil(selection_index, 1)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local selections = current_picker:get_multi_selection()
+  global_state.set_global_key("set_entry", selections[selection_index])
+  action(prompt_bufnr)
+end
+
+function action_utils.with_selection(action, selection_index)
+  return function(prompt_bufnr)
+    action_utils._with_selection(prompt_bufnr, action, selection_index)
+  end
+end
+
+--- Apply `actions` to multi selections or entries in cycle, on entry-after-entry basis.
+--- Commonly used in combination with `action_utils.with_{selections, entries}`.
+--- <pre>
+--- Example Usage: open selections alternatingly vertically and horizontally
+---   local actions = require "telescope.actions"
+---   local action_utils = require "telescope.actions.utils"
+---   require("telescope").setup {
+---     defaults = {
+---       mappings = {
+---         i = {
+---           ['<C-b>'] = action_utils.with_selections(
+---                         action_utils.cycle({actions.select_vertical, actions.select_horizontal})
+---         },
+---       },
+---     },
+---   }
+--- </pre>
+---@param actions table: table of actions to apply iteratively
+function action_utils.cycle(actions)
+  local num_actions = #actions
+  local index = 1
+  local cycle = function(i, n)
+    local result = i % n
+    return result == 0 and n or result
+  end
+  return function(prompt_bufnr)
+    actions[cycle(index, num_actions)](prompt_bufnr)
+    index = index + 1
   end
 end
 

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -6,9 +6,11 @@
 --- Generally used from within other |telescope.actions|
 ---@brief ]]
 
-local action_state = require('telescope.actions.state')
+local action_state = require "telescope.actions.state"
+local global_state = require "telescope.state"
 
-local utils = {}
+local utils = require "telescope.utils"
+local action_utils = {}
 
 --- Apply `f` to the entries of the current picker.
 --- - Notes:
@@ -32,17 +34,23 @@ local utils = {}
 --- </pre>
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto entries of picker that takes (entry, index, row) as viable arguments
-function utils.map_entries(prompt_bufnr, f)
-  vim.validate{
-    f = {f, "function"}
+function action_utils._map_entries(prompt_bufnr, f)
+  vim.validate {
+    f = { f, "function" },
   }
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local index = 1
-    -- indices are 1-indexed, rows are 0-indexed
+  -- indices are 1-indexed, rows are 0-indexed
   for entry in current_picker.manager:iter() do
     local row = current_picker:get_row(index)
     f(entry, index, row)
     index = index + 1
+  end
+end
+
+function action_utils.map_entries(f)
+  return function(prompt_bufnr)
+    action_utils._map_entries(prompt_bufnr, f)
   end
 end
 
@@ -68,9 +76,9 @@ end
 --- </pre>
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto selection of picker that takes (selection) as a viable argument
-function utils.map_selections(prompt_bufnr, f)
-  vim.validate{
-    f = {f, "function"}
+function action_utils._map_selections(prompt_bufnr, f)
+  vim.validate {
+    f = { f, "function" },
   }
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   for _, selection in ipairs(current_picker:get_multi_selection()) do
@@ -78,4 +86,68 @@ function utils.map_selections(prompt_bufnr, f)
   end
 end
 
-return utils
+function action_utils.map_selections(f)
+  return function(prompt_bufnr)
+    action_utils._map_selections(prompt_bufnr, f)
+  end
+end
+
+-- TODO more control flow
+function action_utils._with_selections(prompt_bufnr, action)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  for index, selection in ipairs(current_picker:get_multi_selection()) do
+    global_state.set_global_key("set_entry", selection)
+    action(prompt_bufnr)
+  end
+end
+
+function action_utils.with_selections(action)
+  return function(prompt_bufnr)
+    action_utils._with_selections(prompt_bufnr, action)
+  end
+end
+
+function action_utils.with_selection(action, selection_index)
+  selection_index = vim.F.if_nil(selection_index, 1)
+  return function(prompt_bufnr)
+    local current_picker = action_state.get_current_picker(prompt_bufnr)
+    local selections = current_picker:get_multi_selection()
+    global_state.set_global_key("set_entry", selections[selection_index])
+    action(prompt_bufnr)
+  end
+end
+
+function action_utils.round_robin(actions)
+  local num_actions = #actions
+  local cycle = function(i, n)
+    local result = i % n
+    return result == 0 and n or result
+  end
+  return function(prompt_bufnr)
+    -- level 3 is the calling function
+    local variables = utils.locals(3)
+    if variables.index == nil then
+      print("No index found! Cannot cycle through, attempting to abort safely...")
+      return 
+    end
+    actions[cycle(variables.index, num_actions)](prompt_bufnr)
+  end
+end
+
+function action_utils._with_entries(prompt_bufnr, action)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local index = 1
+  for entry in current_picker.manager:iter() do
+    global_state.set_global_key("set_entry", entry)
+    action(prompt_bufnr)
+    index = index + 1
+  end
+end
+
+function action_utils.with_entries(action)
+  return function(prompt_bufnr)
+    action_utils._with_entries(prompt_bufnr, action)
+  end
+end
+
+return action_utils

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -225,7 +225,9 @@ previewers.new_buffer_previewer = function(opts)
       set_bufnr(self, bufnr)
 
       vim.schedule(function()
-        vim.api.nvim_win_set_buf(status.preview_win, bufnr)
+        if vim.api.nvim_buf_is_valid(bufnr) then
+          vim.api.nvim_win_set_buf(status.preview_win, bufnr)
+        end
       end)
 
       -- TODO(conni2461): We only have to set options once. Right?

--- a/lua/telescope/state.lua
+++ b/lua/telescope/state.lua
@@ -16,6 +16,14 @@ function state.get_global_key(key)
   return TelescopeGlobalState.global[key]
 end
 
+function state.get_and_clear_global_key(key)
+  local value = TelescopeGlobalState.global[key]
+  if value ~= nil then
+    TelescopeGlobalState.global[key] = nil
+  end
+  return value
+end
+
 function state.get_status(prompt_bufnr)
   return TelescopeGlobalState[prompt_bufnr] or {}
 end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -23,23 +23,6 @@ utils.get_default = function(x, default)
   return utils.if_nil(x, default, x)
 end
 
--- get variables of level scope
--- function calling the debug library has level 1, function that called it has level 2, etc
-utils.locals = function(level)
-  local variables = {}
-  local idx = 1
-  while true do
-      local ln, lv = debug.getlocal(level, idx)
-      if ln ~= nil then
-          variables[ln] = lv
-      else
-          break
-      end
-      idx = 1 + idx
-  end
-  return variables
-end
-
 utils.get_lazy_default = function(x, defaulter, ...)
   if x == nil then
     return defaulter(...)

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -23,6 +23,23 @@ utils.get_default = function(x, default)
   return utils.if_nil(x, default, x)
 end
 
+-- get variables of level scope
+-- function calling the debug library has level 1, function that called it has level 2, etc
+utils.locals = function(level)
+  local variables = {}
+  local idx = 1
+  while true do
+      local ln, lv = debug.getlocal(level, idx)
+      if ln ~= nil then
+          variables[ln] = lv
+      else
+          break
+      end
+      idx = 1 + idx
+  end
+  return variables
+end
+
 utils.get_lazy_default = function(x, defaulter, ...)
   if x == nil then
     return defaulter(...)


### PR DESCRIPTION
This PR is a (slightly opinionated) attempt to pick up #807 with the design as laid out below. It should now be ready for review :)

The key question is whether we want `action_state.get_selected_entry` (ie what is considered the selected entry) to be overridden if the global `set_entry` is set (see `telescope.state` and `telescope.actions.state`). The idea is that most `telescope.actions` are performed on what is considered "selected". Thus, multi actions should as such not function any differently (to avoid implicit code duplication). 

I'll be on the road week of 19 July and probably have less time to look/work with comments up until after. but I'm very happy to get some thoughts in the mean time.

To illustrate, the PR would allow for the following:

```lua
local actions = require 'telescope.actions'
local action_utils = require 'telescope.actions.utils'
telescope.setup {
  defaults = {
    mappings = {
      i = {
        ["<C-v>"] = action_utils.with_selections(actions.select_vertical),
        -- obviously only for builtin.git_status :)
        ["<C-s>"] = action_utils.with_entries(actions.git_staging_toggle)
      },
    },
  },
```

In particular, this WIP:
* Cleans up `action_utils`; sorry @Conni2461 I didn't grok the `_` prefix in the original PR :sweat_smile: 
* Introduces the global `set_entry` that allows to temporarily override what `actions_state.get_selected_entry` returns
    * The idea is to keep `actions` on `selected_entry` as atomic as possible (that is, as `actions` on `selected_entry` are currently designed, they are meant to be run on a single entry)
* Introduces new `action_utils` for multi-select style actions
    * `action_utils.with_entries(action)`
    * `action_utils.with_selection(action, selection_index): to mimic `context` as I understood it from #807, but might be off
    * `action_utils.with_selections(action)`
    * `action_utils.cycle`: run `action` on an entry-by-entry basis, e.g. `actions.with_selections(actions.cycle({actions.select_vertical, actions.select_horizontal}))` with 2 selections would first select vertically and then horizontally
 
Some things I think we should discuss:  
- Should we change the signature of atomic actions that exclusively rely on `selected_entry` to `()` (to match `action_state.get_selected_entry`) for consistency (and to separate actions that actually require `prompt_bufnr`)
- We should maybe expand `telescope.actions` in more submodules in mid- to long-run, e.g. `telescope.actions.git`?
- TODO? Should we maybe add a `callback` that takes the list of selections/entries to allow for more complex logic? Eg, open 4 files in a vertical split and that reshape them to 4 squares layout

As a non-sensical showcase, here's all my files in `~/.config/nvim` opened with `actions.select_vertical` :laughing: 

https://user-images.githubusercontent.com/39233597/126034846-3f792d59-478f-42a0-97be-7ad4030a4e9c.mp4
