### PR TITLE
Auto file mask in live grep via additional args function in live_grep

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -332,11 +332,13 @@ builtin.live_grep({opts})                                *builtin.live_grep()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {grep_open_files} (boolean)  if true, restrict search to open files
-                                     only, mutually exclusive with
-                                     `search_dirs`
-        {search_dirs}     (table)    directory/directories to search in,
-                                     mutually exclusive with `grep_open_files`
+        {grep_open_files} (boolean)   if true, restrict search to open files
+                                      only, mutually exclusive with
+                                      `search_dirs`
+        {search_dirs}     (table)     directory/directories to search in,
+                                      mutually exclusive with `grep_open_files`
+        {additional_args} (function)  function(opts) which returns a table of
+                                      additional arguments to be passed on
 
 
 builtin.grep_string({opts})                            *builtin.grep_string()*
@@ -347,10 +349,13 @@ builtin.grep_string({opts})                            *builtin.grep_string()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {search}      (string)   the query to search
-        {search_dirs} (table)    directory/directories to search in
-        {use_regex}   (boolean)  if true, special characters won't be escaped,
-                                 allows for using regex (default is false)
+        {search}          (string)    the query to search
+        {search_dirs}     (table)     directory/directories to search in
+        {use_regex}       (boolean)   if true, special characters won't be
+                                      escaped, allows for using regex (default
+                                      is false)
+        {additional_args} (function)  function(opts) which returns a table of
+                                      additional arguments to be passed on
 
 
 builtin.find_files({opts})                              *builtin.find_files()*

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -70,7 +70,7 @@ files.live_grep = function(opts)
   end
 
   local additional_args = {}
-  if opts.additional_args ~= nil then
+  if opts.additional_args ~= nil and type(opts.additional_args) == "function" then
       local context = {
           filetype = vim.bo.filetype,
           filename = vim.fn.expand(vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf()))

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -79,11 +79,11 @@ files.live_grep = function(opts)
       end
 
       local extraArgs = {}
-      local smart_mask = utils.get_default(opts.smart_mask, require('telescope.config').values.smart_mask)
+      local smart_mask = utils.get_default(opts.smart_mask, conf.smart_mask)
       local filetype = opts.current_filetype or ''
 
       if (smart_mask == true and filetype ~= '') then
-          local smart_mask_args = utils.get_default(opts.smart_mask_args, require('telescope.config').values.smart_mask_args)
+          local smart_mask_args = utils.get_default(opts.smart_mask_args, conf.smart_mask_args)
           table.insert(extraArgs, smart_mask_args[filetype])
       end
 

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -43,7 +43,6 @@ files.live_grep = function(opts)
   local vimgrep_arguments = opts.vimgrep_arguments or conf.vimgrep_arguments
   local search_dirs = opts.search_dirs
   local grep_open_files = opts.grep_open_files
-  local filetype = vim.bo.filetype
   opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
 
   local filelist = {}

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -36,6 +36,7 @@ files.live_grep = function(opts)
   local vimgrep_arguments = opts.vimgrep_arguments or conf.vimgrep_arguments
   local search_dirs = opts.search_dirs
   local grep_open_files = opts.grep_open_files
+  local filetype = vim.bo.filetype
   opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
 
   local filelist = {}
@@ -80,7 +81,6 @@ files.live_grep = function(opts)
 
       local extraArgs = {}
       local smart_mask = utils.get_default(opts.smart_mask, conf.smart_mask)
-      local filetype = opts.current_filetype or ''
 
       if (smart_mask == true and filetype ~= '') then
           local smart_mask_args = utils.get_default(opts.smart_mask_args, conf.smart_mask_args)

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -81,8 +81,9 @@ files.live_grep = function(opts)
       end
 
       local extraArgs = {}
-      local smart_mask = utils.get_default(opts.smart_mask, conf.smart_mask)
-      table.insert(extraArgs, smart_mask[filetype])
+      if (opts.smart_mask ~= nil) then
+          table.insert(extraArgs, opts.smart_mask[filetype])
+      end
 
       return flatten { vimgrep_arguments, extraArgs, prompt, search_list }
     end,

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -69,6 +69,15 @@ files.live_grep = function(opts)
     end
   end
 
+  local additional_args = {}
+  if opts.additional_args ~= nil then
+      local context = {
+          filetype = vim.bo.filetype,
+          filename = vim.fn.expand(vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf()))
+      }
+      additional_args = opts.additional_args(opts, context)
+  end
+
   local live_grepper = finders.new_job(function(prompt)
     -- TODO: Probably could add some options for smart case and whatever else rg offers.
 
@@ -90,12 +99,7 @@ files.live_grep = function(opts)
       search_list = filelist
     end
 
-    local extraArgs = {}
-    if opts.smart_mask ~= nil then
-        table.insert(extraArgs, opts.smart_mask[filetype])
-    end
-
-    return flatten { vimgrep_arguments, extraArgs, prompt, search_list }
+    return flatten { vimgrep_arguments, additional_args, prompt, search_list }
   end, opts.entry_maker or make_entry.gen_from_vimgrep(
     opts
   ), opts.max_results, opts.cwd)

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -90,12 +90,12 @@ files.live_grep = function(opts)
       search_list = filelist
     end
 
-      local extraArgs = {}
-      if (opts.smart_mask ~= nil) then
-          table.insert(extraArgs, opts.smart_mask[filetype])
-      end
+    local extraArgs = {}
+    if (opts.smart_mask ~= nil) then
+        table.insert(extraArgs, opts.smart_mask[filetype])
+    end
 
-      return flatten { vimgrep_arguments, extraArgs, prompt, search_list }
+    return flatten { vimgrep_arguments, extraArgs, prompt, search_list }
   end, opts.entry_maker or make_entry.gen_from_vimgrep(
     opts
   ), opts.max_results, opts.cwd)

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -71,7 +71,7 @@ files.live_grep = function(opts)
 
   local additional_args = {}
   if opts.additional_args ~= nil and type(opts.additional_args) == "function" then
-      additional_args = opts.additional_args(opts)
+    additional_args = opts.additional_args(opts)
   end
 
   local live_grepper = finders.new_job(function(prompt)

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -83,7 +83,7 @@ files.live_grep = function(opts)
       local filetype = opts.current_filetype or ''
 
       if (smart_mask == true and filetype ~= '') then
-          smart_mask_args = utils.get_default(opts.smart_mask_args, require('telescope.config').values.smart_mask_args)
+          local smart_mask_args = utils.get_default(opts.smart_mask_args, require('telescope.config').values.smart_mask_args)
           table.insert(extraArgs, smart_mask_args[filetype])
       end
 

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -121,8 +121,14 @@ files.grep_string = function(opts)
   local word_match = opts.word_match
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_vimgrep(opts)
 
+  local additional_args = {}
+  if opts.additional_args ~= nil and type(opts.additional_args) == "function" then
+    additional_args = opts.additional_args(opts)
+  end
+
   local args = flatten {
     vimgrep_arguments,
+    additional_args,
     word_match,
     search,
   }

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -91,7 +91,7 @@ files.live_grep = function(opts)
     end
 
     local extraArgs = {}
-    if (opts.smart_mask ~= nil) then
+    if opts.smart_mask ~= nil then
         table.insert(extraArgs, opts.smart_mask[filetype])
     end
 

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -71,11 +71,7 @@ files.live_grep = function(opts)
 
   local additional_args = {}
   if opts.additional_args ~= nil and type(opts.additional_args) == "function" then
-      local context = {
-          filetype = vim.bo.filetype,
-          filename = vim.fn.expand(vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf()))
-      }
-      additional_args = opts.additional_args(opts, context)
+      additional_args = opts.additional_args(opts)
   end
 
   local live_grepper = finders.new_job(function(prompt)

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -78,7 +78,16 @@ files.live_grep = function(opts)
         search_list = filelist
       end
 
-      return flatten { vimgrep_arguments, prompt, search_list }
+      local extraArgs = {}
+      local smart_mask = utils.get_default(opts.smart_mask, require('telescope.config').values.smart_mask)
+      local filetype = opts.current_filetype or ''
+
+      if (smart_mask == true and filetype ~= '') then
+          smart_mask_args = utils.get_default(opts.smart_mask_args, require('telescope.config').values.smart_mask_args)
+          table.insert(extraArgs, smart_mask_args[filetype])
+      end
+
+      return flatten { vimgrep_arguments, extraArgs, prompt, search_list }
     end,
     opts.entry_maker or make_entry.gen_from_vimgrep(opts),
     opts.max_results,

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -81,11 +81,7 @@ files.live_grep = function(opts)
 
       local extraArgs = {}
       local smart_mask = utils.get_default(opts.smart_mask, conf.smart_mask)
-
-      if (smart_mask == true and filetype ~= '') then
-          local smart_mask_args = utils.get_default(opts.smart_mask_args, conf.smart_mask_args)
-          table.insert(extraArgs, smart_mask_args[filetype])
-      end
+      table.insert(extraArgs, smart_mask[filetype])
 
       return flatten { vimgrep_arguments, extraArgs, prompt, search_list }
     end,

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -402,8 +402,6 @@ local apply_config = function(mod)
         end
       end
 
-      opts.current_filetype = vim.bo.filetype
-
       v(vim.tbl_extend("force", pconf, opts))
     end
   end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -70,6 +70,7 @@ local builtin = {}
 ---@param opts table: options to pass to the picker
 ---@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
 ---@field search_dirs table: directory/directories to search in, mutually exclusive with `grep_open_files`
+---@field smart_mask table: look up table of filetype => grepper arguments. Example: smart_mask = { ["lua"] = "-tlua", ["cpp"] = "-tcpp" }
 builtin.live_grep = require('telescope.builtin.files').live_grep
 
 --- Searches for the string under your cursor in your current working directory

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -402,6 +402,8 @@ local apply_config = function(mod)
         end
       end
 
+      opts.current_filetype = vim.bo.filetype
+
       v(vim.tbl_extend("force", pconf, opts))
     end
   end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -70,7 +70,7 @@ local builtin = {}
 ---@param opts table: options to pass to the picker
 ---@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
 ---@field search_dirs table: directory/directories to search in, mutually exclusive with `grep_open_files`
----@field smart_mask table: look up table of filetype => grepper arguments. Ex: smart_mask = { ["lua"] = "-tlua" }
+---@field additional_args function: function(opts) which returns a table of additional arguments to be passed on
 builtin.live_grep = require("telescope.builtin.files").live_grep
 
 --- Searches for the string under your cursor in your current working directory

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -70,7 +70,7 @@ local builtin = {}
 ---@param opts table: options to pass to the picker
 ---@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
 ---@field search_dirs table: directory/directories to search in, mutually exclusive with `grep_open_files`
----@field smart_mask table: look up table of filetype => grepper arguments. Example: smart_mask = { ["lua"] = "-tlua", ["cpp"] = "-tcpp" }
+---@field smart_mask table: look up table of filetype => grepper arguments. Ex: smart_mask = { ["lua"] = "-tlua" }
 builtin.live_grep = require('telescope.builtin.files').live_grep
 
 --- Searches for the string under your cursor in your current working directory

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -78,6 +78,7 @@ builtin.live_grep = require("telescope.builtin.files").live_grep
 ---@field search string: the query to search
 ---@field search_dirs table: directory/directories to search in
 ---@field use_regex boolean: if true, special characters won't be escaped, allows for using regex (default is false)
+---@field additional_args function: function(opts) which returns a table of additional arguments to be passed on
 builtin.grep_string = require("telescope.builtin.files").grep_string
 
 --- Lists files in your current working directory, respects .gitignore

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -282,29 +282,6 @@ local telescope_defaults = {
     { "rg", "--color=never", "--no-heading", "--with-filename", "--line-number", "--column", "--smart-case" },
   },
 
-  smart_mask = {
-      {}, [[
-      Lookup table for live grep smart masking.
-
-      Format is:
-          ["filetype"] = "<argument to pass to grep program>"
-
-      Note: 'filetype' is vim's definition of filetype.
-
-      Example (using ripgrep (rg) as the grep program):
-
-        smart_mask = {
-            ["lua"] = "-tlua",
-            ["cs"]  = "-tcs",
-            ["cpp"] = "-tcpp",
-            ["h"]   = "-tcpp"
-        }
-
-      To temporarily invoke live_grep with smart_mask disabled:
-        :lua require('telescope.builtin').live_grep({ smart_mask = {} })
-      ]],
-  },
-
   use_less = { true },
 
   color_devicons = { true },

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -283,9 +283,7 @@ local telescope_defaults = {
   },
 
   smart_mask = {
-      {
-          ["lua"] = "-tlua",
-      }, [[
+      {}, [[
       Lookup table for live grep smart masking.
 
       Format is:

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -282,9 +282,7 @@ local telescope_defaults = {
     { "rg", "--color=never", "--no-heading", "--with-filename", "--line-number", "--column", "--smart-case" },
   },
 
-  smart_mask = { false },
-
-  smart_mask_args = {
+  smart_mask = {
       {
           ["lua"] = "-tlua",
       }, [[
@@ -297,12 +295,15 @@ local telescope_defaults = {
 
       Example (using ripgrep (rg) as the grep program):
 
-        smart_mask_args = {
+        smart_mask = {
             ["lua"] = "-tlua",
             ["cs"]  = "-tcs",
             ["cpp"] = "-tcpp",
             ["h"]   = "-tcpp"
         }
+
+      To temporarily invoke live_grep with smart_mask disabled:
+        :lua require('telescope.builtin').live_grep({ smart_mask = {} })
       ]],
   },
 

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -286,16 +286,19 @@ local telescope_defaults = {
 
   smart_mask_args = {
       {
-          ["cs"] = "-tcs",
+          ["lua"] = "-tlua",
       }, [[
       Lookup table for live grep smart masking.
 
       Format is:
-          ["ext"] = "<argument to pass to grep program>"
+          ["filetype"] = "<argument to pass to grep program>"
+
+      Note: 'filetype' is vim's definition of filetype.
 
       Example (using ripgrep (rg) as the grep program):
 
         smart_mask_args = {
+            ["lua"] = "-tlua",
             ["cs"]  = "-tcs",
             ["cpp"] = "-tcpp",
             ["h"]   = "-tcpp"

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -282,6 +282,27 @@ local telescope_defaults = {
     { "rg", "--color=never", "--no-heading", "--with-filename", "--line-number", "--column", "--smart-case" },
   },
 
+  smart_mask = { false },
+
+  smart_mask_args = {
+      {
+          ["cs"] = "-tcs",
+      }, [[
+      Lookup table for live grep smart masking.
+
+      Format is:
+          ["ext"] = "<argument to pass to grep program>"
+
+      Example (using ripgrep (rg) as the grep program):
+
+        smart_mask_args = {
+            ["cs"]  = "-tcs",
+            ["cpp"] = "-tcpp",
+            ["h"]   = "-tcpp"
+        }
+      ]],
+  },
+
   use_less = { true },
 
   color_devicons = { true },


### PR DESCRIPTION
Add the ability to have runtime additional args to live_grep via a user configurable function. This allows the user to add additional arguments to the grepper program based on custom logic. Example logic that filters search results automatically based on buffer filetype:

```lua
require("telescope").setup {
  defaults = { 
    -- your defaults for telescope
  },
  pickers = {
    live_grep = {
      -- your defaults for live_grep
        additional_args = function(opts)
            if opts.search_all == true then
                return {}
            end

            local args_for_ext = {
                ["cs"]  = "-tcs",
                ["cpp"] = "-tcpp",
                ["c"]   = "-tcpp",
                ["h"]   = "-tcpp",
                ["rs"]  = "-trust",
                ["lua"] = "-tlua"
            }
            return { args_for_ext[vim.bo.filetype] }
        end
    }
  }
}
```

The custom logic allows for reverting back to searching all files by passing search_all = true:
:lua require('telescope.builtin').live_grep({ search_all = true })
 