### PR TITLE
Set a filetype for the results buffer

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -471,6 +471,7 @@ function Picker:find()
 
   -- Do filetype last, so that users can register at the last second.
   pcall(a.nvim_buf_set_option, prompt_bufnr, 'filetype', 'TelescopePrompt')
+  pcall(a.nvim_buf_set_option, results_bufnr, 'filetype', 'TelescopeResults')
 
   if self.default_text then
     self:set_prompt(self.default_text)


### PR DESCRIPTION
**Why** is the change needed?

So that it can be targeted with specific settings. These could include disabling
plugins for the buffer (as in #840) or disabling folding (as per #991).

**How** is the need addressed?

- Add a filetype to the buffer after it has been created.

Closes #991