### PR TITLE
fix: set a filename for entries in `file_browser`

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -394,9 +394,11 @@ builtin.file_browser({opts})                          *builtin.file_browser()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {cwd}      (string)  directory path to browse (default is cwd)
-        {depth}    (number)  file tree depth to display (default is 1)
-        {dir_icon} (string)  change the icon for a directory. default: 
+        {cwd}      (string)   directory path to browse (default is cwd)
+        {depth}    (number)   file tree depth to display (default is 1)
+        {dir_icon} (string)   change the icon for a directory. default: 
+        {hidden}   (boolean)  determines whether to show hidden files or not
+                              (default is false)
 
 
 builtin.treesitter()                                    *builtin.treesitter()*

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -94,7 +94,7 @@ action_set.edit = function(prompt_bufnr, command)
 
   local filename, row, col
 
-  if entry.filename then
+  if entry.path or entry.filename then
     filename = entry.path or entry.filename
 
     -- TODO: Check for off-by-one

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -297,9 +297,6 @@ files.file_browser = function(opts)
           if is_dir(t.value) then retpath = retpath .. os_sep end
           return retpath
         end
-        if k == "filename" then
-          return Path:new(t[1]):absolute()
-        end
 
         return rawget(t, rawget({ value = 1 }, k))
       end

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -304,6 +304,7 @@ files.file_browser = function(opts)
       return function(line)
         local tbl = {line}
         tbl.ordinal = Path:new(line):make_relative(opts.cwd)
+        tbl.filename = Path:new(line):absolute()
         return setmetatable(tbl, mt)
       end
     end

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -297,6 +297,9 @@ files.file_browser = function(opts)
           if is_dir(t.value) then retpath = retpath .. os_sep end
           return retpath
         end
+        if k == "filename" then
+          return Path:new(t[1]):absolute()
+        end
 
         return rawget(t, rawget({ value = 1 }, k))
       end
@@ -304,7 +307,6 @@ files.file_browser = function(opts)
       return function(line)
         local tbl = {line}
         tbl.ordinal = Path:new(line):make_relative(opts.cwd)
-        tbl.filename = Path:new(line):absolute()
         return setmetatable(tbl, mt)
       end
     end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -102,6 +102,7 @@ builtin.fd = builtin.find_files
 ---@field cwd string: directory path to browse (default is cwd)
 ---@field depth number: file tree depth to display (default is 1)
 ---@field dir_icon string: change the icon for a directory. default: 
+---@field hidden boolean: determines whether to show hidden files or not (default is false)
 builtin.file_browser = require('telescope.builtin.files').file_browser
 
 --- Lists function names, variables, and other symbols from treesitter queries


### PR DESCRIPTION
This prevents an issue caused by [this](https://github.com/nvim-telescope/telescope.nvim/blob/8c3f2b630be0241fe10709e61ee9dab473518f32/lua/telescope/actions/set.lua#L116) on Windows, as filepaths will often contain ":", e.g. "C:\foo\bar". The result was that in the `file_browser` any time you open a file on the C drive, it will instead open a file called "C" 🤣.