### PR TITLE
refactor: make luacheckrc stricter

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -8,7 +8,10 @@ self = false
 
 -- Glorious list of warnings: https://luacheck.readthedocs.io/en/stable/warnings.html
 ignore = {
-  "212", -- Unused argument, In the case of callback function, _arg_name is easier to understand than _, so this option is set to off.
+  -- Unused argument/variable starting with _
+  "211/_.*",
+  "212/_.*",
+  "213/_.*",
   "122", -- Indirectly setting a readonly global
 }
 
@@ -27,3 +30,5 @@ globals = {
 read_globals = {
   "vim",
 }
+
+-- vim: set filetype=lua :

--- a/lua/telescope/config/resolve.lua
+++ b/lua/telescope/config/resolve.lua
@@ -99,7 +99,7 @@ local _resolve_map = {}
 _resolve_map[function(val)
   return val == false
 end] = function(_, val)
-  return function(...)
+  return function()
     return val
   end
 end

--- a/lua/telescope/finders/async_oneshot_finder.lua
+++ b/lua/telescope/finders/async_oneshot_finder.lua
@@ -28,7 +28,7 @@ return function(opts)
     end,
     results = results,
   }, {
-    __call = void(async(function(_, prompt, process_result, process_complete)
+    __call = void(async(function(_, _prompt, process_result, process_complete)
       if not job_started then
         local job_opts = fn_command()
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1054,7 +1054,7 @@ function Picker:get_result_processor(find_id, prompt, status_updater)
   end
 end
 
-function Picker:get_result_completor(results_bufnr, find_id, prompt, status_updater)
+function Picker:get_result_completor(results_bufnr, _find_id, prompt, status_updater)
   return function()
     if self.closed == true or self:is_done() then
       return

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -477,7 +477,7 @@ layout_strategies.cursor = make_documented_layout(
     preview.height = results.height + prompt.height + bs
 
     if self.previewer and max_columns >= layout_config.preview_cutoff then
-      preview.width = resolve.resolve_width(if_nil(layout_config.preview_width, function(_, cols)
+      preview.width = resolve.resolve_width(if_nil(layout_config.preview_width, function(_, _cols)
         -- By default, previewer takes 2/3 of the layout
         return 2 * math.floor(max_width / 3)
       end))(self, max_width, max_lines)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -312,7 +312,7 @@ previewers.cat = defaulter(function(opts)
       return from_entry.path(entry, true)
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       local p = from_entry.path(entry, true)
       if p == nil or p == "" then
         return
@@ -360,7 +360,7 @@ previewers.vimgrep = defaulter(function(opts)
       return from_entry.path(entry, true)
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       local p = from_entry.path(entry, true)
       if p == nil or p == "" then
         return
@@ -432,7 +432,7 @@ previewers.ctags = defaulter(function(_)
       return entry.filename
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       conf.buffer_previewer_maker(entry.filename, self.state.bufnr, {
         bufname = self.state.bufname,
         callback = function(bufnr)
@@ -454,7 +454,7 @@ previewers.builtin = defaulter(function(_)
       return entry.filename
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       local module_name = vim.fn.fnamemodify(entry.filename, ":t:r")
       local text
       if entry.text:sub(1, #module_name) ~= module_name then
@@ -482,7 +482,7 @@ previewers.help = defaulter(function(_)
       return entry.filename
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       local query = entry.cmd
       query = query:sub(2)
       query = [[\V]] .. query
@@ -508,7 +508,7 @@ previewers.man = defaulter(function(opts)
       return entry.value
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       local win_width = vim.api.nvim_win_get_width(self.state.winid)
       putils.job_maker({ "man", entry.section, entry.value }, self.state.bufnr, {
         env = { ["PAGER"] = pager, ["MANWIDTH"] = win_width },
@@ -551,7 +551,7 @@ previewers.git_branch_log = defaulter(function(opts)
       return entry.value
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       local cmd = {
         "git",
         "--no-pager",
@@ -604,7 +604,7 @@ previewers.git_commit_diff_to_parent = defaulter(function(opts)
       return entry.value
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       local cmd = { "git", "--no-pager", "diff", entry.value .. "^!" }
       if opts.current_file then
         table.insert(cmd, "--")
@@ -633,7 +633,7 @@ previewers.git_commit_diff_to_head = defaulter(function(opts)
       return entry.value
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       local cmd = { "git", "--no-pager", "diff", "--cached", entry.value }
       if opts.current_file then
         table.insert(cmd, "--")
@@ -662,7 +662,7 @@ previewers.git_commit_diff_as_was = defaulter(function(opts)
       return entry.value
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       local cmd = { "git", "--no-pager", "show" }
       local cf = opts.current_file and Path:new(opts.current_file):make_relative(opts.cwd)
       local value = cf and (entry.value .. ":" .. cf) or entry.value
@@ -694,7 +694,7 @@ previewers.git_commit_message = defaulter(function(opts)
       return entry.value
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       local cmd = { "git", "--no-pager", "log", "-n 1", entry.value }
 
       putils.job_maker(cmd, self.state.bufnr, {
@@ -724,7 +724,7 @@ previewers.git_file_diff = defaulter(function(opts)
       return entry.value
     end,
 
-    define_preview = function(self, entry, status)
+    define_preview = function(self, entry, _status)
       if entry.status and (entry.status == "??" or entry.status == "A ") then
         local p = from_entry.path(entry, true)
         if p == nil or p == "" then

--- a/lua/telescope/sorters.lua
+++ b/lua/telescope/sorters.lua
@@ -149,11 +149,11 @@ function Sorter:score(prompt, entry, cb_add, cb_filter)
   end
 end
 
-function Sorter:_was_discarded(prompt, ordinal)
+function Sorter:_was_discarded(_prompt, ordinal)
   return self.discard and self._discard_state.filtered[ordinal]
 end
 
-function Sorter:_mark_discarded(prompt, ordinal)
+function Sorter:_mark_discarded(_prompt, ordinal)
   if not self.discard then
     return
   end


### PR DESCRIPTION
Instead of completely ignoring `212`, make it so that only arguments starting with `_` is ignored. Also do the same for `211` and `213`.

Code | Description
-- | --
211 | Unused local variable.
212 | Unused argument.
213 | Unused loop variable.

