### PR TITLE
feat: allow caching and resuming picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,8 +439,8 @@ Built-in functions. Ready to be bound to any key you like. :smile:
 | `builtin.highlights`                | Lists all available highlights                                                                                                                              |
 | `builtin.current_buffer_fuzzy_find` | Live fuzzy search inside of the currently open buffer                                                                                                       |
 | `builtin.current_buffer_tags`       | Lists all of the tags for the currently open buffer, with a preview                                                                                         |
-| `builtin.resume`                    | Lists the results incl. multi-selections of the previous picker, if caching is enabled (`true` by default)                                                  |
-| `builtin.pickers`                   | Lists the previous pickers incl. multi-selections, if caching is enabled (`true` by default)                                                                |
+| `builtin.resume`                    | Lists the results incl. multi-selections of the previous picker                                                                                             |
+| `builtin.pickers`                   | Lists the previous pickers incl. multi-selections (see `:h telescope.defaults.cache_picker`)                                                                |
 
 ### Neovim LSP Pickers
 

--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ Built-in functions. Ready to be bound to any key you like. :smile:
 | `builtin.highlights`                | Lists all available highlights                                                                                                                              |
 | `builtin.current_buffer_fuzzy_find` | Live fuzzy search inside of the currently open buffer                                                                                                       |
 | `builtin.current_buffer_tags`       | Lists all of the tags for the currently open buffer, with a preview                                                                                         |
+| `builtin.resume`                    | Lists the results incl. multi-selections of the previous picker, if caching is enabled (`true` by default)                                                  |
+| `builtin.pickers`                   | Lists the previous pickers incl. multi-selections, if caching is enabled (`true` by default)                                                                |
 
 ### Neovim LSP Pickers
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -25,6 +25,28 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Default: true
 
+                                          *telescope.defaults.cache_picker*
+    cache_picker: ~
+        This field handles the configuration for picker caching.
+        By default it is a table, with default values (more below).
+        To disable caching, set it to false.
+
+        Caching preserves all previous multi selections and results and
+        therefore may result in slowdown or increased RAM occupation
+        if too many pickers (`cache_picker.num_pickers`) or entries
+        ('cache_picker.limit_entries`) are cached.
+
+        Fields:
+          - num_pickers:      The number of pickers to be cached.
+                              Set to -1 to preserve all pickers of your session.
+                              If passed to a picker, the cached pickers with
+                              indices larger than `cache_picker.num_pickers` will
+                              be cleared.
+                              Default: 1
+          - limit_entries:    The amount of entries that will be written in the
+                              Default: 1000
+
+
                                       *telescope.defaults.default_mappings*
     default_mappings: ~
         Not recommended to use except for advanced users.
@@ -367,8 +389,8 @@ builtin.live_grep({opts})                                *builtin.live_grep()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {cwd}             (string)    directory path to search from (default
-                                      is cwd, use utils.buffer_dir() to search
+        {cwd}             (string)    root dir to search from (default is cwd,
+                                      use utils.buffer_dir() to search
                                       relative to open buffer)
         {grep_open_files} (boolean)   if true, restrict search to open files
                                       only, mutually exclusive with
@@ -388,8 +410,8 @@ builtin.grep_string({opts})                            *builtin.grep_string()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {cwd}             (string)    directory path to search from (default
-                                      is cwd, use utils.buffer_dir() to search
+        {cwd}             (string)    root dir to search from (default is cwd,
+                                      use utils.buffer_dir() to search
                                       relative to open buffer)
         {search}          (string)    the query to search
         {search_dirs}     (table)     directory/directories to search in
@@ -408,9 +430,9 @@ builtin.find_files({opts})                              *builtin.find_files()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {cwd}          (string)   directory path to search from (default is
-                                  cwd, use utils.buffer_dir() to search
-                                  relative to open buffer)
+        {cwd}          (string)   root dir to search from (default is cwd, use
+                                  utils.buffer_dir() to search relative to
+                                  open buffer)
         {find_command} (table)    command line arguments for `find_files` to
                                   use for the search, overrides default config
         {follow}       (boolean)  if true, follows symlinks (i.e. uses `-L`
@@ -446,8 +468,8 @@ builtin.file_browser({opts})                          *builtin.file_browser()*
         {opts} (table)  options to pass to the picker
 
     Fields: ~
-        {cwd}      (string)   directory path to browse (default is cwd, use
-                              utils.buffer_dir() to browse relative to open
+        {cwd}      (string)   root dir to browse from (default is cwd, use
+                              utils.buffer_dir() to search relative to open
                               buffer)
         {depth}    (number)   file tree depth to display (default is 1)
         {dir_icon} (string)   change the icon for a directory. default: 
@@ -673,6 +695,35 @@ builtin.search_history({opts})                      *builtin.search_history()*
     - Default keymaps:
       - `<C-e>`: open a search window with the text of the currently selected
         search result populated in it
+
+
+    Parameters: ~
+        {opts} (table)  options to pass to the picker
+
+
+builtin.resume({opts})                                      *builtin.resume()*
+    Opens the previous picker in the identical state (incl. multi selections)
+    - Notes:
+      - Requires `cache_picker` in setup or when having invoked pickers, see
+        |telescope.defaults.cache_picker|
+
+
+    Parameters: ~
+        {opts} (table)  options to pass to the picker
+
+    Fields: ~
+        {cache_index} (number)  what picker to resume, where 1 denotes most
+                                recent (default 1)
+
+
+builtin.pickers({opts})                                    *builtin.pickers()*
+    Opens a picker over previously cached pickers in there preserved states
+    (incl. multi selections)
+    - Default keymaps:
+      - `<C-x>`: delete the selected cached picker
+    - Notes:
+      - Requires `cache_picker` in setup or when having invoked pickers, see
+        |telescope.defaults.cache_picker|
 
 
     Parameters: ~
@@ -1576,6 +1627,16 @@ actions.cycle_previewers_next({prompt_bufnr})*actions.cycle_previewers_next()*
 actions.cycle_previewers_prev({prompt_bufnr})*actions.cycle_previewers_prev()*
     Cycle to the previous previewer if there is one available.
     This action is not mapped on default.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.remove_selected_picker({prompt_bufnr})*actions.remove_selected_picker()*
+    Removes the selected picker in |builtin.pickers|.
+    This action is not mapped by default and only intended for
+    |builtin.pickers|.
 
 
     Parameters: ~

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -832,6 +832,21 @@ actions.cycle_previewers_prev = function(prompt_bufnr)
   actions.get_current_picker(prompt_bufnr):cycle_previewers(-1)
 end
 
+--- Removes the selected picker in |builtin.pickers|.<br>
+--- This action is not mapped by default and only intended for |builtin.pickers|.
+---@param prompt_bufnr number: The prompt bufnr
+actions.remove_selected_picker = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local selection_index = current_picker:get_index(current_picker:get_selection_row())
+  local cached_pickers = state.get_global_key "cached_pickers"
+  current_picker:delete_selection(function()
+    table.remove(cached_pickers, selection_index)
+  end)
+  if #cached_pickers == 0 then
+    actions.close(prompt_bufnr)
+  end
+end
+
 -- ==================================================
 -- Transforms modules and sets the corect metatables.
 -- ==================================================

--- a/lua/telescope/algos/linked_list.lua
+++ b/lua/telescope/algos/linked_list.lua
@@ -215,4 +215,41 @@ function LinkedList:ipairs()
   end
 end
 
+function LinkedList:truncate(max_results)
+  if max_results >= self.size then
+    return
+  end
+
+  local current_node
+  if max_results < self.size - max_results then
+    local index = 1
+    current_node = self.head
+    while index < max_results do
+      local node = current_node
+      if not node.next then
+        break
+      end
+      current_node = current_node.next
+      index = index + 1
+    end
+    self.size = max_results
+  else
+    current_node = self.tail
+    while self.size > max_results do
+      if current_node.prev == nil then
+        break
+      end
+      current_node = current_node.prev
+      self.size = self.size - 1
+    end
+  end
+  self.tail = current_node
+  self.tail.next = nil
+  if max_results < self.track_at then
+    self.track_at = max_results
+    self.tracked = current_node.item
+    self._tracked_node = current_node
+  end
+end
+
 return LinkedList

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -243,6 +243,21 @@ builtin.command_history = require("telescope.builtin.internal").command_history
 ---@param opts table: options to pass to the picker
 builtin.search_history = require("telescope.builtin.internal").search_history
 
+--- Opens the previous picker in the identical state (incl. multi selections)
+--- - Notes:
+---   - Requires `cache_picker` in setup or when having invoked pickers, see |telescope.defaults.cache_picker|
+---@param opts table: options to pass to the picker
+---@field cache_index number: what picker to resume, where 1 denotes most recent (default 1)
+builtin.resume = require("telescope.builtin.internal").resume
+
+--- Opens a picker over previously cached pickers in there preserved states (incl. multi selections)
+--- - Default keymaps:
+---   - `<C-x>`: delete the selected cached picker
+--- - Notes:
+---   - Requires `cache_picker` in setup or when having invoked pickers, see |telescope.defaults.cache_picker|
+---@param opts table: options to pass to the picker
+builtin.pickers = require("telescope.builtin.internal").pickers
+
 --- Lists vim options, allows you to edit the current value on `<cr>`
 ---@param opts table: options to pass to the picker
 builtin.vim_options = require("telescope.builtin.internal").vim_options

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -68,7 +68,7 @@ local builtin = {}
 
 --- Search for a string and get results live as you type (respecting .gitignore)
 ---@param opts table: options to pass to the picker
----@field cwd string: directory path to search from (default is cwd, use utils.buffer_dir() to search relative to open buffer)
+---@field cwd string: root dir to search from (default is cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
 ---@field search_dirs table: directory/directories to search in, mutually exclusive with `grep_open_files`
 ---@field additional_args function: function(opts) which returns a table of additional arguments to be passed on
@@ -76,7 +76,7 @@ builtin.live_grep = require("telescope.builtin.files").live_grep
 
 --- Searches for the string under your cursor in your current working directory
 ---@param opts table: options to pass to the picker
----@field cwd string: directory path to search from (default is cwd, use utils.buffer_dir() to search relative to open buffer)
+---@field cwd string: root dir to search from (default is cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field search string: the query to search
 ---@field search_dirs table: directory/directories to search in
 ---@field use_regex boolean: if true, special characters won't be escaped, allows for using regex (default is false)
@@ -85,7 +85,7 @@ builtin.grep_string = require("telescope.builtin.files").grep_string
 
 --- Search for files (respecting .gitignore)
 ---@param opts table: options to pass to the picker
----@field cwd string: directory path to search from (default is cwd, use utils.buffer_dir() to search relative to open buffer)
+---@field cwd string: root dir to search from (default is cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field find_command table: command line arguments for `find_files` to use for the search, overrides default config
 ---@field follow boolean: if true, follows symlinks (i.e. uses `-L` flag for the `find` command)
 ---@field hidden boolean: determines whether to show hidden files or not (default is false)
@@ -105,7 +105,7 @@ builtin.fd = builtin.find_files
 ---       create the file `init.lua` inside of `lua/telescope` and will create the necessary folders (similar to how
 ---       `mkdir -p` would work) if they do not already exist
 ---@param opts table: options to pass to the picker
----@field cwd string: directory path to browse (default is cwd, use utils.buffer_dir() to browse relative to open buffer)
+---@field cwd string: root dir to browse from (default is cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field depth number: file tree depth to display (default is 1)
 ---@field dir_icon string: change the icon for a directory. default: 
 ---@field hidden boolean: determines whether to show hidden files or not (default is false)

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -46,11 +46,22 @@ local smarter_depth_2_extend = function(priority, base)
   return result
 end
 
+local resolve_table_opts = function(priority, base)
+  if priority == false or (priority == nil and base == false) then
+    return false
+  end
+  if priority == nil and type(base) == "table" then
+    return base
+  end
+  return smarter_depth_2_extend(priority, base)
+end
+
 -- TODO: Add other major configuration points here.
 -- selection_strategy
 
 local config = {}
 config.smarter_depth_2_extend = smarter_depth_2_extend
+config.resolve_table_opts = resolve_table_opts
 
 config.values = _TelescopeConfigurationValues
 config.descriptions = {}
@@ -286,6 +297,33 @@ local telescope_defaults = {
   ]],
   },
 
+  cache_picker = {
+    {
+      num_pickers = 1,
+      limit_entries = 1000,
+    },
+    [[
+    This field handles the configuration for picker caching.
+    By default it is a table, with default values (more below).
+    To disable caching, set it to false.
+
+    Caching preserves all previous multi selections and results and
+    therefore may result in slowdown or increased RAM occupation
+    if too many pickers (`cache_picker.num_pickers`) or entries
+    ('cache_picker.limit_entries`) are cached.
+
+    Fields:
+      - num_pickers:      The number of pickers to be cached.
+                          Set to -1 to preserve all pickers of your session.
+                          If passed to a picker, the cached pickers with
+                          indices larger than `cache_picker.num_pickers` will
+                          be cleared.
+                          Default: 20
+      - limit_entries:    The amount of entries that will be written in the
+                          Default: 1000
+    ]],
+  },
+
   -- Builtin configuration
 
   -- List that will be executed.
@@ -416,7 +454,7 @@ function config.set_defaults(user_defaults, tele_defaults)
         vim.tbl_deep_extend("keep", if_nil(config.values[name], {}), if_nil(default_val, {}))
       )
     end
-    if name == "history" then
+    if name == "history" or name == "cache_picker" then
       if user_defaults[name] == false or config.values[name] == false then
         return false
       end

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -318,7 +318,7 @@ local telescope_defaults = {
                           If passed to a picker, the cached pickers with
                           indices larger than `cache_picker.num_pickers` will
                           be cleared.
-                          Default: 20
+                          Default: 1
       - limit_entries:    The amount of entries that will be written in the
                           Default: 1000
     ]],

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -682,7 +682,7 @@ function make_entry.gen_from_picker(opts)
     return {
       value = entry,
       text = entry.prompt_title,
-      ordinal = entry.prompt_title,
+      ordinal = string.format("%s %s", entry.prompt_title, entry.default_text),
       display = make_display,
     }
   end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -662,6 +662,32 @@ function make_entry.gen_from_highlights()
   end
 end
 
+function make_entry.gen_from_picker(opts)
+  local displayer = entry_display.create {
+    separator = " ",
+    items = {
+      { width = 30 },
+      { remaining = true },
+    },
+  }
+
+  local make_display = function(entry)
+    return displayer {
+      entry.value.prompt_title,
+      entry.value.default_text,
+    }
+  end
+
+  return function(entry)
+    return {
+      value = entry,
+      text = entry.prompt_title,
+      ordinal = entry.prompt_title,
+      display = make_display,
+    }
+  end
+end
+
 function make_entry.gen_from_buffer_lines(opts)
   local displayer = entry_display.create {
     separator = " │ ",

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -682,7 +682,7 @@ function make_entry.gen_from_picker(opts)
     return {
       value = entry,
       text = entry.prompt_title,
-      ordinal = string.format("%s %s", entry.prompt_title, entry.default_text),
+      ordinal = string.format("%s %s", entry.prompt_title, utils.get_default(entry.default_text, "")),
       display = make_display,
     }
   end

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -247,6 +247,8 @@ previewers.new_buffer_previewer = function(opts)
         buf_delete(bufnr)
       end
     end
+    -- enable resuming picker with existing previewer to avoid lookup of deleted bufs
+    bufname_table = {}
   end
 
   function opts.preview_fn(self, entry, status)
@@ -848,6 +850,80 @@ previewers.highlights = defaulter(function(_)
           0,
           #entry.value
         )
+      end)
+    end,
+  }
+end, {})
+
+previewers.pickers = defaulter(function(_)
+  local ns_telescope_multiselection = vim.api.nvim_create_namespace "telescope_mulitselection"
+  local get_row = function(picker, preview_height, index)
+    if picker.sorting_strategy == "ascending" then
+      return index - 1
+    else
+      return preview_height - index
+    end
+  end
+  return previewers.new_buffer_previewer {
+
+    dyn_title = function(_, entry)
+      return entry.value.preview_title
+    end,
+
+    get_buffer_by_name = function(_, entry)
+      return tostring(entry.value.prompt_bufnr)
+    end,
+
+    teardown = function(self)
+      if self.state and self.state.last_set_bufnr and vim.api.nvim_buf_is_valid(self.state.last_set_bufnr) then
+        vim.api.nvim_buf_clear_namespace(self.state.last_set_bufnr, ns_telescope_multiselection, 0, -1)
+      end
+    end,
+
+    define_preview = function(self, entry, status)
+      putils.with_preview_window(status, nil, function()
+        local ns_telescope_entry = vim.api.nvim_create_namespace "telescope_entry"
+        local preview_height = vim.api.nvim_win_get_height(status.preview_win)
+
+        if self.state.bufname then
+          return
+        end
+
+        local picker = entry.value
+        -- prefill buffer to be able to set lines individually
+        local placeholder = utils.repeated_table(preview_height, "")
+        vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, placeholder)
+
+        for index = 1, math.min(preview_height, picker.manager:num_results()) do
+          local row = get_row(picker, preview_height, index)
+          local e = picker.manager:get_entry(index)
+          local display, display_highlight = e:display()
+
+          vim.api.nvim_buf_set_lines(self.state.bufnr, row, row + 1, false, { display })
+
+          if display_highlight ~= nil then
+            for _, hl_block in ipairs(display_highlight) do
+              vim.api.nvim_buf_add_highlight(
+                self.state.bufnr,
+                ns_telescope_entry,
+                hl_block[2],
+                row,
+                hl_block[1][1],
+                hl_block[1][2]
+              )
+            end
+          end
+          if picker._multi:is_selected(e) then
+            vim.api.nvim_buf_add_highlight(
+              self.state.bufnr,
+              ns_telescope_multiselection,
+              "TelescopeMultiSelection",
+              row,
+              0,
+              -1
+            )
+          end
+        end
       end)
     end,
   }

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -867,7 +867,10 @@ previewers.pickers = defaulter(function(_)
   return previewers.new_buffer_previewer {
 
     dyn_title = function(_, entry)
-      return entry.value.preview_title
+      if entry.value.default_text and entry.value.default_text ~= "" then
+        return string.format("%s ─ %s", entry.value.prompt_title, entry.value.default_text)
+      end
+      return entry.value.prompt_title
     end,
 
     get_buffer_by_name = function(_, entry)

--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -306,6 +306,7 @@ previewers.man = buffer_previewer.man
 previewers.autocommands = buffer_previewer.autocommands
 previewers.highlights = buffer_previewer.highlights
 previewers.buffers = buffer_previewer.buffers
+previewers.pickers = buffer_previewer.pickers
 
 --- A deprecated way of displaying content more easily. Was written at a time,
 --- where the buffer_previewer interface wasn't present. Nowadays it's easier


### PR DESCRIPTION
Will close #751

What?
- Introduce `resume` (resume last picker) and `pickers` (picker over cached pickers) `builtin` pickers

How?
- Modify `pickers.lua`  so picker attributes are not `nil`-ed on detach but stored in global `cached_pickers` table-stack instead
- `cache_limit` > 0 reduces # of cached entries via `LinkedList:truncate` (primarily to reduce size)
- New buffer previewer that writes original results in preview

Showcase

https://user-images.githubusercontent.com/39233597/127784598-e3d32413-2957-4fc5-8a1e-8ea6598b42b2.mp4
