### PR TITLE
fix(entry_to_qf): handle nil entry.cwd and absolute filenames

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -367,6 +367,8 @@ builtin.find_files({opts})                              *builtin.find_files()*
                                   flag for the `find` command)
         {hidden}       (boolean)  determines whether to show hidden files or
                                   not (default is false)
+        {no_ignore}    (boolean)  show files ignored by .gitignore, .ignore,
+                                  etc. (default is false)
         {search_dirs}  (table)    directory/directories to search in
 
 
@@ -468,6 +470,9 @@ builtin.git_commits({opts})                            *builtin.git_commits()*
     Lists commits for current directory with diff preview
     - Default keymaps:
       - `<cr>`: checks out the currently selected commit
+      - `<C-r>m`: resets current branch to selected commit using mixed mode
+      - `<C-r>s`: resets current branch to selected commit using soft mode
+      - `<C-r>h`: resets current branch to selected commit using hard mode
 
 
     Parameters: ~
@@ -1359,6 +1364,30 @@ actions.git_delete_branch({prompt_bufnr})        *actions.git_delete_branch()*
 
 actions.git_rebase_branch({prompt_bufnr})        *actions.git_rebase_branch()*
     Rebase to selected git branch
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.git_reset_mixed({prompt_bufnr})            *actions.git_reset_mixed()*
+    Reset to selected git commit using mixed mode
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.git_reset_soft({prompt_bufnr})              *actions.git_reset_soft()*
+    Reset to selected git commit using soft mode
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.git_reset_hard({prompt_bufnr})              *actions.git_reset_hard()*
+    Reset to selected git commit using hard mode
 
 
     Parameters: ~

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -17,10 +17,9 @@ local p_scroller = require "telescope.pickers.scroller"
 local action_state = require "telescope.actions.state"
 local action_utils = require "telescope.actions.utils"
 local action_set = require "telescope.actions.set"
+local from_entry = require "telescope.from_entry"
 
 local transform_mod = require("telescope.actions.mt").transform_mod
-
-local Path = require "plenary.path"
 
 local actions = setmetatable({}, {
   __index = function(_, k)
@@ -585,7 +584,7 @@ end
 local entry_to_qf = function(entry)
   return {
     bufnr = entry.bufnr,
-    filename = Path:new(entry.cwd, entry.filename):absolute(),
+    filename = from_entry.path(entry, false),
     lnum = entry.lnum,
     col = entry.col,
     text = entry.text or entry.value.text or entry.value,


### PR DESCRIPTION
When entry.cwd is nil, filename was set to vim's cwd for the quickfix entries

This happens for example with `lsp_references` which returned entries like
```
filename = "/some/absolute/path.hpp",
cwd = nil
```
`Path:new(nil, "/some/absolute/path.hpp")` would turn into `Path:new(nil)` which turns into vim's current working directory with `:absolute()`, leading to the quickfix list items not jumping to the right place.

This should handle the edge-cases correctly, though I didn't find anything that produced a relative `entry.filename` and a `nil` `entry.cwd` at the same time, so I didn't test that explicitly.