### PR TITLE
git_bcommit use absolute path for current file.

### DIFF
--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -102,7 +102,7 @@ end
 
 git.bcommits = function(opts)
   opts.current_line = not opts.current_file and get_current_buf_line(0) or nil
-  opts.current_file = opts.current_file or vim.fn.expand "%"
+  opts.current_file = opts.current_file or vim.fn.expand "%:p"
   local results = utils.get_os_command_output({
     "git",
     "log",


### PR DESCRIPTION
fixes #1055 

Problem is that we previously had `vim.fn.expand("%")`, which sometimes returns a relative path. We create a new job, which executes a command from the correct correct working directory, but then the relative path is no longer accurate. We should be using an absolute path with `vim.fn.expand("%:p")

I'm not exactly sure what the behavior of `%` is. From `:h cmdline-special`:

> Note that these, except "#<n", give the file name as it was typed.  If an
absolute path is needed (when using the file name from a different directory),
you need to add ":p".  See |filename-modifiers|.

So I guess if you try to edit a file with `:e <some relative path>`, then git_bcommits() would break.