### PR TITLE
Feat: multi-select action take 2

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1558,29 +1558,61 @@ action_set.scroll_previewer({prompt_bufnr}, {direction})*action_set.scroll_previ
 ================================================================================
                                                        *telescope.actions.utils*
 
-Utilities to wrap functions around picker selections and entries.
+Utilities to wrap actions and functions around picker selections and entries.
+Generally used with other |telescope.actions| or custom functions that lever
+entries or selections.
 
-Generally used from within other |telescope.actions|
+The functions without the `_` prefix are intended to be mapped at setup,
+whereas `functions` with the `_` prefix are intended to be used in custom
+actions. Refer to the respective function documentation for example use cases.
 
-utils.map_entries({prompt_bufnr}, {f})                   *utils.map_entries()*
-    Apply `f` to the entries of the current picker.
+The functions that take `action(s)` as input typically are |telescope.actions|
+that lever the `action_state.selected_entry`. In particular,
+`action_utils.with_{entries, selection, selections}` intermittently override
+the `selected_entry` to perform the |telescope.actions| accordingly. More
+generally, `actions` as referred to in |telescope.actions.utils| are functions
+are akin to the below example:
+
+  local action_state = require "telescope.actions.state"
+  function(prompt_bufnr)
+    local entry = action_state.get_selected_entry()
+    -- lever entry for function
+    ...
+  end
+
+action_utils._map_entries({prompt_bufnr}, {f})   *action_utils._map_entries()*
+    Apply `f` to the entries of the current picker and prompt.
+    - `f` takes (entry, index, row) as arguments.
     - Notes:
       - Mapped entries may include results not visible in the results popup.
       - Indices are 1-indexed, whereas rows are 0-indexed.
     - Warning: `map_entries` has no return value.
-      - The below example showcases how to collect results
-    Usage:
-        local action_state = require "telescope.actions.state"
-        local action_utils = require "telescope.actions.utils"
-        function entry_value_by_row()
-          local prompt_bufnr = vim.api.nvim_get_current_buf()
-          local current_picker = action_state.get_current_picker(prompt_bufnr)
-          local results = {}
-            action_utils.map_entries(prompt_bufnr, function(entry, index, row)
-            results[row] = entry.value
-          end)
-          return results
-        end
+      - The below example showcase how to collect results.
+
+    Example Usage: collect entries in key-value table
+      local action_state = require "telescope.actions.state"
+      local action_utils = require "telescope.actions.utils"
+      require("telescope").setup {
+        defaults = {
+          mappings = {
+            i = {
+              -- with `action_utils._map_entries`
+              ['<C-e>'] = function(prompt_bufnr)
+                  local results = {}
+                  action_utils._with_entries(prompt_bufnr, function(entry, entry_index)
+                  results[entry_index] = entry
+                  return results
+                end)
+              end,
+              -- with `action_utils.map_entries`
+              ['<C-e>'] = action_utils.with_entries(function(entry, entry_index)
+                  results[entry_index] = entry
+                  return results
+                end)
+            },
+          },
+        },
+      }
 
 
     Parameters: ~
@@ -1590,32 +1622,202 @@ utils.map_entries({prompt_bufnr}, {f})                   *utils.map_entries()*
                                    arguments
 
 
-utils.map_selections({prompt_bufnr}, {f})             *utils.map_selections()*
+action_utils.map_entries()                        *action_utils.map_entries()*
+    Apply `f` to the entries of the current picker and prompt. See
+    |action_utils._map_entries| for further information.
+    - `f` takes (entry, index, row) as arguments.
+
+
+
+action_utils._map_selections({prompt_bufnr}, {f})*action_utils._map_selections()*
     Apply `f` to the multi selections of the current picker and return a table
     of mapped selections.
+    - `f` takes (selection, selection_index) as arguments
     - Notes:
       - Mapped selections may include results not visible in the results popup.
       - Selected entries are returned in order of their selection.
     - Warning: `map_selections` has no return value.
       - The below example showcases how to collect results
-    Usage:
-        local action_state = require "telescope.actions.state"
-        local action_utils = require "telescope.actions.utils"
-        function selection_by_index()
-          local prompt_bufnr = vim.api.nvim_get_current_buf()
-          local current_picker = action_state.get_current_picker(prompt_bufnr)
-          local results = {}
-            action_utils.map_selections(prompt_bufnr, function(entry, index)
-            results[index] = entry.value
-          end)
-          return results
-        end
+
+    Example Usage: collect selections in key-value table
+      local actions = require "telescope.actions"
+      local action_utils = require "telescope.actions.utils"
+      require("telescope").setup {
+        defaults = {
+          mappings = {
+            i = {
+            -- Collect selections
+              -- with `action_utils._map_selections`
+              ['<C-m>'] = function(prompt_bufnr)
+                  local results = {}
+                  action_utils._map_selections(prompt_bufnr, function(selection, selection_index)
+                  results[selection_index] = selection
+                  return results
+                  end),
+                end
+              -- with `action_utils.map_selections`
+              ['<C-m>'] = action_utils.with_selections(function(selection, selection_index)
+                  results[selection_index] = selection
+                  return results
+                end),
+            },
+          },
+        },
+      }
 
 
     Parameters: ~
         {prompt_bufnr} (number)    The prompt bufnr
         {f}            (function)  Function to map onto selection of picker
-                                   that takes (selection) as a viable argument
+                                   that takes (selection, selection_index) as
+                                   arguments
+
+
+action_utils.map_selections({f})               *action_utils.map_selections()*
+    Apply `f` to the multi selections of the current picker and return a table
+    of mapped selections. See |action_utils._map_selections| for further
+    information.
+    - `f` takes (selection, selection_index) as arguments
+
+
+    Parameters: ~
+        {f} (function)  Function to map onto selection of picker that takes
+                        (selection, selection_index) as arguments
+
+
+action_utils._with_entries({f})                 *action_utils._with_entries()*
+    Run an `action` from |telescope.actions| on entries of the current picker
+    and prompt.
+    - Notes:
+      - Mapped entries may include results not visible in the results popup.
+      - See |telescope.action.utils| for information on what functions
+        constitute `actions`.
+
+    Example Usage: |actions.git_staging_toggle|
+      local actions = require "telescope.actions"
+      local action_utils = require "telescope.actions.utils"
+      require("telescope").setup {
+        defaults = {
+          pickers = {
+            git_status = {
+              mappings = {
+                i = {
+                -- Open selections vertically
+                  -- with `action_utils._with_entries`
+                  ['<S-Tab>'] = function(prompt_bufnr)
+                    action_utils.with_entries(prompt_bufnr, actions.git_staging_toggle)
+                    end,
+                  -- with `action_utils.with_entries`
+                  ['<S-Tab>'] = action_utils.with_entries(actions.git_staging_toggle)
+                },
+              },
+            },
+          },
+        }
+      }
+
+
+    Parameters: ~
+        {f} (function)  apply action onto all results
+
+
+action_utils.with_entries({f})                   *action_utils.with_entries()*
+    Run an `action` from |telescope.actions| on the entries of the current
+    picker and prompt.
+    - Note: see |action_utils._with_entries| for further information.
+
+
+    Parameters: ~
+        {f} (function)  apply action onto all results
+
+
+action_utils._with_selections({prompt_bufnr}, {f})*action_utils._with_selections()*
+    Run an `action` from |telescope.actions| on the multi selection.
+    - Note: see |telescope.action.utils| for information on what functions
+      constitute `actions`.
+
+    Example Usage: |actions.select_vertical|
+      local actions = require "telescope.actions"
+      local action_utils = require "telescope.actions.utils"
+      require("telescope").setup {
+        defaults = {
+          mappings = {
+            i = {
+            -- Open selections vertically
+              -- with `action_utils._with_selections`
+              ['<C-v><C-v>'] = function(prompt_bufnr)
+                action_utils.with_selections(prompt_bufnr, actions.select_vertical)
+                end,
+              -- with `action_utils.with_selections`
+              ['<C-v><C-v>'] = action_utils.with_selections(actions.select_vertical)
+            },
+          },
+        },
+      }
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)    The prompt bufnr
+        {f}            (function)  apply `action` onto entries of multi
+                                   selection
+
+
+action_utils.with_selections({f})             *action_utils.with_selections()*
+    Run an `action` from |telescope.actions| on the multi selection.
+    - Note: see |telescope.action.utils| for specification on what functions
+      constitute `actions`.
+
+
+    Parameters: ~
+        {f} (function)  apply `action` onto entries of multi selection
+
+
+action_utils._with_selection({prompt_bufnr}, {f})*action_utils._with_selection()*
+    Run an `action` from |telescope.actions| on an indexed multi selection. The
+    index denotes the order in selection of the entry to run the action on.
+    - Note: see |telescope.action.utils| for specification on what functions
+      constitute `actions`.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)    The prompt bufnr
+        {f}            (function)  apply `action` onto entries of multi
+                                   selection
+
+
+action_utils.with_selection({f})               *action_utils.with_selection()*
+    Run an `action` from |telescope.actions| on an indexed multi selection. The
+    index denotes the order in selection of the entry to run the action on.
+    - Note: see |telescope.action.utils| for specification on what functions
+      constitute `actions`.
+
+
+    Parameters: ~
+        {f} (function)  apply `action` onto entries of multi selection
+
+
+action_utils.cycle({actions})                           *action_utils.cycle()*
+    Apply `actions` to multi selections or entries in cycle, on
+    entry-after-entry basis. Commonly used in combination with
+    `action_utils.with_{selections, entries}`.
+
+    Example Usage: open selections alternatingly vertically and horizontally
+      local actions = require "telescope.actions"
+      local action_utils = require "telescope.actions.utils"
+      require("telescope").setup {
+        defaults = {
+          mappings = {
+            i = {
+              ['<C-b>'] = action_utils.with_selections(
+                            action_utils.cycle({actions.select_vertical, actions.select_horizontal})
+            },
+          },
+        },
+      }
+
+
+    Parameters: ~
+        {actions} (table)  table of actions to apply iteratively
 
 
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -273,9 +273,6 @@ function actions.close_pum(_)
 end
 
 actions._close = function(prompt_bufnr, context, keepinsert)
-  if context ~= nil and context.is_final_entry == false then
-    return
-  end
   action_state.get_current_history():reset()
   local picker = action_state.get_current_picker(prompt_bufnr, context)
   local prompt_win = picker.prompt_win
@@ -287,7 +284,7 @@ actions._close = function(prompt_bufnr, context, keepinsert)
     end
   end
 
-  actions.close_pum(prompt_bufnr)
+  actions.close_pum()
   if not keepinsert then
     vim.cmd [[stopinsert]]
   end
@@ -295,8 +292,11 @@ actions._close = function(prompt_bufnr, context, keepinsert)
   if vim.api.nvim_win_is_valid(prompt_win) then
     vim.api.nvim_win_close(prompt_win, true)
   end
+  
+  if vim.api.nvim_buf_is_valid(prompt_bufnr) then
+    pcall(vim.cmd, string.format([[silent bdelete! %s]], prompt_bufnr))
+  end
 
-  pcall(vim.cmd, string.format([[silent bdelete! %s]], prompt_bufnr))
   pcall(a.nvim_set_current_win, original_win_id)
 end
 

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -121,7 +121,7 @@ action_set.edit = function(prompt_bufnr, context, command)
   end
 
   local entry_bufnr = entry.bufnr
-  
+
   if vim.api.nvim_buf_is_valid(prompt_bufnr) then
     require("telescope.actions").close(prompt_bufnr, context)
   end

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -30,7 +30,7 @@ local action_set = setmetatable({}, {
 --- Handles not overflowing / underflowing the list.
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param change number: The amount to shift the selection by
-action_set.shift_selection = function(prompt_bufnr, change)
+action_set.shift_selection = function(prompt_bufnr, _, change)
   local count = vim.v.count
   count = count == 0 and 1 or count
   count = a.nvim_get_mode().mode == "n" and count or 1
@@ -44,8 +44,8 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param type string: The type of selection to make
 --          Valid types include: "default", "horizontal", "vertical", "tabedit"
-action_set.select = function(prompt_bufnr, type)
-  return action_set.edit(prompt_bufnr, action_state.select_key_to_edit_key(type))
+action_set.select = function(prompt_bufnr, context, type)
+  return action_set.edit(prompt_bufnr, context, action_state.select_key_to_edit_key(type))
 end
 
 -- goal: currently we have a workaround in actions/init.lua where we do this for all files
@@ -84,8 +84,8 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param command string: The command to use to open the file.
 --      Valid commands include: "edit", "new", "vedit", "tabedit"
-action_set.edit = function(prompt_bufnr, command)
-  local entry = action_state.get_selected_entry()
+action_set.edit = function(prompt_bufnr, context, command)
+  local entry = action_state.get_selected_entry(context)
 
   if not entry then
     print "[telescope] Nothing currently selected"
@@ -121,8 +121,10 @@ action_set.edit = function(prompt_bufnr, command)
   end
 
   local entry_bufnr = entry.bufnr
-
-  require("telescope.actions").close(prompt_bufnr)
+  
+  if vim.api.nvim_buf_is_valid(prompt_bufnr) then
+    require("telescope.actions").close(prompt_bufnr, context)
+  end
 
   if entry_bufnr then
     edit_buffer(command, entry_bufnr)

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -30,11 +30,11 @@ local action_set = setmetatable({}, {
 --- Handles not overflowing / underflowing the list.
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param change number: The amount to shift the selection by
-action_set.shift_selection = function(prompt_bufnr, _, change)
+action_set.shift_selection = function(prompt_bufnr, context, change)
   local count = vim.v.count
   count = count == 0 and 1 or count
   count = a.nvim_get_mode().mode == "n" and count or 1
-  action_state.get_current_picker(prompt_bufnr):move_selection(change * count)
+  action_state.get_current_picker(prompt_bufnr, context):move_selection(change * count)
 end
 
 --- Select the current entry. This is the action set to overwrite common
@@ -149,7 +149,7 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param direction number: The direction of the scrolling
 --      Valid directions include: "1", "-1"
-action_set.scroll_previewer = function(prompt_bufnr, direction)
+action_set.scroll_previewer = function(prompt_bufnr, _, direction)
   local previewer = action_state.get_current_picker(prompt_bufnr).previewer
 
   -- Check if we actually have a previewer

--- a/lua/telescope/actions/state.lua
+++ b/lua/telescope/actions/state.lua
@@ -12,7 +12,11 @@ local conf = require("telescope.config").values
 local action_state = {}
 
 --- Get the current entry
-function action_state.get_selected_entry()
+function action_state.get_selected_entry(context)
+  vim.validate { context = { context, "table", true } }
+  if context ~= nil and context.entry then
+    return context.entry
+  end
   return global_state.get_global_key "selected_entry"
 end
 
@@ -23,7 +27,11 @@ end
 
 --- Gets the current picker
 ---@param prompt_bufnr number: The prompt bufnr
-function action_state.get_current_picker(prompt_bufnr)
+function action_state.get_current_picker(prompt_bufnr, context)
+  vim.validate { context = { context, "table", true } }
+  if context ~= nil and context.picker then
+    return context.picker
+  end
   return global_state.get_status(prompt_bufnr).picker
 end
 

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -1,38 +1,70 @@
 ---@tag telescope.actions.utils
 
 ---@brief [[
---- Utilities to wrap functions around picker selections and entries.
+--- Utilities to wrap actions and functions around picker selections and entries.
+--- Generally used with other |telescope.actions| or custom functions that lever entries or selections.
 ---
---- Generally used from within other |telescope.actions|
+--- The functions without the `_` prefix are intended to be mapped at setup, whereas `functions` with the `_` prefix
+--- are intended to be used in custom actions. Refer to the respective function documentation for example use cases.
+---
+--- The functions that take `action(s)` as input typically are |telescope.actions| that lever the
+--- `action_state.selected_entry`. In particular, `action_utils.with_{entries, selection, selections}`
+--- intermittently override the `selected_entry` to perform the |telescope.actions| accordingly.
+--- More generally, `actions` as referred to in |telescope.actions.utils| are functions are akin to the below example:
+---
+--- <pre>
+---   local action_state = require "telescope.actions.state"
+---   function(prompt_bufnr)
+---     local entry = action_state.get_selected_entry()
+---     -- lever entry for function
+---     ...
+---   end
+--- </pre>
 ---@brief ]]
 
 local action_state = require "telescope.actions.state"
+local global_state = require "telescope.state"
+local log = require "telescope.log"
 
-local utils = {}
+local action_utils = {}
 
---- Apply `f` to the entries of the current picker.
+--- Apply `f` to the entries of the current picker and prompt.
+--- - `f` takes (entry, index, row) as arguments.
 --- - Notes:
 ---   - Mapped entries may include results not visible in the results popup.
 ---   - Indices are 1-indexed, whereas rows are 0-indexed.
 --- - Warning: `map_entries` has no return value.
----   - The below example showcases how to collect results
+---   - The below example showcase how to collect results.
+---
 --- <pre>
---- Usage:
----     local action_state = require "telescope.actions.state"
----     local action_utils = require "telescope.actions.utils"
----     function entry_value_by_row()
----       local prompt_bufnr = vim.api.nvim_get_current_buf()
----       local current_picker = action_state.get_current_picker(prompt_bufnr)
----       local results = {}
----         action_utils.map_entries(prompt_bufnr, function(entry, index, row)
----         results[row] = entry.value
----       end)
----       return results
----     end
+--- Example Usage: collect entries in key-value table
+---   local action_state = require "telescope.actions.state"
+---   local action_utils = require "telescope.actions.utils"
+---   require("telescope").setup {
+---     defaults = {
+---       mappings = {
+---         i = {
+---           -- with `action_utils._map_entries`
+---           ['<C-e>'] = function(prompt_bufnr)
+---               local results = {}
+---               action_utils._with_entries(prompt_bufnr, function(entry, entry_index)
+---               results[entry_index] = entry
+---               return results
+---             end)
+---           end,
+---           -- with `action_utils.map_entries`
+---           ['<C-e>'] = action_utils.with_entries(function(entry, entry_index)
+---               results[entry_index] = entry
+---               return results
+---             end)
+---         },
+---       },
+---     },
+---   }
 --- </pre>
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto entries of picker that takes (entry, index, row) as viable arguments
-function utils.map_entries(prompt_bufnr, f)
+function action_utils._map_entries(prompt_bufnr, f)
   vim.validate {
     f = { f, "function" },
   }
@@ -46,36 +78,222 @@ function utils.map_entries(prompt_bufnr, f)
   end
 end
 
+--- Apply `f` to the entries of the current picker and prompt.
+--- See |action_utils._map_entries| for further information.
+--- - `f` takes (entry, index, row) as arguments.
+function action_utils.map_entries(f)
+  return function(prompt_bufnr)
+    action_utils._map_entries(prompt_bufnr, f)
+  end
+end
+
 --- Apply `f` to the multi selections of the current picker and return a table of mapped selections.
+--- - `f` takes (selection, selection_index) as arguments
 --- - Notes:
 ---   - Mapped selections may include results not visible in the results popup.
 ---   - Selected entries are returned in order of their selection.
 --- - Warning: `map_selections` has no return value.
 ---   - The below example showcases how to collect results
+---
 --- <pre>
---- Usage:
----     local action_state = require "telescope.actions.state"
----     local action_utils = require "telescope.actions.utils"
----     function selection_by_index()
----       local prompt_bufnr = vim.api.nvim_get_current_buf()
----       local current_picker = action_state.get_current_picker(prompt_bufnr)
----       local results = {}
----         action_utils.map_selections(prompt_bufnr, function(entry, index)
----         results[index] = entry.value
----       end)
----       return results
----     end
+--- Example Usage: collect selections in key-value table
+---   local actions = require "telescope.actions"
+---   local action_utils = require "telescope.actions.utils"
+---   require("telescope").setup {
+---     defaults = {
+---       mappings = {
+---         i = {
+---         -- Collect selections
+---           -- with `action_utils._map_selections`
+---           ['<C-m>'] = function(prompt_bufnr)
+---               local results = {}
+---               action_utils._map_selections(prompt_bufnr, function(selection, selection_index)
+---               results[selection_index] = selection
+---               return results
+---               end),
+---             end
+---           -- with `action_utils.map_selections`
+---           ['<C-m>'] = action_utils.with_selections(function(selection, selection_index)
+---               results[selection_index] = selection
+---               return results
+---             end),
+---         },
+---       },
+---     },
+---   }
 --- </pre>
 ---@param prompt_bufnr number: The prompt bufnr
----@param f function: Function to map onto selection of picker that takes (selection) as a viable argument
-function utils.map_selections(prompt_bufnr, f)
+---@param f function: Function to map onto selection of picker that takes (selection, selection_index) as arguments
+function action_utils._map_selections(prompt_bufnr, f)
   vim.validate {
     f = { f, "function" },
   }
   local current_picker = action_state.get_current_picker(prompt_bufnr)
-  for _, selection in ipairs(current_picker:get_multi_selection()) do
-    f(selection)
+  for selection_index, selection in ipairs(current_picker:get_multi_selection()) do
+    f(selection, selection_index)
   end
 end
 
-return utils
+--- Apply `f` to the multi selections of the current picker and return a table of mapped selections.
+--- See |action_utils._map_selections| for further information.
+--- - `f` takes (selection, selection_index) as arguments
+---@param f function: Function to map onto selection of picker that takes (selection, selection_index) as arguments
+function action_utils.map_selections(f)
+  return function(prompt_bufnr)
+    action_utils._map_selections(prompt_bufnr, f)
+  end
+end
+
+--- Run an `action` from |telescope.actions| on entries of the current picker and prompt.
+--- - Notes:
+---   - Mapped entries may include results not visible in the results popup.
+---   - See |telescope.action.utils| for information on what functions constitute `actions`.
+---
+--- <pre>
+--- Example Usage: |actions.git_staging_toggle|
+---   local actions = require "telescope.actions"
+---   local action_utils = require "telescope.actions.utils"
+---   require("telescope").setup {
+---     defaults = {
+---       pickers = {
+---         git_status = {
+---           mappings = {
+---             i = {
+---             -- Open selections vertically
+---               -- with `action_utils._with_entries`
+---               ['<S-Tab>'] = function(prompt_bufnr)
+---                 action_utils.with_entries(prompt_bufnr, actions.git_staging_toggle)
+---                 end,
+---               -- with `action_utils.with_entries`
+---               ['<S-Tab>'] = action_utils.with_entries(actions.git_staging_toggle)
+---             },
+---           },
+---         },
+---       },
+---     }
+---   }
+--- </pre>
+---@param f function: apply action onto all results
+function action_utils._with_entries(prompt_bufnr, action)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  for entry in current_picker.manager:iter() do
+    action(prompt_bufnr, { ["entry"] = entry })
+  end
+end
+
+--- Run an `action` from |telescope.actions| on the entries of the current picker and prompt.
+--- - Note: see |action_utils._with_entries| for further information.
+---@param f function: apply action onto all results
+function action_utils.with_entries(action)
+  return function(prompt_bufnr)
+    action_utils._with_entries(prompt_bufnr, action)
+  end
+end
+
+--- Run an `action` from |telescope.actions| on the multi selection.
+--- - Note: see |telescope.action.utils| for information on what functions constitute `actions`.
+---
+--- <pre>
+--- Example Usage: |actions.select_vertical|
+---   local actions = require "telescope.actions"
+---   local action_utils = require "telescope.actions.utils"
+---   require("telescope").setup {
+---     defaults = {
+---       mappings = {
+---         i = {
+---         -- Open selections vertically
+---           -- with `action_utils._with_selections`
+---           ['<C-v><C-v>'] = function(prompt_bufnr)
+---             action_utils.with_selections(prompt_bufnr, actions.select_vertical)
+---             end,
+---           -- with `action_utils.with_selections`
+---           ['<C-v><C-v>'] = action_utils.with_selections(actions.select_vertical)
+---         },
+---       },
+---     },
+---   }
+--- </pre>
+---@param prompt_bufnr number: The prompt bufnr
+---@param f function: apply `action` onto entries of multi selection
+function action_utils._with_selections(prompt_bufnr, action, smart)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local selections = current_picker:get_multi_selection()
+  local context = {["picker"] = current_picker}
+  if vim.tbl_isempty(selections) then
+    if smart then
+      action(prompt_bufnr)
+    else
+      log.warn "No entries are selected to perform multi-select action on."
+    end
+  else
+    for _, selection in ipairs(selections) do
+      context["entry"] = selection
+      action(prompt_bufnr, context)
+    end
+  end
+end
+
+--- Run an `action` from |telescope.actions| on the multi selection.
+--- - Note: see |telescope.action.utils| for specification on what functions constitute `actions`.
+---@param f function: apply `action` onto entries of multi selection
+function action_utils.with_selections(action, smart)
+  return function(prompt_bufnr)
+    action_utils._with_selections(prompt_bufnr, action, smart)
+  end
+end
+
+--- Run an `action` from |telescope.actions| on an indexed multi selection.
+--- The index denotes the order in selection of the entry to run the action on.
+--- - Note: see |telescope.action.utils| for specification on what functions constitute `actions`.
+---@param prompt_bufnr number: The prompt bufnr
+---@param f function: apply `action` onto entries of multi selection
+function action_utils._with_selection(prompt_bufnr, action, selection_index)
+  selection_index = vim.F.if_nil(selection_index, 1)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  local selections = current_picker:get_multi_selection()
+  action(prompt_bufnr, { ["entry"] = selection })
+end
+
+--- Run an `action` from |telescope.actions| on an indexed multi selection.
+--- The index denotes the order in selection of the entry to run the action on.
+--- - Note: see |telescope.action.utils| for specification on what functions constitute `actions`.
+---@param f function: apply `action` onto entries of multi selection
+function action_utils.with_selection(action, selection_index)
+  return function(prompt_bufnr)
+    action_utils._with_selection(prompt_bufnr, action, selection_index)
+  end
+end
+
+--- Apply `actions` to multi selections or entries in cycle, on entry-after-entry basis.
+--- Commonly used in combination with `action_utils.with_{selections, entries}`.
+---
+--- <pre>
+--- Example Usage: open selections alternatingly vertically and horizontally
+---   local actions = require "telescope.actions"
+---   local action_utils = require "telescope.actions.utils"
+---   require("telescope").setup {
+---     defaults = {
+---       mappings = {
+---         i = {
+---           ['<C-b>'] = action_utils.with_selections(
+---                         action_utils.cycle({actions.select_vertical, actions.select_horizontal})
+---         },
+---       },
+---     },
+---   }
+--- </pre>
+---@param actions table: table of actions to apply iteratively
+function action_utils.cycle(actions)
+  local num_actions = #actions
+  local index = 1
+  local cycle = function(i, n)
+    local result = i % n
+    return result == 0 and n or result
+  end
+  return function(prompt_bufnr)
+    actions[cycle(index, num_actions)](prompt_bufnr)
+    index = index + 1
+  end
+end
+
+return action_utils

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -177,11 +177,8 @@ function action_utils._with_entries(prompt_bufnr, action)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local num_results = current_picker.manager:num_results()
   local index = 1
-  local context = { ["picker"] = current_picker, ["is_final_entry"] = false }
+  local context = { ["picker"] = current_picker }
   for entry in current_picker.manager:iter() do
-    if index == num_results then
-      context.is_final_entry = true
-    end
     context.entry = entry
     action(prompt_bufnr, context)
     index = index + 1
@@ -225,7 +222,7 @@ end
 function action_utils._with_selections(prompt_bufnr, action, smart)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local selections = current_picker:get_multi_selection()
-  local context = { ["picker"] = current_picker, ["is_final_entry"] = false }
+  local context = { ["picker"] = current_picker }
   if vim.tbl_isempty(selections) then
     if smart then
       action(prompt_bufnr)
@@ -234,9 +231,6 @@ function action_utils._with_selections(prompt_bufnr, action, smart)
     end
   else
     for index, selection in ipairs(selections) do
-      if index == #selections then
-        context.is_final_entry = true
-      end
       context.entry = selection
       action(prompt_bufnr, context)
     end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -486,7 +486,7 @@ internal.help_tags = function(opts)
     previewer = previewers.help.new(opts),
     sorter = conf.generic_sorter(opts),
     attach_mappings = function(prompt_bufnr)
-      action_set.select:replace(function(_, cmd)
+      action_set.select:replace(function(_, _, cmd)
         local selection = action_state.get_selected_entry()
         actions.close(prompt_bufnr)
         if cmd == "default" or cmd == "horizontal" then

--- a/lua/tests/automated/action_spec.lua
+++ b/lua/tests/automated/action_spec.lua
@@ -300,7 +300,7 @@ describe("actions", function()
 
   describe("action_set", function()
     it("can replace `action_set.edit`", function()
-      action_set.edit:replace(function(_, arg)
+      action_set.edit:replace(function(_, _, arg)
         return "replaced:" .. arg
       end)
       eq("replaced:edit", actions.file_edit())
@@ -312,12 +312,12 @@ describe("actions", function()
       --  In config, we have { ["<CR>"] = actions.select, ... }
       --  In caller, we have actions._goto:replace(...)
       --  Person calls `select`, does not see update
-      action_set.edit:replace(function(_, arg)
+      action_set.edit:replace(function(_, _, arg)
         return "default_to_edit:" .. arg
       end)
       eq("default_to_edit:edit", actions.select_default())
 
-      action_set.select:replace(function(_, arg)
+      action_set.select:replace(function(_, _, arg)
         return "override_with_select:" .. arg
       end)
       eq("override_with_select:default", actions.select_default())


### PR DESCRIPTION
Raw WIP, I'll update progress and TODOs (as I'm on and of travelling)

- [x] Change function signature of actions and iterators (to be further reviewed) to take `context` that can effecticely override `entry` and `picker` (think actions on multiple pickers incl. their selections & entries, will depend on #1051 )
- [x] Autosupport for builtin actions via `smart_`, `multi_`, and `entries_` through `__index` method
- [ ] Review and possibly move to `plenary.iterators` where applicable
- [ ] Refactor `actions.mt` to work with custom actions
- [ ] If autosupport is fine: refactor `actions` to only comprise atomic actions
- [ ] Maybe, we should include a general `actions` override in `telescope.setup` like mappings to better facilitate combining variants of actions