### PR TITLE
docs: Comment out the custom action in mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,11 +327,11 @@ require('telescope').setup{
         ["<cr>"] = actions.select_default + actions.center,
 
         -- You can perform as many actions in a row as you like
-        ["<cr>"] = actions.select_default + actions.center + my_cool_custom_action,
+        -- ["<cr>"] = actions.select_default + actions.center + my_cool_custom_action,
       },
       n = {
         ["<esc>"] = actions.close,
-        ["<C-i>"] = my_cool_custom_action,
+        -- ["<C-i>"] = my_cool_custom_action,
       },
     },
   }


### PR DESCRIPTION
Just comment out the custom action in mappings to make it a working config without any change.

Last night, I install this wonderful plugin and give it a try. Several minutes later I want to change the default mapping,
so I open the doc and just copy the configs **without any change**, then I find that config does not work as I expect.
After about ten minutes struggle, I finally realize that config failed to work because `my_cool_custom_action` is not defined.

Maybe we can comment out these two lines, if someone needs to customize action, he will get a clue from the comment.
What's more, it will potentially reduce the unexpected surprise  for impatient people like me.