### PR TITLE
feat: allow tables in vimscript command parser

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -279,29 +279,30 @@ api.
 
 The lua api is the more direct way to interact with Telescope, as you directly
 call the lua functions that Telescope defines. It can be called in a lua file
-using commands like: `require("telescope.builtin").find_files({hidden=true,
-layout_config={prompt_position="top"}})` If you want to use this api from a vim
-file you should prepend `lua` to the command, as below: `lua
-require("telescope.builtin").find_files({hidden=true,
-layout_config={prompt_position="top"}})` If you want to use this api from a
-neovim command line you should prepend `:lua` to the command, as below: `:lua
-require("telescope.builtin").find_files({hidden=true,
-layout_config={prompt_position="top"}})`
+using commands like:
+`require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
+If you want to use this api from a vim file you should prepend `lua` to the
+command, as below:
+`lua require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
+If you want to use this api from a neovim command line you should prepend
+`:lua` to the command, as below:
+`:lua require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
 
 The viml api is more indirect, as first the command must be parsed to the
 relevant lua equivalent, which brings some limitations. The viml api can be
-called using commands like: `:Telescope find_files hidden=true
-layout_config={"prompt_position":"top"}` This involves setting options using an
-`=` and using viml syntax for lists and dictionaries when the corresponding lua
-function requires a table.
+called using commands like:
+`:Telescope find_files hidden=true layout_config={"prompt_position":"top"}`
+This involves setting options using an `=` and using viml syntax for lists and
+dictionaries when the corresponding lua function requires a table.
 
 One limitation of the viml api is that there can be no spaces in any of the
 options. For example, if you want to use the `cwd` option for `find_files` to
 specify that you only want to search within the folder `/foo bar/subfolder/`
 you could not do that using the viml api, as the path name contains a space.
 Similarly, you could NOT set the `prompt_position` to `"top"` using the
-following command: `:Telescope find_files layout_config={ "prompt_position" :
-"top" }` as there are spaces in the option.
+following command:
+`:Telescope find_files layout_config={ "prompt_position" : "top" }`
+as there are spaces in the option.
 
 
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -272,6 +272,40 @@ telescope.extensions()                                *telescope.extensions()*
 
 
 ================================================================================
+                                                             *telescope.command*
+
+Telescope commands can be called through two apis, the lua api and the viml
+api.
+
+The lua api is the more direct way to interact with Telescope, as you directly
+call the lua functions that Telescope defines. It can be called in a lua file
+using commands like: `require("telescope.builtin").find_files({hidden=true,
+layout_config={prompt_position="top"}})` If you want to use this api from a vim
+file you should prepend `lua` to the command, as below: `lua
+require("telescope.builtin").find_files({hidden=true,
+layout_config={prompt_position="top"}})` If you want to use this api from a
+neovim command line you should prepend `:lua` to the command, as below: `:lua
+require("telescope.builtin").find_files({hidden=true,
+layout_config={prompt_position="top"}})`
+
+The viml api is more indirect, as first the command must be parsed to the
+relevant lua equivalent, which brings some limitations. The viml api can be
+called using commands like: `:Telescope find_files hidden=true
+layout_config={"prompt_position":"top"}` This involves setting options using an
+`=` and using viml syntax for lists and dictionaries when the corresponding lua
+function requires a table.
+
+One limitation of the viml api is that there can be no spaces in any of the
+options. For example, if you want to use the `cwd` option for `find_files` to
+specify that you only want to search within the folder `/foo bar/subfolder/`
+you could not do that using the viml api, as the path name contains a space.
+Similarly, you could NOT set the `prompt_position` to `"top"` using the
+following command: `:Telescope find_files layout_config={ "prompt_position" :
+"top" }` as there are spaces in the option.
+
+
+
+================================================================================
                                                              *telescope.builtin*
 
 Telescope Builtins is a collection of community maintained pickers to support

--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -8,17 +8,25 @@
 --- The lua api is the more direct way to interact with Telescope, as you directly call the
 --- lua functions that Telescope defines.
 --- It can be called in a lua file using commands like:
+--- <pre>
 --- `require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
+--- </pre>
 --- If you want to use this api from a vim file you should prepend `lua` to the command, as below:
+--- <pre>
 --- `lua require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
+--- </pre>
 --- If you want to use this api from a neovim command line you should prepend `:lua` to
 --- the command, as below:
+--- <pre>
 --- `:lua require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
+--- </pre>
 ---
 --- The viml api is more indirect, as first the command must be parsed to the relevant lua
 --- equivalent, which brings some limitations.
 --- The viml api can be called using commands like:
+--- <pre>
 --- `:Telescope find_files hidden=true layout_config={"prompt_position":"top"}`
+--- </pre>
 --- This involves setting options using an `=` and using viml syntax for lists and
 --- dictionaries when the corresponding lua function requires a table.
 ---
@@ -27,7 +35,9 @@
 --- only want to search within the folder `/foo bar/subfolder/` you could not do that using the
 --- viml api, as the path name contains a space.
 --- Similarly, you could NOT set the `prompt_position` to `"top"` using the following command:
+--- <pre>
 --- `:Telescope find_files layout_config={ "prompt_position" : "top" }`
+--- </pre>
 --- as there are spaces in the option.
 ---
 ---@brief ]]
@@ -53,6 +63,7 @@ local split_keywords = {
   ["vimgrep_arguments"] = true,
   ["sections"] = true,
   ["search_dirs"] = true,
+  ["symbols"] = true,
 }
 
 -- convert command line string arguments to

--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -53,7 +53,12 @@ local function convert_user_opts(user_opts)
       if ok then
         user_opts[key] = eval
       else
-        user_opts[key] = nil
+        eval = assert(loadstring("return " .. val))()
+        if type(eval) == "table" then
+          user_opts[key] = eval
+        else
+          user_opts[key] = nil
+        end
       end
     end,
   }
@@ -73,13 +78,8 @@ local function convert_user_opts(user_opts)
         user_opts[key] = vim.split(val, ",")
       end
     elseif default_opts[key] ~= nil then
-      -- vim.fn.input('1')
-      -- dump(key,val)
       _switch[type(default_opts[key])](key, val)
     else
-      -- vim.fn.input('2')
-      -- dump(key,val)
-      -- print('type',type(default_opts[key]))
       _switch["string"](key, val)
     end
   end

--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -168,10 +168,12 @@ function command.load_command(cmd, ...)
       user_opts["extension_type"] = arg
     else
       local param = vim.split(arg, "=")
-      if param[1] == "theme" then
-        user_opts["theme"] = param[2]
+      local key = table.remove(param,1)
+      param = table.concat(param, "=")
+      if key == "theme" then
+        user_opts["theme"] = param
       else
-        user_opts.opts[param[1]] = param[2]
+        user_opts.opts[key] = param
       end
     end
   end

--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -41,6 +41,9 @@ local function convert_user_opts(user_opts)
         user_opts[key] = bool_type[val]
       end
     end,
+    ["table"] = function(key, val)
+      user_opts[key] = vim.fn.eval(val)
+    end,
   }
 
   local _switch_metatable = {

--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -1,3 +1,36 @@
+---@tag telescope.command
+
+---@brief [[
+---
+--- Telescope commands can be called through two apis,
+--- the lua api and the viml api.
+---
+--- The lua api is the more direct way to interact with Telescope, as you directly call the
+--- lua functions that Telescope defines.
+--- It can be called in a lua file using commands like:
+--- `require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
+--- If you want to use this api from a vim file you should prepend `lua` to the command, as below:
+--- `lua require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
+--- If you want to use this api from a neovim command line you should prepend `:lua` to
+--- the command, as below:
+--- `:lua require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
+---
+--- The viml api is more indirect, as first the command must be parsed to the relevant lua
+--- equivalent, which brings some limitations.
+--- The viml api can be called using commands like:
+--- `:Telescope find_files hidden=true layout_config={"prompt_position":"top"}`
+--- This involves setting options using an `=` and using viml syntax for lists and
+--- dictionaries when the corresponding lua function requires a table.
+---
+--- One limitation of the viml api is that there can be no spaces in any of the options.
+--- For example, if you want to use the `cwd` option for `find_files` to specify that you
+--- only want to search within the folder `/foo bar/subfolder/` you could not do that using the
+--- viml api, as the path name contains a space.
+--- Similarly, you could NOT set the `prompt_position` to `"top"` using the following command:
+--- `:Telescope find_files layout_config={ "prompt_position" : "top" }`
+--- as there are spaces in the option.
+---
+---@brief ]]
 local themes = require "telescope.themes"
 local builtin = require "telescope.builtin"
 local extensions = require("telescope._extensions").manager

--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -168,7 +168,7 @@ function command.load_command(cmd, ...)
       user_opts["extension_type"] = arg
     else
       local param = vim.split(arg, "=")
-      local key = table.remove(param,1)
+      local key = table.remove(param, 1)
       param = table.concat(param, "=")
       if key == "theme" then
         user_opts["theme"] = param

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -10,6 +10,7 @@ docs.test = function()
   -- TODO: Fix the other files so that we can add them here.
   local input_files = {
     "./lua/telescope/init.lua",
+    "./lua/telescope/command.lua",
     "./lua/telescope/builtin/init.lua",
     "./lua/telescope/themes.lua",
     "./lua/telescope/pickers/layout_strategies.lua",


### PR DESCRIPTION
This PR allows users to pass vimscripts lists and dictionaries (which are converted to lua tables) when using the vimscript commands for telescope.

For example:
- `:Telescope find_files layout_config={'prompt_position':'top'}` will now move the prompt to the top
- `:Telescope find_files search_dirs=['~/foo','~/bar']` will set the `search_dirs` to `~/foo` and `~/bar`
- `:Telescope find_files search_dirs=~/foo,~bar` will still work too

Implementation:
- The implementation relies on `vim.fn.eval`, as it seemed better to me to rely on a robust existing method for converting between vimscript objects and lua objects, rather than try to make my own and miss some edge cases.
- This choice of implementation can cause some unusual methods of configuration for some things, e.g. `:Telescope find_files layout_config={'border':v:false}`, but these are idiosyncrasies of vimscript that I feel like you sign up for when using the vimscript api for telescope.

TODO:
- [x] docs

Related discussion:
- https://github.com/nvim-telescope/telescope.nvim/issues/1036#issuecomment-885491418
- https://github.com/nvim-telescope/telescope.nvim/issues/901#issuecomment-889802749

@Conni2461 could you have a look at this when you get a chance?

---

Also, I think docgen was not run on a previous PR before merge, as I definitely haven't changed anything with Telescopes git stuff 🤣 