### PR TITLE
Add `only-cwd` option to `lsp.workspace_diagnostics`;

### DIFF
--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -375,6 +375,7 @@ builtin.lsp_document_diagnostics = require("telescope.builtin.lsp").diagnostics
 ---@field severity_bound string|number: keep diagnostics equal or less severe wrt severity name (string) or id (number)
 ---@field no_sign bool: hide LspDiagnosticSigns from Results (default is false)
 ---@field line_width number: set length of diagnostic entry text in Results
+---@field only_cwd boolean: if true, only show diagnostics for files in the current working directory (default false)
 builtin.lsp_workspace_diagnostics = require("telescope.builtin.lsp").workspace_diagnostics
 
 local apply_config = function(mod)

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -221,11 +221,13 @@ utils.diagnostics_to_tbl = function(opts)
   local buffer_diags = opts.get_all and vim.lsp.diagnostic.get_all()
     or { [current_buf] = vim.lsp.diagnostic.get(current_buf, opts.client_id) }
   for bufnr, diags in pairs(buffer_diags) do
-    for _, diag in ipairs(diags) do
-      -- workspace diagnostics may include empty tables for unused bufnr
-      if not vim.tbl_isempty(diag) then
-        if filter_diag_severity(opts, diag.severity) then
-          table.insert(items, preprocess_diag(diag, bufnr))
+    if not opts.only_cwd or (opts.only_cwd and string.find(vim.api.nvim_buf_get_name(bufnr), vim.loop.cwd(), 1, true) ) then
+      for _, diag in ipairs(diags) do
+        -- workspace diagnostics may include empty tables for unused bufnr
+        if not vim.tbl_isempty(diag) then
+          if filter_diag_severity(opts, diag.severity) then
+            table.insert(items, preprocess_diag(diag, bufnr))
+          end
         end
       end
     end


### PR DESCRIPTION
To show diagnostics only for files in the current working directory.

### Motivation
`rust-analyzer` LSP server loads and pushes diagnostics for dependencies (external crates) when you open their files (via "jump to definition", etc.).