### PR TITLE
Add missing disable_devicons option

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ EOF
 | `scroll_strategy`      | How to behave when the when there are no more item next/prev | cycle, nil           |
 | `winblend`             | How transparent is the telescope window should be.    | number                      |
 | `borderchars`          | The border chars, it gives border telescope window    | dict                        |
+| `disable_devicons`     | Whether to display devicons or not                    | boolean                     |
 | `color_devicons`       | Whether to color devicons or not                      | boolean                     |
 | `use_less`             | Whether to use less with bat or less/cat if bat not installed | boolean             |
 | `set_env`              | Set environment variables for previewer               | dict                        |


### PR DESCRIPTION
When looking for a way to disable devicons, there's nothing about it on the readme, had to look into the [source code](https://github.com/nvim-telescope/telescope.nvim/blob/ca195e32e0d6e9238fb2dd405e2f794ab8c90819/lua/telescope/builtin/files.lua#L322) in order to find it, it's also not documented on help pages, might be interesting to include this one