### PR TITLE
fix: registering custom actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,11 +295,11 @@ you can pick from to remap your telescope buffer mappings, or create a new custo
 <!-- TODO: add custom action in addition to a function that gets ran after a given action--->
 ```lua
 -- Built-in actions
-local transform_mod = require('telescope.actions.mt').transform_mod
+local actions = require('telescope.actions')
 
 -- or create your custom action
-local my_cool_custom_action = transform_mod({
-  x = function()
+actions.register_actions({
+  my_cool_custom_action = function()
     print("This function ran after another action. Prompt_bufnr: " .. prompt_bufnr)
     -- Enter your function logic here. You can take inspiration from lua/telescope/actions.lua
   end,
@@ -327,7 +327,7 @@ require('telescope').setup{
         ["<cr>"] = actions.select_default + actions.center,
 
         -- You can perform as many actions in a row as you like
-        ["<cr>"] = actions.select_default + actions.center + my_cool_custom_action,
+        ["<cr>"] = actions.select_default + actions.center + actions.my_cool_custom_action,
       },
       n = {
         ["<esc>"] = actions.close,

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1526,6 +1526,38 @@ actions.cycle_previewers_prev({prompt_bufnr})*actions.cycle_previewers_prev()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
+actions.register_actions({fn})                    *actions.register_actions()*
+    Register your custom actions.
+    Example usage: modifying |actions.select_vertical|
+    local actions = require "telescope.actions"
+    local action_state = require "telescope.actions.state"
+    -- fn should be a table of {action_name = action_function, ...}
+    local print_entry = actions.register_action({
+      print_entry = function()
+        print(vim.inspect(action_state.get_selected_entry()))
+      end,
+    })[1] -- get first entry of returned functions
+    telescope.setup {
+      defaults = {
+        mappings = {
+          i = {
+            -- Both `print_entry` and `actions.print_entry` can be used
+            ["<C-v>"] = print_entry + actions.select_vertical,
+            ["<C-v>"] = actions.print_entry + actions.select_vertical,
+          }
+        }
+      }
+    }
+
+
+    Parameters: ~
+        {fn} (table)  table comprising named custom action(s), i.e.
+                      {action_name = action, ... }
+
+    Return: ~
+        table: table of registered actions
+
+
 
 ================================================================================
                                                        *telescope.actions.state*

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -805,18 +805,17 @@ actions.cycle_previewers_prev = function(prompt_bufnr)
   actions.get_current_picker(prompt_bufnr):cycle_previewers(-1)
 end
 
---- Register your custom actions.
+--- Register your custom actions.<br>
 --- Example usage: modifying |actions.select_vertical|
 --- <pre>
 --- local actions = require "telescope.actions"
 --- local action_state = require "telescope.actions.state"
---- -- func should be a table of {action_name = action_function}
+--- -- fn should be a table of {action_name = action_function, ...}
 --- local print_entry = actions.register_action({
 ---   print_entry = function()
 ---     print(vim.inspect(action_state.get_selected_entry()))
 ---   end,
 --- })[1] -- get first entry of returned functions
----
 --- telescope.setup {
 ---   defaults = {
 ---     mappings = {
@@ -829,12 +828,12 @@ end
 ---   }
 --- }
 --- </pre>
----@param func table: table comprising named custom action(s), i.e. {action_name = action, ... }
+---@param fn table: table comprising named custom action(s), i.e. {action_name = action, ... }
 ---@return table: table of registered actions
-actions.register_actions = function(func)
-  local mt = action_mt.create(func)
+actions.register_actions = function(fn)
+  local mt = action_mt.create(fn)
   local ret = {}
-  for k, v in pairs(func) do
+  for k, v in pairs(fn) do
     -- actions is "redirect" of actions_mt when registering actions
     actions[k] = action_mt.transform(k, mt, v)
     table.insert(ret, actions[k])

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -831,11 +831,11 @@ end
 ---@param fn table: table comprising named custom action(s), i.e. {action_name = action, ... }
 ---@return table: table of registered actions
 actions.register_actions = function(fn)
-  local mt = action_mt.create(fn)
+  action_mt.register(fn)
   local ret = {}
   for k, v in pairs(fn) do
     -- actions is "redirect" of actions_mt when registering actions
-    actions[k] = action_mt.transform(k, mt, v)
+    actions[k] = action_mt.transform(k, v)
     table.insert(ret, actions[k])
   end
   return ret

--- a/lua/telescope/actions/mt.lua
+++ b/lua/telescope/actions/mt.lua
@@ -122,7 +122,7 @@ function mt:enhance(opts)
   return self
 end
 
-action_mt.create = function(mod)
+action_mt.register = function(mod)
   registered_actions = vim.tbl_extend("force", registered_actions, mod)
 end
 
@@ -137,7 +137,7 @@ action_mt.transform = function(k, v)
 end
 
 action_mt.transform_mod = function(mod)
-  action_mt.create(mod)
+  action_mt.register(mod)
 
   -- Pass the metatable of the module if applicable.
   --    This allows for custom errors, lookups, etc.

--- a/lua/telescope/actions/mt.lua
+++ b/lua/telescope/actions/mt.lua
@@ -15,117 +15,118 @@ local run_replace_or_original = function(replacements, original_func, ...)
   return original_func(...)
 end
 
-action_mt.create = function(mod)
-  registered_actions = vim.tbl_extend("force", registered_actions, mod)
-  local mt = {
-    __call = function(t, ...)
-      local values = {}
-      for _, action_name in ipairs(t) do
-        if t._static_pre[action_name] then
-          t._static_pre[action_name](...)
-        end
-        if t._pre[action_name] then
-          t._pre[action_name](...)
-        end
-
-        local result = {
-          run_replace_or_original(t._replacements[action_name], registered_actions[action_name], ...),
-        }
-        for _, res in ipairs(result) do
-          table.insert(values, res)
-        end
-
-        if t._static_post[action_name] then
-          t._static_post[action_name](...)
-        end
-        if t._post[action_name] then
-          t._post[action_name](...)
-        end
+-- all registered actions should use identical original instance of `mt`
+-- such that actions._clear() works
+local mt = {
+  __call = function(t, ...)
+    local values = {}
+    for _, action_name in ipairs(t) do
+      if t._static_pre[action_name] then
+        t._static_pre[action_name](...)
+      end
+      if t._pre[action_name] then
+        t._pre[action_name](...)
       end
 
-      return unpack(values)
-    end,
-
-    __add = function(lhs, rhs)
-      local new_actions = {}
-      for _, v in ipairs(lhs) do
-        table.insert(new_actions, v)
+      local result = {
+        run_replace_or_original(t._replacements[action_name], registered_actions[action_name], ...),
+      }
+      for _, res in ipairs(result) do
+        table.insert(values, res)
       end
 
-      for _, v in ipairs(rhs) do
-        table.insert(new_actions, v)
+      if t._static_post[action_name] then
+        t._static_post[action_name](...)
       end
-
-      return setmetatable(new_actions, getmetatable(lhs))
-    end,
-
-    _static_pre = {},
-    _pre = {},
-    _replacements = {},
-    _static_post = {},
-    _post = {},
-  }
-
-  mt.__index = mt
-
-  mt.clear = function()
-    mt._pre = {}
-    mt._replacements = {}
-    mt._post = {}
-  end
-
-  --- Replace the reference to the function with a new one temporarily
-  function mt:replace(v)
-    assert(#self == 1, "Cannot replace an already combined action")
-
-    return self:replace_map { [true] = v }
-  end
-
-  function mt:replace_if(condition, replacement)
-    assert(#self == 1, "Cannot replace an already combined action")
-
-    return self:replace_map { [condition] = replacement }
-  end
-
-  --- Replace table with
-  -- Example:
-  --
-  -- actions.select:replace_map {
-  --   [function() return filetype == 'lua' end] = actions.file_split,
-  --   [function() return filetype == 'other' end] = actions.file_split_edit,
-  -- }
-  function mt:replace_map(tbl)
-    assert(#self == 1, "Cannot replace an already combined action")
-
-    local action_name = self[1]
-
-    if not mt._replacements[action_name] then
-      mt._replacements[action_name] = {}
+      if t._post[action_name] then
+        t._post[action_name](...)
+      end
     end
 
-    table.insert(mt._replacements[action_name], 1, tbl)
-    return self
-  end
+    return unpack(values)
+  end,
 
-  function mt:enhance(opts)
-    assert(#self == 1, "Cannot enhance already combined actions")
-
-    local action_name = self[1]
-    if opts.pre then
-      mt._pre[action_name] = opts.pre
+  __add = function(lhs, rhs)
+    local new_actions = {}
+    for _, v in ipairs(lhs) do
+      table.insert(new_actions, v)
     end
 
-    if opts.post then
-      mt._post[action_name] = opts.post
+    for _, v in ipairs(rhs) do
+      table.insert(new_actions, v)
     end
 
-    return self
-  end
+    return setmetatable(new_actions, getmetatable(lhs))
+  end,
 
-  return mt
+  _static_pre = {},
+  _pre = {},
+  _replacements = {},
+  _static_post = {},
+  _post = {},
+}
+
+mt.__index = mt
+
+mt.clear = function()
+  mt._pre = {}
+  mt._replacements = {}
+  mt._post = {}
 end
 
-action_mt.transform = function(k, mt, v)
+--- Replace the reference to the function with a new one temporarily
+function mt:replace(v)
+  assert(#self == 1, "Cannot replace an already combined action")
+
+  return self:replace_map { [true] = v }
+end
+
+function mt:replace_if(condition, replacement)
+  assert(#self == 1, "Cannot replace an already combined action")
+
+  return self:replace_map { [condition] = replacement }
+end
+
+--- Replace table with
+-- Example:
+--
+-- actions.select:replace_map {
+--   [function() return filetype == 'lua' end] = actions.file_split,
+--   [function() return filetype == 'other' end] = actions.file_split_edit,
+-- }
+function mt:replace_map(tbl)
+  assert(#self == 1, "Cannot replace an already combined action")
+
+  local action_name = self[1]
+
+  if not mt._replacements[action_name] then
+    mt._replacements[action_name] = {}
+  end
+
+  table.insert(mt._replacements[action_name], 1, tbl)
+  return self
+end
+
+function mt:enhance(opts)
+  assert(#self == 1, "Cannot enhance already combined actions")
+
+  local action_name = self[1]
+  if opts.pre then
+    mt._pre[action_name] = opts.pre
+  end
+
+  if opts.post then
+    mt._post[action_name] = opts.post
+  end
+
+  return self
+end
+
+action_mt.create = function(mod)
+  registered_actions = vim.tbl_extend("force", registered_actions, mod)
+end
+
+action_mt.transform = function(k, v)
   local res = setmetatable({ k }, mt)
   if type(v) == "table" then
     res._static_pre[k] = v.pre
@@ -136,14 +137,14 @@ action_mt.transform = function(k, mt, v)
 end
 
 action_mt.transform_mod = function(mod)
-  local mt = action_mt.create(mod)
+  action_mt.create(mod)
 
   -- Pass the metatable of the module if applicable.
   --    This allows for custom errors, lookups, etc.
   local redirect = setmetatable({}, getmetatable(mod) or {})
 
   for k, v in pairs(mod) do
-    redirect[k] = action_mt.transform(k, mt, v)
+    redirect[k] = action_mt.transform(k, v)
   end
 
   redirect._clear = mt.clear


### PR DESCRIPTION
Closes #684 

This fixes registering custom actions by unifying the lookup (`mod` vs `registered_actions` in `action_mt`) and adding the custom action subsequently to `actions`, which allows nice things as illustrated in docs.

How does it work?
- Rather than keeping an inaccessible copy of actions in the function-local `mod` of `action_mt.create` in `actions_mt`, we now maintain an explicit copy of registered actions on which `run_replace_or_original` can rely and which new actions can be added to 
- `mt of actions/mt.lua` is now instantiated once and set as the metatable also for newly registered actions such that `actions._clear` works when a metatable is instantiated
- Newly registered actions are added to `actions` which already is the `redirect` of `transform_mod` in `actions_mt` (ie has the right metatables) once an action can be registered; this adds the nicety that actions can be called via `actions.my_cool_custom_action` anywhere after registration

**old tests regarding actions having to point to the same `mt` below**

-----

One thing I've run into and haven't fully wrapped my head around yet: edit -> That's because `actions._clear` does not affect `actions.print_entry` in the above example due to differing metatables, which is now fixed by instantiating `mt` in `actions/mt.lua` once and letting all actions have the same original metatable such that `actions._clear` works for newly instantiated actions just as well.

```lua
local actions = require "telescope.actions"
local action_state = require "telescope.actions.state"

local print_entry = actions.register_actions({
  print_entry = function()
    print(vim.inspect(action_state.get_selected_entry()))
  end,
  print_ordinal = function()
    print(vim.inspect(action_state.get_selected_entry()))
  end,
})[1]

require"telescope".setup {
    mappings = {
      i = {
        -- now fixed
        -- why does this work and the others below do not? E: this should not work; picker clears actions upon call
        ["<C-v>"] = actions.print_entry:enhance({post = actions.select_vertical}),
        -- of course maybe not super sensible, though neither of the below works (also not on master) -- should they?
        ["<C-v>"] = actions.toggle_selection:enhance({pre = actions.print_entry}),
        ["<C-v>"] = actions.toggle_selection:enhance({post = actions.select_vertical}),
        ["<C-v>"] = actions.toggle_selection:enhance({post = function() print(action_state.get_selected_entry() end}),
        -- addition variants all work ie actions.toggle_selection + actions.print_entry
      }
    }
  }
```

Update: these work as intended on both master (where applicable) and this branch

```lua
R("telescope.builtin").find_files {
  attach_mappings = function(prompt_bufnr)
    actions.toggle_selection:enhance { post = actions.vertical_select }
    actions.toggle_selection:enhance { post = actions.print_entry }
    return true
  end,
}
```

