### PR TITLE
feat: api for clearing completion cb in userspace

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -970,6 +970,10 @@ function Picker:register_completion_callback(cb)
   table.insert(self._completion_callbacks, cb)
 end
 
+function Picker:clear_completion_callbacks()
+  self._completion_callbacks = {}
+end
+
 function Picker:_on_complete()
   for _, v in ipairs(self._completion_callbacks) do
     pcall(v, self)


### PR DESCRIPTION
I guess it's orthogonal enough to #987 to be able to merge it right away. Hope there's nothing more to it :sweat_smile: 

More generally, some lower-lever picker functions (specifically, `default_text`, `on_complete`, or that some options can also be passed to pickers individually like `file_ignore_patterns`)  useful to end users are not yet documented though we should document these options at least after #987 or as part of #1024.

Examples: #1095, #1042, frecency's usage of `on_input_filter_cb`, and gitter discussion from which this PR evolved