### PR TITLE
Builtin `list_or_jump` now handles non list replies from the server.

### DIFF
--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -58,6 +58,13 @@ local function list_or_jump(action, title, opts)
   local flattened_results = {}
   for _, server_results in pairs(result) do
     if server_results.result then
+
+      -- textDocument/definition can return Location or Location[]
+      if not vim.tbl_islist(server_results.result) then
+        flattened_results = {server_results.result}
+        break
+      end
+
       vim.list_extend(flattened_results, server_results.result)
     end
   end

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -58,10 +58,9 @@ local function list_or_jump(action, title, opts)
   local flattened_results = {}
   for _, server_results in pairs(result) do
     if server_results.result then
-
       -- textDocument/definition can return Location or Location[]
       if not vim.tbl_islist(server_results.result) then
-        flattened_results = {server_results.result}
+        flattened_results = { server_results.result }
         break
       end
 


### PR DESCRIPTION
This PR fixes the bug described in issue #1068 

The `list_or_jump` function could only handle responses in a list format, however servers can also send a single result without surrounding table. This resulted in the jump function not working on some servers, such as zls and clojure_lsp.