### PR TITLE
Change the default sorter for live_grep to empty()

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -103,7 +103,7 @@ files.live_grep = function(opts)
     prompt_title = "Live Grep",
     finder = live_grepper,
     previewer = conf.grep_previewer(opts),
-    sorter = conf.generic_sorter(opts),
+    sorter = conf.empty_sorter(opts),
   }):find()
 end
 

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -360,6 +360,7 @@ local telescope_defaults = {
     ]],
   },
 
+  empty_sorter = { sorters.empty },
   generic_sorter = { sorters.get_generic_fuzzy_sorter },
   prefilter_sorter = { sorters.prefilter },
   file_sorter = { sorters.get_fuzzy_file },


### PR DESCRIPTION
Since live_grep passes its entire input text to rg (or well, the program
in vimgrep_arguments), there's nothing to fuzzy-search by, and the empty
sorter seems a more appropriate default, to present the results as-is.

Note that the default generic_sorter does in fact leave the results alone here, though perhaps more by coincidence than by design. I stumbled on this because the `fzy` native extension DOES change the order of the results—but in my opinion, live_grep is a special case and empty() is conceptually the correct default for it (which can, of course, still be overriden on request).