### PR TITLE
Fix broken reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Community driven built-in [pickers](#pickers), [sorters](#sorters) and [previewe
 - [Vim](#vim-pickers)
 - [Files](#file-pickers)
 - [Git](#git-pickers)
-- [LSP](#lsp-pickers)
+- [LSP](#neovim-lsp-pickers)
 - [Treesitter](#treesitter-picker)
 
 ![Preview](https://i.imgur.com/TTTja6t.gif)


### PR DESCRIPTION
Fix the reference to neovim LSP pickers by correcting the linked heading name.