### PR TITLE
fix: for telescope.symbols

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -560,12 +560,22 @@ builtin.planets({opts})                                    *builtin.planets()*
 
 
 builtin.symbols({opts})                                    *builtin.symbols()*
-    Lists symbols inside of data/telescope-sources/*.json found in your runtime
-    path. Check README for more info
+    Lists symbols inside of `data/telescope-sources/*.json` found in your
+    runtime path or found in `stdpath("data")/telescope/symbols/*.json`. The
+    second path can be customized. We provide a couple of default symbols which
+    can be found in https://github.com/nvim-telescope/telescope-symbols.nvim.
+    This repos README also provides more information about the format in which
+    the symbols have to be.
 
 
     Parameters: ~
         {opts} (table)  options to pass to the picker
+
+    Fields: ~
+        {symbol_path} (string)  specify the second path. Default:
+                                `stdpath("data")/telescope/symbols/*.json`
+        {sources}     (table)   specify a table of sources you want to load
+                                this time
 
 
 builtin.commands({opts})                                  *builtin.commands()*

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -373,9 +373,13 @@ actions.run_builtin = function(prompt_bufnr)
 end
 
 actions.insert_symbol = function(prompt_bufnr)
-  local selection = action_state.get_selected_entry()
+  local symbol = action_state.get_selected_entry().value[1]
   actions.close(prompt_bufnr)
-  vim.api.nvim_put({ selection.value[1] }, "", true, true)
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  vim.api.nvim_buf_set_text(0, cursor[1] - 1, cursor[2], cursor[1] - 1, cursor[2], { symbol })
+  vim.schedule(function()
+    vim.api.nvim_win_set_cursor(0, { cursor[1], cursor[2] + #symbol })
+  end)
 end
 
 -- TODO: Think about how to do this.

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -375,6 +375,12 @@ end
 actions.insert_symbol = function(prompt_bufnr)
   local symbol = action_state.get_selected_entry().value[1]
   actions.close(prompt_bufnr)
+  vim.api.nvim_put({ symbol }, "", true, true)
+end
+
+actions.insert_symbol_i = function(prompt_bufnr)
+  local symbol = action_state.get_selected_entry().value[1]
+  actions._close(prompt_bufnr, true)
   local cursor = vim.api.nvim_win_get_cursor(0)
   vim.api.nvim_buf_set_text(0, cursor[1] - 1, cursor[2], cursor[1] - 1, cursor[2], { symbol })
   vim.schedule(function()

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -202,8 +202,14 @@ builtin.builtin = require("telescope.builtin.internal").builtin
 ---@param opts table: options to pass to the picker
 builtin.planets = require("telescope.builtin.internal").planets
 
---- Lists symbols inside of data/telescope-sources/*.json found in your runtime path. Check README for more info
+--- Lists symbols inside of `data/telescope-sources/*.json` found in your runtime path
+--- or found in `stdpath("data")/telescope/symbols/*.json`. The second path can be customized.
+--- We provide a couple of default symbols which can be found in
+--- https://github.com/nvim-telescope/telescope-symbols.nvim. This repos README also provides more
+--- information about the format in which the symbols have to be.
 ---@param opts table: options to pass to the picker
+---@field symbol_path string: specify the second path. Default: `stdpath("data")/telescope/symbols/*.json`
+---@field sources table: specify a table of sources you want to load this time
 builtin.symbols = require("telescope.builtin.internal").symbols
 
 --- Lists available plugin/user commands and runs them on `<cr>`

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -172,21 +172,9 @@ internal.symbols = function(opts)
     sorter = conf.generic_sorter(opts),
     attach_mappings = function(_)
       if initial_mode == "i" then
-        actions.select_default:replace(function(prompt_bufnr)
-          local symbol = action_state.get_selected_entry().value[1]
-          actions._close(prompt_bufnr, true)
-          local cursor = vim.api.nvim_win_get_cursor(0)
-          vim.api.nvim_buf_set_text(0, cursor[1] - 1, cursor[2], cursor[1] - 1, cursor[2], { symbol })
-          vim.schedule(function()
-            vim.api.nvim_win_set_cursor(0, { cursor[1], cursor[2] + #symbol })
-          end)
-        end)
+        actions.select_default:replace(actions.insert_symbol_i)
       else
-        actions.select_default:replace(function(prompt_bufnr)
-          local symbol = action_state.get_selected_entry().value[1]
-          actions.close(prompt_bufnr)
-          vim.api.nvim_put({ symbol }, "", true, true)
-        end)
+        actions.select_default:replace(actions.insert_symbol)
       end
       return true
     end,

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -113,8 +113,22 @@ internal.planets = function(opts)
 end
 
 internal.symbols = function(opts)
+  local initial_mode = vim.fn.mode()
   local files = vim.api.nvim_get_runtime_file("data/telescope-sources/*.json", true)
-  if table.getn(files) == 0 then
+  local data_path = (function()
+    if not opts.symbol_path then
+      return Path:new { vim.fn.stdpath "data", "telescope", "symbols" }
+    else
+      return Path:new { opts.symbol_path }
+    end
+  end)()
+  if data_path:exists() then
+    for _, v in ipairs(require("plenary.scandir").scan_dir(data_path:absolute(), { search_pattern = "%.json$" })) do
+      table.insert(files, v)
+    end
+  end
+
+  if #files == 0 then
     print(
       "No sources found! Check out https://github.com/nvim-telescope/telescope-symbols.nvim "
         .. "for some prebuild symbols or how to create you own symbol source."
@@ -158,6 +172,13 @@ internal.symbols = function(opts)
     sorter = conf.generic_sorter(opts),
     attach_mappings = function(_)
       actions.select_default:replace(actions.insert_symbol)
+      actions.insert_symbol:enhance {
+        post = vim.schedule_wrap(function()
+          if initial_mode == "i" then
+            vim.cmd [[startinsert]]
+          end
+        end),
+      }
       return true
     end,
   }):find()

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -171,14 +171,23 @@ internal.symbols = function(opts)
     },
     sorter = conf.generic_sorter(opts),
     attach_mappings = function(_)
-      actions.select_default:replace(actions.insert_symbol)
-      actions.insert_symbol:enhance {
-        post = vim.schedule_wrap(function()
-          if initial_mode == "i" then
-            vim.cmd [[startinsert]]
-          end
-        end),
-      }
+      if initial_mode == "i" then
+        actions.select_default:replace(function(prompt_bufnr)
+          local symbol = action_state.get_selected_entry().value[1]
+          actions._close(prompt_bufnr, true)
+          local cursor = vim.api.nvim_win_get_cursor(0)
+          vim.api.nvim_buf_set_text(0, cursor[1] - 1, cursor[2], cursor[1] - 1, cursor[2], { symbol })
+          vim.schedule(function()
+            vim.api.nvim_win_set_cursor(0, { cursor[1], cursor[2] + #symbol })
+          end)
+        end)
+      else
+        actions.select_default:replace(function(prompt_bufnr)
+          local symbol = action_state.get_selected_entry().value[1]
+          actions.close(prompt_bufnr)
+          vim.api.nvim_put({ symbol }, "", true, true)
+        end)
+      end
       return true
     end,
   }):find()


### PR DESCRIPTION
Closes #1072

- keep insert
- also look in `.local/share/nvim/telescope/symbols/*.json` for symbols
  can be overriden with `symbol_path`

The only thing that is currently bothering me is that you end up in insert mode even if you started in normal mode. 
- Done this with actions `:enhance` good interface

CC @clason better late than never :rofl: 