### PR TITLE
fix: (terminal) buffer previewer

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -787,6 +787,11 @@ end
 actions.delete_buffer = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   current_picker:delete_selection(function(selection)
+    -- avoid preview win from closing by creating tmp buffer
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
+    local preview_win = state.get_status(prompt_bufnr).preview_win
+    vim.api.nvim_win_set_buf(preview_win, buf)
     vim.api.nvim_buf_delete(selection.bufnr, { force = true })
   end)
 end

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -788,10 +788,12 @@ actions.delete_buffer = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   current_picker:delete_selection(function(selection)
     -- avoid preview win from closing by creating tmp buffer
-    local buf = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
     local preview_win = state.get_status(prompt_bufnr).preview_win
-    vim.api.nvim_win_set_buf(preview_win, buf)
+    if preview_win ~= nil and vim.api.nvim_win_is_valid(preview_win) then
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
+      vim.api.nvim_win_set_buf(preview_win, buf)
+    end
     vim.api.nvim_buf_delete(selection.bufnr, { force = true })
   end)
 end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -846,7 +846,9 @@ internal.keymaps = function(opts)
       end)
       return true
     end,
-  }):find() end internal.filetypes = function(opts)
+  }):find()
+end
+internal.filetypes = function(opts)
   local filetypes = vim.fn.getcompletion("", "filetype")
 
   pickers.new(opts, {

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -644,7 +644,7 @@ internal.buffers = function(opts)
       action_set.select:enhance {
         post = function()
           local entry = action_state.get_selected_entry()
-          vim.api.nvim_win_set_cursor(0, { entry.lnum, entry.col })
+          vim.api.nvim_win_set_cursor(0, { entry.lnum, entry.col or 0 })
         end,
       }
     end,
@@ -834,6 +834,7 @@ internal.keymaps = function(opts)
     end,
   }):find()
 end
+
 internal.filetypes = function(opts)
   local filetypes = vim.fn.getcompletion("", "filetype")
 

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -578,6 +578,17 @@ internal.reloader = function(opts)
 end
 
 internal.buffers = function(opts)
+  -- TODO upstream issue? if chosen buffer was not yet attached to window, minimal style of previewer is used
+  local winopts = {
+    ["number"] = vim.api.nvim_win_get_option(0, "number"),
+    ["relativenumber"] = vim.api.nvim_win_get_option(0, "relativenumber"),
+    ["cursorline"] = vim.api.nvim_win_get_option(0, "cursorline"),
+    ["signcolumn"] = vim.api.nvim_win_get_option(0, "signcolumn"),
+    ["spell"] = vim.api.nvim_win_get_option(0, "spell"),
+    ["wrap"] = vim.api.nvim_win_get_option(0, "wrap"),
+    ["list"] = vim.api.nvim_win_get_option(0, "list"),
+    ["colorcolumn"] = vim.api.nvim_win_get_option(0, "colorcolumn"),
+  }
   local bufnrs = filter(function(b)
     if 1 ~= vim.fn.buflisted(b) then
       return false
@@ -640,6 +651,17 @@ internal.buffers = function(opts)
     previewer = previewers.buffers.new(opts),
     sorter = conf.generic_sorter(opts),
     default_selection_index = default_selection_idx,
+    attach_mappings = function(_, _)
+      action_set.select:enhance {
+        post = function()
+          local entry = action_state.get_selected_entry()
+          for opt, value in pairs(winopts) do
+            vim.api.nvim_win_set_option(0, opt, value)
+          end
+          vim.api.nvim_win_set_cursor(0, { entry.lnum, entry.col })
+        end,
+      }
+    end,
   }):find()
 end
 
@@ -824,10 +846,7 @@ internal.keymaps = function(opts)
       end)
       return true
     end,
-  }):find()
-end
-
-internal.filetypes = function(opts)
+  }):find() end internal.filetypes = function(opts)
   local filetypes = vim.fn.getcompletion("", "filetype")
 
   pickers.new(opts, {

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -578,17 +578,6 @@ internal.reloader = function(opts)
 end
 
 internal.buffers = function(opts)
-  -- TODO upstream issue? if chosen buffer was not yet attached to window, minimal style of previewer is used
-  local winopts = {
-    ["number"] = vim.api.nvim_win_get_option(0, "number"),
-    ["relativenumber"] = vim.api.nvim_win_get_option(0, "relativenumber"),
-    ["cursorline"] = vim.api.nvim_win_get_option(0, "cursorline"),
-    ["signcolumn"] = vim.api.nvim_win_get_option(0, "signcolumn"),
-    ["spell"] = vim.api.nvim_win_get_option(0, "spell"),
-    ["wrap"] = vim.api.nvim_win_get_option(0, "wrap"),
-    ["list"] = vim.api.nvim_win_get_option(0, "list"),
-    ["colorcolumn"] = vim.api.nvim_win_get_option(0, "colorcolumn"),
-  }
   local bufnrs = filter(function(b)
     if 1 ~= vim.fn.buflisted(b) then
       return false
@@ -655,9 +644,6 @@ internal.buffers = function(opts)
       action_set.select:enhance {
         post = function()
           local entry = action_state.get_selected_entry()
-          for opt, value in pairs(winopts) do
-            vim.api.nvim_win_set_option(0, opt, value)
-          end
           vim.api.nvim_win_set_cursor(0, { entry.lnum, entry.col })
         end,
       }

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -637,7 +637,7 @@ internal.buffers = function(opts)
       results = buffers,
       entry_maker = opts.entry_maker or make_entry.gen_from_buffer(opts),
     },
-    previewer = conf.grep_previewer(opts),
+    previewer = previewers.buffers.new(opts),
     sorter = conf.generic_sorter(opts),
     default_selection_index = default_selection_idx,
   }):find()

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -872,4 +872,39 @@ previewers.display_content = defaulter(function(_)
   }
 end, {})
 
+previewers.buffers = defaulter(function(opts)
+  opts = opts or {}
+  local cwd = opts.cwd or vim.loop.cwd()
+  return Previewer:new {
+    title = function()
+      return "Buffers"
+    end,
+    dyn_title = function(_, entry)
+      return Path:new(from_entry.path(entry, true)):normalize(cwd)
+    end,
+    preview_fn = function(self, entry, status)
+      if vim.api.nvim_buf_is_valid(entry.bufnr) then
+        vim.api.nvim_win_set_buf(status.preview_win, entry.bufnr)
+        vim.api.nvim_win_set_option(status.preview_win, "winhl", "Normal:TelescopePreviewNormal")
+        vim.api.nvim_win_set_option(status.preview_win, "signcolumn", "no")
+        vim.api.nvim_win_set_option(status.preview_win, "foldlevel", 100)
+        vim.api.nvim_win_set_option(status.preview_win, "wrap", false)
+        self.state.bufnr = entry.bufnr
+      end
+    end,
+    scroll_fn = function(self, direction)
+      if not self.state then
+        return
+      end
+
+      local input = direction > 0 and [[]] or [[]]
+      local count = math.abs(direction)
+
+      vim.api.nvim_buf_call(self.state.bufnr, function()
+        vim.cmd([[normal! ]] .. count .. input)
+      end)
+    end,
+  }
+end, {})
+
 return previewers

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -927,7 +927,9 @@ previewers.buffers = defaulter(function(opts)
       end
       -- clear extmarks for previewed buffers
       for buf, _ in pairs(self.state.previewed_buffers) do
-        vim.api.nvim_buf_clear_namespace(buf, ns_previewer, 0, -1)
+        if vim.api.nvim_buf_is_valid(buf) then
+          vim.api.nvim_buf_clear_namespace(buf, ns_previewer, 0, -1)
+        end
       end
     end,
     dyn_title = function(_, entry)

--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -305,6 +305,7 @@ previewers.help = buffer_previewer.help
 previewers.man = buffer_previewer.man
 previewers.autocommands = buffer_previewer.autocommands
 previewers.highlights = buffer_previewer.highlights
+previewers.buffers = buffer_previewer.buffers
 
 --- A deprecated way of displaying content more easily. Was written at a time,
 --- where the buffer_previewer interface wasn't present. Nowadays it's easier

--- a/lua/telescope/previewers/previewer.lua
+++ b/lua/telescope/previewers/previewer.lua
@@ -23,7 +23,7 @@ function Previewer:preview(entry, status)
 
   if not self.state then
     if self._setup_func then
-      self.state = self:_setup_func()
+      self.state = self:_setup_func(status)
     else
       self.state = {}
     end

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -294,9 +294,6 @@ previewers.vimgrep = defaulter(function(opts)
       if p == nil or p == "" then
         return
       end
-      if entry.bufnr and (p == "[No Name]" or vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= "") then
-        return
-      end
 
       local lnum = entry.lnum or 0
 


### PR DESCRIPTION
Would close #714 by introducing a new previewer that reuses existing buffers.

@Conni2461 Idk, personally a bit torn on this. While `previewers.new_buffer_previewer` feels backward for `builtin.buffers` that we already have, though now ofc the buffer for `actions.delete` has to be replaced prior to deletion and the solution generally feels bloat. I'm not sure there are other side effects (that's why I abstained touching `new_buffer_previewer`, as we'd have conflicting logic ala creating buffers vs using existing ones).

I'm personally fine with terminal buffers not being highlighted ;)