### PR TITLE
Allow range parameters on command parser

### DIFF
--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -255,8 +255,8 @@ lsp.code_actions = function(opts)
   }):find()
 end
 
-lsp.range_code_actions = function(opts, start_pos, end_pos)
-  opts.params = vim.lsp.util.make_given_range_params(start_pos, end_pos)
+lsp.range_code_actions = function(opts)
+  opts.params = vim.lsp.util.make_given_range_params({ opts.start_line, 1 }, { opts.end_line, 1 })
   lsp.code_actions(opts)
 end
 

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -255,8 +255,8 @@ lsp.code_actions = function(opts)
   }):find()
 end
 
-lsp.range_code_actions = function(opts)
-  opts.params = vim.lsp.util.make_given_range_params()
+lsp.range_code_actions = function(opts, start_pos, end_pos)
+  opts.params = vim.lsp.util.make_given_range_params(start_pos, end_pos)
   lsp.code_actions(opts)
 end
 

--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -196,7 +196,7 @@ function command.register_keyword(keyword)
   split_keywords[keyword] = true
 end
 
-function command.load_command(cmd, ...)
+function command.load_command(start_line, end_line, count, cmd, ...)
   local args = { ... }
   if cmd == nil then
     run_command { cmd = "builtin" }
@@ -205,7 +205,11 @@ function command.load_command(cmd, ...)
 
   local user_opts = {}
   user_opts["cmd"] = cmd
-  user_opts.opts = {}
+  user_opts.opts = {
+    start_line = start_line,
+    end_line = end_line,
+    count = count,
+  }
 
   for _, arg in ipairs(args) do
     if arg:find("=", 1) == nil then

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -111,4 +111,4 @@ function! s:telescope_complete(arg,line,pos)
 endfunction
 
 " Telescope Commands with complete
-command! -nargs=* -complete=custom,s:telescope_complete Telescope    lua require('telescope.command').load_command(<f-args>)
+command! -nargs=* -range -complete=custom,s:telescope_complete Telescope    lua require('telescope.command').load_command(<f-args>)

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -111,4 +111,4 @@ function! s:telescope_complete(arg,line,pos)
 endfunction
 
 " Telescope Commands with complete
-command! -nargs=* -range -complete=custom,s:telescope_complete Telescope    lua require('telescope.command').load_command(<f-args>)
+command! -nargs=* -range -complete=custom,s:telescope_complete Telescope    lua require('telescope.command').load_command(<line1>, <line2>, <count>, <f-args>)


### PR DESCRIPTION
This fixes #1119 which was caused by lacking range support for the command parser `:Telescope`. 

Based on the documentation for `:h command-range`, it should not have any side-effect apart from allowing ranges on the command. I also forward the line numbers to the command parser and store the values in the `opts` table. Any function can access these values later on.

With this patch it works both with visual select (`:<,>Telescope lsp_range_code_actions`) and with direct range numbers (`:13,15Telescope lsp_range_code_actions`).