### PR TITLE
fix(command parser): evaluate valid lua expressions

### DIFF
--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -104,7 +104,7 @@ local function convert_user_opts(user_opts)
           user_opts[key] = nil
         elseif select("#", assert(eval)()) == 1 and type(assert(eval)()) == "table" then
           -- allow if return a single table only
-          user_opts[key] = eval
+          user_opts[key] = assert(eval)()
         else
           -- otherwise return nil (allows split check later)
           user_opts[key] = nil


### PR DESCRIPTION
Found another mistake immediately after we merged #1124, sorry guys 😅
Currently `master` doesn't work if you use lua syntax for tables.

---

I feel like we should have some sort of tests for the command parser to avoid this happening in the future, but not really sure how to set it up. Is there a good way of testing if a picker has loaded correctly with the current testing framework?
@tjdevries / @Conni2461 any ideas?