### PR TITLE
fix(command_parser): wrap eval in pcall

### DIFF
--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -102,7 +102,7 @@ local function convert_user_opts(user_opts)
         if err ~= nil then
           -- discard invalid lua expression
           user_opts[key] = nil
-        elseif select("#", assert(eval)()) == 1 and type(assert(eval)()) == "table" then
+        elseif pcall(eval) and select("#", assert(eval)()) == 1 and type(assert(eval)()) == "table" then
           -- allow if return a single table only
           user_opts[key] = assert(eval)()
         else


### PR DESCRIPTION
Recent changes in the command parser now try to parse values for table arguments as a return statement. For example, for `Telescope find_files find_command=rg,--ignore,--hidden,--files`, the value is parsed as a table. But before trying a split, we try to wrap that in a function and evaluate `return rg,--ignore,--hidden,--files`. This of course doesn't work because `--var` is invalid syntax, but if we try to do the same with single dash options, like `Telescope find_files find_command=fd,-t,f,-H`, the syntax is valid but the command fails with:

```
E5108: Error executing lua [string "return fd,-t,f,-t,l,-H"]:1: attempt to perform arithmetic on global 't' (a nil value)
```

This PR tries to check if the call will succeed by wrapping it in `pcall(eval)` and checking if that returns true.

Was wondering if we could also replace all the checks with this pcall only, like so:

```lua
local val
ok, val = pcall(eval)
if ok and type(val) == "table" then
  user_opts[key] = val
```

, because right now we're doing a bunch of `assert(eval)()` which seems kinda pointless...