### PR TITLE
fix(command_definition): default to nil on empty <f-args>

### DIFF
--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -111,4 +111,4 @@ function! s:telescope_complete(arg,line,pos)
 endfunction
 
 " Telescope Commands with complete
-command! -nargs=* -range -complete=custom,s:telescope_complete Telescope    lua require('telescope.command').load_command(<line1>, <line2>, <count>, <f-args>)
+command! -nargs=* -range -complete=custom,s:telescope_complete Telescope    lua require('telescope.command').load_command(<line1>, <line2>, <count>, unpack({<f-args>}))


### PR DESCRIPTION
Should close #1132

When no arguments are passed to a command, `<f-args>` is simply removed from the definition, which causes `:Telescope` command to fail because of bad syntax (it calls `lua require('telescope.command').load_command(<line1>, <line2>, <count>, )`)

With `unpack({<f-args>})`, if no arguments are provided it returns `nil` by default, and then when arguments are provided, they are expanded correctly