### PR TITLE
fix: action mt so we can again concat actions from two different tables

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -248,6 +248,7 @@ actions._close = function(prompt_bufnr, keepinsert)
   end
 
   require("telescope.pickers").on_close_prompt(prompt_bufnr)
+  require("telescope.mappings").clear(prompt_bufnr)
   pcall(a.nvim_set_current_win, original_win_id)
 end
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -248,7 +248,6 @@ actions._close = function(prompt_bufnr, keepinsert)
   end
 
   require("telescope.pickers").on_close_prompt(prompt_bufnr)
-  require("telescope.mappings").clear(prompt_bufnr)
   pcall(a.nvim_set_current_win, original_win_id)
 end
 

--- a/lua/telescope/actions/mt.lua
+++ b/lua/telescope/actions/mt.lua
@@ -24,6 +24,9 @@ local append_action_copy = function(new, v, old)
   new._post[v] = old._post[v]
 end
 
+--TODO(conni2461): Not a fan of this solution/hack. Needs to be addressed
+local all_mts = {}
+
 --- an action is metatable which allows replacement(prepend or append) of the function
 ---@class Action
 ---@field _func table<string, function>: the original action function
@@ -143,6 +146,7 @@ action_mt.create = function()
     return self
   end
 
+  table.insert(all_mts, mt)
   return mt
 end
 
@@ -177,6 +181,12 @@ action_mt.transform_mod = function(mod)
   end
 
   return redirect
+end
+
+action_mt.clear_all = function()
+  for _, v in ipairs(all_mts) do
+    pcall(v.clear)
+  end
 end
 
 return action_mt

--- a/lua/telescope/actions/mt.lua
+++ b/lua/telescope/actions/mt.lua
@@ -149,17 +149,22 @@ action_mt.transform = function(k, mt, v)
 end
 
 action_mt.transform_mod = function(mod)
-  local mt = action_mt.create()
-
   -- Pass the metatable of the module if applicable.
   --    This allows for custom errors, lookups, etc.
   local redirect = setmetatable({}, getmetatable(mod) or {})
 
   for k, v in pairs(mod) do
+    local mt = action_mt.create()
     redirect[k] = action_mt.transform(k, mt, v)
   end
 
-  redirect._clear = mt.clear
+  redirect._clear = function()
+    for k, v in pairs(redirect) do
+      if k ~= "_clear" then
+        pcall(v.clear)
+      end
+    end
+  end
 
   return redirect
 end

--- a/lua/telescope/actions/mt.lua
+++ b/lua/telescope/actions/mt.lua
@@ -45,28 +45,32 @@ action_mt.create = function()
     end,
 
     __add = function(lhs, rhs)
-      local new_actions = setmetatable({}, action_mt.create())
+      local new_action = setmetatable({}, action_mt.create())
       for _, v in ipairs(lhs) do
-        table.insert(new_actions, v)
-        new_actions._func[v] = lhs._func[v]
-        new_actions._static_pre[v] = lhs._static_pre[v]
-        new_actions._pre[v] = lhs._pre[v]
-        new_actions._replacements[v] = lhs._replacements[v]
-        new_actions._static_post[v] = lhs._static_post[v]
-        new_actions._post[v] = lhs._post[v]
+        table.insert(new_action, v)
+        new_action._func[v] = lhs._func[v]
+        new_action._static_pre[v] = lhs._static_pre[v]
+        new_action._pre[v] = lhs._pre[v]
+        new_action._replacements[v] = lhs._replacements[v]
+        new_action._static_post[v] = lhs._static_post[v]
+        new_action._post[v] = lhs._post[v]
       end
 
       for _, v in ipairs(rhs) do
-        table.insert(new_actions, v)
-        new_actions._func[v] = rhs._func[v]
-        new_actions._static_pre[v] = rhs._static_pre[v]
-        new_actions._pre[v] = rhs._pre[v]
-        new_actions._replacements[v] = rhs._replacements[v]
-        new_actions._static_post[v] = rhs._static_post[v]
-        new_actions._post[v] = rhs._post[v]
+        table.insert(new_action, v)
+        new_action._func[v] = rhs._func[v]
+        new_action._static_pre[v] = rhs._static_pre[v]
+        new_action._pre[v] = rhs._pre[v]
+        new_action._replacements[v] = rhs._replacements[v]
+        new_action._static_post[v] = rhs._static_post[v]
+        new_action._post[v] = rhs._post[v]
+      end
+      new_action.clear = function()
+        lhs.clear()
+        rhs.clear()
       end
 
-      return new_actions
+      return new_action
     end,
 
     _func = {},

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -233,9 +233,11 @@ mappings.execute_keymap = function(prompt_bufnr, keymap_identifier)
 end
 
 mappings.clear = function(prompt_bufnr)
-  for _, v in ipairs(keymap_store[prompt_bufnr]) do
-    pcall(v.clear)
-  end
+  require("telescope.actions.mt").clear_all()
+  -- TODO(conni2461): This seems like the better solution but it won't clear actions that were never mapped
+  -- for _, v in ipairs(keymap_store[prompt_bufnr]) do
+  --   pcall(v.clear)
+  -- end
 
   keymap_store[prompt_bufnr] = nil
 end

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -221,10 +221,6 @@ mappings.apply_keymap = function(prompt_bufnr, attach_mappings, buffer_keymap)
       end
     end
   end
-
-  vim.cmd(
-    string.format([[autocmd BufDelete %s :lua require('telescope.mappings').clear(%s)]], prompt_bufnr, prompt_bufnr)
-  )
 end
 
 mappings.execute_keymap = function(prompt_bufnr, keymap_identifier)
@@ -237,6 +233,10 @@ mappings.execute_keymap = function(prompt_bufnr, keymap_identifier)
 end
 
 mappings.clear = function(prompt_bufnr)
+  for _, v in ipairs(keymap_store[prompt_bufnr]) do
+    pcall(v.clear)
+  end
+
   keymap_store[prompt_bufnr] = nil
 end
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1297,6 +1297,7 @@ function pickers.on_close_prompt(prompt_bufnr)
   end
 
   picker.close_windows(status)
+  mappings.clear(prompt_bufnr)
 end
 
 function pickers.on_resize_window(prompt_bufnr)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -8,7 +8,6 @@ local channel = require("plenary.async.control").channel
 local popup = require "plenary.popup"
 
 local actions = require "telescope.actions"
-local action_set = require "telescope.actions.set"
 local config = require "telescope.config"
 local debounce = require "telescope.debounce"
 local deprecated = require "telescope.deprecated"
@@ -47,12 +46,6 @@ function Picker:new(opts)
   if opts.layout_strategy and opts.get_window_options then
     error "layout_strategy and get_window_options are not compatible keys"
   end
-
-  -- Reset actions for any replaced / enhanced actions.
-  -- TODO: Think about how we could remember to NOT have to do this...
-  --        I almost forgot once already, cause I'm not smart enough to always do it.
-  actions._clear()
-  action_set._clear()
 
   deprecated.options(opts)
 

--- a/lua/tests/automated/action_spec.lua
+++ b/lua/tests/automated/action_spec.lua
@@ -205,6 +205,29 @@ describe("actions", function()
     eq(true, called_post)
   end)
 
+  it("static_pre static_post", function()
+    local called_pre = false
+    local called_post = false
+    local static_post = 0
+    local a = transform_mod {
+      x = {
+        pre = function()
+          called_pre = true
+        end,
+        action = function()
+          return "x"
+        end,
+        post = function()
+          called_post = true
+        end,
+      },
+    }
+
+    eq("x", a.x())
+    eq(true, called_pre)
+    eq(true, called_post)
+  end)
+
   it("can call both", function()
     local a = transform_mod {
       x = function()
@@ -297,14 +320,16 @@ describe("actions", function()
   end)
 
   it("handles add with two different tables", function()
+    local count_a = 0
+    local count_b = 0
     local a = transform_mod {
       x = function()
-        return "x"
+        count_a = count_a + 1
       end,
     }
     local b = transform_mod {
       y = function()
-        return "y"
+        count_b = count_b + 1
       end,
     }
 
@@ -324,6 +349,70 @@ describe("actions", function()
     x_plus_y()
 
     eq(2, called_count)
+    eq(1, count_a)
+    eq(1, count_b)
+  end)
+
+  it("handles tripple concat with static pre post", function()
+    local count_a = 0
+    local count_b = 0
+    local count_c = 0
+    local static_pre = 0
+    local static_post = 0
+    local a = transform_mod {
+      x = {
+        pre = function()
+          static_pre = static_pre + 1
+        end,
+        action = function()
+          count_a = count_a + 1
+        end,
+        post = function()
+          static_post = static_post + 1
+        end,
+      },
+    }
+    local b = transform_mod {
+      y = {
+        pre = function()
+          static_pre = static_pre + 1
+        end,
+        action = function()
+          count_b = count_b + 1
+        end,
+        post = function()
+          static_post = static_post + 1
+        end,
+      },
+    }
+    local c = transform_mod {
+      z = {
+        pre = function()
+          static_pre = static_pre + 1
+        end,
+        action = function()
+          count_c = count_c + 1
+        end,
+        post = function()
+          static_post = static_post + 1
+        end,
+      },
+    }
+
+    local replace_count = 0
+    a.x:replace(function()
+      replace_count = replace_count + 1
+    end)
+
+    local x_plus_y_plus_z = a.x + b.y + c.z
+    x_plus_y_plus_z()
+
+    eq(0, count_a)
+    eq(1, count_b)
+    eq(1, count_c)
+    eq(1, replace_count)
+    eq(3, static_pre)
+    eq(3, static_post)
   end)
 
   describe("action_set", function()

--- a/lua/tests/automated/action_spec.lua
+++ b/lua/tests/automated/action_spec.lua
@@ -298,6 +298,36 @@ describe("actions", function()
     eq("modified: 5", a.x(5))
   end)
 
+  it("handles add with two different tables", function()
+    local a = transform_mod {
+      x = function()
+        return "x"
+      end,
+    }
+    local b = transform_mod {
+      y = function()
+        return "y"
+      end,
+    }
+
+    local called_count = 0
+    local count_inc = function()
+      called_count = called_count + 1
+    end
+
+    a.x:enhance {
+      post = count_inc,
+    }
+    b.y:enhance {
+      post = count_inc,
+    }
+
+    local x_plus_y = a.x + b.y
+    x_plus_y()
+
+    eq(2, called_count)
+  end)
+
   describe("action_set", function()
     it("can replace `action_set.edit`", function()
       action_set.edit:replace(function(_, arg)

--- a/lua/tests/automated/action_spec.lua
+++ b/lua/tests/automated/action_spec.lua
@@ -3,9 +3,7 @@ local action_set = require "telescope.actions.set"
 
 local transform_mod = require("telescope.actions.mt").transform_mod
 
-local eq = function(a, b)
-  assert.are.same(a, b)
-end
+local eq = assert.are.same
 
 describe("actions", function()
   it("should allow creating custom actions", function()


### PR DESCRIPTION
Closes #684

- without actually changing the public interface
- without having a local table that keeps track of all actions

I could write more tests for this but its Friday evening and it was a long day ...

My take on https://github.com/nvim-telescope/telescope.nvim/pull/1093