### PR TITLE
fix(pickers): attach_mappings on builtins.buffers needs return

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -665,6 +665,7 @@ internal.buffers = function(opts)
           vim.api.nvim_win_set_cursor(0, { entry.lnum, entry.col or 0 })
         end,
       }
+      return true
     end,
   }):find()
 end


### PR DESCRIPTION
In #1120, builtins.buffers added an `attach_mappings` function, but didn't return a value from it.

This causes an error in:
```
E5108: Error executing lua ...k/packer/start/telescope.nvim/lua/telescope/mappings.lua:178: Attach mappings must always return a value. `true` means use default mappings, `false` means only use atta
ched mappings  
```