### PR TITLE
fix: autocommands cursor outside of buffer

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -790,7 +790,7 @@ previewers.autocommands = defaulter(function(_)
       end
 
       vim.api.nvim_buf_add_highlight(self.state.bufnr, ns_previewer, "TelescopePreviewLine", selected_row + 1, 0, -1)
-      vim.api.nvim_win_set_cursor(status.preview_win, { selected_row + 1, 0 })
+      vim.api.nvim_win_set_cursor(status.preview_win, { selected_row, 0 })
 
       self.state.last_set_bufnr = self.state.bufnr
     end,


### PR DESCRIPTION
Closes #957