### PR TITLE
fix: safe teardown of buffer previewer

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -921,15 +921,17 @@ previewers.buffers = defaulter(function(opts)
       return state
     end,
     teardown = function(self)
-      -- reapply proper buffer-window options..
-      for opt, value in pairs(self.state.win_options) do
-        vim.api.nvim_win_set_option(self.state.winid, opt, value)
-      end
-      -- TODO precautious clearing of extmark though likely no effect due to ephemeral
-      -- clear extmarks for previewed buffers
-      for buf, _ in pairs(self.state.previewed_buffers) do
-        if vim.api.nvim_buf_is_valid(buf) then
-          vim.api.nvim_buf_clear_namespace(buf, ns_previewer, 0, -1)
+      if self.state then
+        -- reapply proper buffer-window options..
+        for opt, value in pairs(self.state.win_options) do
+          vim.api.nvim_win_set_option(self.state.winid, opt, value)
+        end
+        -- TODO precautious clearing of extmark though likely no effect due to ephemeral
+        -- clear extmarks for previewed buffers
+        for buf, _ in pairs(self.state.previewed_buffers) do
+          if vim.api.nvim_buf_is_valid(buf) then
+            vim.api.nvim_buf_clear_namespace(buf, ns_previewer, 0, -1)
+          end
         end
       end
       previewer_active = false


### PR DESCRIPTION
Flex previewer (I guess?) may lead to the previewer not being shown and therefore `preview_fn` is never called and `state` is never set up. This ensures we only teardown `state` if it's actually created.

Edge case I've of course ran into coming home and using the buffer picker (which I never use) once again :laughing: