### PR TITLE
fix(ts-highlighting): get hl name from the capture

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -505,8 +505,8 @@ files.current_buffer_fuzzy_find = function(opts)
       end,
     })
     for id, node in query:iter_captures(root, bufnr, 0, -1) do
-      local hl = highlighter_query.hl_cache[id]
-      if hl then
+      local hl = highlighter_query:_get_hl_from_capture(id)
+      if hl and type(hl) ~= "number" then
         local row1, col1, row2, col2 = node:range()
 
         if row1 == row2 then


### PR DESCRIPTION
After this commit (https://github.com/neovim/neovim/commit/2460f0a7028550ea2d87492a4e8b95914fdba7b1), the `hl_cache` variable
stores the hl_ID instead of the group name.

Another way to get the hl name which is adopted from the method used
here `_get_hl_from_capture`:

```lua
local hl = vim.treesitter.highlighter.hl_map[query.captures[id]]
```

But, as the method covers another case, we can directly use it.

I've also added the type guard so that, in the future, it does not
explode like it does now.

For reference, the method used here: https://github.com/neovim/neovim/blob/a373ca1d826b1386f1fa291de70ee5d6bb81ec9b/runtime/lua/vim/treesitter/highlighter.lua#L109-L121

fixes: #1151