### PR TITLE
Add word to prompt title for grep string

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -143,7 +143,7 @@ files.grep_string = function(opts)
   end
 
   pickers.new(opts, {
-    prompt_title = "Find Word",
+    prompt_title = "Find Word (" .. word .. ")",
     finder = finders.new_oneshot_job(args, opts),
     previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),


### PR DESCRIPTION
This PR adds the word to the prompt title for grep string. Example when `use` is searched for:

<img width="840" alt="Screen Shot 2021-08-31 at 5 21 04 AM" src="https://user-images.githubusercontent.com/1813121/131493985-9e89ea8d-74ff-402d-b08c-00d72fe18666.png">
