### PR TITLE
fix: should not use git log command in git stash picker

### DIFF
--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -87,11 +87,9 @@ git.stash = function(opts)
     finder = finders.new_oneshot_job(
       vim.tbl_flatten {
         "git",
-        "log",
-        "--pretty=oneline",
-        "--abbrev-commit",
-        "--",
-        ".",
+        "--no-pager",
+        "stash",
+        "list"
       },
       opts
     ),


### PR DESCRIPTION
This is a regression introduced not so long ago in https://github.com/nvim-telescope/telescope.nvim/commit/4d691fdc236006d6123560570af3e949a3b2c06e#diff-0b2350537ecf272d7adf81c80da8e63bd696f7b9d7f4c9f9de609a4df66107c5L82-R97.