### PR TITLE
fix: clear buffer previewer fully for caching

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -1021,6 +1021,8 @@ previewers.buffers = defaulter(function(opts)
         end
       end
       previewer_active = false
+      -- setup previewer fully anew for `builtin.{resume, pickers}`
+      self.state = nil
     end,
     dyn_title = function(_, entry)
       return Path:new(from_entry.path(entry, true)):normalize(cwd)


### PR DESCRIPTION
Thankfully a very easy fix to close #1200 by clearing out the previous state adequately.

@ram02z would you please confirm that it fixes the issue for you as well? I realize change seems trivial and it does everything it's supposed to on my end, but just to make sure it works elsewhere just as well :)