### PR TITLE
fix: exiting picker from insert mode

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -65,8 +65,6 @@ local action_utils = require "telescope.actions.utils"
 local action_set = require "telescope.actions.set"
 local entry_display = require "telescope.pickers.entry_display"
 local from_entry = require "telescope.from_entry"
-local async = require "plenary.async"
-local await_schedule = async.util.scheduler
 
 local transform_mod = require("telescope.actions.mt").transform_mod
 local resolver = require "telescope.config.resolve"
@@ -345,20 +343,17 @@ end
 --- Close the Telescope window, usually used within an action
 ---@param prompt_bufnr number: The prompt bufnr
 actions.close = function(prompt_bufnr)
-  action_state.get_current_history():reset()
   local picker = action_state.get_current_picker(prompt_bufnr)
   local original_win_id = picker.original_win_id
   local original_cursor = a.nvim_win_get_cursor(original_win_id)
 
   actions.close_pum(prompt_bufnr)
-  await_schedule(function()
-    if a.nvim_win_is_valid(original_win_id) then
-      a.nvim_win_set_cursor(original_win_id, original_cursor)
-    end
-  end)
 
   require("telescope.pickers").on_close_prompt(prompt_bufnr)
   pcall(a.nvim_set_current_win, original_win_id)
+  if a.nvim_get_mode().mode == "i" then
+    pcall(a.nvim_win_set_cursor, original_win_id, { original_cursor[1], original_cursor[2] + 1 })
+  end
 end
 
 --- Close the Telescope window, usually used within an action<br>

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -131,7 +131,7 @@ action_set.edit = function(prompt_bufnr, command)
   local entry_bufnr = entry.bufnr
 
   local picker = action_state.get_current_picker(prompt_bufnr)
-  require("telescope.actions").close(prompt_bufnr)
+  require("telescope.pickers").on_close_prompt(prompt_bufnr)
   local win_id = picker.get_selection_window(picker, entry)
 
   if picker.push_cursor_on_edit then

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1416,6 +1416,7 @@ end
 function pickers.on_close_prompt(prompt_bufnr)
   local status = state.get_status(prompt_bufnr)
   local picker = status.picker
+  require("telescope.actions.state").get_current_history():reset()
 
   if type(picker.cache_picker) == "table" then
     local cached_pickers = state.get_global_key "cached_pickers" or {}


### PR DESCRIPTION
Closes #1185 

This is quite similar to #1165. If I understand it correctly `vim.cmd [[stopinsert]]` is just too slow. So I guess what happens then is you actually land in the original window in insert mode and only leave it there, which, being on the original cursor position, means you exit insert mode to land in one column to the left. (Conversely, exitting in normal mode works just fine).

The other solution I supposed would be to await `vim.cmd` though this should surely feel faster (& not sure how I'd to that in new plenary async).

