### PR TITLE
Add builtin.jumplist back into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Built-in functions. Ready to be bound to any key you like. :smile:
 | `builtin.colorscheme`               | Lists available colorschemes and applies them on `<cr>`                                                                                                     |
 | `builtin.quickfix`                  | Lists items in the quickfix list                                                                                                                            |
 | `builtin.loclist`                   | Lists items from the current window's location list                                                                                                         |
+| `builtin.jumplist`                  | Lists Jump List entries                                                                                                                                     |
 | `builtin.vim_options`               | Lists vim options, allows you to edit the current value on `<cr>`                                                                                           |
 | `builtin.registers`                 | Lists vim registers, pastes the contents of the register on `<cr>`                                                                                          |
 | `builtin.autocommands`              | Lists vim autocommands and goes to their declaration on `<cr>`                                                                                              |


### PR DESCRIPTION
Looks like 618e0e6075b4215e43c6a848daa37ef4e354b5dc dropped this entry, just adding it back.