### PR TITLE
Fix: Escape live grep prompt characters

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -93,7 +93,7 @@ files.live_grep = function(opts)
       search_list = filelist
     end
 
-    return flatten { vimgrep_arguments, additional_args, prompt, search_list }
+    return flatten { vimgrep_arguments, additional_args, escape_chars(prompt), search_list }
   end, opts.entry_maker or make_entry.gen_from_vimgrep(
     opts
   ), opts.max_results, opts.cwd)


### PR DESCRIPTION
When using `:Telescope live_grep` using the default settings for `rg`, searching for `-c` leads to Telescope failing and a warning being thrown because `-c` is not being escaped.

To fix this and potentially other issues, the prompt will now use `escape_chars` for live_grep