### PR TITLE
[Fix] Add no more flags delimiter for ripgrep

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -93,7 +93,7 @@ files.live_grep = function(opts)
       search_list = filelist
     end
 
-    return flatten { vimgrep_arguments, additional_args, prompt, search_list }
+    return flatten { vimgrep_arguments, additional_args, "--", prompt, search_list }
   end, opts.entry_maker or make_entry.gen_from_vimgrep(
     opts
   ), opts.max_results, opts.cwd)
@@ -131,6 +131,7 @@ files.grep_string = function(opts)
     vimgrep_arguments,
     additional_args,
     word_match,
+    "--",
     search,
   }
 


### PR DESCRIPTION
This matches the behavior of fzf, if a user needs to pass additional
arguments they can use additional_args or change vimgrep_arguments.

See #1211 for discussion of this solution, this fixes bugs that were introduced by #987