### PR TITLE
Exclude unlisted buffers in oldfiles picker

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -344,7 +344,7 @@ internal.oldfiles = function(opts)
   local results = {}
 
   if opts.include_current_session then
-    for _, buffer in ipairs(vim.split(vim.fn.execute ":buffers! t", "\n")) do
+    for _, buffer in ipairs(vim.split(vim.fn.execute ":buffers t", "\n")) do
       local match = tonumber(string.match(buffer, "%s*(%d+)"))
       if match then
         local file = vim.api.nvim_buf_get_name(match)


### PR DESCRIPTION
By excluding unlisted buffers in oldfiles picker when `include_current_session` is set, we exclude files opened by LSPs.