### PR TITLE
feat: lsp type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,18 +446,19 @@ Built-in functions. Ready to be bound to any key you like. :smile:
 
 ### Neovim LSP Pickers
 
-| Functions                                   | Description                                                                                                       |
-|---------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| `builtin.lsp_references`                    | Lists LSP references for word under the cursor                                                                    |
-| `builtin.lsp_document_symbols`              | Lists LSP document symbols in the current buffer                                                                  |
-| `builtin.lsp_workspace_symbols`             | Lists LSP document symbols in the current workspace                                                               |
-| `builtin.lsp_dynamic_workspace_symbols`     | Dynamically Lists LSP for all workspace symbols                                                                   |
-| `builtin.lsp_code_actions`                  | Lists any LSP actions for the word under the cursor, that can be triggered with `<cr>`                            |
-| `builtin.lsp_range_code_actions`            | Lists any LSP actions for a given range, that can be triggered with `<cr>`                                        |
-| `builtin.lsp_document_diagnostics`          | Lists LSP diagnostics for the current buffer                                                                      |
-| `builtin.lsp_workspace_diagnostics`         | Lists LSP diagnostics for the current workspace if supported, otherwise searches in all open buffers              |
-| `builtin.lsp_implementations`               | Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope |
-| `builtin.lsp_definitions`                   | Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope    |
+| Functions                                   | Description                                                                                                               |
+|---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `builtin.lsp_references`                    | Lists LSP references for word under the cursor                                                                            |
+| `builtin.lsp_document_symbols`              | Lists LSP document symbols in the current buffer                                                                          |
+| `builtin.lsp_workspace_symbols`             | Lists LSP document symbols in the current workspace                                                                       |
+| `builtin.lsp_dynamic_workspace_symbols`     | Dynamically Lists LSP for all workspace symbols                                                                           |
+| `builtin.lsp_code_actions`                  | Lists any LSP actions for the word under the cursor, that can be triggered with `<cr>`                                    |
+| `builtin.lsp_range_code_actions`            | Lists any LSP actions for a given range, that can be triggered with `<cr>`                                                |
+| `builtin.lsp_document_diagnostics`          | Lists LSP diagnostics for the current buffer                                                                              |
+| `builtin.lsp_workspace_diagnostics`         | Lists LSP diagnostics for the current workspace if supported, otherwise searches in all open buffers                      |
+| `builtin.lsp_implementations`               | Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope         |
+| `builtin.lsp_definitions`                   | Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope            |
+| `builtin.lsp_type_definitions`              | Goto the definition of the type of the word under the cursor, if there's only one, otherwise show all options in Telescope|
 
 #### Pre-filtering option for LSP pickers
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -903,6 +903,18 @@ builtin.lsp_definitions({opts})                    *builtin.lsp_definitions()*
                               values: "tab", "split", "vsplit", "never"
 
 
+builtin.lsp_type_definitions({opts})          *builtin.lsp_type_definitions()*
+    Goto the definition of the type of the word under the cursor, if there's
+    only one, otherwise show all options in Telescope
+
+
+    Parameters: ~
+        {opts} (table)  options to pass to the picker
+
+    Fields: ~
+        {jump_type} (string)  how to goto definition if there is only one,
+                              values: "tab", "split", "vsplit", "never"
+
 builtin.lsp_implementations({opts})            *builtin.lsp_implementations()*
     Goto the implementation of the word under the cursor if there's only one,
     otherwise show all options in Telescope

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -343,6 +343,11 @@ builtin.lsp_references = require("telescope.builtin.lsp").references
 ---@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
 builtin.lsp_definitions = require("telescope.builtin.lsp").definitions
 
+--- Goto the definition of the type of the word under the cursor, if there's only one, otherwise show all options in Telescope
+---@param opts table: options to pass to the picker
+---@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
+builtin.lsp_type_definitions = require("telescope.builtin.lsp").type_definitions
+
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto implementation if there is only one, values: "tab", "split", "vsplit", "never"

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -343,7 +343,8 @@ builtin.lsp_references = require("telescope.builtin.lsp").references
 ---@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
 builtin.lsp_definitions = require("telescope.builtin.lsp").definitions
 
---- Goto the definition of the type of the word under the cursor, if there's only one, otherwise show all options in Telescope
+--- Goto the definition of the type of the word under the cursor, if there's only one,
+--- otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
 builtin.lsp_type_definitions = require("telescope.builtin.lsp").type_definitions

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -95,6 +95,10 @@ lsp.definitions = function(opts)
   return list_or_jump("textDocument/definition", "LSP Definitions", opts)
 end
 
+lsp.type_definitions = function(opts)
+  return list_or_jump("textDocument/typeDefinition", "LSP Type Definitions", opts)
+end
+
 lsp.implementations = function(opts)
   return list_or_jump("textDocument/implementation", "LSP Implementations", opts)
 end
@@ -403,6 +407,7 @@ local feature_map = {
   ["document_symbols"] = "document_symbol",
   ["references"] = "find_references",
   ["definitions"] = "goto_definition",
+  ["type_definitions"] = "type_definition",
   ["implementations"] = "implementation",
   ["workspace_symbols"] = "workspace_symbol",
 }


### PR DESCRIPTION
Adds `lsp_type_definitions`, similar to `lsp_definitions` and `lsp_implementations`.