### PR TITLE
fix: stale lnum in buffer previewer

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -463,7 +463,7 @@ function make_entry.gen_from_buffer(opts)
 
       bufnr = entry.bufnr,
       filename = bufname,
-
+      -- account for potentially stale lnum as getbufinfo might not be updated or from resuming buffers picker
       lnum = entry.info.lnum ~= 0 and math.max(math.min(entry.info.lnum, line_count), 1) or 1,
       indicator = indicator,
     }

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -452,6 +452,7 @@ function make_entry.gen_from_buffer(opts)
     local readonly = vim.api.nvim_buf_get_option(entry.bufnr, "readonly") and "=" or " "
     local changed = entry.info.changed == 1 and "+" or " "
     local indicator = entry.flag .. hidden .. readonly .. changed
+    local line_count = vim.api.nvim_buf_line_count(entry.bufnr)
 
     return {
       valid = true,
@@ -463,7 +464,7 @@ function make_entry.gen_from_buffer(opts)
       bufnr = entry.bufnr,
       filename = bufname,
 
-      lnum = entry.info.lnum ~= 0 and entry.info.lnum or 1,
+      lnum = entry.info.lnum ~= 0 and math.max(math.min(entry.info.lnum, line_count), 1) or 1,
       indicator = indicator,
     }
   end

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -956,12 +956,13 @@ end, {})
 previewers.buffers = defaulter(function(opts)
   opts = opts or {}
   local cwd = opts.cwd or vim.loop.cwd()
-  local previewer_active = true -- decouple provider from preview_win
+  local previewer_active -- decouple provider from preview_win
   return Previewer:new {
     title = function()
       return "Buffers"
     end,
     setup = function(_, status)
+      previewer_active = true
       local win_id = status.picker.original_win_id
       -- required because of see `:h local-options` as
       -- buffers not yet attached to a current window take the options from the `minimal` popup ...

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -1031,16 +1031,20 @@ previewers.buffers = defaulter(function(opts)
     preview_fn = function(self, entry, status)
       if vim.api.nvim_buf_is_valid(entry.bufnr) then
         vim.api.nvim_win_set_buf(status.preview_win, entry.bufnr)
+        self.state.bufnr = entry.bufnr
         vim.api.nvim_win_set_option(status.preview_win, "winhl", "Normal:TelescopePreviewNormal")
         vim.api.nvim_win_set_option(status.preview_win, "signcolumn", "no")
         vim.api.nvim_win_set_option(status.preview_win, "foldlevel", 100)
         vim.api.nvim_win_set_option(status.preview_win, "wrap", false)
-        self.state.bufnr = entry.bufnr
-        if not entry.col then
-          local _, col = unpack(vim.api.nvim_win_get_cursor(status.preview_win))
-          entry.col = col + 1
-        end
+
         if self.state.previewed_buffers[entry.bufnr] ~= true then
+          if entry.lnum then
+            local lnum, col = unpack(vim.api.nvim_win_get_cursor(status.preview_win))
+            entry.lnum = lnum
+            if not entry.col then
+              entry.col = col + 1
+            end
+          end
           self.state.previewed_buffers[entry.bufnr] = true
         end
       end


### PR DESCRIPTION
Closes #1226 

@Akinsho does this also work for you? Your hunch is correct and I can reproduce this when resuming a buffer previewer to jump to a buffer for which the lnum for the respective buffer became stale in the mean time (eg from deleting bottom).

Not 100% sure about your tabpage log buffer scenario though :sweat_smile: I've tried to keep it simple and practical.

