### PR TITLE
Save position into jumplist before 'edit' action.

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -129,7 +129,12 @@ action_set.edit = function(prompt_bufnr, command)
 
   local entry_bufnr = entry.bufnr
 
+  local picker = action_state.get_current_picker(prompt_bufnr)
   require("telescope.actions").close(prompt_bufnr)
+
+  if picker.push_cursor_on_edit then
+    vim.cmd "normal! m'"
+  end
 
   if entry_bufnr then
     if not vim.api.nvim_buf_get_option(entry_bufnr, "buflisted") then

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -933,6 +933,7 @@ internal.marks = function(opts)
     },
     previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
+    push_cursor_on_edit = true,
   }):find()
 end
 

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -45,6 +45,7 @@ lsp.references = function(opts)
       },
       previewer = conf.qflist_previewer(opts),
       sorter = conf.generic_sorter(opts),
+      push_cursor_on_edit = true,
     }):find()
   end)
 end
@@ -151,6 +152,7 @@ lsp.document_symbols = function(opts)
         tag = "symbol_type",
         sorter = conf.generic_sorter(opts),
       },
+      push_cursor_on_edit = true,
     }):find()
   end)
 end

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -110,6 +110,8 @@ function Picker:new(opts)
     tiebreak = get_default(opts.tiebreak, config.values.tiebreak),
     selection_strategy = get_default(opts.selection_strategy, config.values.selection_strategy),
 
+    push_cursor_on_edit = get_default(opts.push_cursor_on_edit, config.values.push_cursor_on_edit),
+
     layout_strategy = layout_strategy,
     layout_config = config.smarter_depth_2_extend(opts.layout_config or {}, config.values.layout_config or {}),
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -110,7 +110,7 @@ function Picker:new(opts)
     tiebreak = get_default(opts.tiebreak, config.values.tiebreak),
     selection_strategy = get_default(opts.selection_strategy, config.values.selection_strategy),
 
-    push_cursor_on_edit = get_default(opts.push_cursor_on_edit, config.values.push_cursor_on_edit),
+    push_cursor_on_edit = get_default(opts.push_cursor_on_edit, false),
 
     layout_strategy = layout_strategy,
     layout_config = config.smarter_depth_2_extend(opts.layout_config or {}, config.values.layout_config or {}),


### PR DESCRIPTION
fixes https://github.com/nvim-telescope/telescope.nvim/issues/1038
fixes #1520

Whenever telescope does not sort of edit/selection action, it calls `nvim_win_set_cursor()`, which does not add anything to the jumplist. As noted in the issue, this affects `lsp_references` picker. This PR adds the current location to the jumplist, as [neovim builtin LSP does when jumping to location](https://github.com/neovim/neovim/blob/master/runtime/lua/vim/lsp/util.lua#L1015-L1021).

Builtin LSP also adds the current word to the tagstack. I didn't add it in this PR because I don't want to copy and paste code, but if we want it I can quickly add it in.

This change affects all edit/selection actions, and I'm not sure if its desirable in all cases and pickers. Open to discussion.