### PR TITLE
fix: Docs missing quotes around 'prompt_prefix'

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ and some other functions can be easily changed in custom pickers or built-in fun
 nnoremap <leader>ff :lua require('telescope.builtin').find_files({previewer = false})<cr>
 
 -- Change prompt prefix for find_files builtin function:
-nnoremap <leader>fg :lua require('telescope.builtin').live_grep({ prompt_prefix=🔍 })<cr>
+nnoremap <leader>fg :lua require('telescope.builtin').live_grep({ prompt_prefix="🔍" })<cr>
 nnoremap <leader>fg :Telescope live_grep prompt_prefix=🔍<cr>
 ```
 


### PR DESCRIPTION
The 'prompt_prefix' must be wrap in quotes when passed as part of lua
table options when calling a Telescope built-in function.

This commit fixes the missing quotes on the documentation example.