### PR TITLE
fix: default make_entry

### DIFF
--- a/lua/telescope/finders.lua
+++ b/lua/telescope/finders.lua
@@ -44,7 +44,7 @@ function JobFinder:new(opts)
   assert(not opts.static, "`static` should be used with finder.new_oneshot_job")
 
   local obj = setmetatable({
-    entry_maker = opts.entry_maker or make_entry.from_string,
+    entry_maker = opts.entry_maker or make_entry.gen_from_string,
     fn_command = opts.fn_command,
     cwd = opts.cwd,
     writer = opts.writer,
@@ -122,7 +122,7 @@ function DynamicFinder:new(opts)
   local obj = setmetatable({
     curr_buf = opts.curr_buf,
     fn = opts.fn,
-    entry_maker = opts.entry_maker or make_entry.from_string,
+    entry_maker = opts.entry_maker or make_entry.gen_from_string,
   }, self)
 
   return obj

--- a/lua/telescope/finders/async_oneshot_finder.lua
+++ b/lua/telescope/finders/async_oneshot_finder.lua
@@ -9,7 +9,7 @@ local await_count = 1000
 return function(opts)
   opts = opts or {}
 
-  local entry_maker = opts.entry_maker or make_entry.from_string
+  local entry_maker = opts.entry_maker or make_entry.gen_from_string
   local cwd = opts.cwd
   local fn_command = assert(opts.fn_command, "Must pass `fn_command`")
 


### PR DESCRIPTION
`from_string` doesnt exist. Its called `gen_from_string`