### PR TITLE
fix: wrap vim.cmd in pcall to avoid error

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -131,7 +131,7 @@ action_set.edit = function(prompt_bufnr, command)
     -- prevents restarting lsp server
     if vim.api.nvim_buf_get_name(0) ~= filename or command ~= "edit" then
       filename = Path:new(vim.fn.fnameescape(filename)):normalize(vim.loop.cwd())
-      vim.cmd(string.format("%s %s", command, filename))
+      pcall(vim.cmd, string.format("%s %s", command, filename))
     end
   end
 


### PR DESCRIPTION
When opening a file under swap from the "fd" finder results an error was
printed after the file was opened, wrapping the call to "vim.cmd" in a
pcall avoids the error.

Issue: #445 