### PR TITLE
fix: fallback to syntax hl if treesitter fails

### DIFF
--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -74,7 +74,7 @@ utils.highlighter = function(bufnr, ft, opts)
   if ts_highlighting then
     ts_success = utils.ts_highlighter(bufnr, ft)
   end
-  if not (ts_highlighting or ts_success) then
+  if not ts_highlighting or ts_success == false then
     utils.regex_highlighter(bufnr, ft)
   end
 end


### PR DESCRIPTION
Slight logical error that syntax highlighting fallback doesn't kick in in case treesitter test returns false while having `preview = { treesitter = true}}`.

@clason I think that should fix your issues if I understood them correctly. Apologies, my bad.