### PR TITLE
fix: stacked hooks in buffer previewer

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -237,8 +237,8 @@ previewers.file_maker = function(filepath, bufnr, opts)
               vim.schedule(function()
                 set_timeout_message(bufnr, opts.winid, "File exceeds preview size limit")
               end)
-              return
             end
+            return
           end
         end
 
@@ -264,8 +264,8 @@ previewers.file_maker = function(filepath, bufnr, opts)
               opts.preview.timeout_hook(filepath, bufnr, opts)
             else
               set_timeout_message(bufnr, opts.winid, "Previewer timed out")
-              return
             end
+            return
           end
         end))
       end


### PR DESCRIPTION
Closes #1252 

Does that fix it for you @Akeboshiwind? Sorry, copied from the wrong one where return slipped in the else clause. Wasn't an issue for `mime_hook`.