### PR TITLE
feat: `truncate` option for `path_display`

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -182,6 +182,8 @@ telescope.setup({opts})                                    *telescope.setup()*
                       the difference between the displayed paths
         - "shorten"   only display the first character of each directory in
                       the path
+        - "truncate"  truncates the start of the path when the whole path will
+                      not fit
 
         You can also specify the number of characters of each directory name
         to keep by setting `path_display.shorten = num`.

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -246,6 +246,8 @@ append(
                 the difference between the displayed paths
   - "shorten"   only display the first character of each directory in
                 the path
+  - "truncate"  truncates the start of the path when the whole path will
+                not fit
 
   You can also specify the number of characters of each directory name
   to keep by setting `path_display.shorten = num`.

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -330,6 +330,7 @@ end
 
 function make_entry.gen_from_lsp_symbols(opts)
   opts = opts or {}
+
   local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
 
   local display_items = {
@@ -932,6 +933,7 @@ end
 
 function make_entry.gen_from_lsp_diagnostics(opts)
   opts = opts or {}
+
   local lsp_type_diagnostic = vim.lsp.protocol.DiagnosticSeverity
 
   local signs

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -1,8 +1,10 @@
-local truncate = require("plenary.strings").truncate
 local Path = require "plenary.path"
 local Job = require "plenary.job"
 
 local log = require "telescope.log"
+
+local truncate = require("plenary.strings").truncate
+local get_status = require("telescope.state").get_status
 
 local utils = {}
 
@@ -363,7 +365,7 @@ utils.transform_path = function(opts, path)
         transformed_path = Path:new(transformed_path):shorten(path_display["shorten"])
       end
       if vim.tbl_contains(path_display, "truncate") or path_display.truncate then
-        local status = require("telescope.state").get_status(vim.api.nvim_get_current_buf())
+        local status = get_status(vim.api.nvim_get_current_buf())
         local width = vim.api.nvim_win_get_width(status.results_win) - 5
         transformed_path = truncate(transformed_path, width, nil, -1)
       end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -366,7 +366,7 @@ utils.transform_path = function(opts, path)
       end
       if vim.tbl_contains(path_display, "truncate") or path_display.truncate then
         local status = get_status(vim.api.nvim_get_current_buf())
-        local width = vim.api.nvim_win_get_width(status.results_win) - 5
+        local width = vim.api.nvim_win_get_width(status.results_win) - status.picker.selection_caret:len() - 2
         transformed_path = truncate(transformed_path, width, nil, -1)
       end
     end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -1,3 +1,4 @@
+local truncate = require("plenary.strings").truncate
 local Path = require "plenary.path"
 local Job = require "plenary.job"
 
@@ -360,6 +361,11 @@ utils.transform_path = function(opts, path)
 
       if vim.tbl_contains(path_display, "shorten") or path_display["shorten"] ~= nil then
         transformed_path = Path:new(transformed_path):shorten(path_display["shorten"])
+      end
+      if vim.tbl_contains(path_display, "truncate") or path_display.truncate then
+        local status = require("telescope.state").get_status(vim.api.nvim_get_current_buf())
+        local width = vim.api.nvim_win_get_width(status.results_win) - 5
+        transformed_path = truncate(transformed_path, width, nil, -1)
       end
     end
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -365,9 +365,10 @@ utils.transform_path = function(opts, path)
         transformed_path = Path:new(transformed_path):shorten(path_display["shorten"])
       end
       if vim.tbl_contains(path_display, "truncate") or path_display.truncate then
-        local status = get_status(vim.api.nvim_get_current_buf())
-        local width = vim.api.nvim_win_get_width(status.results_win) - status.picker.selection_caret:len() - 2
-        transformed_path = truncate(transformed_path, width, nil, -1)
+        if opts.__length == nil then
+          opts.__length = utils.calc_result_length()
+        end
+        transformed_path = truncate(transformed_path, opts.__length, nil, -1)
       end
     end
 
@@ -376,6 +377,11 @@ utils.transform_path = function(opts, path)
     log.warn("`path_display` must be either a function or a table.", "See `:help telescope.defaults.path_display.")
     return transformed_path
   end
+end
+
+utils.calc_result_length = function()
+  local status = get_status(vim.api.nvim_get_current_buf())
+  return vim.api.nvim_win_get_width(status.results_win) - status.picker.selection_caret:len() - 2
 end
 
 -- local x = utils.make_default_callable(function(opts)

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -329,6 +329,11 @@ local is_uri = function(filename)
   return string.match(filename, "^%w+://") ~= nil
 end
 
+local calc_result_length = function()
+  local status = get_status(vim.api.nvim_get_current_buf())
+  return vim.api.nvim_win_get_width(status.results_win) - status.picker.selection_caret:len() - 2
+end
+
 utils.transform_path = function(opts, path)
   if is_uri(path) then
     return path
@@ -366,7 +371,7 @@ utils.transform_path = function(opts, path)
       end
       if vim.tbl_contains(path_display, "truncate") or path_display.truncate then
         if opts.__length == nil then
-          opts.__length = utils.calc_result_length()
+          opts.__length = calc_result_length()
         end
         transformed_path = truncate(transformed_path, opts.__length, nil, -1)
       end
@@ -377,11 +382,6 @@ utils.transform_path = function(opts, path)
     log.warn("`path_display` must be either a function or a table.", "See `:help telescope.defaults.path_display.")
     return transformed_path
   end
-end
-
-utils.calc_result_length = function()
-  local status = get_status(vim.api.nvim_get_current_buf())
-  return vim.api.nvim_win_get_width(status.results_win) - status.picker.selection_caret:len() - 2
 end
 
 -- local x = utils.make_default_callable(function(opts)


### PR DESCRIPTION
**WIP**

Use the new left truncation of strings from plenary to truncate paths.
Currently just a minimal implementation that doesn't take stuff like "are there icons" or "how long is the selection_caret" into account.
Also think it _could_ be a bit of a performance hit with this implementation, but haven't thought about it properly yet.

Demo:
![image](https://user-images.githubusercontent.com/35707277/133856152-2d141167-3a9b-41ea-a0ba-2d1c4964419f.png)

Could be useful for [this issue](https://github.com/nvim-telescope/telescope.nvim/issues/1167) and similar to implementation in [this comment](https://github.com/nvim-telescope/telescope.nvim/issues/1167#issuecomment-921268416).