### PR TITLE
fix(builtin): internal.help_tags not finding all tags

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -526,7 +526,7 @@ internal.help_tags = function(opts)
   end
 
   local help_files = {}
-  local all_files = vim.fn.globpath(vim.o.runtimepath, "doc/*", 1, 1)
+  local all_files = vim.api.nvim_get_runtime_file("doc/*", true)
   for _, fullpath in ipairs(all_files) do
     local file = utils.path_tail(fullpath)
     if file == "tags" then


### PR DESCRIPTION
After changes on &rtp in neovim/neovim it's neccessary to use `nvim_get_runtime_file` instead https://github.com/neovim/neovim/pull/15632 

Checked the rest of the codebase and the issue pattern `globpath(&rtp ...)` is not present anywhere else.