### PR TITLE
refactor: use new `Diagnostic` sign names

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -943,7 +943,7 @@ function make_entry.gen_from_lsp_diagnostics(opts)
       -- pcall to catch entirely unbound or cleared out sign hl group
       if type(severity) == "string" then
         local status, sign = pcall(function()
-          return vim.trim(vim.fn.sign_getdefined("LspDiagnosticsSign" .. severity)[1].text)
+          return vim.trim(vim.fn.sign_getdefined("DiagnosticSign" .. severity)[1].text)
         end)
         if not status then
           sign = severity:sub(1, 1)


### PR DESCRIPTION
Related to #1250 (but not dependent on)

Complying with: https://github.com/neovim/neovim/pull/15585

Backwards compatible: https://github.com/neovim/neovim/commit/2e8103475e18d1e4aa0d6355107f393815a886a6#diff-8df5fbf5803bbea8d9e9d4d8a63f0bac3a32e1925d74990a43c6327fad2aad03