### PR TITLE
feat: filetype_hook & improved docs; fix preview partial override

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -315,14 +315,52 @@ telescope.setup({opts})                                    *telescope.setup()*
                               complete within `timeout` milliseconds.
                               Set to false to not timeout preview.
                               Default: 250
-          - hook(s):          Function(s) that takes `(filepath, bufnr, opts)`
-                              to be run if the buffer previewer was not shown due to
-                              the respective test.
-                              Available hooks are: {mime, filesize, timeout}_hook, e.g.
-                              preview = {
-                                mime_hook = function(filepath, bufnr, opts) ... end
-                              }
-                              See `telescope/previewers/*.lua` for relevant examples.
+          - hook(s):          Function(s) that takes `(filepath, bufnr, opts)`, where opts
+                              exposes winid and ft (filetype).
+                              Available hooks (in order of priority):
+                              {filetype, mime, filesize, timeout}_hook
+                              Important: the filetype_hook must return true or false
+                              to indicate whether to continue (true) previewing or not (false),
+                              respectively.
+                              Two examples:
+                              local putils = require("telescope.previewers.utils")
+                              ... -- preview is called in telescope.setup { ... }
+                                preview = {
+                                  -- 1) Do not show previewer for certain files
+                                  filetype_hook = function(filepath, bufnr, opts)
+                                    -- you could analogously check opts.ft for filetypes
+                                    local excluded = vim.tbl_filter(function(ending)
+                                      return filepath:match(ending)
+                                    end, {
+                                      ".*%.csv",
+                                      ".*%.toml",
+                                    })
+                                    if not vim.tbl_isempty(excluded) then
+                                      putils.set_preview_message(
+                                        bufnr,
+                                        opts.winid,
+                                        string.format("I don't like %s files!",
+                                        excluded[1]:sub(5, -1))
+                                      )
+                                      return false
+                                    end
+                                    return true
+                                  end,
+                                  -- 2) Truncate lines to preview window for too large files
+                                  filesize_hook = function(filepath, bufnr, opts)
+                                    local path = require("plenary.path"):new(filepath)
+                                    -- opts exposes winid
+                                    local height = vim.api.nvim_win_get_height(opts.winid)
+                                    local lines = vim.split(path:head(height), "[\r]?\n")
+                                    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+                                  end,
+                                }
+                              The configuration recipes for relevant examples.
+                              Note: if plenary does not recognize your filetype yet --
+                              1) Please consider contributing to:
+                                 $PLENARY_REPO/data/plenary/filetypes/builtin.lua
+                              2) Register your filetype locally as per link
+                                 https://github.com/nvim-lua/plenary.nvim#plenaryfiletype
                               Default: nil
           - treesitter:       Determines whether the previewer performs treesitter
                               highlighting, which falls back to regex-based highlighting.
@@ -331,6 +369,8 @@ telescope.setup({opts})                                    *telescope.setup()*
                               `table`: table of filetypes for which to attach treesitter
                               highlighting
                               Default: true
+          - msg_bg_fillchar:  Character to fill background of unpreviewable buffers with
+                              Default: "╱"
 
 
                                      *telescope.defaults.vimgrep_arguments*

--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -1,4 +1,7 @@
 local context_manager = require "plenary.context_manager"
+local ts_utils = require "telescope.utils"
+local strings = require "plenary.strings"
+local conf = require("telescope.config").values
 
 local has_ts, _ = pcall(require, "nvim-treesitter")
 local _, ts_configs = pcall(require, "nvim-treesitter.configs")
@@ -66,7 +69,10 @@ end
 utils.highlighter = function(bufnr, ft, opts)
   opts = opts or {}
   opts.preview = opts.preview or {}
-  opts.preview.treesitter = vim.F.if_nil(opts.preview.treesitter, true)
+  opts.preview.treesitter = vim.F.if_nil(
+    opts.preview.treesitter,
+    type(conf.preview) == "table" and conf.preview.treesitter
+  )
   local ts_highlighting = opts.preview.treesitter == true
     or type(opts.preview.treesitter) == "table" and vim.tbl_contains(opts.preview.treesitter, ft)
 
@@ -125,6 +131,43 @@ utils.ts_highlighter = function(bufnr, ft)
     return treesitter_attach(bufnr, ft)
   end
   return false
+end
+
+utils.set_preview_message = function(bufnr, winid, message, fillchar)
+  fillchar = vim.F.if_nil(fillchar, "╱")
+  local height = vim.api.nvim_win_get_height(winid)
+  local width = vim.api.nvim_win_get_width(winid)
+  vim.api.nvim_buf_set_lines(
+    bufnr,
+    0,
+    -1,
+    false,
+    ts_utils.repeated_table(height, table.concat(ts_utils.repeated_table(width, fillchar), ""))
+  )
+  local anon_ns = vim.api.nvim_create_namespace ""
+  local padding = table.concat(ts_utils.repeated_table(#message + 4, " "), "")
+  local lines = {
+    padding,
+    "  " .. message .. "  ",
+    padding,
+  }
+  vim.api.nvim_buf_set_extmark(
+    bufnr,
+    anon_ns,
+    0,
+    0,
+    { end_line = height, hl_group = "TelescopePreviewMessageFillchar" }
+  )
+  local col = math.floor((width - strings.strdisplaywidth(lines[2])) / 2)
+  for i, line in ipairs(lines) do
+    vim.api.nvim_buf_set_extmark(
+      bufnr,
+      anon_ns,
+      math.floor(height / 2) - 1 + i,
+      0,
+      { virt_text = { { line, "TelescopePreviewMessage" } }, virt_text_pos = "overlay", virt_text_win_col = col }
+    )
+  end
 end
 
 return utils

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -53,8 +53,8 @@ highlight default link TelescopePreviewSize String
 highlight default link TelescopePreviewUser Constant
 highlight default link TelescopePreviewGroup Constant
 highlight default link TelescopePreviewDate Directory
-
 highlight default link TelescopePreviewMessage TelescopePreviewNormal
+highlight default link TelescopePreviewFillchar TelescopePreviewNormal
 
 " Used for Picker specific Results highlighting
 highlight default link TelescopeResultsClass Function


### PR DESCRIPTION
~~I think some users will appreciate this `head` example using plenary (which I used b/c I wasn't sure whether `head` command is fully OS-agnostic, whereas plenary implementation looks like it is).~~

PR got quite a bit broader:
- Improve docs
- Introduce filetype_hook
- Allow setting highlight groups for `TelescopePreviewMessage` and `TelescopePreviewMessageFillchar`
- Allow setting `msg_bg_fillchar` via `preview` in `telescope.setup`
- factor out `set_timeout_message` to `set_preview_message`

And closes #1288 