### PR TITLE
fix(lsp): check if action.command.arguments is nil

### DIFF
--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -255,7 +255,7 @@ lsp.code_actions = function(opts)
       -- Is only run on lsp codeactions which contain a comand or a arguments field
       -- Fixed Java/jdtls compatibility with Telescope
       -- See fix_zero_version commentary for more information
-      if action.command or action.arguments then
+      if (action.command and action.command.arguments) or action.arguments then
         if action.command.command then
           action.edit = fix_zero_version(action.command.arguments[1])
         else


### PR DESCRIPTION
The code added in #738 attempts to access `action.command.arguments[1]` unconditionally, but the [LSP specification](https://microsoft.github.io/language-server-protocol/specification#command) defines `arguments` as optional. This PR adds a check to make sure `action.command.arguments` is not `nil` before accessing it. 