### PR TITLE
feat: more prompt position strategies

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -120,6 +120,7 @@ telescope.setup({opts})                                    *telescope.setup()*
           center = {
             height = 0.9,
             preview_cutoff = 40,
+            prompt_position = "top",
             width = 0.8
           },
           cursor = {

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -114,7 +114,8 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Default: {
           bottom_pane = {
-            height = 25
+            height = 25,
+            prompt_position = "top"
           },
           center = {
             height = 0.9,
@@ -135,6 +136,7 @@ telescope.setup({opts})                                    *telescope.setup()*
           vertical = {
             height = 0.9,
             preview_cutoff = 40,
+            prompt_position = "bottom",
             width = 0.8
           }
         }
@@ -1679,7 +1681,8 @@ layout_strategies.vertical()                    *layout_strategies.vertical()*
         - Change the height of Telescope's preview window
         - See |resolver.resolve_height()|
       - prompt_position:
-        - (unimplemented, but we plan on supporting)
+        - Where to place prompt window.
+        - Available Values: 'bottom', 'top'
 
 
 layout_strategies.flex()                            *layout_strategies.flex()*

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -105,6 +105,7 @@ local layout_config_defaults = {
 
   bottom_pane = {
     height = 25,
+    prompt_position = "top",
   },
 }
 

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -95,6 +95,7 @@ local layout_config_defaults = {
     width = 0.8,
     height = 0.9,
     preview_cutoff = 40,
+    prompt_position = "top",
   },
 
   cursor = {

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -87,6 +87,7 @@ local layout_config_defaults = {
   vertical = {
     width = 0.8,
     height = 0.9,
+    prompt_position = "bottom",
     preview_cutoff = 40,
   },
 

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -765,7 +765,7 @@ end)
 layout_strategies.bottom_pane = make_documented_layout(
   "bottom_pane",
   vim.tbl_extend("error", shared_options, {
-    -- No custom options...
+    prompt_position = { "Where to place prompt window.", "Available Values: 'bottom', 'top'" },
   }),
   function(self, max_columns, max_lines, layout_config)
     local initial_options = p_window.get_initial_window_options(self)
@@ -806,9 +806,17 @@ layout_strategies.bottom_pane = make_documented_layout(
     end
 
     -- Line
-    prompt.line = max_lines - results.height - (1 + bs) + 1
-    results.line = prompt.line + 1
-    preview.line = results.line + bs
+    if layout_config.prompt_position == "top" then
+      prompt.line = max_lines - results.height - (1 + bs) + 1
+      results.line = prompt.line + 1
+      preview.line = results.line + bs
+    elseif layout_config.prompt_position == "bottom" then
+      results.line = max_lines - results.height - (1 + bs) + 1
+      preview.line = results.line
+      prompt.line = max_lines - bs
+    else
+      error("Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config))
+    end
 
     -- Col
     prompt.col = 0 -- centered

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -442,6 +442,9 @@ layout_strategies.center = make_documented_layout(
     elseif layout_config.prompt_position == "bottom" then
       results.line = topline
       prompt.line = results.line + results.height + bs
+      if type(prompt.title) == "string" then
+        prompt.title = {{ pos = "S", text = prompt.title}}
+      end
     else
       error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
     end
@@ -455,9 +458,6 @@ layout_strategies.center = make_documented_layout(
     end
 
     results.col, preview.col, prompt.col = 0, 0, 0 -- all centered
-
-    -- Ensure that the prompt is always on top
-    prompt.zindex = 51
 
     if tbln then
       prompt.line = prompt.line + 1

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -351,13 +351,7 @@ layout_strategies.horizontal = make_documented_layout(
       results.line = preview.line
       prompt.line = results.line + results.height + 1 + bs
     else
-      error(
-        string.format(
-          "Unknown prompt_position: %s\n%s",
-          self.window.prompt_position,
-          vim.inspect(layout_config)
-        )
-      )
+      error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
     end
 
     if tbln then
@@ -654,13 +648,7 @@ layout_strategies.vertical = make_documented_layout(
         results.line = (preview.height == 0) and preview.line or preview.line + preview.height + (1 + bs)
         prompt.line = results.line + results.height + (1 + bs)
       else
-        error(
-          string.format(
-            "Unknown prompt_position: %s\n%s",
-            self.window.prompt_position,
-            vim.inspect(layout_config)
-          )
-        )
+        error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
       end
     else
       if layout_config.prompt_position == "top" then
@@ -672,13 +660,7 @@ layout_strategies.vertical = make_documented_layout(
         prompt.line = results.line + results.height + (1 + bs)
         preview.line = prompt.line + prompt.height + (1 + bs)
       else
-        error(
-          string.format(
-            "Unknown prompt_position: %s\n%s",
-            self.window.prompt_position,
-            vim.inspect(layout_config)
-          )
-        )
+        error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
       end
     end
 

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -594,7 +594,7 @@ layout_strategies.vertical = make_documented_layout(
   vim.tbl_extend("error", shared_options, {
     preview_cutoff = "When lines are less than this value, the preview will be disabled",
     preview_height = { "Change the height of Telescope's preview window", "See |resolver.resolve_height()|" },
-    prompt_position = { "(unimplemented, but we plan on supporting)" },
+    prompt_position = { "Where to place prompt window.", "Available Values: 'bottom', 'top'" },
   }),
   function(self, max_columns, max_lines, layout_config)
     local initial_options = p_window.get_initial_window_options(self)
@@ -640,13 +640,28 @@ layout_strategies.vertical = make_documented_layout(
 
     local height_padding = math.floor((max_lines - height) / 2)
     if not layout_config.mirror then
-      preview.line = height_padding + bs + 1
-      results.line = (preview.height == 0) and preview.line or preview.line + preview.height + (1 + bs)
-      prompt.line = results.line + results.height + (1 + bs)
+      preview.line = height_padding + (1 + bs)
+      if layout_config.prompt_position == "top" then
+        prompt.line = (preview.height == 0) and preview.line or preview.line + preview.height + (1 + bs)
+        results.line = prompt.line + prompt.height + (1 + bs)
+      elseif layout_config.prompt_position == "bottom" then
+        results.line = (preview.height == 0) and preview.line or preview.line + preview.height + (1 + bs)
+        prompt.line = results.line + results.height + (1 + bs)
+      else
+        error("Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config))
+      end
     else
-      prompt.line = height_padding + bs + 1
-      results.line = prompt.line + prompt.height + (1 + bs)
-      preview.line = results.line + results.height + (1 + bs)
+      if layout_config.prompt_position == "top" then
+        prompt.line = height_padding + (1 + bs)
+        results.line = prompt.line + prompt.height + (1 + bs)
+        preview.line = results.line + results.height + (1 + bs)
+      elseif layout_config.prompt_position == "bottom" then
+        results.line = height_padding + (1 + bs)
+        prompt.line = results.line + results.height + (1 + bs)
+        preview.line = prompt.line + prompt.height + (1 + bs)
+      else
+        error("Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config))
+      end
     end
 
     if tbln then

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -456,6 +456,9 @@ layout_strategies.center = make_documented_layout(
 
     results.col, preview.col, prompt.col = 0, 0, 0 -- all centered
 
+    -- Ensure that the prompt is always on top
+    prompt.zindex = 51
+
     if tbln then
       prompt.line = prompt.line + 1
       results.line = results.line + 1

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -443,7 +443,7 @@ layout_strategies.center = make_documented_layout(
       results.line = topline
       prompt.line = results.line + results.height + bs
       if type(prompt.title) == "string" then
-        prompt.title = {{ pos = "S", text = prompt.title}}
+        prompt.title = { { pos = "S", text = prompt.title } }
       end
     else
       error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
@@ -826,7 +826,7 @@ layout_strategies.bottom_pane = make_documented_layout(
       preview.line = results.line
       prompt.line = max_lines - bs
       if type(prompt.title) == "string" then
-        prompt.title = {{ pos = "S", text = prompt.title }}
+        prompt.title = { { pos = "S", text = prompt.title } }
       end
     else
       error("Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config))

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -433,15 +433,23 @@ layout_strategies.center = make_documented_layout(
     prompt.height = 1
     results.height = height - prompt.height - h_space
 
+    local topline = (max_lines / 2) - ((results.height + (2 * bs)) / 2) + 1
     -- Align the prompt and results so halfway up the screen is
     -- in the middle of this combined block
-    prompt.line = (max_lines / 2) - ((results.height + (2 * bs)) / 2) + 1
-    results.line = prompt.line + 1 + bs
+    if layout_config.prompt_position == "top" then
+      prompt.line = topline
+      results.line = prompt.line + 1 + bs
+    elseif layout_config.prompt_position == "bottom" then
+      results.line = topline
+      prompt.line = results.line + results.height + bs
+    else
+      error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
+    end
 
     preview.line = 2
 
     if self.previewer and max_lines >= layout_config.preview_cutoff then
-      preview.height = math.floor(prompt.line - (3 + bs))
+      preview.height = math.floor(topline - (3 + bs))
     else
       preview.height = 0
     end

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -825,6 +825,9 @@ layout_strategies.bottom_pane = make_documented_layout(
       results.line = max_lines - results.height - (1 + bs) + 1
       preview.line = results.line
       prompt.line = max_lines - bs
+      if type(prompt.title) == "string" then
+        prompt.title = {{ pos = "S", text = prompt.title }}
+      end
     else
       error("Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config))
     end

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -351,7 +351,13 @@ layout_strategies.horizontal = make_documented_layout(
       results.line = preview.line
       prompt.line = results.line + results.height + 1 + bs
     else
-      error("Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config))
+      error(
+        string.format(
+          "Unknown prompt_position: %s\n%s",
+          self.window.prompt_position,
+          vim.inspect(layout_config)
+        )
+      )
     end
 
     if tbln then
@@ -649,7 +655,11 @@ layout_strategies.vertical = make_documented_layout(
         prompt.line = results.line + results.height + (1 + bs)
       else
         error(
-          "Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config)
+          string.format(
+            "Unknown prompt_position: %s\n%s",
+            self.window.prompt_position,
+            vim.inspect(layout_config)
+          )
         )
       end
     else
@@ -663,7 +673,11 @@ layout_strategies.vertical = make_documented_layout(
         preview.line = prompt.line + prompt.height + (1 + bs)
       else
         error(
-          "Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config)
+          string.format(
+            "Unknown prompt_position: %s\n%s",
+            self.window.prompt_position,
+            vim.inspect(layout_config)
+          )
         )
       end
     end

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -648,7 +648,9 @@ layout_strategies.vertical = make_documented_layout(
         results.line = (preview.height == 0) and preview.line or preview.line + preview.height + (1 + bs)
         prompt.line = results.line + results.height + (1 + bs)
       else
-        error("Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config))
+        error(
+          "Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config)
+        )
       end
     else
       if layout_config.prompt_position == "top" then
@@ -660,7 +662,9 @@ layout_strategies.vertical = make_documented_layout(
         prompt.line = results.line + results.height + (1 + bs)
         preview.line = prompt.line + prompt.height + (1 + bs)
       else
-        error("Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config))
+        error(
+          "Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config)
+        )
       end
     end
 

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -52,6 +52,13 @@ function themes.get_dropdown(opts)
       preview = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
     },
   }
+  if opts.layout_config and opts.layout_config.prompt_position == "bottom" then
+    theme_opts.borderchars = {
+      prompt = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
+      results = { "─", "│", "─", "│", "╭", "╮", "┤", "├" },
+      preview = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
+    }
+  end
 
   return vim.tbl_deep_extend("force", theme_opts, opts)
 end
@@ -99,7 +106,7 @@ end
 function themes.get_ivy(opts)
   opts = opts or {}
 
-  return vim.tbl_deep_extend("force", {
+  local theme_opts = {
     theme = "ivy",
 
     sorting_strategy = "ascending",
@@ -117,7 +124,16 @@ function themes.get_ivy(opts)
       results = { " " },
       preview = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
     },
-  }, opts)
+  }
+  if opts.layout_config and opts.layout_config.prompt_position == "bottom" then
+    theme_opts.borderchars = {
+      prompt = { " ", " ", "─", " ", " ", " ", "─", "─" },
+      results = { "─", " ", " ", " ", "─", "─", " ", " " },
+      preview = { "─", " ", "─", "│", "┬", "─", "─", "╰" },
+    }
+  end
+
+  return vim.tbl_deep_extend("force", theme_opts, opts)
 end
 
 return themes

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -54,7 +54,7 @@ function themes.get_dropdown(opts)
   }
   if opts.layout_config and opts.layout_config.prompt_position == "bottom" then
     theme_opts.borderchars = {
-      prompt = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
+      prompt = { "─", "│", "─", "│", "├", "┤", "╯", "╰" },
       results = { "─", "│", "─", "│", "╭", "╮", "┤", "├" },
       preview = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
     }

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -54,7 +54,7 @@ function themes.get_dropdown(opts)
   }
   if opts.layout_config and opts.layout_config.prompt_position == "bottom" then
     theme_opts.borderchars = {
-      prompt = { "─", "│", "─", "│", "├", "┤", "╯", "╰" },
+      prompt = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
       results = { "─", "│", "─", "│", "╭", "╮", "┤", "├" },
       preview = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
     }


### PR DESCRIPTION
This PR adds the `prompt_position` option for the following layout stratgies:
- `vertical`
- `bottom_pane`
- `center`

`vertical` was noted as being "planned" in the code
`bottom_pane` was requested in [this comment](https://github.com/nvim-telescope/telescope.nvim/issues/765#issuecomment-851753342)

---

EDIT: I have now also added some more flexibility to the `get_dropdown` and `get_ivy` themes if the user customises the `prompt_position`