### PR TITLE
feat: add highlight group: TelescopePreviewMessage

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -66,6 +66,9 @@ local function set_timeout_message(bufnr, winid, message)
     false,
     utils.repeated_table(height, table.concat(utils.repeated_table(width, "╱"), ""))
   )
+  for linenr = 0, height do
+      vim.api.nvim_buf_add_highlight(bufnr, -1, "TelescopePreviewMessage", linenr, 0, -1)
+  end
   local anon_ns = vim.api.nvim_create_namespace ""
   local padding = table.concat(utils.repeated_table(#message + 4, " "), "")
   local lines = {
@@ -81,7 +84,7 @@ local function set_timeout_message(bufnr, winid, message)
       anon_ns,
       math.floor(height / 2) - 1 + i,
       0,
-      { virt_text = { { line, "Normal" } }, virt_text_pos = "overlay", virt_text_win_col = col }
+      { virt_text = { { line, "TelescopePreviewMessage" } }, virt_text_pos = "overlay", virt_text_win_col = col }
     )
   end
 end

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -67,7 +67,7 @@ local function set_timeout_message(bufnr, winid, message)
     utils.repeated_table(height, table.concat(utils.repeated_table(width, "╱"), ""))
   )
   for linenr = 0, height do
-      vim.api.nvim_buf_add_highlight(bufnr, -1, "TelescopePreviewMessage", linenr, 0, -1)
+    vim.api.nvim_buf_add_highlight(bufnr, -1, "TelescopePreviewMessage", linenr, 0, -1)
   end
   local anon_ns = vim.api.nvim_create_namespace ""
   local padding = table.concat(utils.repeated_table(#message + 4, " "), "")

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -54,6 +54,8 @@ highlight default link TelescopePreviewUser Constant
 highlight default link TelescopePreviewGroup Constant
 highlight default link TelescopePreviewDate Directory
 
+highlight default link TelescopePreviewMessage TelescopePreviewNormal
+
 " Used for Picker specific Results highlighting
 highlight default link TelescopeResultsClass Function
 highlight default link TelescopeResultsConstant Constant


### PR DESCRIPTION
Add a highlight group to be used when displaying a message in the ```buffer_previewer``` with the function [```set_timeout_message```](https://github.com/nvim-telescope/telescope.nvim/blob/4816a27d7680feed293d21a945c476947af20d29/lua/telescope/previewers/buffer_previewer.lua#L59).