### PR TITLE
fix: show error message when nothing is selected

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -301,13 +301,20 @@ end
 
 actions.edit_command_line = function(prompt_bufnr)
   local entry = action_state.get_selected_entry()
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
   actions.close(prompt_bufnr)
   a.nvim_feedkeys(a.nvim_replace_termcodes(":" .. entry.value, true, false, true), "t", true)
 end
 
 actions.set_command_line = function(prompt_bufnr)
   local entry = action_state.get_selected_entry()
-
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
   actions.close(prompt_bufnr)
   vim.fn.histadd("cmd", entry.value)
   vim.cmd(entry.value)
@@ -315,13 +322,20 @@ end
 
 actions.edit_search_line = function(prompt_bufnr)
   local entry = action_state.get_selected_entry()
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
   actions.close(prompt_bufnr)
   a.nvim_feedkeys(a.nvim_replace_termcodes("/" .. entry.value, true, false, true), "t", true)
 end
 
 actions.set_search_line = function(prompt_bufnr)
   local entry = action_state.get_selected_entry()
-
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
   actions.close(prompt_bufnr)
   a.nvim_feedkeys(a.nvim_replace_termcodes("/" .. entry.value .. "<CR>", true, false, true), "t", true)
 end
@@ -350,6 +364,10 @@ end
 
 actions.paste_register = function(prompt_bufnr)
   local entry = action_state.get_selected_entry()
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
 
   actions.close(prompt_bufnr)
 
@@ -362,6 +380,10 @@ end
 
 actions.run_builtin = function(prompt_bufnr)
   local entry = action_state.get_selected_entry()
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
 
   actions._close(prompt_bufnr, true)
   if string.match(entry.text, " : ") then
@@ -395,6 +417,10 @@ end
 -- TODO: Think about how to do this.
 actions.insert_value = function(prompt_bufnr)
   local entry = action_state.get_selected_entry()
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
 
   vim.schedule(function()
     actions.close(prompt_bufnr)
@@ -435,6 +461,10 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 actions.git_apply_stash = function(prompt_bufnr)
   local selection = action_state.get_selected_entry()
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
   actions.close(prompt_bufnr)
   local _, ret, stderr = utils.get_os_command_output { "git", "stash", "apply", "--index", selection.value }
   if ret == 0 then
@@ -449,6 +479,10 @@ end
 actions.git_checkout = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
   actions.close(prompt_bufnr)
   local _, ret, stderr = utils.get_os_command_output({ "git", "checkout", selection.value }, cwd)
   if ret == 0 then
@@ -465,6 +499,10 @@ end
 actions.git_switch_branch = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
   actions.close(prompt_bufnr)
   local pattern = "^refs/remotes/%w+/"
   local branch = selection.value
@@ -483,6 +521,10 @@ local function make_git_branch_action(opts)
   return function(prompt_bufnr)
     local cwd = action_state.get_current_picker(prompt_bufnr).cwd
     local selection = action_state.get_selected_entry()
+    if selection == nil then
+      print "[telescope] Nothing currently selected"
+      return
+    end
 
     local should_confirm = opts.should_confirm
     if should_confirm then
@@ -552,6 +594,10 @@ actions.git_rebase_branch = make_git_branch_action {
 local git_reset_branch = function(prompt_bufnr, mode)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
 
   local confirmation = vim.fn.input("Do you really wanna " .. mode .. " reset to " .. selection.value .. "? [Y/n] ")
   if confirmation ~= "" and string.lower(confirmation) ~= "y" then
@@ -588,6 +634,10 @@ end
 actions.git_checkout_current_buffer = function(prompt_bufnr)
   local cwd = actions.get_current_picker(prompt_bufnr).cwd
   local selection = actions.get_selected_entry()
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
   actions.close(prompt_bufnr)
   utils.get_os_command_output({ "git", "checkout", selection.value, "--", selection.file }, cwd)
 end
@@ -597,7 +647,10 @@ end
 actions.git_staging_toggle = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
   local selection = action_state.get_selected_entry()
-
+  if selection == nil then
+    print "[telescope] Nothing currently selected"
+    return
+  end
   if selection.status:sub(2) == " " then
     utils.get_os_command_output({ "git", "restore", "--staged", selection.value }, cwd)
   else

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -300,62 +300,62 @@ function actions.close(prompt_bufnr)
 end
 
 actions.edit_command_line = function(prompt_bufnr)
-  local entry = action_state.get_selected_entry()
+  local selection = action_state.get_selected_entry()
   if selection == nil then
     print "[telescope] Nothing currently selected"
     return
   end
   actions.close(prompt_bufnr)
-  a.nvim_feedkeys(a.nvim_replace_termcodes(":" .. entry.value, true, false, true), "t", true)
+  a.nvim_feedkeys(a.nvim_replace_termcodes(":" .. selection.value, true, false, true), "t", true)
 end
 
 actions.set_command_line = function(prompt_bufnr)
-  local entry = action_state.get_selected_entry()
+  local selection = action_state.get_selected_entry()
   if selection == nil then
     print "[telescope] Nothing currently selected"
     return
   end
   actions.close(prompt_bufnr)
-  vim.fn.histadd("cmd", entry.value)
-  vim.cmd(entry.value)
+  vim.fn.histadd("cmd", selection.value)
+  vim.cmd(selection.value)
 end
 
 actions.edit_search_line = function(prompt_bufnr)
-  local entry = action_state.get_selected_entry()
+  local selection = action_state.get_selected_entry()
   if selection == nil then
     print "[telescope] Nothing currently selected"
     return
   end
   actions.close(prompt_bufnr)
-  a.nvim_feedkeys(a.nvim_replace_termcodes("/" .. entry.value, true, false, true), "t", true)
+  a.nvim_feedkeys(a.nvim_replace_termcodes("/" .. selection.value, true, false, true), "t", true)
 end
 
 actions.set_search_line = function(prompt_bufnr)
-  local entry = action_state.get_selected_entry()
+  local selection = action_state.get_selected_entry()
   if selection == nil then
     print "[telescope] Nothing currently selected"
     return
   end
   actions.close(prompt_bufnr)
-  a.nvim_feedkeys(a.nvim_replace_termcodes("/" .. entry.value .. "<CR>", true, false, true), "t", true)
+  a.nvim_feedkeys(a.nvim_replace_termcodes("/" .. selection.value .. "<CR>", true, false, true), "t", true)
 end
 
 actions.edit_register = function(prompt_bufnr)
-  local entry = action_state.get_selected_entry()
+  local selection = action_state.get_selected_entry()
   local picker = action_state.get_current_picker(prompt_bufnr)
 
   vim.fn.inputsave()
-  local updated_value = vim.fn.input("Edit [" .. entry.value .. "] ❯ ", entry.content)
+  local updated_value = vim.fn.input("Edit [" .. selection.value .. "] ❯ ", selection.content)
   vim.fn.inputrestore()
-  if updated_value ~= entry.content then
-    vim.fn.setreg(entry.value, updated_value)
-    entry.content = updated_value
+  if updated_value ~= selection.content then
+    vim.fn.setreg(selection.value, updated_value)
+    selection.content = updated_value
   end
 
   -- update entry in results table
   -- TODO: find way to redraw finder content
   for _, v in pairs(picker.finder.results) do
-    if v == entry then
+    if v == selection then
       v.content = updated_value
     end
   end
@@ -363,7 +363,7 @@ actions.edit_register = function(prompt_bufnr)
 end
 
 actions.paste_register = function(prompt_bufnr)
-  local entry = action_state.get_selected_entry()
+  local selection = action_state.get_selected_entry()
   if selection == nil then
     print "[telescope] Nothing currently selected"
     return
@@ -374,27 +374,27 @@ actions.paste_register = function(prompt_bufnr)
   -- ensure that the buffer can be written to
   if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), "modifiable") then
     print "Paste!"
-    vim.api.nvim_paste(entry.content, true, -1)
+    vim.api.nvim_paste(selection.content, true, -1)
   end
 end
 
 actions.run_builtin = function(prompt_bufnr)
-  local entry = action_state.get_selected_entry()
+  local selection = action_state.get_selected_entry()
   if selection == nil then
     print "[telescope] Nothing currently selected"
     return
   end
 
   actions._close(prompt_bufnr, true)
-  if string.match(entry.text, " : ") then
+  if string.match(selection.text, " : ") then
     -- Call appropriate function from extensions
-    local split_string = vim.split(entry.text, " : ")
+    local split_string = vim.split(selection.text, " : ")
     local ext = split_string[1]
     local func = split_string[2]
     require("telescope").extensions[ext][func]()
   else
     -- Call appropriate telescope builtin
-    require("telescope.builtin")[entry.text]()
+    require("telescope.builtin")[selection.text]()
   end
 end
 
@@ -416,7 +416,7 @@ end
 
 -- TODO: Think about how to do this.
 actions.insert_value = function(prompt_bufnr)
-  local entry = action_state.get_selected_entry()
+  local selection = action_state.get_selected_entry()
   if selection == nil then
     print "[telescope] Nothing currently selected"
     return
@@ -426,7 +426,7 @@ actions.insert_value = function(prompt_bufnr)
     actions.close(prompt_bufnr)
   end)
 
-  return entry.value
+  return selection.value
 end
 
 --- Create and checkout a new git branch if it doesn't already exist

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -178,8 +178,12 @@ internal.planets = function(opts)
     attach_mappings = function(prompt_bufnr)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
-        actions.close(prompt_bufnr)
+        if selection == nil then
+            print "[telescope] Nothing currently selected"
+            return
+        end
 
+        actions.close(prompt_bufnr)
         print("Enjoy astronomy! You viewed:", selection.display)
       end)
 
@@ -278,6 +282,11 @@ internal.commands = function(opts)
     attach_mappings = function(prompt_bufnr)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
+        if selection == nil then
+            print "[telescope] Nothing currently selected"
+            return
+        end
+
         actions.close(prompt_bufnr)
         local val = selection.value
         local cmd = string.format([[:%s ]], val.name)
@@ -587,6 +596,7 @@ internal.help_tags = function(opts)
           print "[telescope] Nothing currently selected"
           return
         end
+
         actions.close(prompt_bufnr)
         if cmd == "default" or cmd == "horizontal" then
           vim.cmd("help " .. selection.value)
@@ -623,8 +633,8 @@ internal.man_pages = function(opts)
           print "[telescope] Nothing currently selected"
           return
         end
-        local args = selection.section .. " " .. selection.value
 
+        local args = selection.section .. " " .. selection.value
         actions.close(prompt_bufnr)
         if cmd == "default" or cmd == "horizontal" then
           vim.cmd("Man " .. args)
@@ -670,6 +680,10 @@ internal.reloader = function(opts)
     attach_mappings = function(prompt_bufnr)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
+        if selection == nil then
+            print "[telescope] Nothing currently selected"
+            return
+        end
 
         actions.close(prompt_bufnr)
         require("plenary.reload").reload_module(selection.value)
@@ -747,8 +761,8 @@ internal.buffers = function(opts)
     attach_mappings = function(_, _)
       action_set.select:enhance {
         post = function()
-          local entry = action_state.get_selected_entry()
-          vim.api.nvim_win_set_cursor(0, { entry.lnum, entry.col or 0 })
+          local selection = action_state.get_selected_entry()
+          vim.api.nvim_win_set_cursor(0, { selection.lnum, selection.col or 0 })
         end,
       }
       return true
@@ -827,8 +841,12 @@ internal.colorscheme = function(opts)
     attach_mappings = function(prompt_bufnr)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
-        actions.close(prompt_bufnr)
+        if selection == nil then
+            print "[telescope] Nothing currently selected"
+            return
+        end
 
+        actions.close(prompt_bufnr)
         need_restore = false
         vim.cmd("colorscheme " .. selection.value)
       end)
@@ -932,6 +950,11 @@ internal.keymaps = function(opts)
     attach_mappings = function(prompt_bufnr)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
+        if selection == nil then
+            print "[telescope] Nothing currently selected"
+            return
+        end
+
         vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(selection.value.lhs, true, false, true), "t", true)
         return actions.close(prompt_bufnr)
       end)
@@ -952,6 +975,11 @@ internal.filetypes = function(opts)
     attach_mappings = function(prompt_bufnr)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
+        if selection == nil then
+            print "[telescope] Nothing currently selected"
+            return
+        end
+
         actions.close(prompt_bufnr)
         vim.cmd("setfiletype " .. selection[1])
       end)
@@ -973,6 +1001,11 @@ internal.highlights = function(opts)
     attach_mappings = function(prompt_bufnr)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
+        if selection == nil then
+            print "[telescope] Nothing currently selected"
+            return
+        end
+
         actions.close(prompt_bufnr)
         vim.cmd("hi " .. selection.value)
       end)
@@ -1064,6 +1097,11 @@ internal.autocommands = function(opts)
     attach_mappings = function(prompt_bufnr)
       action_set.select:replace(function(_, type)
         local selection = action_state.get_selected_entry()
+        if selection == nil then
+            print "[telescope] Nothing currently selected"
+            return
+        end
+
         actions.close(prompt_bufnr)
         vim.cmd(action_state.select_key_to_edit_key(type) .. " " .. selection.value)
       end)
@@ -1090,6 +1128,11 @@ internal.spell_suggest = function(opts)
     attach_mappings = function(prompt_bufnr)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
+        if selection == nil then
+            print "[telescope] Nothing currently selected"
+            return
+        end
+
         actions.close(prompt_bufnr)
         vim.cmd("normal! ciw" .. selection[1])
         vim.cmd "stopinsert"

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -465,8 +465,12 @@ internal.vim_options = function(opts)
     attach_mappings = function()
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
-        local esc = ""
+        if selection == nil then
+          print "[telescope] Nothing currently selected"
+          return
+        end
 
+        local esc = ""
         if vim.fn.mode() == "i" then
           -- TODO: don't make this local
           esc = vim.api.nvim_replace_termcodes("<esc>", true, false, true)

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -179,8 +179,8 @@ internal.planets = function(opts)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
         if selection == nil then
-            print "[telescope] Nothing currently selected"
-            return
+          print "[telescope] Nothing currently selected"
+          return
         end
 
         actions.close(prompt_bufnr)
@@ -283,8 +283,8 @@ internal.commands = function(opts)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
         if selection == nil then
-            print "[telescope] Nothing currently selected"
-            return
+          print "[telescope] Nothing currently selected"
+          return
         end
 
         actions.close(prompt_bufnr)
@@ -685,8 +685,8 @@ internal.reloader = function(opts)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
         if selection == nil then
-            print "[telescope] Nothing currently selected"
-            return
+          print "[telescope] Nothing currently selected"
+          return
         end
 
         actions.close(prompt_bufnr)
@@ -846,8 +846,8 @@ internal.colorscheme = function(opts)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
         if selection == nil then
-            print "[telescope] Nothing currently selected"
-            return
+          print "[telescope] Nothing currently selected"
+          return
         end
 
         actions.close(prompt_bufnr)
@@ -955,8 +955,8 @@ internal.keymaps = function(opts)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
         if selection == nil then
-            print "[telescope] Nothing currently selected"
-            return
+          print "[telescope] Nothing currently selected"
+          return
         end
 
         vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(selection.value.lhs, true, false, true), "t", true)
@@ -980,8 +980,8 @@ internal.filetypes = function(opts)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
         if selection == nil then
-            print "[telescope] Nothing currently selected"
-            return
+          print "[telescope] Nothing currently selected"
+          return
         end
 
         actions.close(prompt_bufnr)
@@ -1006,8 +1006,8 @@ internal.highlights = function(opts)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
         if selection == nil then
-            print "[telescope] Nothing currently selected"
-            return
+          print "[telescope] Nothing currently selected"
+          return
         end
 
         actions.close(prompt_bufnr)
@@ -1102,8 +1102,8 @@ internal.autocommands = function(opts)
       action_set.select:replace(function(_, type)
         local selection = action_state.get_selected_entry()
         if selection == nil then
-            print "[telescope] Nothing currently selected"
-            return
+          print "[telescope] Nothing currently selected"
+          return
         end
 
         actions.close(prompt_bufnr)
@@ -1133,8 +1133,8 @@ internal.spell_suggest = function(opts)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
         if selection == nil then
-            print "[telescope] Nothing currently selected"
-            return
+          print "[telescope] Nothing currently selected"
+          return
         end
 
         actions.close(prompt_bufnr)


### PR DESCRIPTION
This continues the fixes done in 4816a27d7680feed293d21a945c476947af20d29 (ref #1283).

The only picker that shows this error now (of those I tested) is `Telescope buffers` - I did not fix this one because there is already a message saying "[telescope] Nothing currently selected" above the nil error message (not sure why it's shown twice).