### PR TITLE
fix highlight declaration of 'TelescopePreviewMessageFillchar'

### DIFF
--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -54,7 +54,7 @@ highlight default link TelescopePreviewUser Constant
 highlight default link TelescopePreviewGroup Constant
 highlight default link TelescopePreviewDate Directory
 highlight default link TelescopePreviewMessage TelescopePreviewNormal
-highlight default link TelescopePreviewFillchar TelescopePreviewNormal
+highlight default link TelescopePreviewMessageFillchar TelescopePreviewMessage
 
 " Used for Picker specific Results highlighting
 highlight default link TelescopeResultsClass Function


### PR DESCRIPTION
I was testing the plugin with the lastest merge in the master and noted the highlight 'TelescopePreviewMessageFillchar' was incorrectly declared as 'TelescopePreviewFillchar'.

I also think it should by default link to 'TelescopePreviewMessage', so the user can choose to set 'TelescopePreviewMessage' to change both or to set each one individually.