### PR TITLE
fix: which key float positioning

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1029,7 +1029,9 @@ actions.which_key = function(prompt_bufnr, opts)
   local picker = action_state.get_current_picker(prompt_bufnr)
   local prompt_win = picker.prompt_win
   local prompt_row = a.nvim_win_get_position(prompt_win)[1]
-  local prompt_pos = prompt_row <= 0.5 * vim.o.lines
+  -- TODO(fdschmidt93): resolve side in more principled fashion
+  -- ivy theme right around 0.5 * vim.o.lines; simple heuristic to circumvent
+  local prompt_pos = prompt_row < 0.45 * vim.o.lines
 
   local modes = { n = "Normal", i = "Insert" }
   local title_mode = opts.only_show_current_mode and modes[mode] .. " Mode " or ""
@@ -1041,8 +1043,8 @@ actions.which_key = function(prompt_bufnr, opts)
     maxwidth = vim.o.columns,
     minheight = winheight,
     maxheight = winheight,
-    line = prompt_pos == true and vim.o.lines - winheight or 1,
-    col = 1,
+    line = prompt_pos == true and vim.o.lines - winheight + 1 or 1,
+    col = 0,
     border = { prompt_pos and 1 or 0, 0, not prompt_pos and 1 or 0, 0 },
     borderchars = { prompt_pos and "─" or " ", "", not prompt_pos and "─" or " ", "", "", "", "", "" },
     noautocmd = true,

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1026,12 +1026,16 @@ actions.which_key = function(prompt_bufnr, opts)
   local winheight = opts.num_rows + 2 * opts.line_padding
 
   -- place hints at top or bottom relative to prompt
+  local win_central_row = function(win_nr)
+    return a.nvim_win_get_position(win_nr)[1] + 0.5 * a.nvim_win_get_height(win_nr)
+  end
+  -- TODO(fdschmidt93|l-kershaw): better generalization of where to put which key float
   local picker = action_state.get_current_picker(prompt_bufnr)
-  local prompt_win = picker.prompt_win
-  local prompt_row = a.nvim_win_get_position(prompt_win)[1]
-  -- TODO(fdschmidt93): resolve side in more principled fashion
-  -- ivy theme right around 0.5 * vim.o.lines; simple heuristic to circumvent
-  local prompt_pos = prompt_row < 0.45 * vim.o.lines
+  local prompt_row = win_central_row(picker.prompt_win)
+  local results_row = win_central_row(picker.results_win)
+  local preview_row = win_central_row(picker.preview_win)
+  local prompt_pos = prompt_row < 0.4 * vim.o.lines
+    or prompt_row < 0.6 * vim.o.lines and results_row + preview_row < vim.o.lines
 
   local modes = { n = "Normal", i = "Insert" }
   local title_mode = opts.only_show_current_mode and modes[mode] .. " Mode " or ""

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1041,7 +1041,7 @@ actions.which_key = function(prompt_bufnr, opts)
     maxwidth = vim.o.columns,
     minheight = winheight,
     maxheight = winheight,
-    line = prompt_pos == true and vim.o.lines - winheight or 0,
+    line = prompt_pos == true and vim.o.lines - winheight or 1,
     col = 1,
     border = { prompt_pos and 1 or 0, 0, not prompt_pos and 1 or 0, 0 },
     borderchars = { prompt_pos and "─" or " ", "", not prompt_pos and "─" or " ", "", "", "", "", "" },


### PR DESCRIPTION
@l-kershaw could it be that one of the recent plenary popup PRs might have broken positioning of `actions.which_key`? :sweat_smile:  Judging by one of the PR titles alone I tried this fix and seems to work. If you could please confirm this should be fine, that'd be great :) thanks