### PR TITLE
fix: stacking highlights in buffer previewer

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -1124,8 +1124,9 @@ previewers.buffers = defaulter(function(opts)
           -- only set if winid and rows are matching
           pcall(vim.api.nvim_buf_set_extmark, bufnr, ns_previewer, lnum - 1, 0, {
             end_col = #line,
+            virt_text = {{line, "TelescopePreviewLine"}},
             virt_text_pos = "overlay",
-            hl_group = "TelescopePreviewLine",
+            hl_mode = "combine",
             ephemeral = true,
             priority = 101, -- 1 higher than treesitter
           })

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -1124,7 +1124,7 @@ previewers.buffers = defaulter(function(opts)
           -- only set if winid and rows are matching
           pcall(vim.api.nvim_buf_set_extmark, bufnr, ns_previewer, lnum - 1, 0, {
             end_col = #line,
-            virt_text = {{line, "TelescopePreviewLine"}},
+            virt_text = { { line, "TelescopePreviewLine" } },
             virt_text_pos = "overlay",
             hl_mode = "combine",
             ephemeral = true,


### PR DESCRIPTION
Closes #1213 

This is a slightly (but totally ok) hacky solution because we'd otherwise need `hl_mode` to affect `hl_group` in `nvim_buf_set_extmark`.

@lcrockett does it now work as expected for you? For me it seems to work as expected with your minimal config.