### PR TITLE
chore: highlight which_key on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ require('telescope').setup{
         -- map actions.which_key to <C-h> (default: <C-/>)
         -- actions.which_key shows the mappings for your picker,
         -- e.g. git_{create, delete, ...}_branch for the git_branches picker
-        [<C-h>] = "which_key"
+        ["<C-h>"] = "which_key"
       }
     }
   },

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Many familiar mapping patterns are setup as defaults.
 To see the full list of mappings, check out `lua/telescope/mappings.lua` and the
 `default_mappings` table. 
 
-**Tip**: you can use `<C-/>` and `?` in insert and normal mode, respectively, to show the builtin mappings for your picker.
+**Tip**: you can use `<C-/>` and `?` in insert and normal mode, respectively, to show the actions mapped to your picker.
 
 Much like [builtin pickers](#pickers), there are a number of
 [actions](https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/actions/init.lua)

--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ Many familiar mapping patterns are setup as defaults.
 | `<C-t>`        | Go to a file in a new tab                   |
 | `<C-u>`        | Scroll up in preview window                 |
 | `<C-d>`        | Scroll down in preview window               |
-| `<C-/>/?`      | Show mapped picker actions (in insert & normal mode, respectively) |
+| `<C-/>`      | Show mappings for picker actions (insert mode)|
+| `?`          | Show mappings for picker actions (normal mode)|
 | `<C-c>`        | Close telescope                             |
 | `<Esc>`        | Close telescope (in normal mode)            |
 | `<Tab>`        | Toggle selection and move to next selection |

--- a/README.md
+++ b/README.md
@@ -139,7 +139,14 @@ require('telescope').setup{
   defaults = {
     -- Default configuration for telescope goes here:
     -- config_key = value,
-    -- ..
+    mappings = {
+      i = {
+        -- map actions.which_key to <C-h> (default: <C-/>)
+        -- actions.which_key shows the mappings for your picker,
+        -- e.g. git_{create, delete, ...}_branch for the git_branches picker
+        [<C-h>] = "which_key"
+      }
+    }
   },
   pickers = {
     -- Default configuration for builtin pickers goes here:
@@ -194,7 +201,7 @@ Many familiar mapping patterns are setup as defaults.
 | `<C-t>`        | Go to a file in a new tab                   |
 | `<C-u>`        | Scroll up in preview window                 |
 | `<C-d>`        | Scroll down in preview window               |
-| `<C-/>/?`      | Show picker mappings (in insert & normal mode, respectively) |
+| `<C-/>/?`      | Show mapped picker actions (in insert & normal mode, respectively) |
 | `<C-c>`        | Close telescope                             |
 | `<Esc>`        | Close telescope (in normal mode)            |
 | `<Tab>`        | Toggle selection and move to next selection |
@@ -204,7 +211,9 @@ Many familiar mapping patterns are setup as defaults.
 
 
 To see the full list of mappings, check out `lua/telescope/mappings.lua` and the
-`default_mappings` table.
+`default_mappings` table. 
+
+**Tip**: you can use `<C-/>` and `?` in insert and normal mode, respectively, to show the builtin mappings for your picker.
 
 Much like [builtin pickers](#pickers), there are a number of
 [actions](https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/actions/init.lua)


### PR DESCRIPTION
This came up on Gitter. You can make the argument `telescope.setup` per README is not "clean" anymore, but it's not intended as a COPYME. Nevertheless, it's an outlier. I don't really have an opinion, whatever works.

~~(Created the PR right from GH, there's a slight error that `<C-h>` needs to be a string, don't behead me just yet ;)~~

cc @clason