### PR TITLE
Added the option to open selection in a popup - Issue #365

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -249,6 +249,18 @@ actions.select_tab = {
 
 -- TODO: consider adding float!
 -- https://github.com/nvim-telescope/telescope.nvim/issues/365
+actions.select_popup = {
+  pre = function(prompt_bufnr)
+    action_state.get_current_history():append(
+      action_state.get_current_line(),
+      action_state.get_current_picker(prompt_bufnr)
+    )
+  end,
+  action = function(prompt_bufnr)
+    --actions.file_popup(prompt_bufnr)
+    return action_set.select(prompt_bufnr, "popup")
+  end,
+}
 
 function actions.file_edit(prompt_bufnr)
   return action_set.edit(prompt_bufnr, "edit")

--- a/lua/telescope/actions/state.lua
+++ b/lua/telescope/actions/state.lua
@@ -32,6 +32,7 @@ local select_to_edit_map = {
   horizontal = "new",
   vertical = "vnew",
   tab = "tabedit",
+  popup = "popup",
 }
 function action_state.select_key_to_edit_key(type)
   return select_to_edit_map[type]

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -21,6 +21,7 @@ mappings.default_mappings = config.values.default_mappings
       ["<C-x>"] = actions.select_horizontal,
       ["<C-v>"] = actions.select_vertical,
       ["<C-t>"] = actions.select_tab,
+      ["<C-f>"] = actions.select_popup,
 
       ["<C-u>"] = actions.preview_scrolling_up,
       ["<C-d>"] = actions.preview_scrolling_down,
@@ -39,6 +40,7 @@ mappings.default_mappings = config.values.default_mappings
       ["<C-x>"] = actions.select_horizontal,
       ["<C-v>"] = actions.select_vertical,
       ["<C-t>"] = actions.select_tab,
+      ["<C-f>"] = actions.select_popup,
 
       ["<Tab>"] = actions.toggle_selection + actions.move_selection_worse,
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,


### PR DESCRIPTION
Added an option to open the selection in a popup window. I've added a default mapping of <C-f>, f for floating window.

It's sized to fill the space used by all telescope windows so it gives the impression the prompt and results windows have been closed to expand the Preview window.

An autocmd is added to make sure the border of the popup is closed when the popup gets closed.

When this window opens we are completely outside of Telescope, but this causes issues if you try to use Telescope while this popup is open. In general Telescope should probably check if it's being opened in a popup.
If this is fixed then It might be possible to use `Telescope resume` to go back to the previous state.

This code could be made simpler if we used the `opts.keep_last_buf` which keeps alive the preview buffer.