### PR TITLE
entry_to_qf should use the entry.path

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -671,7 +671,7 @@ local entry_to_qf = function(entry)
 
   return {
     bufnr = entry.bufnr,
-    filename = from_entry.path(entry, false),
+    filename = entry.path,
     lnum = vim.F.if_nil(entry.lnum, 1),
     col = vim.F.if_nil(entry.col, 1),
     text = text,

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -20,6 +20,7 @@ local action_state = require "telescope.actions.state"
 local action_utils = require "telescope.actions.utils"
 local action_set = require "telescope.actions.set"
 local entry_display = require "telescope.pickers.entry_display"
+local from_entry = require "telescope.from_entry"
 
 local transform_mod = require("telescope.actions.mt").transform_mod
 local resolver = require "telescope.config.resolve"
@@ -670,7 +671,7 @@ local entry_to_qf = function(entry)
 
   return {
     bufnr = entry.bufnr,
-    filename = entry.path,
+    filename = from_entry.path(entry, false, true),
     lnum = vim.F.if_nil(entry.lnum, 1),
     col = vim.F.if_nil(entry.col, 1),
     text = text,

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -671,7 +671,7 @@ local entry_to_qf = function(entry)
 
   return {
     bufnr = entry.bufnr,
-    filename = from_entry.path(entry, false, true),
+    filename = from_entry.path(entry, false, false),
     lnum = vim.F.if_nil(entry.lnum, 1),
     col = vim.F.if_nil(entry.col, 1),
     text = text,

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -20,7 +20,6 @@ local action_state = require "telescope.actions.state"
 local action_utils = require "telescope.actions.utils"
 local action_set = require "telescope.actions.set"
 local entry_display = require "telescope.pickers.entry_display"
-local from_entry = require "telescope.from_entry"
 
 local transform_mod = require("telescope.actions.mt").transform_mod
 local resolver = require "telescope.config.resolve"

--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -10,12 +10,13 @@ This will provide standard mechanism for accessing information from an entry.
 
 local from_entry = {}
 
-function from_entry.path(entry, validate, skip_escaping)
-  local path = entry.path and vim.fn.fnameescape(entry.path) or nil
-  if skip_escaping then
+function from_entry.path(entry, validate, fnameescape)
+  fnameescape = vim.F.if_nil(fnameescape, true)
+  local path
+
+  if entry.path then
     path = entry.path
   end
-
   if path == nil then
     path = entry.filename
   end
@@ -30,6 +31,8 @@ function from_entry.path(entry, validate, skip_escaping)
   if validate and not vim.fn.filereadable(path) then
     return
   end
+
+  path = fnameescape and vim.fn.fnameescape(path) or path
 
   return path
 end

--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -10,8 +10,12 @@ This will provide standard mechanism for accessing information from an entry.
 
 local from_entry = {}
 
-function from_entry.path(entry, validate)
+function from_entry.path(entry, validate, skip_escaping)
   local path = entry.path and vim.fn.fnameescape(entry.path) or nil
+  if skip_escaping then
+    path = entry.path
+  end
+
   if path == nil then
     path = entry.filename
   end


### PR DESCRIPTION
## Summary
I noticed when using the quickfix and location list actions, the file path is escaped using `fnameescape`. This is no good because when navigating the list you'll see file names with spaces are escaped with `\ `. This is not needed as it will cause navigating the list to not work properly.

## Screenshots

- Before
![image](https://user-images.githubusercontent.com/763/136048928-1ff44511-17ed-455f-9f59-1825a0621f44.png)
- After
![image](https://user-images.githubusercontent.com/763/136048729-b0811c10-2698-48b5-9c2d-4771ebaa5cbc.png)
- Using vim's builtin `:lv favorite **/*92*`
![image](https://user-images.githubusercontent.com/763/136049220-e6eb52ab-bd25-4e30-aced-62fdb88c6ad4.png)