### PR TITLE
feat(pickers): hide cursor in normal mode

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1108,6 +1108,14 @@ actions.which_key = function(prompt_bufnr, opts)
   end
 end
 
+actions._toggle_cursor = function()
+  if vim.o.termguicolors and vim.o.guicursor ~= "" and vim.o.guicursor ~= "a:HiddenCursor" then
+    state.set_global_key("guicursor", vim.o.guicursor)
+    vim.o.guicursor = "a:HiddenCursor"
+  else
+    vim.o.guicursor = state.get_global_key "guicursor"
+  end
+end
 -- ==================================================
 -- Transforms modules and sets the correct metatables.
 -- ==================================================

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -390,6 +390,7 @@ function Picker:find()
         -- otherwise (i) insert mode exitted faster than `picker:set_prompt`; (ii) cursor on wrong pos
         await_schedule(function()
           vim.cmd [[stopinsert]]
+          actions._toggle_cursor()
         end)
       end
     else
@@ -641,6 +642,10 @@ function Picker.close_windows(status)
   end, 10)
 
   state.clear_status(status.prompt_bufnr)
+
+  if status.picker.initial_mode == "normal" then
+    actions._toggle_cursor()
+  end
 end
 
 function Picker:get_selection()

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -78,6 +78,10 @@ highlight default link TelescopeResultsDiffAdd DiffAdd
 highlight default link TelescopeResultsDiffDelete DiffDelete
 highlight default link TelescopeResultsDiffUntracked NonText
 
+augroup TelescopeAutocmds
+  autocmd! ColorScheme * highlight HiddenCursor gui=reverse blend=100
+augroup END
+
 " This is like "<C-R>" in your terminal.
 "   To use it, do `cmap <C-R> <Plug>(TelescopeFuzzyCommandSearch)
 cnoremap <silent> <Plug>(TelescopeFuzzyCommandSearch) <C-\>e


### PR DESCRIPTION
### Purpose

Make cursor hidden when `initial_mode == "normal"`.

### Todos 

- [x] Hide/Unhide cursor with `intial_mode == "normal"`
- [ ] Toggle back cursor when going back to insert mode.
  - Maybe autocmd? ++once?
- [ ] update docs for initial_mode