### PR TITLE
feat: add lsp_codelens_actions builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Built-in functions. Ready to be bound to any key you like.
 | `builtin.lsp_dynamic_workspace_symbols`     | Dynamically Lists LSP for all workspace symbols                                                                           |
 | `builtin.lsp_code_actions`                  | Lists any LSP actions for the word under the cursor, that can be triggered with `<cr>`                                    |
 | `builtin.lsp_range_code_actions`            | Lists any LSP actions for a given range, that can be triggered with `<cr>`                                                |
+| `builtin.lsp_codelens_actions`              | Lists any LSP codelens actions for the word under the cursor, that can be triggered with `<cr>`                           |
 | `builtin.lsp_document_diagnostics`          | Lists LSP diagnostics for the current buffer                                                                              |
 | `builtin.lsp_workspace_diagnostics`         | Lists LSP diagnostics for the current workspace if supported, otherwise searches in all open buffers                      |
 | `builtin.lsp_implementations`               | Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope         |

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -397,6 +397,11 @@ builtin.lsp_code_actions = require_on_exported_call("telescope.builtin.lsp").cod
 ---@field start_line number: where the code action ends (default: handled by :'<,'>Telescope lsp_range_code_actions)
 builtin.lsp_range_code_actions = require_on_exported_call("telescope.builtin.lsp").range_code_actions
 
+--- Lists any LSP codelens actions for the word under the cursor which can be triggered with `<cr>`
+---@param opts table: options to pass to the picker
+---@field timeout number: timeout for the sync call (default: 10000)
+builtin.lsp_codelens_actions = require_on_exported_call("telescope.builtin.lsp").codelens_actions
+
 --- Lists LSP document symbols in the current buffer
 --- - Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -315,6 +315,107 @@ lsp.range_code_actions = function(opts)
   lsp.code_actions(opts)
 end
 
+lsp.codelens_actions = function(opts)
+  local results_lsp = vim.lsp.codelens.get(0)
+
+  if not results_lsp or vim.tbl_isempty(results_lsp) then
+    print "No executable codelens actions found at the current buffer"
+    return
+  end
+
+  local idx = 1
+  local results = {}
+  local widths = {
+    idx = 0,
+    command_title = 0,
+    client_name = 0,
+  }
+
+  for _, result in ipairs(results_lsp) do
+    if result.command then
+      local entry = {
+        idx = idx,
+        command_title = result.command.title:gsub("\r\n", "\\r\\n"):gsub("\n", "\\n"):gsub("▶︎ ",""),
+        command = result.command,
+        client_name = result.command.command,
+      }
+
+      for key, value in pairs(widths) do
+        widths[key] = math.max(value, strings.strdisplaywidth(entry[key]))
+      end
+
+      table.insert(results, entry)
+      idx = idx + 1
+    end
+  end
+
+  if #results == 0 then
+    print "No codelens actions available"
+    return
+  end
+
+  local displayer = entry_display.create {
+    separator = " ",
+    items = {
+      { width = widths.idx + 1 }, -- +1 for ":" suffix
+      { width = widths.command_title },
+      { width = widths.client_name },
+    },
+  }
+
+  local function make_display(entry)
+    return displayer {
+      { entry.idx .. ":", "TelescopePromptPrefix" },
+      { entry.command_title },
+      { entry.client_name, "TelescopeResultsComment" },
+    }
+  end
+
+  local execute_action = opts.execute_action
+    or function(action)
+      if action.edit or type(action.command) == "table" then
+        if action.edit then
+          vim.lsp.util.apply_workspace_edit(action.edit)
+        end
+        if type(action.command) == "table" then
+          vim.lsp.buf.execute_command(action.command)
+        end
+      else
+        vim.lsp.buf.execute_command(action)
+      end
+    end
+
+  pickers.new(opts, {
+    prompt_title = "LSP CodeLens Actions",
+    finder = finders.new_table {
+      results = results,
+      entry_maker = function(line)
+        return {
+          valid = line ~= nil,
+          value = line.command,
+          ordinal = line.idx .. line.command_title,
+          command_title = line.command_title,
+          idx = line.idx,
+          client_name = line.client_name,
+          display = make_display,
+        }
+      end,
+    },
+    attach_mappings = function(prompt_bufnr)
+      actions.select_default:replace(function()
+        local selection = action_state.get_selected_entry()
+        actions.close(prompt_bufnr)
+        local action = selection.value
+
+        execute_action(action)
+      end)
+
+      return true
+    end,
+    sorter = conf.generic_sorter(opts),
+  }):find()
+end
+
 lsp.workspace_symbols = function(opts)
   local params = { query = opts.query or "" }
   local results_lsp, err = vim.lsp.buf_request_sync(0, "workspace/symbol", params, opts.timeout or 10000)
@@ -456,6 +557,7 @@ local function check_capabilities(feature)
 end
 
 local feature_map = {
+  ["codelens_actions"] = "code_lens",
   ["code_actions"] = "code_action",
   ["document_symbols"] = "document_symbol",
   ["references"] = "find_references",


### PR DESCRIPTION
I wanted to use the lovely telescope UI to show and select code lens actions when possible
![Screen_Shot_2021-10-06_at_1](https://user-images.githubusercontent.com/10992695/136111104-bfa08e58-21e1-4049-8fe0-d90aff88b4bc.png)

sidenote: I can merge code_actions and codelens_actions, but not sure if that is a good idea or not 