### PR TITLE
don't escape qflist entry filename

### DIFF
--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -11,7 +11,7 @@ This will provide standard mechanism for accessing information from an entry.
 local from_entry = {}
 
 function from_entry.path(entry, validate)
-  local path = entry.path and vim.fn.fnameescape(entry.path) or nil
+  local path = entry.path or nil
   if path == nil then
     path = entry.filename
   end


### PR DESCRIPTION
Filenames that do contain characters that are escaped seems to break due do this. The `setqflist()` docs are not clear whether it needs to be escaped or not, so not sure why it's currently done.

See https://asciinema.org/a/BanU8o9Ry5wbjMBYeNKjiXpkg

Figured I'd immediately open a PR instead of an issue