### PR TITLE
fix: set scrolloff in local not global scope

### DIFF
--- a/ftplugin/TelescopeResults.lua
+++ b/ftplugin/TelescopeResults.lua
@@ -1,2 +1,2 @@
 -- Don't have scrolloff, it makes things weird.
-vim.opt.scrolloff = 0
+vim.opt_local.scrolloff = 0


### PR DESCRIPTION
Without this change, scrolloff from init.vim is overridden after first usage of telescope.