### PR TITLE
fix: processed count to exclude entries that got ignored in make_entry

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -998,11 +998,11 @@ function Picker:get_result_processor(find_id, prompt, status_updater)
       return true
     end
 
-    self:_increment "processed"
-
     if not entry or entry.valid == false then
       return
     end
+
+    self:_increment "processed"
 
     count = count + 1
 


### PR DESCRIPTION
It doesnt make sense to count these. Most likely they were never shown.
Example: `man_pages` excludes pages from different sections. So you
filter for man pages and end up with like 5 entries and the counter
still says 1000. Not a good experience.