### PR TITLE
fix: highlighting when `color_devicons=false`

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -897,8 +897,10 @@ function Picker:entry_adder(index, entry, _, insert)
   end
 
   local set_ok, msg = pcall(vim.api.nvim_buf_set_lines, self.results_bufnr, row, row + offset, false, { display })
-  if set_ok and display_highlights then
-    self.highlighter:hi_display(row, prefix, display_highlights)
+  if set_ok then
+    if display_highlights then
+      self.highlighter:hi_display(row, prefix, display_highlights)
+    end
     self:highlight_one_row(self.results_bufnr, self:_get_prompt(), display, row)
   end
 


### PR DESCRIPTION
This fixes the highlighting issue shown below (introduced in dea927d), which occurs when `color_devicons` is set to `false` or devicons are disabled.

Since `display_highlights` is `nil` in both of these cases, `highlight_one_row()` was never getting called.

https://user-images.githubusercontent.com/35406425/136682848-de79906d-4081-4623-bf3e-2ef0a1da6384.mp4
