### PR TITLE
fix: Bug with nil action error

### DIFF
--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -314,7 +314,11 @@ lsp.code_actions = function(opts)
               vim.notify(resolved_err.code .. ": " .. resolved_err.message, vim.log.levels.ERROR)
               return
             end
-            execute_action(transform_action(resolved_action))
+            if resolved_action then
+              execute_action(transform_action(resolved_action))
+            else
+              execute_action(transform_action(action))
+            end
           end)
         else
           execute_action(transform_action(action))


### PR DESCRIPTION
After https://github.com/nvim-telescope/telescope.nvim/pull/1311 being merged I started to get the following error while trying to run a code action with clojure-lsp:
```
Error executing vim.schedule lua callback: ...acker/start/telescope.nvim/lua/telescope/builtin/lsp.lua:264: attempt to index local 'action' (a nil value)
```
So to fix this I added this extra check to use the right `action` when `resolved_action` is null.