### PR TITLE
The `git_files` picker falls back to `find_files` when outside of a git repository

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -838,16 +838,20 @@ builtin.git_files({opts})                                *builtin.git_files()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}                (string)   specify the path of the repo
-        {use_git_root}       (boolean)  if we should use git root as cwd or
-                                        the cwd (important for submodule)
-                                        (default: true)
-        {show_untracked}     (boolean)  if true, adds `--others` flag to
-                                        command and shows untracked files
-                                        (default: true)
-        {recurse_submodules} (boolean)  if true, adds the
-                                        `--recurse-submodules` flag to command
-                                        (default: false)
+        {cwd}                 (string)   specify the path of the repo
+        {use_git_root}        (boolean)  if we should use git root as cwd or
+                                         the cwd (important for submodule)
+                                         (default: true)
+        {show_untracked}      (boolean)  if true, adds `--others` flag to
+                                         command and shows untracked files
+                                         (default: true)
+        {recurse_submodules}  (boolean)  if true, adds the
+                                        ` --recurse-submodules` flag to command
+                                         (default: false)
+        {find_files_fallback} (boolean)  if true, the find_files picker is run
+                                         instead when the picker is used
+                                         outside of a git repository
+                                         (default: true)
 
 
 builtin.git_commits({opts})                            *builtin.git_commits()*

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -19,10 +19,15 @@ git.files = function(opts)
   local recurse_submodules = utils.get_default(opts.recurse_submodules, false)
   local find_files_fallback = utils.get_default(opts.find_files_fallback, true)
 
-  if find_files_fallback and opts.not_in_git_repo then
-    command.load_command(opts.start_line, opts.end_line, opts.count, 'find_files')
-    return
+  if opts.not_in_git_repo then
+    if find_files_fallback then
+      command.load_command(opts.start_line, opts.end_line, opts.count, 'find_files')
+      return
+    else
+      error(opts.cwd .. " is not a git directory")
+    end
   end
+
   if show_untracked and recurse_submodules then
     error "Git does not support both --others and --recurse-submodules"
   end

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -388,7 +388,6 @@ local set_opts_cwd = function(opts)
   -- Find root of git directory and remove trailing newline characters
   local git_root, ret = utils.get_os_command_output({ "git", "rev-parse", "--show-toplevel" }, opts.cwd)
   local use_git_root = utils.get_default(opts.use_git_root, true)
-  local find_files_fallback = utils.get_default(opts.find_files_fallback, true)
 
   if ret ~= 0 then
     local output = utils.get_os_command_output({ "git", "rev-parse", "--is-inside-work-tree" }, opts.cwd)

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -170,12 +170,12 @@ git.bcommits = function(opts)
         return bufnr
       end
 
-      local vimdiff = function(selection, command)
+      local vimdiff = function(selection, position)
         local ft = vim.bo.filetype
         vim.cmd "diffthis"
 
         local bufnr = get_buffer_of_orig(selection)
-        vim.cmd(string.format("%s %s", command, bufnr))
+        vim.cmd(string.format("%s %s", position, bufnr))
         vim.bo.filetype = ft
         vim.cmd "diffthis"
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -146,6 +146,7 @@ builtin.current_buffer_tags = require_on_exported_call("telescope.builtin.files"
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field show_untracked boolean: if true, adds `--others` flag to command and shows untracked files (default: true)
 ---@field recurse_submodules boolean: if true, adds the `--recurse-submodules` flag to command (default: false)
+---@field find_files_fallback boolean: if true, the find_files picker is run instead when the picker is used outside of a git repository (default: true)
 builtin.git_files = require_on_exported_call("telescope.builtin.git").files
 
 --- Lists commits for current directory with diff preview

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -146,7 +146,8 @@ builtin.current_buffer_tags = require_on_exported_call("telescope.builtin.files"
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field show_untracked boolean: if true, adds `--others` flag to command and shows untracked files (default: true)
 ---@field recurse_submodules boolean: if true, adds the `--recurse-submodules` flag to command (default: false)
----@field find_files_fallback boolean: if true, the find_files picker is run instead when the picker is used outside of a git repository (default: true)
+---@field find_files_fallback boolean: if true, the find_files picker is run instead when the picker is used
+--        outside of a git repository (default: true)
 builtin.git_files = require_on_exported_call("telescope.builtin.git").files
 
 --- Lists commits for current directory with diff preview


### PR DESCRIPTION
Optionally can be disabled with the `find_files_fallback` option. Continuation of the discussion in #1338.

This makes https://github.com/nvim-telescope/telescope.nvim/wiki/Configuration-Recipes#falling-back-to-find_files-if-git_files-cant-find-a-git-directory obsolete