### PR TITLE
help: "Fix" scroll_speed

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -157,6 +157,8 @@ action_set.scroll_previewer = function(prompt_bufnr, direction)
 
   local status = state.get_status(prompt_bufnr)
   local default_speed = vim.api.nvim_win_get_height(status.preview_win) / 2
+
+  -- status.picker.layout_config.{vertical,horizontal}.scroll_speed?
   local speed = status.picker.layout_config.scroll_speed or default_speed
 
   previewer:scroll_fn(math.floor(speed * direction))


### PR DESCRIPTION
Figured this would be more useful than an issue as I've poked around enough to know what the problem is, just not 100% sure how to go about fixing it.

With the changes to the `layout_config`, it looks like the `scroll_speed` is now a part of the `layout_config.{horizontal,vertical}` rather than directly a part of the `layout_config` itself. From this, the section doing:

```lua
local speed = status.picker.layout_config.scroll_speed or default_speed
```

would need to be looking at `horizontal` or `vertical` as well.

---

I've looked around, but I don't understand how in this function we know if we are "oriented" (and hence scrolling?) horizontally or vertically. The `direction` is just representing up/down or left/right, and I don't see anything particularly useful from the previewer that would note its "orientation" (along with a general search for keywords `vertical` or `horizontal` in the code base).

Curious if anyone would be able to help point me in the right direction?

---

Note I could also be completely missing the point around where `scroll_speed` is supposed to go, and it is indeed a key under `layout_config`, and I'm just being an idiot and specifying it under `layout_config.{horizontal,vertical}` :wink: 