### PR TITLE
fix: preview title key and a bug with dynamic_title

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -61,7 +61,8 @@ function Picker:new(opts)
   local obj = setmetatable({
     prompt_title = get_default(opts.prompt_title, "Prompt"),
     results_title = get_default(opts.results_title, "Results"),
-    preview_title = get_default(opts.preview_title, "Preview"),
+    -- either whats passed in by the user or whats defined by the previewer
+    preview_title = opts.preview_title,
 
     prompt_prefix = get_default(opts.prompt_prefix, config.values.prompt_prefix),
     selection_caret = get_default(opts.selection_caret, config.values.selection_caret),
@@ -125,6 +126,11 @@ function Picker:new(opts)
       obj.all_previewers = { obj.all_previewers }
     end
     obj.previewer = obj.all_previewers[1]
+    if obj.preview_title == nil then
+      obj.preview_title = obj.previewer:title(nil, config.values.dynamic_preview_title)
+    else
+      obj.fix_preview_title = true
+    end
   else
     obj.previewer = false
   end
@@ -894,10 +900,14 @@ function Picker:refresh_previewer()
 
     self.previewer:preview(self._selection_entry, status)
     if self.preview_border then
-      if config.values.dynamic_preview_title == true then
-        self.preview_border:change_title(self.previewer:dynamic_title(self._selection_entry))
-      else
-        self.preview_border:change_title(self.previewer:title())
+      if self.fix_preview_title then
+        return
+      end
+
+      local new_title = self.previewer:title(self._selection_entry, config.values.dynamic_preview_title)
+      if new_title ~= nil and new_title ~= self.preview_title then
+        self.preview_title = new_title
+        self.preview_border:change_title(new_title)
       end
     end
   end

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -277,8 +277,6 @@ previewers.new_buffer_previewer = function(opts)
 
   local opt_setup = opts.setup
   local opt_teardown = opts.teardown
-  local opt_title = opts.title
-  local opt_dyn_title = opts.dyn_title
 
   local old_bufs = {}
   local bufname_table = {}
@@ -314,24 +312,6 @@ previewers.new_buffer_previewer = function(opts)
         bufname_table[value] = get_bufnr(self)
       end
     end
-  end
-
-  function opts.title(self)
-    if opt_title then
-      if type(opt_title) == "function" then
-        return opt_title(self)
-      else
-        return opt_title
-      end
-    end
-    return "Preview"
-  end
-
-  function opts.dyn_title(self, entry)
-    if opt_dyn_title then
-      return opt_dyn_title(self, entry)
-    end
-    return "Preview"
   end
 
   function opts.setup(self)

--- a/lua/telescope/previewers/previewer.lua
+++ b/lua/telescope/previewers/previewer.lua
@@ -1,13 +1,25 @@
 local Previewer = {}
 Previewer.__index = Previewer
 
+local force_function_wrap = function(value)
+  if value ~= nil then
+    if type(value) ~= "function" then
+      return function()
+        return tostring(value)
+      end
+    else
+      return value
+    end
+  end
+end
+
 function Previewer:new(opts)
   opts = opts or {}
 
   return setmetatable({
     state = nil,
-    _title_fn = opts.title,
-    _dyn_title_fn = opts.dyn_title,
+    _title_fn = force_function_wrap(opts.title),
+    _dyn_title_fn = force_function_wrap(opts.dyn_title),
     _setup_func = opts.setup,
     _teardown_func = opts.teardown,
     _send_input = opts.send_input,
@@ -32,18 +44,16 @@ function Previewer:preview(entry, status)
   return self:preview_fn(entry, status)
 end
 
-function Previewer:title()
-  if self._title_fn then
-    return self:_title_fn()
-  end
-  return "Preview"
-end
-
-function Previewer:dynamic_title(entry)
-  if self._title_fn then
+function Previewer:title(entry, dynamic)
+  if dynamic == true and self._dyn_title_fn ~= nil then
+    if entry == nil then
+      return nil
+    end
     return self:_dyn_title_fn(entry)
   end
-  return "Preview"
+  if self._title_fn ~= nil then
+    return self:_title_fn()
+  end
 end
 
 function Previewer:teardown()

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -118,8 +118,6 @@ previewers.new_termopen_previewer = function(opts)
 
   local opt_setup = opts.setup
   local opt_teardown = opts.teardown
-  local opt_title = opts.title
-  local opt_dyn_title = opts.dyn_title
 
   local old_bufs = {}
 
@@ -153,24 +151,6 @@ previewers.new_termopen_previewer = function(opts)
     if self.state then
       self.state.termopen_bufnr = value
     end
-  end
-
-  function opts.title(self)
-    if opt_title then
-      if type(opt_title) == "function" then
-        return opt_title(self)
-      else
-        return opt_title
-      end
-    end
-    return "Preview"
-  end
-
-  function opts.dyn_title(self, entry)
-    if opt_dyn_title then
-      return opt_dyn_title(self, entry)
-    end
-    return "Preview"
   end
 
   function opts.setup(self)

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -29,7 +29,6 @@ function themes.get_dropdown(opts)
     theme = "dropdown",
 
     results_title = false,
-    preview_title = "Preview",
 
     sorting_strategy = "ascending",
     layout_strategy = "center",
@@ -110,8 +109,6 @@ function themes.get_ivy(opts)
     theme = "ivy",
 
     sorting_strategy = "ascending",
-
-    preview_title = "",
 
     layout_strategy = "bottom_pane",
     layout_config = {


### PR DESCRIPTION
fix #1347

Plus a refactoring. I no longer like how i implemented titles defined by previewer and dynamic titles.

This should be simpler than the current solution.

Also there is a bug (or something unpredictable). If dynamic title is enabled and not provided rather than falling back to the normal defined title it was outputing just "Preview". Example would be `git_commits` which says "Git Diff to Parent Preview" usually but if dynamic title is enabled it didnt.