### PR TITLE
feat: separate highlight for titles in picker windows

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -308,13 +308,16 @@ function Picker:find()
   popup_opts.results.minheight = popup_opts.results.height
   popup_opts.results.highlight = "TelescopeNormal"
   popup_opts.results.borderhighlight = "TelescopeResultsBorder"
+  popup_opts.results.titlehighlight = "TelescopeResultsTitle"
   popup_opts.prompt.minheight = popup_opts.prompt.height
   popup_opts.prompt.highlight = "TelescopeNormal"
   popup_opts.prompt.borderhighlight = "TelescopePromptBorder"
+  popup_opts.prompt.titlehighlight = "TelescopePromptTitle"
   if popup_opts.preview then
     popup_opts.preview.minheight = popup_opts.preview.height
     popup_opts.preview.highlight = "TelescopeNormal"
     popup_opts.preview.borderhighlight = "TelescopePreviewBorder"
+    popup_opts.preview.titlehighlight = "TelescopePreviewTitle"
   end
 
   -- local results_win, results_opts = popup.create("", popup_opts.results)

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -27,6 +27,14 @@ highlight default link TelescopePromptBorder TelescopeBorder
 highlight default link TelescopeResultsBorder TelescopeBorder
 highlight default link TelescopePreviewBorder TelescopeBorder
 
+" Title highlight groups.
+"   Use TelescopeTitle to override the default.
+"   Otherwise set them specifically
+highlight default link TelescopeTitle TelescopeBorder
+highlight default link TelescopePromptTitle TelescopeTitle
+highlight default link TelescopeResultsTitle TelescopeTitle
+highlight default link TelescopePreviewTitle TelescopeTitle
+
 " Used for highlighting characters that you match.
 highlight default link TelescopeMatching Special
 


### PR DESCRIPTION
Requires nvim-lua/plenary.nvim#260
Resolves #1071
@siduck76 does this work for you?

Most of the work for this is handled in the plenary PR

**Demo pictures of just this feature**

![title_highlight_01](https://user-images.githubusercontent.com/35707277/138127671-abd9a406-08d2-467c-a96f-bdfa553e910b.png)
![title_highlight_02](https://user-images.githubusercontent.com/35707277/138127669-d9effe36-b9d3-4a92-898e-99fb6ceb1326.png)

**Demo pictures with changes to other highlights and borderchars**

![title_highlight_03](https://user-images.githubusercontent.com/35707277/138127724-82a0b4dd-935c-4511-bcd4-0ab869fc459e.png)
![title_highlight_04](https://user-images.githubusercontent.com/35707277/138127729-61b9fb63-d6e0-40ad-9e8d-83d8ee07e1c6.png)

