### PR TITLE
docs: fix typo in qflist_previewer's default value

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -545,7 +545,7 @@ telescope.setup({opts})                                    *telescope.setup()*
         previewer or use the command-line program bat as the previewer:
           require("telescope.previewers").qflist.new
 
-        Default: require("telescope.previewers").vim_buffer_vimgrep.new
+        Default: require("telescope.previewers").vim_buffer_qflist.new
 
                                 *telescope.defaults.buffer_previewer_maker*
     buffer_previewer_maker: ~

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -703,7 +703,7 @@ append(
     previewer or use the command-line program bat as the previewer:
       require("telescope.previewers").qflist.new
 
-    Default: require("telescope.previewers").vim_buffer_vimgrep.new]]
+    Default: require("telescope.previewers").vim_buffer_qflist.new]]
 )
 
 append(


### PR DESCRIPTION
The PR fixes a simple typo in the description of `qflist_previewer`.

PS: The `Auto-updates from CI` section from `contribution.md` should mention enabling GH Actions for a newly forked repository.