### PR TITLE
Fix LSP code actions not working for some language servers

### DIFF
--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -266,7 +266,7 @@ lsp.code_actions = function(opts)
         return action
       end
       local arguments = (action.command and action.command.arguments) or action.arguments
-      action.edit = fix_zero_version(argments[1])
+      action.edit = fix_zero_version(arguments[1])
       return action
     end
 

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -258,16 +258,15 @@ lsp.code_actions = function(opts)
   local transform_action = opts.transform_action
     or function(action)
       -- Remove 0 -version from LSP codeaction request payload.
-      -- Is only run on lsp codeactions which contain a comand or a arguments field
+      -- Is only run on the "java.apply.workspaceEdit" codeaction.
       -- Fixed Java/jdtls compatibility with Telescope
       -- See fix_zero_version commentary for more information
-      if (action.command and action.command.arguments) or action.arguments then
-        if action.command.command then
-          action.edit = fix_zero_version(action.command.arguments[1])
-        else
-          action.edit = fix_zero_version(action.arguments[1])
-        end
+      local command = (action.command and action.command.command) or action.command
+      if not (command == "java.apply.workspaceEdit") then
+        return action
       end
+      local arguments = (action.command and action.command.arguments) or action.arguments
+      action.edit = fix_zero_version(argments[1])
       return action
     end
 


### PR DESCRIPTION
After https://github.com/nvim-telescope/telescope.nvim/pull/738 was merged, codeactions stopped working with some language servers. They work correctly e.g. for elmls, but fail for purescriptls and haskell-language-server.

Actions popup shows up, but when an action is selected, no changes are applied.

The problem seems to be with the `transform_action` function:
https://github.com/nvim-telescope/telescope.nvim/blob/782d802d44077e07f80189560f91c86370f11e39/lua/telescope/builtin/lsp.lua#L258-L272

An example code action payload that I get from purescriptls is:
```lua
{
  "title": "Remove unused references",
  "command": "purescript.replaceSuggestion",
  "arguments": {
    "file:///path/to/Main.purs",
    "import Some.Module (xx)",
    {
      "end": {
        "line": 16,
        "character": 60,
      },
      "start": {
        "line": 16,
        "character": 0,
      },
    }
  }
}
```

Calling `transform_action` with this creates an `edit` key in the `action` table (artificially changing this `command` to an `edit`) which causes the code to enter the first if branch instead of the second one in the following snippet later down the lines:
https://github.com/nvim-telescope/telescope.nvim/blob/782d802d44077e07f80189560f91c86370f11e39/lua/telescope/builtin/lsp.lua#L277-L282

Deleting the `transform_action` function completely does the job (verified with purescriptls, hls; it didn't introduce regression for elmls too), but I understand Java folks need it. Based on the nvim-lspconfig PR mentioned in the original PR (https://github.com/neovim/nvim-lspconfig/pull/429) I infer that the `transform_action` only makes sense for the `java.apply.workspaceEdit` action, so I've refactored the code to only be effective with this action.

Interested to hear your thoughts.