### PR TITLE
feat: add find_runtime_files

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -25,10 +25,15 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.url }}-${{ hashFiles('todays-date') }}
 
       - name: Prepare
+        env:
+         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           test -d _neovim || {
             mkdir -p _neovim
-            curl -sL ${{ matrix.url }} | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
+            gh api "repos/neovim/neovim/releases/latest" --jq '.assets[].browser_download_url' \
+                  | grep 'nvim-linux64.tar.gz$' \
+                  | xargs -I % curl -sL % \
+                  | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
           }
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -234,6 +234,13 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Default: function that shows current count / all
 
+                                         *telescope.defaults.hl_result_eol*
+    hl_result_eol: ~
+        Changes if the highlight for the selected item in the results
+        window is always the full width of the window
+
+        Default: true
+
                                  *telescope.defaults.dynamic_preview_title*
     dynamic_preview_title: ~
         Will change the title of the preview window dynamically, where it

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1260,6 +1260,19 @@ builtin.jumplist({opts})                                  *builtin.jumplist()*
         {ignore_filename} (boolean)  dont show filenames (default: true)
 
 
+builtin.find_runtime_files({opts})              *builtin.find_runtime_files()*
+    Lists directories from `vim.opt.runtimepath` and allows to quickly jump,
+    search for file, or grep for text in any entry
+    - Default keymaps:
+      - `<cr>` or `<C-f>`: search for files in selectied directory
+      - `<C-g>`: grep for text in selectied directory
+      - `<C-y>`: change CWD to selectied directory
+
+
+    Parameters: ~
+        {opts} (table)  options to pass to the picker
+
+
 builtin.lsp_references({opts})                      *builtin.lsp_references()*
     Lists LSP references for word under the cursor, jumps to reference on
     `<cr>`

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1264,9 +1264,9 @@ builtin.find_runtime_files({opts})              *builtin.find_runtime_files()*
     Lists directories from `vim.opt.runtimepath` and allows to quickly jump,
     search for file, or grep for text in any entry
     - Default keymaps:
-      - `<cr>` or `<C-f>`: search for files in selectied directory
-      - `<C-g>`: grep for text in selectied directory
-      - `<C-y>`: change CWD to selectied directory
+      - `<cr>` or `<C-f>`: search for files in selected directory
+      - `<C-g>`: grep for text in selected directory
+      - `<C-y>`: change CWD to selected directory
 
 
     Parameters: ~

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -335,23 +335,32 @@ actions.paste_register = function(prompt_bufnr)
   end
 end
 
-actions.run_builtin = function(prompt_bufnr)
-  local selection = action_state.get_selected_entry()
-  if selection == nil then
-    print "[telescope] Nothing currently selected"
-    return
+---Run a builtin pickers based on opts.next_picker
+---@param prompt_bufnr number: the prompt bufnr
+---@param opts table: options
+---@field next_picker string the name of the next picker to execute, e.g. "find_files"
+---@field entry_cb function can be used to modify the current options, e.g. modify `opts.cwd` based on selection
+actions.run_builtin = function(prompt_bufnr, opts)
+  -- make sure the options are cleanly separated
+  local picker_opts = vim.deepcopy(opts)
+
+  picker_opts.next_picker = nil
+  picker_opts.entry_cb = nil
+
+  if opts.entry_cb and type(opts.entry_cb) == "function" then
+    picker_opts = vim.tbl_deep_extend("force", picker_opts, opts.entry_cb(prompt_bufnr, opts))
   end
 
   actions._close(prompt_bufnr, true)
-  if string.match(selection.text, " : ") then
+  if string.match(opts.next_picker, " : ") then
     -- Call appropriate function from extensions
-    local split_string = vim.split(selection.text, " : ")
+    local split_string = vim.split(opts.next_picker, " : ")
     local ext = split_string[1]
     local func = split_string[2]
-    require("telescope").extensions[ext][func]()
+    require("telescope").extensions[ext][func](picker_opts)
   else
     -- Call appropriate telescope builtin
-    require("telescope.builtin")[selection.text]()
+    require("telescope.builtin")[opts.next_picker](picker_opts)
   end
 end
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -357,6 +357,13 @@ builtin.tagstack = require_on_exported_call("telescope.builtin.internal").tagsta
 ---@field ignore_filename boolean: dont show filenames (default: true)
 builtin.jumplist = require_on_exported_call("telescope.builtin.internal").jumplist
 
+--- Lists directories from `vim.opt.runtimepath` and allows to quickly jump, search for file, or grep for text in any entry
+--- - Default keymaps:
+---   - `<cr>` or `<C-f>`: search for files in selectied directory
+---   - `<C-g>`: grep for text in selectied directory
+---   - `<C-y>`: change CWD to selectied directory
+---@param opts table: options to pass to the picker
+builtin.find_runtime_files = require_on_exported_call("telescope.builtin.internal").find_runtime_files
 --
 --
 -- LSP-related Pickers

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -359,9 +359,9 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.internal").jumpli
 
 --- Lists directories from `vim.opt.runtimepath` and allows to quickly jump, search for file, or grep for text in any entry
 --- - Default keymaps:
----   - `<cr>` or `<C-f>`: search for files in selectied directory
----   - `<C-g>`: grep for text in selectied directory
----   - `<C-y>`: change CWD to selectied directory
+---   - `<cr>` or `<C-f>`: search for files in selected directory
+---   - `<C-g>`: grep for text in selected directory
+---   - `<C-y>`: change CWD to selected directory
 ---@param opts table: options to pass to the picker
 builtin.find_runtime_files = require_on_exported_call("telescope.builtin.internal").find_runtime_files
 --

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -1230,15 +1230,12 @@ end
 
 internal.find_runtime_files = function(opts)
   opts = opts or {}
+  opts.pre_filter = opts.pre_filter or ""
+  local runtimedirs = vim.api.nvim_get_runtime_file(opts.pre_filter, true)
+
   local files = require "telescope.builtin.files"
-  local runtimepath = vim.opt.runtimepath:get()
-  local runtimedirs = {}
 
-  for _, entry in ipairs(runtimepath) do
-    vim.list_extend(runtimedirs, vim.fn.globpath(entry, "", 1, 1))
-  end
-
-  local find_in_dir = function()
+  local find_in_dir = function(prompt_bufnr)
     local entry = action_state.get_selected_entry()
     opts.cwd = entry.value
     files.find_files(opts)
@@ -1252,7 +1249,7 @@ internal.find_runtime_files = function(opts)
     vim.cmd [[normal! A]]
   end
 
-  local set_cwd = function()
+  local set_cwd = function(prompt_bufnr)
     local entry = action_state.get_selected_entry()
     local dir = entry.value
     if dir ~= nil and vim.fn.getcwd() ~= dir then
@@ -1263,10 +1260,9 @@ internal.find_runtime_files = function(opts)
   end
 
   pickers.new(opts, {
-    prompt_title = "select a runtime directory",
-    layout_strategy = "flex",
+    prompt_title = "Select A Runtime Directory",
     finder = finders.new_table(runtimedirs),
-    sorter = sorters.get_generic_fuzzy_sorter(opts),
+    sorter = conf.file_sorter(opts),
     attach_mappings = function(_, map)
       map("i", "<cr>", find_in_dir)
       map("n", "<cr>", find_in_dir)


### PR DESCRIPTION
Search for file, grep for text or jump to any directory from `vim.opt.runtimepath`.

Inspired by https://github.com/tpope/vim-scriptease

- Default keymaps:
 - `<cr>` or `<C-f>`: search for files in selectied directory
 - `<C-g>`: grep for text in selectied directory
 - `<C-y>`: change CWD to selectied directory