### PR TITLE
fix: actions.paste_register selctions content

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -374,7 +374,7 @@ actions.paste_register = function(prompt_bufnr)
   -- ensure that the buffer can be written to
   if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), "modifiable") then
     print "Paste!"
-    vim.api.nvim_paste(selection.content, true, -1)
+    vim.api.nvim_paste(selection[1], true, -1)
   end
 end
 


### PR DESCRIPTION
I got the following error when using the `actions.paste_register`.
```
E5108: Error executing lua ...cker/start/telescope.nvim/lua/telescope/actions/init.lua:377: Expected lua string 
```
I inspected the `selection` variable selection and there is no `content` member, see
```lua
{ "doc-requirements.txt",                                                                                                                                                                                                                                             
  <metatable> = {                                                                                                                                                                                                                                                     
    __index = <function 1>,                                                                                                                                                                                                                                           
    cwd = "/home/",                                                                                                                                                                                                                                      
    display = <function 2>                                                                                                                                                                                                                                            
  }                                                                                                                                                                                                                                                                   
}                                                                                                                                                                                                                                                                     
```