### PR TITLE
fix: buitin.tags broke when tags-file was in wildignore

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -566,7 +566,7 @@ files.tags = function(opts)
 
   local results = {}
   for _, ctags_file in ipairs(tagfiles) do
-    for line in Path:new(vim.fn.expand(ctags_file)):iter() do
+    for line in Path:new(vim.fn.expand(ctags_file, true)):iter() do
       results[#results + 1] = line
     end
   end


### PR DESCRIPTION
regression from
6f829bf6bc333809dd97e532dbc88a7fcf297b02
https://github.com/nvim-telescope/telescope.nvim/pull/1122

I'm happy to add docs or tests when someone could point me to where :) 

In a local, manual test this fixed the problem, tags were still found even when these files are in `wildignore`