### PR TITLE
fix: revert buffers previewer

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -874,13 +874,6 @@ end
 actions.delete_buffer = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   current_picker:delete_selection(function(selection)
-    -- avoid preview win from closing by creating tmp buffer
-    local preview_win = state.get_status(prompt_bufnr).preview_win
-    if preview_win ~= nil and vim.api.nvim_win_is_valid(preview_win) then
-      local buf = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
-      vim.api.nvim_win_set_buf(preview_win, buf)
-    end
     vim.api.nvim_buf_delete(selection.bufnr, { force = true })
   end)
 end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -779,18 +779,9 @@ internal.buffers = function(opts)
       results = buffers,
       entry_maker = opts.entry_maker or make_entry.gen_from_buffer(opts),
     },
-    previewer = previewers.buffers.new(opts),
+    previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
     default_selection_index = default_selection_idx,
-    attach_mappings = function(_, _)
-      action_set.select:enhance {
-        post = function()
-          local selection = action_state.get_selected_entry()
-          vim.api.nvim_win_set_cursor(0, { selection.lnum, selection.col or 0 })
-        end,
-      }
-      return true
-    end,
   }):find()
 end
 

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -474,14 +474,21 @@ previewers.vimgrep = defaulter(function(opts)
         pcall(vim.api.nvim_buf_clear_namespace, self.state.last_set_bufnr, ns_previewer, 0, -1)
       end
 
-      conf.buffer_previewer_maker(p, self.state.bufnr, {
-        bufname = self.state.bufname,
-        winid = self.state.winid,
-        preview = opts.preview,
-        callback = function(bufnr)
-          jump_to_line(self, bufnr, entry.lnum)
-        end,
-      })
+      -- Workaround for unnamed buffer when using builtin.buffer
+      if entry.bufnr and (p == "[No Name]" or vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= "") then
+        local lines = vim.api.nvim_buf_get_lines(entry.bufnr, 0, -1, false)
+        vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+        jump_to_line(self, self.state.bufnr, entry.lnum)
+      else
+        conf.buffer_previewer_maker(p, self.state.bufnr, {
+          bufname = self.state.bufname,
+          winid = self.state.winid,
+          preview = opts.preview,
+          callback = function(bufnr)
+            jump_to_line(self, bufnr, entry.lnum)
+          end,
+        })
+      end
     end,
   }
 end, {})
@@ -1056,107 +1063,6 @@ previewers.display_content = defaulter(function(_)
         entry.preview_command(entry, self.state.bufnr)
       end)
     end,
-  }
-end, {})
-
-previewers.buffers = defaulter(function(opts)
-  opts = opts or {}
-  local cwd = opts.cwd or vim.loop.cwd()
-  local previewer_active -- decouple provider from preview_win
-  return Previewer:new {
-    title = function()
-      return "Buffers"
-    end,
-    setup = function(_, status)
-      previewer_active = true
-      local win_id = status.picker.original_win_id
-      -- required because of see `:h local-options` as
-      -- buffers not yet attached to a current window take the options from the `minimal` popup ...
-      local state = {
-        ["previewed_buffers"] = {},
-        ["winid"] = status.preview_win,
-        ["win_options"] = {
-          ["colorcolumn"] = vim.api.nvim_win_get_option(win_id, "colorcolumn"),
-          ["cursorline"] = vim.api.nvim_win_get_option(win_id, "cursorline"),
-          ["foldlevel"] = vim.api.nvim_win_get_option(win_id, "foldlevel"),
-          ["list"] = vim.api.nvim_win_get_option(win_id, "list"),
-          ["number"] = vim.api.nvim_win_get_option(win_id, "number"),
-          ["relativenumber"] = vim.api.nvim_win_get_option(win_id, "relativenumber"),
-          ["signcolumn"] = vim.api.nvim_win_get_option(win_id, "signcolumn"),
-          ["spell"] = vim.api.nvim_win_get_option(win_id, "spell"),
-          ["winhl"] = vim.api.nvim_win_get_option(win_id, "winhl"),
-          ["wrap"] = vim.api.nvim_win_get_option(win_id, "wrap"),
-        },
-      }
-      -- TODO clear explicitly once API should become available
-      -- decoration provider is hierachical on_start -> win
-      vim.api.nvim_set_decoration_provider(ns_previewer, {
-        on_start = function()
-          -- defacto disable provider if status.preview_win does not exist anymore
-          return previewer_active
-        end,
-        on_win = function(_, winid, bufnr, _)
-          if winid ~= status.preview_win then
-            return false -- skip setting extmark for any window other than status.preview_win
-          end
-          local lnum, _ = unpack(vim.api.nvim_win_get_cursor(winid))
-          local line = vim.api.nvim_buf_get_lines(bufnr, lnum - 1, lnum, false)[1]
-          -- only set if winid and rows are matching
-          pcall(vim.api.nvim_buf_set_extmark, bufnr, ns_previewer, lnum - 1, 0, {
-            end_col = #line,
-            virt_text = { { line, "TelescopePreviewLine" } },
-            virt_text_pos = "overlay",
-            hl_mode = "combine",
-            ephemeral = true,
-            priority = 101, -- 1 higher than treesitter
-          })
-        end,
-      })
-      return state
-    end,
-    teardown = function(self)
-      if self.state then
-        -- reapply proper buffer-window options..
-        for opt, value in pairs(self.state.win_options) do
-          vim.api.nvim_win_set_option(self.state.winid, opt, value)
-        end
-        -- TODO precautious clearing of extmark though likely no effect due to ephemeral
-        -- clear extmarks for previewed buffers
-        for buf, _ in pairs(self.state.previewed_buffers) do
-          if vim.api.nvim_buf_is_valid(buf) then
-            vim.api.nvim_buf_clear_namespace(buf, ns_previewer, 0, -1)
-          end
-        end
-      end
-      previewer_active = false
-      -- setup previewer fully anew for `builtin.{resume, pickers}`
-      self.state = nil
-    end,
-    dyn_title = function(_, entry)
-      return Path:new(from_entry.path(entry, true)):normalize(cwd)
-    end,
-    preview_fn = function(self, entry, status)
-      if vim.api.nvim_buf_is_valid(entry.bufnr) then
-        vim.api.nvim_win_set_buf(status.preview_win, entry.bufnr)
-        self.state.bufnr = entry.bufnr
-        vim.api.nvim_win_set_option(status.preview_win, "winhl", "Normal:TelescopePreviewNormal")
-        vim.api.nvim_win_set_option(status.preview_win, "signcolumn", "no")
-        vim.api.nvim_win_set_option(status.preview_win, "foldlevel", 100)
-        vim.api.nvim_win_set_option(status.preview_win, "wrap", false)
-
-        if self.state.previewed_buffers[entry.bufnr] ~= true then
-          if entry.lnum then
-            local lnum, col = unpack(vim.api.nvim_win_get_cursor(status.preview_win))
-            entry.lnum = lnum
-            if not entry.col then
-              entry.col = col + 1
-            end
-          end
-          self.state.previewed_buffers[entry.bufnr] = true
-        end
-      end
-    end,
-    scroll_fn = scroll_fn,
   }
 end, {})
 

--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -305,7 +305,6 @@ previewers.help = buffer_previewer.help
 previewers.man = buffer_previewer.man
 previewers.autocommands = buffer_previewer.autocommands
 previewers.highlights = buffer_previewer.highlights
-previewers.buffers = buffer_previewer.buffers
 previewers.pickers = buffer_previewer.pickers
 
 --- A deprecated way of displaying content more easily. Was written at a time,

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -274,6 +274,9 @@ previewers.vimgrep = defaulter(function(opts)
       if p == nil or p == "" then
         return
       end
+      if entry.bufnr and (p == "[No Name]" or vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= "") then
+        return
+      end
 
       local lnum = entry.lnum or 0
 


### PR DESCRIPTION
This essentially reverts #1120 (my mortal enemy :laughing: ) because of a multitude of issues and unexpected behavior.

To elaborate:
- very tedious to apply highlights to the actual buffer without interfering with the actual buffer
- mru is unfixably broken because the previewer defacto uses the buffer
- Unexpected behavior with autocmds (see also https://github.com/nvim-telescope/telescope.nvim/issues/1345)
- Some other stuff I don't remember/can easily trace right now

Closes https://github.com/nvim-telescope/telescope.nvim/issues/1300