### PR TITLE
Added an opts parameter to be used when entry scores are tied

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -74,6 +74,20 @@ telescope.setup({opts})                                    *telescope.setup()*
         - "descending" (default)
         - "ascending"
 
+                                              *telescope.defaults.tiebreak*
+    tiebreak: ~
+        A function that determines how to break a tie when two entries have
+        the same score.
+        Having a function that always returns false would keep the entries in
+        the order they are found, so existing_entry before current_entry.
+        Vice versa always returning true would place the current_entry
+        before the existing_entry.
+
+        Signature: function(current_entry, existing_entry, prompt) -> boolean
+
+        Default: function that breaks the tie based on the length of the
+                 entry's ordinal
+
                                     *telescope.defaults.selection_strategy*
     selection_strategy: ~
         Determines how the cursor acts after each sort iteration.

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -154,6 +154,20 @@ append(
 )
 
 append(
+  "fzf_tiebreak",
+  function(current_entry, existing_entry)
+    return #current_entry < #existing_entry
+  end,
+  [[
+  fzf_tiebreak can be set to a function
+
+  Signature: function(current_entry.ordinal,existing_entry.ordinal) -> boolean
+
+  Default: function that breaks the tie based on entry length
+  ]]
+)
+
+append(
   "selection_strategy",
   "reset",
   [[
@@ -274,20 +288,6 @@ append(
   Boolean defining if borders are added to Telescope windows.
 
   Default: true]]
-)
-
-append(
-  "fzf_tiebreak",
-  function(current_entry, existing_entry)
-    return #current_entry < #existing_entry
-  end,
-  [[
-  fzf_tiebreak can be set to a function
-
-  Signature: function(entry2,entry1) -> boolean
-
-  Default: function that breaks the tie based on entry length
-  ]]
 )
 
 append(

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -276,11 +276,9 @@ append(
   Default: true]]
 )
 
-
-
 append(
   "fzf_tiebreak",
-  function( current_entry, existing_entry )
+  function(current_entry, existing_entry)
     return #current_entry < #existing_entry
   end,
   [[

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -159,13 +159,17 @@ append(
     return #current_entry.ordinal < #existing_entry.ordinal
   end,
   [[
-  tiebreak can be set to a function which decides how to break
-  a tie when 2 entries have the same score
+  A function that determines how to break a tie when two entries have
+  the same score.
+  Having a function that always returns false would keep the entries in
+  the order they are found, so existing_entry before current_entry.
+  Vice versa always returning true would place the current_entry
+  before the existing_entry.
 
-  Signature: function(current_entry,existing_entry, prompt) -> boolean
+  Signature: function(current_entry, existing_entry, prompt) -> boolean
 
-  Default: function that breaks the tie based on the length of the entry's ordinal
-  ]]
+  Default: function that breaks the tie based on the length of the
+           entry's ordinal]]
 )
 
 append(

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -154,16 +154,17 @@ append(
 )
 
 append(
-  "fzf_tiebreak",
-  function(current_entry, existing_entry)
-    return #current_entry < #existing_entry
+  "tiebreak",
+  function(current_entry, existing_entry, _)
+    return #current_entry.ordinal < #existing_entry.ordinal
   end,
   [[
-  fzf_tiebreak can be set to a function
+  tiebreak can be set to a function which decides how to break
+  a tie when 2 entries have the same score
 
-  Signature: function(current_entry.ordinal,existing_entry.ordinal) -> boolean
+  Signature: function(current_entry,existing_entry, prompt) -> boolean
 
-  Default: function that breaks the tie based on entry length
+  Default: function that breaks the tie based on the length of the entry's ordinal
   ]]
 )
 

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -276,6 +276,22 @@ append(
   Default: true]]
 )
 
+
+
+append(
+  "fzf_tiebreak",
+  function( current_entry, existing_entry )
+    return #current_entry < #existing_entry
+  end,
+  [[
+  fzf_tiebreak can be set to a function
+
+  Signature: function(entry2,entry1) -> boolean
+
+  Default: function that breaks the tie based on entry length
+  ]]
+)
+
 append(
   "path_display",
   {},

--- a/lua/telescope/entry_manager.lua
+++ b/lua/telescope/entry_manager.lua
@@ -1,5 +1,4 @@
 local log = require "telescope.log"
-local config = require "telescope.config"
 
 local LinkedList = require "telescope.algos.linked_list"
 

--- a/lua/telescope/entry_manager.lua
+++ b/lua/telescope/entry_manager.lua
@@ -130,6 +130,8 @@ function EntryManager:add_entry(picker, score, entry)
     return
   end
 
+  -- may need the prompt for tiebreak
+  local prompt = picker:_get_prompt()
   for index, container, node in self.linked_states:ipairs() do
     info.looped = info.looped + 1
 
@@ -137,7 +139,7 @@ function EntryManager:add_entry(picker, score, entry)
       return self:_insert_container_before(picker, index, node, new_container)
     end
 
-    if score < 1 and container[2] == score and picker.fzf_tiebreak(entry.ordinal, container[1].ordinal) then
+    if score < 1 and container[2] == score and picker.tiebreak(entry, container[1], prompt) then
       return self:_insert_container_before(picker, index, node, new_container)
     end
 

--- a/lua/telescope/entry_manager.lua
+++ b/lua/telescope/entry_manager.lua
@@ -137,7 +137,15 @@ function EntryManager:add_entry(picker, score, entry)
       return self:_insert_container_before(picker, index, node, new_container)
     end
 
-    if score < 1 and container[2] == score and #entry.ordinal < #container[1].ordinal then
+    -- this handles entries with the same score by using the length to break the tie
+    -- fzf allows a tiebreaker to be specified which can work in this way
+    -- length - the default which prefers shorter lines
+    -- begin - prefers line with the match closer to the beginnings
+    -- end - prefers lines with he match closer to the end
+    -- index - prefers lines that appeared earlier in the input stream
+    -- let's define the tiebreaker function
+
+    if score < 1 and container[2] == score and picker.fzf_tiebreak( #entry.ordinal < #container[1].ordinal ) then
       return self:_insert_container_before(picker, index, node, new_container)
     end
 

--- a/lua/telescope/entry_manager.lua
+++ b/lua/telescope/entry_manager.lua
@@ -1,4 +1,5 @@
 local log = require "telescope.log"
+local config = require "telescope.config"
 
 local LinkedList = require "telescope.algos.linked_list"
 
@@ -137,15 +138,7 @@ function EntryManager:add_entry(picker, score, entry)
       return self:_insert_container_before(picker, index, node, new_container)
     end
 
-    -- this handles entries with the same score by using the length to break the tie
-    -- fzf allows a tiebreaker to be specified which can work in this way
-    -- length - the default which prefers shorter lines
-    -- begin - prefers line with the match closer to the beginnings
-    -- end - prefers lines with he match closer to the end
-    -- index - prefers lines that appeared earlier in the input stream
-    -- let's define the tiebreaker function
-
-    if score < 1 and container[2] == score and picker.fzf_tiebreak( #entry.ordinal < #container[1].ordinal ) then
+    if score < 1 and container[2] == score and picker.fzf_tiebreak(entry.ordinal, container[1].ordinal) then
       return self:_insert_container_before(picker, index, node, new_container)
     end
 

--- a/lua/telescope/entry_manager.lua
+++ b/lua/telescope/entry_manager.lua
@@ -105,7 +105,7 @@ function EntryManager:_append_container(picker, new_container, should_update)
   end
 end
 
-function EntryManager:add_entry(picker, score, entry)
+function EntryManager:add_entry(picker, score, entry, prompt)
   score = score or 0
 
   local max_res = self.max_results
@@ -130,8 +130,6 @@ function EntryManager:add_entry(picker, score, entry)
     return
   end
 
-  -- may need the prompt for tiebreak
-  local prompt = picker:_get_prompt()
   for index, container, node in self.linked_states:ipairs() do
     info.looped = info.looped + 1
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -76,8 +76,6 @@ function Picker:new(opts)
     initial_mode = get_default(opts.initial_mode, config.values.initial_mode),
     debounce = get_default(tonumber(opts.debounce), nil),
 
-    fzf_tiebreak = get_default(opts.fzf_tiebrerak, config.values.fzf_tiebreak),
-
     default_text = opts.default_text,
     get_status_text = get_default(opts.get_status_text, config.values.get_status_text),
     _on_input_filter_cb = opts.on_input_filter_cb or function() end,
@@ -107,6 +105,7 @@ function Picker:new(opts)
 
     scroll_strategy = get_default(opts.scroll_strategy, config.values.scroll_strategy),
     sorting_strategy = get_default(opts.sorting_strategy, config.values.sorting_strategy),
+    fzf_tiebreak = get_default(opts.fzf_tiebreak, config.values.fzf_tiebreak),
     selection_strategy = get_default(opts.selection_strategy, config.values.selection_strategy),
 
     layout_strategy = layout_strategy,

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -76,6 +76,8 @@ function Picker:new(opts)
     initial_mode = get_default(opts.initial_mode, config.values.initial_mode),
     debounce = get_default(tonumber(opts.debounce), nil),
 
+    fzf_tiebreak = get_default(opts.fzf_tiebreak, config.values.fzf_tiebreak),
+
     default_text = opts.default_text,
     get_status_text = get_default(opts.get_status_text, config.values.get_status_text),
     _on_input_filter_cb = opts.on_input_filter_cb or function() end,

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1211,7 +1211,8 @@ function Picker:get_result_processor(find_id, prompt, status_updater)
   local count = 0
 
   local cb_add = function(score, entry)
-    self.manager:add_entry(self, score, entry)
+    -- may need the prompt for tiebreak
+    self.manager:add_entry(self, score, entry, prompt)
     status_updater { completed = false }
   end
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -76,7 +76,7 @@ function Picker:new(opts)
     initial_mode = get_default(opts.initial_mode, config.values.initial_mode),
     debounce = get_default(tonumber(opts.debounce), nil),
 
-    fzf_tiebreak = get_default(opts.fzf_tiebreak, config.values.fzf_tiebreak),
+    fzf_tiebreak = get_default(opts.fzf_tiebrerak, config.values.fzf_tiebreak),
 
     default_text = opts.default_text,
     get_status_text = get_default(opts.get_status_text, config.values.get_status_text),

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -105,7 +105,7 @@ function Picker:new(opts)
 
     scroll_strategy = get_default(opts.scroll_strategy, config.values.scroll_strategy),
     sorting_strategy = get_default(opts.sorting_strategy, config.values.sorting_strategy),
-    fzf_tiebreak = get_default(opts.fzf_tiebreak, config.values.fzf_tiebreak),
+    tiebreak = get_default(opts.tiebreak, config.values.tiebreak),
     selection_strategy = get_default(opts.selection_strategy, config.values.selection_strategy),
 
     layout_strategy = layout_strategy,


### PR DESCRIPTION
`opts.fzf_tiebreak()` can be set to a function which is passed the ordinal of the entry we're checking and the ordinal of the existing result when they have identical scores.

The default value sorts them based on the length of the ordinal, this is the default for fzf.

If you want to sort them in the order they appear in the file then you could use this:
```
opts.fzf_tiebreak = function( current_entry, existing_entry ) return false end
```

FZF allows a tiebreak to choose based on where the matched pattern is in the string. I need to check if we have access tot he search word or if we need to pass it as a 3rd parameter to this function.