### PR TITLE
breaking: bump nvim version requirement to 0.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
             manager: sudo apt-get
             packages: -y fd-find
           - os: ubuntu-20.04
-            url: https://github.com/neovim/neovim/releases/download/v0.5.0/nvim-linux64.tar.gz
+            url: https://github.com/neovim/neovim/releases/download/v0.5.1/nvim-linux64.tar.gz
             manager: sudo apt-get
             packages: -y fd-find
           - os: macos-10.15
@@ -23,7 +23,7 @@ jobs:
             manager: brew
             packages: fd
           - os: macos-10.15
-            url: https://github.com/neovim/neovim/releases/download/v0.5.0/nvim-macos.tar.gz
+            url: https://github.com/neovim/neovim/releases/download/v0.5.1/nvim-macos.tar.gz
             manager: brew
             packages: fd
     steps:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Telescope Wiki</sub>
 
 This section should guide you to run your first builtin pickers.
 
-[Neovim (v0.5)](https://github.com/neovim/neovim/releases/tag/v0.5.0) or newer
+[Neovim (v0.5.1)](https://github.com/neovim/neovim/releases/tag/v0.5.1) or newer
   is required for `telescope.nvim` to work.
 
 ### Suggested dependencies

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -26,8 +26,8 @@
 --- </code>
 ---@brief ]]
 
-if 1 ~= vim.fn.has "nvim-0.5" then
-  vim.api.nvim_err_writeln "This plugins requires neovim 0.5"
+if 1 ~= vim.fn.has "nvim-0.5.1" then
+  vim.api.nvim_err_writeln "This plugins requires neovim 0.5.1"
   vim.api.nvim_err_writeln "Please update your neovim."
   return
 end

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -1,4 +1,4 @@
-if !has('nvim-0.5')
+if !has('nvim-0.5.1')
   echoerr "Telescope.nvim requires at least nvim-0.5. Please update or uninstall"
   finish
 end


### PR DESCRIPTION
Neovim 0.5.1 is required for #1403 or it will cause a segfault.