### PR TITLE
feat: extend functionality of `entry_display.create`

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -666,9 +666,9 @@ end
 
 function make_entry.gen_from_picker(opts)
   local displayer = entry_display.create {
-    separator = " ",
+    separator = " │ ",
     items = {
-      { width = 30 },
+      { width = 0.5 },
       { remaining = true },
     },
   }
@@ -957,17 +957,17 @@ function make_entry.gen_from_lsp_diagnostics(opts)
     end
   end
 
-  local layout = {
+  local display_items = {
     { width = utils.if_nil(signs, 8, 10) },
     { remaining = true },
   }
-  local line_width = utils.get_default(opts.line_width, 45)
+  local line_width = utils.get_default(opts.line_width, 0.5)
   if not utils.is_path_hidden(opts) then
-    table.insert(layout, 2, { width = line_width })
+    table.insert(display_items, 2, { width = line_width })
   end
   local displayer = entry_display.create {
     separator = "▏",
-    items = layout,
+    items = display_items,
   }
 
   local make_display = function(entry)
@@ -1049,7 +1049,7 @@ function make_entry.gen_from_commands(_)
   local displayer = entry_display.create {
     separator = "▏",
     items = {
-      { width = 25 },
+      { width = 0.2 },
       { width = 4 },
       { width = 4 },
       { width = 11 },

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -290,7 +290,7 @@ function make_entry.gen_from_quickfix(opts)
     separator = "▏",
     items = {
       { width = 8 },
-      { width = 50 },
+      { width = 0.45 },
       { remaining = true },
     },
   }

--- a/lua/telescope/pickers/entry_display.lua
+++ b/lua/telescope/pickers/entry_display.lua
@@ -10,15 +10,15 @@ entry_display.create = function(configuration)
   for _, v in ipairs(configuration.items) do
     if v.width then
       local justify = v.right_justify
-      local s
+      local width
       table.insert(generator, function(item)
-        if s == nil then
+        if width == nil then
           local status = state.get_status(vim.api.nvim_get_current_buf())
-          s = {}
+          local s = {}
           s[1] = vim.api.nvim_win_get_width(status.results_win) - #status.picker.selection_caret
           s[2] = vim.api.nvim_win_get_height(status.results_win)
+          width = resolve.resolve_width(v.width)(nil, s[1], s[2])
         end
-        local width = resolve.resolve_width(v.width)(nil, s[1], s[2])
         if type(item) == "table" then
           return strings.align_str(entry_display.truncate(item[1], width), width, justify), item[2]
         else

--- a/lua/telescope/pickers/entry_display.lua
+++ b/lua/telescope/pickers/entry_display.lua
@@ -1,4 +1,6 @@
 local strings = require "plenary.strings"
+local state = require "telescope.state"
+local resolve = require "telescope.config.resolve"
 
 local entry_display = {}
 entry_display.truncate = strings.truncate
@@ -8,11 +10,19 @@ entry_display.create = function(configuration)
   for _, v in ipairs(configuration.items) do
     if v.width then
       local justify = v.right_justify
+      local s
       table.insert(generator, function(item)
+        if s == nil then
+          local status = state.get_status(vim.api.nvim_get_current_buf())
+          s = {}
+          s[1] = vim.api.nvim_win_get_width(status.results_win) - #status.picker.selection_caret
+          s[2] = vim.api.nvim_win_get_height(status.results_win)
+        end
+        local width = resolve.resolve_width(v.width)(nil, s[1], s[2])
         if type(item) == "table" then
-          return strings.align_str(entry_display.truncate(item[1], v.width), v.width, justify), item[2]
+          return strings.align_str(entry_display.truncate(item[1], width), width, justify), item[2]
         else
-          return strings.align_str(entry_display.truncate(item, v.width), v.width, justify)
+          return strings.align_str(entry_display.truncate(item, width), width, justify)
         end
       end)
     else


### PR DESCRIPTION
This PR extends `entry_display.create` to allow passing functions or fractional values to `width` option.
It also adjusts one of the widths in `make_entry.gen_from_quickfix`.

The widths in other `make_entry` functions can also be adjusted in the same way, but I am less familiar with them, so don't know what good choices would be for them.

This PR is aimed at reducing issues like #1380, where the hardcoded values for widths aren't optimal for some screen/picker sizes. That being said I'm not 100% sure if this resolves #1380. @wellcomez does this (or something along these lines) fix your issue?