### PR TITLE
Fix option handling for lsp_document_symbols

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1195,9 +1195,11 @@ builtin.quickfix({opts})                        *telescope.builtin.quickfix()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {ignore_filename} (boolean)  dont show filenames (default: true)
-        {trim_text}       (boolean)  trim results text (default: false)
-        {nr}              (number)   specify the quickfix list number
+        {show_line}   (boolean)  show results text (default: true)
+        {trim_text}   (boolean)  trim results text (default: false)
+        {fname_width} (number)   defines the width of the filename section
+                                 (default: 30)
+        {nr}          (number)   specify the quickfix list number
 
 
 builtin.quickfixhistory({opts})          *telescope.builtin.quickfixhistory()*
@@ -1219,8 +1221,10 @@ builtin.loclist({opts})                          *telescope.builtin.loclist()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {ignore_filename} (boolean)  dont show filenames (default: true)
-        {trim_text}       (boolean)  trim results text (default: false)
+        {show_line}   (boolean)  show results text (default: true)
+        {trim_text}   (boolean)  trim results text (default: false)
+        {fname_width} (number)   defines the width of the filename section
+                                 (default: 30)
 
 
 builtin.oldfiles({opts})                        *telescope.builtin.oldfiles()*
@@ -1419,8 +1423,10 @@ builtin.tagstack({opts})                        *telescope.builtin.tagstack()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {ignore_filename} (boolean)  dont show filenames (default: true)
-        {trim_text}       (boolean)  trim results text (default: false)
+        {show_line}   (boolean)  show results text (default: true)
+        {trim_text}   (boolean)  trim results text (default: false)
+        {fname_width} (number)   defines the width of the filename section
+                                 (default: 30)
 
 
 builtin.jumplist({opts})                        *telescope.builtin.jumplist()*
@@ -1431,8 +1437,10 @@ builtin.jumplist({opts})                        *telescope.builtin.jumplist()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {ignore_filename} (boolean)  dont show filenames (default: true)
-        {trim_text}       (boolean)  trim results text (default: false)
+        {show_line}   (boolean)  show results text (default: true)
+        {trim_text}   (boolean)  trim results text (default: false)
+        {fname_width} (number)   defines the width of the filename section
+                                 (default: 30)
 
 
 builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
@@ -1449,6 +1457,8 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
         {include_current_line} (boolean)  include current line (default:
                                           false)
         {trim_text}            (boolean)  trim results text (default: false)
+        {fname_width}          (number)   defines the width of the filename
+                                          section (default: 30)
 
 
 builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
@@ -1460,11 +1470,12 @@ builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}       (string)   how to goto definition if there is only
-                                     one, values: "tab", "split", "vsplit",
-                                     "never"
-        {ignore_filename} (boolean)  dont show filenames (default: true)
-        {trim_text}       (boolean)  trim results text (default: false)
+        {jump_type}   (string)   how to goto definition if there is only one,
+                                 values: "tab", "split", "vsplit", "never"
+        {show_line}   (boolean)  show results text (default: true)
+        {trim_text}   (boolean)  trim results text (default: false)
+        {fname_width} (number)   defines the width of the filename section
+                                 (default: 30)
 
 
 builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
@@ -1476,11 +1487,12 @@ builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}       (string)   how to goto definition if there is only
-                                     one, values: "tab", "split", "vsplit",
-                                     "never"
-        {ignore_filename} (boolean)  dont show filenames (default: true)
-        {trim_text}       (boolean)  trim results text (default: false)
+        {jump_type}   (string)   how to goto definition if there is only one,
+                                 values: "tab", "split", "vsplit", "never"
+        {show_line}   (boolean)  show results text (default: true)
+        {trim_text}   (boolean)  trim results text (default: false)
+        {fname_width} (number)   defines the width of the filename section
+                                 (default: 30)
 
 
 builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
@@ -1492,11 +1504,13 @@ builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}       (string)   how to goto implementation if there is
-                                     only one, values: "tab", "split",
-                                     "vsplit", "never"
-        {ignore_filename} (boolean)  dont show filenames (default: true)
-        {trim_text}       (boolean)  trim results text (default: false)
+        {jump_type}   (string)   how to goto implementation if there is only
+                                 one, values: "tab", "split", "vsplit",
+                                 "never"
+        {show_line}   (boolean)  show results text (default: true)
+        {trim_text}   (boolean)  trim results text (default: false)
+        {fname_width} (number)   defines the width of the filename section
+                                 (default: 30)
 
 
 builtin.lsp_document_symbols({opts}) *telescope.builtin.lsp_document_symbols()*

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1532,8 +1532,6 @@ builtin.lsp_workspace_symbols({opts}) *telescope.builtin.lsp_workspace_symbols()
     Options: ~
         {query}             (string)        for what to query the workspace
                                             (default: "")
-        {ignore_filename}   (boolean)       dont show filenames (default:
-                                            false)
         {show_line}         (boolean)       if true, shows the content of the
                                             line the tag is found on (default:
                                             false)
@@ -1554,8 +1552,6 @@ builtin.lsp_dynamic_workspace_symbols({opts}) *telescope.builtin.lsp_dynamic_wor
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {ignore_filename}   (boolean)       dont show filenames (default:
-                                            false)
         {show_line}         (boolean)       if true, shows the content of the
                                             line the symbol is found on
                                             (default: false)

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1510,8 +1510,6 @@ builtin.lsp_document_symbols({opts}) *telescope.builtin.lsp_document_symbols()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {ignore_filename}   (boolean)       dont show filenames (default:
-                                            true)
         {show_line}         (boolean)       if true, shows the content of the
                                             line the tag is found on (default:
                                             false)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -399,7 +399,6 @@ builtin.lsp_implementations = require_on_exported_call("telescope.builtin.lsp").
 --- - Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
 ---@param opts table: options to pass to the picker
----@field ignore_filename boolean: dont show filenames (default: true)
 ---@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
 ---@field ignore_symbols string|table: list of symbols to ignore

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -410,7 +410,6 @@ builtin.lsp_document_symbols = require_on_exported_call("telescope.builtin.lsp")
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
 ---@param opts table: options to pass to the picker
 ---@field query string: for what to query the workspace (default: "")
----@field ignore_filename boolean: dont show filenames (default: false)
 ---@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
 ---@field ignore_symbols string|table: list of symbols to ignore
@@ -421,7 +420,6 @@ builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.lsp"
 --- - Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
 ---@param opts table: options to pass to the picker
----@field ignore_filename boolean: dont show filenames (default: false)
 ---@field show_line boolean: if true, shows the content of the line the symbol is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
 ---@field ignore_symbols string|table: list of symbols to ignore

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -245,8 +245,9 @@ builtin.commands = require_on_exported_call("telescope.builtin.internal").comman
 
 --- Lists items in the quickfix list, jumps to location on `<cr>`
 ---@param opts table: options to pass to the picker
----@field ignore_filename boolean: dont show filenames (default: true)
+---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field nr number: specify the quickfix list number
 builtin.quickfix = require_on_exported_call("telescope.builtin.internal").quickfix
 
@@ -257,8 +258,9 @@ builtin.quickfixhistory = require_on_exported_call("telescope.builtin.internal")
 
 --- Lists items from the current window's location list, jumps to location on `<cr>`
 ---@param opts table: options to pass to the picker
----@field ignore_filename boolean: dont show filenames (default: true)
+---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field fname_width number: defines the width of the filename section (default: 30)
 builtin.loclist = require_on_exported_call("telescope.builtin.internal").loclist
 
 --- Lists previously open files, opens on `<cr>`
@@ -350,14 +352,16 @@ builtin.spell_suggest = require_on_exported_call("telescope.builtin.internal").s
 
 --- Lists the tag stack for the current window, jumps to tag on `<cr>`
 ---@param opts table: options to pass to the picker
----@field ignore_filename boolean: dont show filenames (default: true)
+---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field fname_width number: defines the width of the filename section (default: 30)
 builtin.tagstack = require_on_exported_call("telescope.builtin.internal").tagstack
 
 --- Lists items from Vim's jumplist, jumps to location on `<cr>`
 ---@param opts table: options to pass to the picker
----@field ignore_filename boolean: dont show filenames (default: true)
+---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field fname_width number: defines the width of the filename section (default: 30)
 builtin.jumplist = require_on_exported_call("telescope.builtin.internal").jumplist
 
 --
@@ -371,28 +375,32 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.internal").jumpli
 ---@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
 ---@field include_current_line boolean: include current line (default: false)
 ---@field trim_text boolean: trim results text (default: false)
+---@field fname_width number: defines the width of the filename section (default: 30)
 builtin.lsp_references = require_on_exported_call("telescope.builtin.lsp").references
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
----@field ignore_filename boolean: dont show filenames (default: true)
+---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field fname_width number: defines the width of the filename section (default: 30)
 builtin.lsp_definitions = require_on_exported_call("telescope.builtin.lsp").definitions
 
 --- Goto the definition of the type of the word under the cursor, if there's only one,
 --- otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
----@field ignore_filename boolean: dont show filenames (default: true)
+---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field fname_width number: defines the width of the filename section (default: 30)
 builtin.lsp_type_definitions = require("telescope.builtin.lsp").type_definitions
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto implementation if there is only one, values: "tab", "split", "vsplit", "never"
----@field ignore_filename boolean: dont show filenames (default: true)
+---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field fname_width number: defines the width of the filename section (default: 30)
 builtin.lsp_implementations = require_on_exported_call("telescope.builtin.lsp").implementations
 
 --- Lists LSP document symbols in the current buffer

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -144,7 +144,6 @@ lsp.document_symbols = function(opts)
       return
     end
 
-    opts.ignore_filename = opts.ignore_filename or true
     pickers.new(opts, {
       prompt_title = "LSP Document Symbols",
       finder = finders.new_table {

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -144,6 +144,7 @@ lsp.document_symbols = function(opts)
       return
     end
 
+    opts.path_display = { "hidden" }
     pickers.new(opts, {
       prompt_title = "LSP Document Symbols",
       finder = finders.new_table {


### PR DESCRIPTION
As discussed in https://github.com/nvim-telescope/telescope.nvim/issues/1409, the lsp_document_symbols picker wasn't handling its options properly. The `ignore_filename` option was always set to `true`, and the `show_line` option was effectively ignored. In addition, if `show_line` did work, it would result in the line and column number being displayed, rather than the actual source line (which is what other pickers do, except for the treesitter picker).

This commit fixes both issues. When `show_line` is enabled, the source line is displayed. Line and column numbers are not shown, mostly to keep the behaviour the same as other pickers. If this information should be shown (which didn't work before anyway), it should probably use a separate option.

This fixes https://github.com/nvim-telescope/telescope.nvim/issues/1409

