### PR TITLE
fix: deactivate binary ft detection for Win32

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -310,7 +310,7 @@ telescope.setup({opts})                                    *telescope.setup()*
                               Windows users get `file` from:
                               https://github.com/julian-r/file-windows
                               Set to false to attempt to preview any mime type.
-                              Default: true
+                              Default: true for all OS excl. Windows
           - filesize_limit:   The maximum file size in MB attempted to be previewed.
                               Set to false to attempt to preview any file size.
                               Default: 25

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -3,6 +3,7 @@ local deprecated = require "telescope.deprecated"
 local sorters = require "telescope.sorters"
 local if_nil = vim.F.if_nil
 local os_sep = require("plenary.path").path.sep
+local has_win = vim.fn.has "win32" == 1
 
 -- Keep the values around between reloads
 _TelescopeConfigurationValues = _TelescopeConfigurationValues or {}
@@ -401,7 +402,7 @@ append(
 append(
   "preview",
   {
-    check_mime_type = true,
+    check_mime_type = not has_win,
     filesize_limit = 25,
     timeout = 250,
     treesitter = true,
@@ -422,7 +423,7 @@ append(
                           Windows users get `file` from:
                           https://github.com/julian-r/file-windows
                           Set to false to attempt to preview any mime type.
-                          Default: true
+                          Default: true for all OS excl. Windows
       - filesize_limit:   The maximum file size in MB attempted to be previewed.
                           Set to false to attempt to preview any file size.
                           Default: 25


### PR DESCRIPTION
Closes #1404, #1263

Binary filetype detection with `file` should be opt-in for Windows users as they don't have it by default, and if they have it, it seems to be causing some issues.

