### PR TITLE
fix: Border window also need to be winblend due to window overlap in multigrid UI

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -291,6 +291,9 @@ function Picker:_create_window(bufnr, popup_opts, nowrap)
     a.nvim_win_set_option(win, "wrap", false)
   end
   local border_win = opts and opts.border and opts.border.win_id
+  if border_win then
+    a.nvim_win_set_option(border_win, "winblend", self.window.winblend)
+  end
   return win, opts, border_win
 end
 


### PR DESCRIPTION
In a GUI that follows the multigrid UI, `winblend` must be set for all overlapping float windows in order to make them transparent. 
Since the current telescope.nvim does not have `winblend` set for border windows, the winblend setting in the telescope is disabled in the multigrid GUI. Thus, there is a border window that is not set to be transparent behind each float window.

This PR also sets `winblend` for the border float window generated by telescope.nvim, which fixes this problem.