### PR TITLE
docs: generate docs for `hl_result_eol`

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -234,6 +234,13 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Default: function that shows current count / all
 
+                                         *telescope.defaults.hl_result_eol*
+    hl_result_eol: ~
+        Changes if the highlight for the selected item in the results
+        window is always the full width of the window
+
+        Default: true
+
                                  *telescope.defaults.dynamic_preview_title*
     dynamic_preview_title: ~
         Will change the title of the preview window dynamically, where it


### PR DESCRIPTION
Think the docgen didn't run for some reason on #1403.