### PR TITLE
feat: `exclude` option for `shorten` in `path_display`

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -207,6 +207,20 @@ telescope.setup({opts})                                    *telescope.setup()*
           Similarly, `path_display.shorten = 2` will give a path like:
             `al/be/ga/delta.txt`
 
+        You can also further customise the shortening behaviour by
+        setting `path_display.shorten = { len = num, exclude = list }`,
+        where `len` acts as above, and `exclude` is a list of positions
+        that are not shortened. Negative numbers in the list are considered
+        relative to the end of the path.
+          e.g. for a path like
+            `alpha/beta/gamma/delta.txt`
+          setting `path_display.shorten = { len = 1, exclude = {1, -1} }`
+          will give a path like:
+            `alpha/b/g/delta.txt`
+          setting `path_display.shorten = { len = 2, exclude = {2, -2} }`
+          will give a path like:
+            `al/beta/gamma/de`
+
         path_display can also be set to 'hidden' string to hide file names
 
         path_display can also be set to a function for custom formatting of

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -273,6 +273,20 @@ append(
     Similarly, `path_display.shorten = 2` will give a path like:
       `al/be/ga/delta.txt`
 
+  You can also further customise the shortening behaviour by
+  setting `path_display.shorten = { len = num, exclude = list }`,
+  where `len` acts as above, and `exclude` is a list of positions
+  that are not shortened. Negative numbers in the list are considered
+  relative to the end of the path.
+    e.g. for a path like
+      `alpha/beta/gamma/delta.txt`
+    setting `path_display.shorten = { len = 1, exclude = {1, -1} }`
+    will give a path like:
+      `alpha/b/g/delta.txt`
+    setting `path_display.shorten = { len = 2, exclude = {2, -2} }`
+    will give a path like:
+      `al/beta/gamma/de`
+
   path_display can also be set to 'hidden' string to hide file names
 
   path_display can also be set to a function for custom formatting of

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -363,7 +363,12 @@ utils.transform_path = function(opts, path)
       end
 
       if vim.tbl_contains(path_display, "shorten") or path_display["shorten"] ~= nil then
-        transformed_path = Path:new(transformed_path):shorten(path_display["shorten"])
+        if type(path_display["shorten"]) == "table" then
+          local shorten = path_display["shorten"]
+          transformed_path = Path:new(transformed_path):shorten(shorten.len, shorten.exclude)
+        else
+          transformed_path = Path:new(transformed_path):shorten(path_display["shorten"])
+        end
       end
       if vim.tbl_contains(path_display, "truncate") or path_display.truncate then
         if opts.__length == nil then


### PR DESCRIPTION
Requires nvim-lua/plenary.nvim#268

Users can specify which parts of the path to exclude from shortening.
Still defaults to shortening everything except the tail of the path.
Will probably mostly be used as `exclude = {1,-1}`, which shortens everything except the first folder, and the tail.

Resolves #880