### PR TITLE
Fix typo in telescope.txt

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1487,8 +1487,8 @@ builtin.lsp_workspace_diagnostics({opts}) *builtin.lsp_workspace_diagnostics()*
 
 Themes are ways to combine several elements of styling together.
 
-They are helpful for managing the several differnt UI aspects for telescope and
-provide a simple interface for users to get a particular "style" of picker.
+They are helpful for managing the several different UI aspects for telescope
+and provide a simple interface for users to get a particular "style" of picker.
 
 themes.get_dropdown()                                  *themes.get_dropdown()*
     Dropdown style theme.

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -8,7 +8,7 @@
 ---@brief [[
 --- Themes are ways to combine several elements of styling together.
 ---
---- They are helpful for managing the several differnt UI aspects for telescope and provide
+--- They are helpful for managing the several different UI aspects for telescope and provide
 --- a simple interface for users to get a particular "style" of picker.
 ---@brief ]]
 


### PR DESCRIPTION
There seems to be a typo in the themes section of the help text.