### PR TITLE
feat: results scrolling actions

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2198,6 +2198,15 @@ action_set.scroll_previewer({prompt_bufnr}, {direction}) *action_set.scroll_prev
         {direction}    (number)  The direction of the scrolling
 
 
+action_set.scroll_results({prompt_bufnr}, {direction}) *action_set.scroll_results()*
+    Scrolls the results up or down
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+        {direction}    (number)  The direction of the scrolling
+
+
 
 ================================================================================
                                                        *telescope.actions.utils*

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2190,7 +2190,9 @@ action_set.edit({prompt_bufnr}, {command})                 *action_set.edit()*
 
 
 action_set.scroll_previewer({prompt_bufnr}, {direction}) *action_set.scroll_previewer()*
-    Scrolls the previewer up or down
+    Scrolls the previewer up or down. Defaults to a half page scroll, but can
+    be overridden using the `scroll_speed` option in `layout_config`. See
+    |telescope.layout| for more details.
 
 
     Parameters: ~
@@ -2199,7 +2201,9 @@ action_set.scroll_previewer({prompt_bufnr}, {direction}) *action_set.scroll_prev
 
 
 action_set.scroll_results({prompt_bufnr}, {direction}) *action_set.scroll_results()*
-    Scrolls the results up or down
+    Scrolls the results up or down. Defaults to a half page scroll, but can be
+    overridden using the `scroll_speed` option in `layout_config`. See
+    |telescope.layout| for more details.
 
 
     Parameters: ~

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -152,6 +152,14 @@ function actions.preview_scrolling_down(prompt_bufnr)
   action_set.scroll_previewer(prompt_bufnr, 1)
 end
 
+function actions.results_scrolling_up(prompt_bufnr)
+  action_set.scroll_results(prompt_bufnr, -1)
+end
+
+function actions.results_scrolling_down(prompt_bufnr)
+  action_set.scroll_results(prompt_bufnr, 1)
+end
+
 function actions.center(_)
   vim.cmd ":normal! zz"
 end

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -143,7 +143,9 @@ action_set.edit = function(prompt_bufnr, command)
   end
 end
 
---- Scrolls the previewer up or down
+--- Scrolls the previewer up or down.
+--- Defaults to a half page scroll, but can be overridden using the `scroll_speed`
+--- option in `layout_config`. See |telescope.layout| for more details.
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param direction number: The direction of the scrolling
 --      Valid directions include: "1", "-1"
@@ -162,7 +164,9 @@ action_set.scroll_previewer = function(prompt_bufnr, direction)
   previewer:scroll_fn(math.floor(speed * direction))
 end
 
---- Scrolls the results up or down
+--- Scrolls the results up or down.
+--- Defaults to a half page scroll, but can be overridden using the `scroll_speed`
+--- option in `layout_config`. See |telescope.layout| for more details.
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param direction number: The direction of the scrolling
 --      Valid directions include: "1", "-1"

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -171,7 +171,13 @@ action_set.scroll_results = function(prompt_bufnr, direction)
   local default_speed = vim.api.nvim_win_get_height(status.results_win) / 2
   local speed = status.picker.layout_config.scroll_speed or default_speed
 
-  action_set.shift_selection(prompt_bufnr, math.floor(speed * direction))
+  local input = direction > 0 and [[]] or [[]]
+
+  vim.api.nvim_win_call(status.results_win, function()
+    vim.cmd([[normal! ]] .. math.floor(speed) .. input)
+  end)
+
+  action_set.shift_selection(prompt_bufnr, math.floor(speed) * direction)
 end
 
 -- ==================================================

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -162,6 +162,18 @@ action_set.scroll_previewer = function(prompt_bufnr, direction)
   previewer:scroll_fn(math.floor(speed * direction))
 end
 
+--- Scrolls the results up or down
+---@param prompt_bufnr number: The prompt bufnr
+---@param direction number: The direction of the scrolling
+--      Valid directions include: "1", "-1"
+action_set.scroll_results = function(prompt_bufnr, direction)
+  local status = state.get_status(prompt_bufnr)
+  local default_speed = vim.api.nvim_win_get_height(status.results_win) / 2
+  local speed = status.picker.layout_config.scroll_speed or default_speed
+
+  action_set.shift_selection(prompt_bufnr, math.floor(speed * direction))
+end
+
 -- ==================================================
 -- Transforms modules and sets the corect metatables.
 -- ==================================================

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -25,6 +25,9 @@ mappings.default_mappings = config.values.default_mappings
       ["<C-u>"] = actions.preview_scrolling_up,
       ["<C-d>"] = actions.preview_scrolling_down,
 
+      ["<PageUp>"] = actions.results_scrolling_up,
+      ["<PageDown>"] = actions.results_scrolling_down,
+
       ["<Tab>"] = actions.toggle_selection + actions.move_selection_worse,
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
@@ -59,6 +62,10 @@ mappings.default_mappings = config.values.default_mappings
 
       ["<C-u>"] = actions.preview_scrolling_up,
       ["<C-d>"] = actions.preview_scrolling_down,
+
+      ["<PageUp>"] = actions.results_scrolling_up,
+      ["<PageDown>"] = actions.results_scrolling_down,
+
       ["?"] = actions.which_key,
     },
   }


### PR DESCRIPTION
WIP

Doesn't look quite right to me when scrolling upwards as the selection looks like it is alternating between the top and the middle of the results window. Any suggestions to fix this would be appreciated 🙂

Fixes #1430
Fixes #1326