### PR TITLE
Fix actions.git_checkout_current_buffer calling wrong method

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -590,7 +590,7 @@ end
 
 actions.git_checkout_current_buffer = function(prompt_bufnr)
   local cwd = action_state.get_current_picker(prompt_bufnr).cwd
-  local selection = actions.get_selected_entry()
+  local selection = action_state.get_selected_entry()
   if selection == nil then
     print "[telescope] Nothing currently selected"
     return


### PR DESCRIPTION
`actions.git_checkout_current_buffer` should call `action_state.get_selected_entry` instead of `actions.get_selected_entry`.