### PR TITLE
docs: add a changelog entry for updated version requirements

### DIFF
--- a/doc/telescope_changelog.txt
+++ b/doc/telescope_changelog.txt
@@ -127,8 +127,8 @@ PR: https://github.com/nvim-telescope/telescope.nvim/pull/1406
 Telescope requires Neovim release 0.5.1 or a recent nightly
 
 Due to making use of newly implemented extmark features, Telescope now
-requires users to be on Neovim 0.5.1 (the most recent stable version) or on a
-recent version of Neovim nightly (at most 1 week old).
+requires users to be on Neovim 0.5.1 (the most recent stable version) or on
+the LATEST version of Neovim nightly.
 
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/doc/telescope_changelog.txt
+++ b/doc/telescope_changelog.txt
@@ -119,5 +119,16 @@ Guide to switch over to plenary.path
         before: require("telescope.path").read_file_async(filepath, callback)
         now:    require("plenary.path"):new(filepath):read(callback)
 
+                                                    *telescope.changelog-1406*
+
+Date: November 4, 2021
+PR: https://github.com/nvim-telescope/telescope.nvim/pull/1406
+
+Telescope requires Neovim release 0.5.1 or a recent nightly
+
+Due to making use of newly implemented extmark features, Telescope now
+requires users to be on Neovim 0.5.1 (the most recent stable version) or on a
+recent version of Neovim nightly (at most 1 week old).
+
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -1,5 +1,5 @@
 if !has('nvim-0.5.1')
-  echoerr "Telescope.nvim requires at least nvim-0.5.1. Please update or uninstall"
+  echoerr "Telescope.nvim requires at least nvim-0.5.1. See `:h telescope.changelog-1406`"
   finish
 end
 


### PR DESCRIPTION
Adds a changelog explaining the version bump and points users to it when they don't have the right version.

I can't think of a way of checking if someone has an old version of nightly to give them the error on launch as well.
If anyone can think of one, then that would be helpful.

Fixes #1443