### PR TITLE
feat(draft): experimental parsing colors from rg

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2367,7 +2367,7 @@ work and make it really easy create new previewers.
 
 Furthermore, there are a collection of previewers already defined which can be
 used for every picker, as long as the entries of the picker provide the
-necessary fields. The more important ones are
+necessary fields. The more important once are
   - `previewers.cat`
   - `previewers.vimgrep`
   - `previewers.qflist`

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -94,7 +94,7 @@ files.live_grep = function(opts)
     end
 
     return flatten { vimgrep_arguments, additional_args, "--", prompt, search_list }
-  end, opts.entry_maker or make_entry.gen_from_vimgrep(
+  end, opts.entry_maker or make_entry.gen_from_vimgrep_json(
     opts
   ), opts.max_results, opts.cwd)
 
@@ -120,7 +120,7 @@ files.grep_string = function(opts)
   local word = opts.search or vim.fn.expand "<cword>"
   local search = opts.use_regex and word or escape_chars(word)
   local word_match = opts.word_match
-  opts.entry_maker = opts.entry_maker or make_entry.gen_from_vimgrep(opts)
+  opts.entry_maker = opts.entry_maker or make_entry.gen_from_vimgrep_json(opts)
 
   local additional_args = {}
   if opts.additional_args ~= nil and type(opts.additional_args) == "function" then

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -502,7 +502,8 @@ append(
 
 append(
   "vimgrep_arguments",
-  { "rg", "--color=never", "--no-heading", "--with-filename", "--line-number", "--column", "--smart-case" },
+  -- { "rg", "--color=never", "--no-heading", "--with-filename", "--line-number", "--column", "--smart-case" },
+  { "rg", "--json", "--no-heading", "--smart-case" },
   [[
     Defines the command that will be used for `live_grep` and `grep_string`
     pickers.

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -230,7 +230,9 @@ function Picker:highlight_one_row(results_bufnr, prompt, display, row)
     return
   end
 
-  local highlights = self.sorter:highlighter(prompt, display)
+  -- local highlights = self.sorter:highlighter(prompt, display)
+  local entry = self.manager:get_entry(self:get_index(row))
+  local highlights = entry.highlight
 
   if highlights then
     for _, hl in ipairs(highlights) do


### PR DESCRIPTION
experimental branch to parse colors from `rg` directly.

It sort of works:

- offset computation for highlighting requires mores sophistication (why +4, proper devicons handling)
- combining with `fzy` highlighting required for eg `grep_string`
- integrating highlight from `entry_maker` into `pickers.highlight_one_row`

Not sure if I'll finish this this but seems quite a bit easier than #1281 -- very happy for someone who desires this feature to take over.

Tagging #1240 