### PR TITLE
feat(lap_references): exclude current line

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1342,10 +1342,12 @@ builtin.lsp_type_definitions({opts})          *builtin.lsp_type_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}       (string)   how to goto definition if there is only
-                                     one, values: "tab", "split", "vsplit",
-                                     "never"
-        {ignore_filename} (boolean)  dont show filenames (default: true)
+        {jump_type}           (string)   how to goto definition if there is
+                                         only one, values: "tab", "split",
+                                         "vsplit", "never"
+        {ignore_filename}     (boolean)  dont show filenames (default: true)
+        {include_declaration} (boolean)  include symbol declaration in the lsp
+                                         references (default: true)
 
 
 builtin.lsp_implementations({opts})            *builtin.lsp_implementations()*

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -365,6 +365,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.lsp").defi
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
 ---@field ignore_filename boolean: dont show filenames (default: true)
+---@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
 builtin.lsp_type_definitions = require("telescope.builtin.lsp").type_definitions
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope


### PR DESCRIPTION
### Purpose

~I don't know why this isn't default, but I added an option `include_declaration` in case someone, for some reason want to have the current line from which the lsp-references was called be the first item in the picker.~

Recent changes will just ignore current line from the result by default. Which is sufficient. `include_declaration` will still be an option though default to true.