### PR TITLE
fix typo in previewers documentation

### DIFF
--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -9,7 +9,7 @@
 ---
 --- Furthermore, there are a collection of previewers already defined which
 --- can be used for every picker, as long as the entries of the picker provide
---- the necessary fields. The more important once are
+--- the necessary fields. The more important ones are
 ---   - `previewers.cat`
 ---   - `previewers.vimgrep`
 ---   - `previewers.qflist`


### PR DESCRIPTION
While trying out generating documentation on my local machine I have noticed PR #1433 has modified the documentation file but not the source file the content is being generated from.