### PR TITLE
fix: git stash entry formatting

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -971,6 +971,8 @@ builtin.git_stash({opts})                                *builtin.git_stash()*
         {cwd}          (string)   specify the path of the repo
         {use_git_root} (boolean)  if we should use git root as cwd or the cwd
                                   (important for submodule) (default: true)
+        {show_branch}  (boolean)  if we should display the branch name for git
+                                  stash entries (default: true)
 
 
 builtin.builtin({opts})                                    *builtin.builtin()*

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -72,7 +72,8 @@ git.commits = function(opts)
 end
 
 git.stash = function(opts)
-  opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_stash())
+  opts.show_branch = vim.F.if_nil(opts.show_branch, true)
+  opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_stash(opts))
 
   pickers.new(opts, {
     prompt_title = "Git Stash",

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -204,6 +204,7 @@ builtin.git_status = require_on_exported_call("telescope.builtin.git").status
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
+---@field show_branch boolean: if we should display the branch name for git stash entries (default: true)
 builtin.git_stash = require_on_exported_call("telescope.builtin.git").stash
 
 --

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -230,15 +230,39 @@ do
 end
 
 function make_entry.gen_from_git_stash()
+  local displayer = entry_display.create {
+    separator = " ",
+    items = {
+      { width = 10 },
+      { width = 15 },
+      { remaining = true },
+    },
+  }
+
+  local make_display = function(entry)
+    return displayer {
+      { entry.value, "TelescopeResultsLineNr" },
+      { entry.branch_name, "TelescopeResultsIdentifier" },
+      entry.commit_info,
+    }
+  end
+
   return function(entry)
     if entry == "" then
       return nil
     end
+
     local splitted = utils.max_split(entry, ": ", 2)
+    local stash_idx = splitted[1]
+    local _, branch_name = string.match(splitted[2], "^([WIP on|On]+) (.+)")
+    local commit_info = splitted[3]
+
     return {
-      value = splitted[1],
-      ordinal = splitted[3],
-      display = splitted[3],
+      value = stash_idx,
+      ordinal = stash_idx,
+      branch_name = branch_name,
+      commit_info = commit_info,
+      display = make_display,
     }
   end
 end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -259,7 +259,7 @@ function make_entry.gen_from_git_stash()
 
     return {
       value = stash_idx,
-      ordinal = stash_idx,
+      ordinal = commit_info,
       branch_name = branch_name,
       commit_info = commit_info,
       display = make_display,

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -234,7 +234,7 @@ function make_entry.gen_from_git_stash()
     if entry == "" then
       return nil
     end
-    local splitted = vim.split(entry, ":")
+    local splitted = utils.max_split(entry, ": ", 2)
     return {
       value = splitted[1],
       ordinal = splitted[3],

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -229,12 +229,12 @@ do
   end
 end
 
-function make_entry.gen_from_git_stash()
+function make_entry.gen_from_git_stash(opts)
   local displayer = entry_display.create {
     separator = " ",
     items = {
       { width = 10 },
-      { width = 15 },
+      opts.show_branch and { width = 15 } or "",
       { remaining = true },
     },
   }
@@ -242,7 +242,7 @@ function make_entry.gen_from_git_stash()
   local make_display = function(entry)
     return displayer {
       { entry.value, "TelescopeResultsLineNr" },
-      { entry.branch_name, "TelescopeResultsIdentifier" },
+      opts.show_branch and { entry.branch_name, "TelescopeResultsIdentifier" } or "",
       entry.commit_info,
     }
   end


### PR DESCRIPTION
Currently entry items in git stash aren't displayed properly. Here's an example:

_Before_

![screenshot_20211114_181906](https://user-images.githubusercontent.com/12140044/141693480-04d58114-5a28-484c-a9f0-08ae06b2c59f.png)

Note that:

1. There is a space before the entry item text
2. The whole entry is not displayed (because this commit message contains a colon)

Here is the equivalent output from `git stash --no-pager list`

![screenshot_20211114_182316](https://user-images.githubusercontent.com/12140044/141693567-69d3182a-b1b6-466b-a3fb-6b75537642f6.png)

This commit fixes this issue by changing the split delimiter and including everything after the second '`:`' in the displayed entry text.

_After_

![screenshot_20211114_181921](https://user-images.githubusercontent.com/12140044/141693622-03d88e3b-8385-44b3-98a1-014170a7f035.png)

As an aside, I do think it would be useful to also show the branch name, as you get with the command line output. Happy to add this into the PR if you agree.