### PR TITLE
breaking: remove file browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ Built-in functions. Ready to be bound to any key you like.
 | `builtin.git_files`                 | Fuzzy search through the output of `git ls-files` command, respects .gitignore, optionally ignores untracked files                |
 | `builtin.grep_string`               | Searches for the string under your cursor in your current working directory                                                       |
 | `builtin.live_grep`                 | Search for a string in your current working directory and get results live as you type (respecting .gitignore)                    |
-| `builtin.file_browser`              | Lists files and folders in your current working directory, open files, navigate your filesystem, and create new files and folders |
 
 ### Vim Pickers
 

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -1,4 +1,3 @@
-local actions = require "telescope.actions"
 local action_state = require "telescope.actions.state"
 local action_set = require "telescope.actions.set"
 local finders = require "telescope.finders"
@@ -10,9 +9,7 @@ local utils = require "telescope.utils"
 local conf = require("telescope.config").values
 local log = require "telescope.log"
 
-local scan = require "plenary.scandir"
 local Path = require "plenary.path"
-local os_sep = Path.path.sep
 
 local flatten = vim.tbl_flatten
 local filter = vim.tbl_filter
@@ -261,142 +258,6 @@ local function prepare_match(entry, kind)
   end
 
   return entries
-end
-
-files.file_browser = function(opts)
-  vim.api.nvim_err_writeln [[Deprecation notice: file browser will be carved out into a more featureful extension, see:
-https://github.com/nvim-telescope/telescope-file-browser.nvim]]
-
-  opts = opts or {}
-
-  local is_dir = function(value)
-    return value:sub(-1, -1) == os_sep
-  end
-
-  opts.depth = opts.depth or 1
-  opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
-  opts.new_finder = opts.new_finder
-    or function(path)
-      opts.cwd = path
-      local data = {}
-
-      scan.scan_dir(path, {
-        hidden = opts.hidden or false,
-        add_dirs = true,
-        depth = opts.depth,
-        on_insert = function(entry, typ)
-          table.insert(data, typ == "directory" and (entry .. os_sep) or entry)
-        end,
-      })
-      table.insert(data, 1, ".." .. os_sep)
-
-      local maker = function()
-        local mt = {}
-        mt.cwd = opts.cwd
-        mt.display = function(entry)
-          local hl_group
-          local display = utils.transform_path(opts, entry.value)
-          if is_dir(entry.value) then
-            display = display .. os_sep
-            if not opts.disable_devicons then
-              display = (opts.dir_icon or "") .. " " .. display
-              hl_group = "Default"
-            end
-          else
-            display, hl_group = utils.transform_devicons(entry.value, display, opts.disable_devicons)
-          end
-
-          if hl_group then
-            return display, { { { 1, 3 }, hl_group } }
-          else
-            return display
-          end
-        end
-
-        mt.__index = function(t, k)
-          local raw = rawget(mt, k)
-          if raw then
-            return raw
-          end
-
-          if k == "path" then
-            local retpath = Path:new({ t.cwd, t.value }):absolute()
-            if not vim.loop.fs_access(retpath, "R", nil) then
-              retpath = t.value
-            end
-            if is_dir(t.value) then
-              retpath = retpath .. os_sep
-            end
-            return retpath
-          end
-
-          return rawget(t, rawget({ value = 1 }, k))
-        end
-
-        return function(line)
-          local tbl = { line }
-          tbl.ordinal = Path:new(line):make_relative(opts.cwd)
-          return setmetatable(tbl, mt)
-        end
-      end
-
-      return finders.new_table { results = data, entry_maker = maker() }
-    end
-
-  pickers.new(opts, {
-    prompt_title = "File Browser",
-    finder = opts.new_finder(opts.cwd),
-    previewer = conf.file_previewer(opts),
-    sorter = conf.file_sorter(opts),
-    attach_mappings = function(prompt_bufnr, map)
-      action_set.select:replace_if(function()
-        return is_dir(action_state.get_selected_entry().path)
-      end, function()
-        local new_cwd = vim.fn.expand(action_state.get_selected_entry().path:sub(1, -2))
-        local current_picker = action_state.get_current_picker(prompt_bufnr)
-        current_picker.cwd = new_cwd
-        current_picker:refresh(opts.new_finder(new_cwd), { reset_prompt = true })
-      end)
-
-      local create_new_file = function()
-        local current_picker = action_state.get_current_picker(prompt_bufnr)
-        local file = action_state.get_current_line()
-        if file == "" then
-          print(
-            "To create a new file or directory(add "
-              .. os_sep
-              .. " at the end of file) "
-              .. "write the desired new into the prompt and press <C-e>. "
-              .. "It works for not existing nested input as well."
-              .. "Example: this"
-              .. os_sep
-              .. "is"
-              .. os_sep
-              .. "a"
-              .. os_sep
-              .. "new_file.lua"
-          )
-          return
-        end
-
-        local fpath = current_picker.cwd .. os_sep .. file
-        if not is_dir(fpath) then
-          actions.close(prompt_bufnr)
-          Path:new(fpath):touch { parents = true }
-          vim.cmd(string.format(":e %s", fpath))
-        else
-          Path:new(fpath:sub(1, -2)):mkdir { parents = true }
-          local new_cwd = vim.fn.expand(fpath)
-          current_picker.cwd = new_cwd
-          current_picker:refresh(opts.new_finder(new_cwd), { reset_prompt = true })
-        end
-      end
-
-      map("i", "<C-e>", create_new_file)
-      map("n", "<C-e>", create_new_file)
-      return true
-    end,
-  }):find()
 end
 
 --  TODO: finish docs for opts.show_line

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -86,22 +86,6 @@ builtin.find_files = require_on_exported_call("telescope.builtin.files").find_fi
 --- This is an alias for the `find_files` picker
 builtin.fd = builtin.find_files
 
---- Lists files and folders in your current working directory, open files, navigate your filesystem, and create new
---- files and folders
---- - Default keymaps:
----   - `<cr>`: opens the currently selected file, or navigates to the currently selected directory
----   - `<C-e>`: creates new file in current directory, creates new directory if the name contains a trailing '/'
----     - Note: you can create files nested into several directories with `<C-e>`, i.e. `lua/telescope/init.lua` would
----       create the file `init.lua` inside of `lua/telescope` and will create the necessary folders (similar to how
----       `mkdir -p` would work) if they do not already exist
----@deprecated Please move to https://github.com/nvim-telescope/telescope-file-browser.nvim
----@param opts table: options to pass to the picker
----@field cwd string: root dir to browse from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
----@field depth number: file tree depth to display (default: 1)
----@field dir_icon string: change the icon for a directory. (default: )
----@field hidden boolean: determines whether to show hidden files or not (default: false)
-builtin.file_browser = require_on_exported_call("telescope.builtin.files").file_browser
-
 --- Lists function names, variables, and other symbols from treesitter queries
 --- - Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by kind of ts node you want to see (i.e. `:var:`)


### PR DESCRIPTION
The `builtin.file_browser` will be spun off into its own extension: https://github.com/nvim-telescope/telescope-file-browser.nvim (not yet accessible to public) The extension will incorporate a lot of demanded features and essentially constitutes #1257.

Hence, it makes sense to cut out the picker from `telescope-core`. Note that the PR should not yet be merged but is a prep for the initial release of the extension, which will happen throughout the upcoming week.

(Cutting out is also necessary, such that `:Telescope file_browser` adequately forwards to the extension.)