### PR TITLE
chore: reformat files.lua after stylua update

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -94,9 +94,7 @@ files.live_grep = function(opts)
     end
 
     return flatten { vimgrep_arguments, additional_args, "--", prompt, search_list }
-  end, opts.entry_maker or make_entry.gen_from_vimgrep(
-    opts
-  ), opts.max_results, opts.cwd)
+  end, opts.entry_maker or make_entry.gen_from_vimgrep(opts), opts.max_results, opts.cwd)
 
   pickers.new(opts, {
     prompt_title = "Live Grep",


### PR DESCRIPTION
Unclear to me at first sight as to why stylua job on `master` [fails](https://github.com/nvim-telescope/telescope.nvim/runs/4215016043?check_suite_focus=true) with a 4 months old change :sweat_smile: 

Testing how CI reacts if we were to make that change.

E: That's fine, though my local stylua keeps formatting it the same way.. probably stylua has change somehow? I'll update the binary once I'm home.