### PR TITLE
feat: layout actions (including `toggle_preview`)

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -143,6 +143,20 @@ telescope.setup({opts})                                    *telescope.setup()*
         }
 
 
+                                     *telescope.defaults.cycle_layout_list*
+    cycle_layout_list: ~
+        Determines the layouts to cycle through when using `actions.cycle_layout_next`
+        and `actions.cycle_layout_prev`.
+        Should be a list of "layout setups".
+        Each "layout setup" can take one of two forms:
+        1. string <br>
+            This is interpreted as the name of a `layout_strategy`
+        2. table <br>
+            A table with possible keys `layout_strategy`, `layout_config` and `previewer`
+
+        Default: TODO
+
+
                                               *telescope.defaults.winblend*
     winblend: ~
         Configure winblend for telescope floating windows. See |winblend| for
@@ -2235,6 +2249,65 @@ action_set.scroll_results({prompt_bufnr}, {direction}) *action_set.scroll_result
     Parameters: ~
         {prompt_bufnr} (number)  The prompt bufnr
         {direction}    (number)  The direction of the scrolling
+
+
+
+================================================================================
+                                                      *telescope.actions.layout*
+
+The layout actions are actions to be used to change the layout of a picker.
+
+action_layout.toggle_preview({prompt_bufnr})  *action_layout.toggle_preview()*
+    Toggle preview window.
+    - Note: preview window can be toggled even if preview is set to false.
+
+    This action is not mapped by default.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+action_layout.toggle_prompt_position({prompt_bufnr}) *action_layout.toggle_prompt_position()*
+    Toggles the `prompt_position` option between "top" and "bottom". Checks if
+    `prompt_position` is an option for the current layout.
+
+    This action is not mapped by default.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+action_layout.toggle_mirror({prompt_bufnr})    *action_layout.toggle_mirror()*
+    Toggles the `mirror` option between `true` and `false`. Checks if `mirror`
+    is an option for the current layout.
+
+    This action is not mapped by default.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+action_layout.cycle_layout_next({prompt_bufnr}) *action_layout.cycle_layout_next()*
+    Cycles to the next layout in `cycle_layout_list`.
+
+    This action is not mapped by default.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+action_layout.cycle_layout_prev({prompt_bufnr}) *action_layout.cycle_layout_prev()*
+    Cycles to the previous layout in `cycle_layout_list`.
+
+    This action is not mapped by default.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
 
 
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -154,7 +154,7 @@ telescope.setup({opts})                                    *telescope.setup()*
         2. table <br>
             A table with possible keys `layout_strategy`, `layout_config` and `previewer`
 
-        Default: TODO
+        Default: { "horizontal", "vertical" }
 
 
                                               *telescope.defaults.winblend*
@@ -1920,15 +1920,6 @@ actions.toggle_all({prompt_bufnr})                      *actions.toggle_all()*
     Toggle multi selection for all entries.
     - Note: toggled entries may include results not visible in the results
       popup.
-
-
-    Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
-
-actions.toggle_preview({prompt_bufnr})              *actions.toggle_preview()*
-    Toggle preview window.
-    - Note: preview window can be toggled even if preview is set to false.
 
 
     Parameters: ~

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -395,6 +395,9 @@ telescope.setup({opts})                                    *telescope.setup()*
                               Default: true
           - msg_bg_fillchar:  Character to fill background of unpreviewable buffers with
                               Default: "╱"
+          - hide_on_startup:  Hide previewer when picker starts. Previewer can be toggled
+                              with actions.toggle_preview.
+                              Default: false
 
 
                                      *telescope.defaults.vimgrep_arguments*
@@ -1903,6 +1906,15 @@ actions.toggle_all({prompt_bufnr})                      *actions.toggle_all()*
     Toggle multi selection for all entries.
     - Note: toggled entries may include results not visible in the results
       popup.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.toggle_preview({prompt_bufnr})              *actions.toggle_preview()*
+    Toggle preview window.
+    - Note: preview window can be toggled even if preview is set to false.
 
 
     Parameters: ~

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -144,13 +144,6 @@ function actions.toggle_all(prompt_bufnr)
   end)
 end
 
---- Toggle preview window.
---- - Note: preview window can be toggled even if preview is set to false.
----@param prompt_bufnr number: The prompt bufnr
-function actions.toggle_preview(prompt_bufnr)
-  action_state.get_current_picker(prompt_bufnr):toggle_preview()
-end
-
 function actions.preview_scrolling_up(prompt_bufnr)
   action_set.scroll_previewer(prompt_bufnr, -1)
 end

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -144,6 +144,13 @@ function actions.toggle_all(prompt_bufnr)
   end)
 end
 
+--- Toggle preview window.
+--- - Note: preview window can be toggled even if preview is set to false.
+---@param prompt_bufnr number: The prompt bufnr
+function actions.toggle_preview(prompt_bufnr)
+  action_state.get_current_picker(prompt_bufnr):toggle_preview()
+end
+
 function actions.preview_scrolling_up(prompt_bufnr)
   action_set.scroll_previewer(prompt_bufnr, -1)
 end
@@ -240,23 +247,14 @@ end
 actions._close = function(prompt_bufnr, keepinsert)
   action_state.get_current_history():reset()
   local picker = action_state.get_current_picker(prompt_bufnr)
-  local prompt_win = state.get_status(prompt_bufnr).prompt_win
   local original_win_id = picker.original_win_id
-
-  if picker.previewer then
-    for _, v in ipairs(picker.all_previewers) do
-      v:teardown()
-    end
-  end
 
   actions.close_pum(prompt_bufnr)
   if not keepinsert then
     vim.cmd [[stopinsert]]
   end
 
-  vim.api.nvim_win_close(prompt_win, true)
-
-  pcall(vim.cmd, string.format([[silent bdelete! %s]], prompt_bufnr))
+  require("telescope.pickers").on_close_prompt(prompt_bufnr)
   pcall(a.nvim_set_current_win, original_win_id)
 end
 

--- a/lua/telescope/actions/layout.lua
+++ b/lua/telescope/actions/layout.lua
@@ -1,0 +1,140 @@
+---@tag telescope.actions.layout
+
+---@brief [[
+--- The layout actions are actions to be used to change the layout of a picker.
+---@brief ]]
+
+local action_state = require "telescope.actions.state"
+local state = require "telescope.state"
+local layout_strats = require "telescope.pickers.layout_strategies"
+
+local action_layout = {}
+
+--- Toggle preview window.
+--- - Note: preview window can be toggled even if preview is set to false.
+---
+--- This action is not mapped by default.
+---@param prompt_bufnr number: The prompt bufnr
+action_layout.toggle_preview = function(prompt_bufnr)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+  local status = state.get_status(picker.prompt_bufnr)
+
+  if picker.previewer and status.preview_win then
+    picker.hidden_previewer = picker.previewer
+    picker.previewer = nil
+  elseif picker.hidden_previewer and not status.preview_win then
+    picker.previewer = picker.hidden_previewer
+    picker.hidden_previewer = nil
+  else
+    return
+  end
+  picker:full_layout_update()
+end
+
+-- TODO IMPLEMENT (mentored project available, contact @l-kershaw)
+action_layout.toggle_padding = function(prompt_bufnr)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+  -- if padding ~= 0
+  --    1. Save `height` and `width` of picker
+  --    2. Set both to `{padding = 0}`
+  -- else
+  --    1. Lookup previous `height` and `width` of picker
+  --    2. Set both to previous values
+  picker:full_layout_update()
+end
+
+--- Toggles the `prompt_position` option between "top" and "bottom".
+--- Checks if `prompt_position` is an option for the current layout.
+---
+--- This action is not mapped by default.
+---@param prompt_bufnr number: The prompt bufnr
+action_layout.toggle_prompt_position = function(prompt_bufnr)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+  picker.layout_config = picker.layout_config or {}
+  picker.layout_config[picker.layout_strategy] = picker.layout_config[picker.layout_strategy] or {}
+  -- flex layout is weird and needs handling separately
+  if picker.layout_strategy == "flex" then
+    picker.layout_config.flex.horizontal = picker.layout_config.flex.horizontal or {}
+    picker.layout_config.flex.vertical = picker.layout_config.flex.vertical or {}
+    local old_pos = picker.layout_config.flex[picker.__flex_strategy].prompt_position
+    local new_pos = old_pos == "top" and "bottom" or "top"
+    picker.layout_config[picker.__flex_strategy].prompt_position = new_pos
+    picker.layout_config.flex[picker.__flex_strategy].prompt_position = new_pos
+    picker:full_layout_update()
+  elseif layout_strats._configurations[picker.layout_strategy].prompt_position then
+    if picker.layout_config.prompt_position == "top" then
+      picker.layout_config.prompt_position = "bottom"
+      picker.layout_config[picker.layout_strategy].prompt_position = "bottom"
+    else
+      picker.layout_config.prompt_position = "top"
+      picker.layout_config[picker.layout_strategy].prompt_position = "top"
+    end
+    picker:full_layout_update()
+  end
+end
+
+--- Toggles the `mirror` option between `true` and `false`.
+--- Checks if `mirror` is an option for the current layout.
+---
+--- This action is not mapped by default.
+---@param prompt_bufnr number: The prompt bufnr
+action_layout.toggle_mirror = function(prompt_bufnr)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+  -- flex layout is weird and needs handling separately
+  if picker.layout_strategy == "flex" then
+    picker.layout_config.flex.horizontal = picker.layout_config.flex.horizontal or {}
+    picker.layout_config.flex.vertical = picker.layout_config.flex.vertical or {}
+    local new_mirror = not picker.layout_config.flex[picker.__flex_strategy].mirror
+    picker.layout_config[picker.__flex_strategy].mirror = new_mirror
+    picker.layout_config.flex[picker.__flex_strategy].mirror = new_mirror
+    picker:full_layout_update()
+  elseif layout_strats._configurations[picker.layout_strategy].mirror then
+    picker.layout_config = picker.layout_config or {}
+    local new_mirror = not picker.layout_config.mirror
+    picker.layout_config.mirror = new_mirror
+    picker.layout_config[picker.layout_strategy] = picker.layout_config[picker.layout_strategy] or {}
+    picker.layout_config[picker.layout_strategy].mirror = new_mirror
+    picker:full_layout_update()
+  end
+end
+
+-- Helper function for `cycle_layout_next` and `cycle_layout_prev`.
+local get_cycle_layout = function(dir)
+  return function(prompt_bufnr)
+    local picker = action_state.get_current_picker(prompt_bufnr)
+    if picker.__layout_index then
+      picker.__layout_index = ((picker.__layout_index + dir - 1) % #picker.__cycle_layout_list) + 1
+    else
+      picker.__layout_index = 1
+    end
+    local new_layout = picker.__cycle_layout_list[picker.__layout_index]
+    if type(new_layout) == "string" then
+      picker.layout_strategy = new_layout
+      picker.layout_config = nil
+      picker.previewer = picker.all_previewers and picker.all_previewers[1] or nil
+    elseif type(new_layout) == "table" then
+      picker.layout_strategy = new_layout.layout_strategy
+      picker.layout_config = new_layout.layout_config
+      picker.previewer = (new_layout.previewer == nil and picker.all_previewers[picker.current_previewer_index])
+        or new_layout.previewer
+    else
+      error("Not a valid layout setup: " .. vim.inspect(new_layout) .. "\nShould be a string or a table")
+    end
+
+    picker:full_layout_update()
+  end
+end
+
+--- Cycles to the next layout in `cycle_layout_list`.
+---
+--- This action is not mapped by default.
+---@param prompt_bufnr number: The prompt bufnr
+action_layout.cycle_layout_next = get_cycle_layout(1)
+
+--- Cycles to the previous layout in `cycle_layout_list`.
+---
+--- This action is not mapped by default.
+---@param prompt_bufnr number: The prompt bufnr
+action_layout.cycle_layout_prev = get_cycle_layout(-1)
+
+return action_layout

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -190,6 +190,23 @@ append(
 append("layout_config", layout_config_defaults, layout_config_description)
 
 append(
+  "cycle_layout_list",
+  { "horizontal", "vertical", { layout_strategy = "horizontal", previewer = false } },
+  [[
+  Determines the layouts to cycle through when using `actions.cycle_layout_next`
+  and `actions.cycle_layout_prev`.
+  Should be a list of "layout setups".
+  Each "layout setup" can take one of two forms:
+  1. string <br>
+      This is interpreted as the name of a `layout_strategy`
+  2. table <br>
+      A table with possible keys `layout_strategy`, `layout_config` and `previewer`
+
+  Default: TODO
+  ]]
+)
+
+append(
   "winblend",
   0,
   [[

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -191,7 +191,7 @@ append("layout_config", layout_config_defaults, layout_config_description)
 
 append(
   "cycle_layout_list",
-  { "horizontal", "vertical", { layout_strategy = "horizontal", previewer = false } },
+  { "horizontal", "vertical" },
   [[
   Determines the layouts to cycle through when using `actions.cycle_layout_next`
   and `actions.cycle_layout_prev`.
@@ -202,7 +202,7 @@ append(
   2. table <br>
       A table with possible keys `layout_strategy`, `layout_config` and `previewer`
 
-  Default: TODO
+  Default: { "horizontal", "vertical" }
   ]]
 )
 

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -431,6 +431,7 @@ append(
     timeout = 250,
     treesitter = true,
     msg_bg_fillchar = "╱",
+    hide_on_startup = false,
   },
   [[
     This field handles the global configuration for previewers.
@@ -511,6 +512,9 @@ append(
                           Default: true
       - msg_bg_fillchar:  Character to fill background of unpreviewable buffers with
                           Default: "╱"
+      - hide_on_startup:  Hide previewer when picker starts. Previewer can be toggled
+                          with actions.toggle_preview.
+                          Default: false
     ]]
 )
 

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -707,8 +707,10 @@ layout_strategies.flex = make_documented_layout(
     local flip_lines = if_nil(layout_config.flip_lines, 20)
 
     if max_columns < flip_columns and max_lines > flip_lines then
+      self.__flex_strategy = "vertical"
       return layout_strategies.vertical(self, max_columns, max_lines, layout_config.vertical)
     else
+      self.__flex_strategy = "horizontal"
       return layout_strategies.horizontal(self, max_columns, max_lines, layout_config.horizontal)
     end
   end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -438,6 +438,25 @@ function utils.buf_delete(bufnr)
   end
 end
 
+function utils.win_delete(name, win_id, force, bdelete)
+  if win_id == nil or not vim.api.nvim_win_is_valid(win_id) then
+    return
+  end
+
+  local bufnr = vim.api.nvim_win_get_buf(win_id)
+  if bdelete then
+    utils.buf_delete(bufnr)
+  end
+
+  if not vim.api.nvim_win_is_valid(win_id) then
+    return
+  end
+
+  if not pcall(vim.api.nvim_win_close, win_id, force) then
+    log.trace("Unable to close window: ", name, "/", win_id)
+  end
+end
+
 function utils.max_split(s, pattern, maxsplit)
   pattern = pattern or " "
   maxsplit = maxsplit or -1

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -18,6 +18,7 @@ docs.test = function()
     "./lua/telescope/actions/init.lua",
     "./lua/telescope/actions/state.lua",
     "./lua/telescope/actions/set.lua",
+    "./lua/telescope/actions/layout.lua",
     "./lua/telescope/actions/utils.lua",
     "./lua/telescope/actions/generate.lua",
     "./lua/telescope/previewers/init.lua",


### PR DESCRIPTION
This is a combination of #1305 and #1383.
Big thanks to @johnybx for the implementation of the preview toggle.

Demo:
`toggle_preview`
![toggle_preview](https://user-images.githubusercontent.com/35707277/141857913-ceb697c7-1633-43d1-90a8-652c41ba2539.gif)

`toggle_prompt_position`
![toggle_prompt_position2](https://user-images.githubusercontent.com/35707277/141857923-2769736f-5366-482f-b0e4-72cdaa464175.gif)

`toggle_mirror`
![toggle_mirror2](https://user-images.githubusercontent.com/35707277/141857959-ea84fb96-00de-4f6c-8758-cac37162d32c.gif)

`cycle_layout_next`/`cycle_layout_prev`
![cycle_layout](https://user-images.githubusercontent.com/35707277/141857986-23b5ce26-c63a-4b7b-ac0a-1af1e85ab0ce.gif)