### PR TITLE
feat: allow results in async_oneshot_finder

### DIFF
--- a/lua/telescope/finders/async_oneshot_finder.lua
+++ b/lua/telescope/finders/async_oneshot_finder.lua
@@ -13,8 +13,8 @@ return function(opts)
   local cwd = opts.cwd
   local fn_command = assert(opts.fn_command, "Must pass `fn_command`")
 
-  local results = {}
-  local num_results = 0
+  local results = vim.F.if_nil(opts.results, {})
+  local num_results = #results
 
   local job_started = false
   local job_completed = false


### PR DESCRIPTION
The use case for this in `telescope-file-browser` is prepending the current directory in the folder browser when using `fd`, since `fd` of course blocks a lot less than scan dir in large repos.

The canonical shell equivalent of that would be `echo "." && `fd -t d` (see also https://github.com/sharkdp/fd/issues/364) but I don't think plenary Jobs supports that.

I guess it's a bit of an edge case and I honestly couldn't think of other good uses. At the same time it should be pretty harmless because `finders` yells if `results` are passed, so you'd have to user the lower level api anyways.
