### PR TITLE
fix: use `string.format` on `builtin.resume` error message

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -98,7 +98,7 @@ internal.resume = function(opts)
   end
   local picker = cached_pickers[opts.cache_index]
   if picker == nil then
-    print("Index too large as there are only %s pickers cached", #cached_pickers)
+    print(string.format("Index too large as there are only %s pickers cached", #cached_pickers))
     return
   end
   -- reset layout strategy and get_window_options if default as only one is valid


### PR DESCRIPTION
Little fix for error message on `builtin.resume` when trying to resume a picker past the cache size