### PR TITLE
fix: enable unmapping default attach_mappings

### DIFF
--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -178,8 +178,11 @@ mappings.apply_keymap = function(prompt_bufnr, attach_mappings, buffer_keymap)
     mode = string.lower(mode)
     local key_bind_internal = a.nvim_replace_termcodes(key_bind, true, true, true)
     applied_mappings[mode][key_bind_internal] = true
-
-    telescope_map(prompt_bufnr, mode, key_bind, key_func, opts)
+    if key_func == false then
+      pcall(vim.api.nvim_buf_del_keymap, prompt_bufnr, mode, key_bind_internal)
+    else
+      telescope_map(prompt_bufnr, mode, key_bind, key_func, opts)
+    end
   end
 
   if attach_mappings then


### PR DESCRIPTION
I think this fixes https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/5#issuecomment-973917663

Pasting example:

```lua
require "telescope".setup {
  pickers = {
    git_branches = {
      mappings = {
        i = {
          ["<C-a>"] = false, -- should unmap create branch, does not
          ["<C-a>"] = function() print("test") end, -- successfully overrides
        },
      },
    },
  },
}
```

This could probably be more elegantly implemented, but between default mappings, picker mappings & attach mappings, attach mappings on picker call it's quite convoluted.

`map(mode, keybind, false)` will always be passed somewhere by the user and therefore should definitively disallow any mapping to that key.