### PR TITLE
docs: fix layout_config width description

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -120,8 +120,7 @@ local layout_config_description = string.format(
     Allows setting defaults for all strategies as top level options and
     for overriding for specific options.
     For example, the default values below set the default width to 80%% of
-    the screen width for all strategies except 'center', which has width
-    of 50%% of the screen width.
+    the screen width for all strategies except 'bottom_pane'.
 
     Default: %s
 ]],


### PR DESCRIPTION
Doc for `layout_config` currently:
```
...
For example, the default values below set the default width to 80% of
the screen width for all strategies except 'center', which has width
of 50% of the screen width.

Default: {
  bottom_pane = {
    height = 25,
    prompt_position = "top"
  },
  center = {
    height = 0.9,
    preview_cutoff = 40,
    prompt_position = "top",
    width = 0.8
  },
  cursor = {
    height = 0.9,
    preview_cutoff = 40,
    width = 0.8
  },
  horizontal = {
    height = 0.9,
    preview_cutoff = 120,
    prompt_position = "bottom",
    width = 0.8
  },
  vertical = {
    height = 0.9,
    preview_cutoff = 40,
    prompt_position = "bottom",
    width = 0.8
  }
}
```
`width` for 'center' is set as 80% just like the others unless I'm wildly confused.