### PR TITLE
fix: check for Windows drive letter when parsing vimgrep

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -115,7 +115,7 @@ do
     local start, _, filename, lnum, col, text = string.find(t.value, [[([^:]+):(%d+):(%d+):(.*)]])
 
     -- Handle Windows drive letter (e.g. "C:") at the beginning (if present)
-    if Path.path_sep == "\\" and start == 3 then
+    if Path.path.sep == "\\" and start == 3 then
       filename = string.sub(t.value, 1, 3) .. filename
     end
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -112,7 +112,12 @@ do
 
   -- Gets called only once to parse everything out for the vimgrep, after that looks up directly.
   local parse = function(t)
-    local _, _, filename, lnum, col, text = string.find(t.value, [[([^:]+):(%d+):(%d+):(.*)]])
+    local start, _, filename, lnum, col, text = string.find(t.value, [[([^:]+):(%d+):(%d+):(.*)]])
+
+    -- Handle Windows drive letter (e.g. "C:") at the beginning (if present)
+    if Path.path_sep == "\\" and start == 3 then
+      filename = string.sub(t.value, 1, 3) .. filename
+    end
 
     local ok
     ok, lnum = pcall(tonumber, lnum)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -110,14 +110,29 @@ do
     ordinal = 1,
   }
 
+  local find = (function()
+    if Path.path.sep == "\\" then
+      return function(t)
+        local start, _, filename, lnum, col, text = string.find(t.value, [[([^:]+):(%d+):(%d+):(.*)]])
+
+        -- Handle Windows drive letter (e.g. "C:") at the beginning (if present)
+        if start == 3 then
+          filename = string.sub(t.value, 1, 3) .. filename
+        end
+
+        return filename, lnum, col, text
+      end
+    else
+      return function(t)
+        local _, _, filename, lnum, col, text = string.find(t.value, [[([^:]+):(%d+):(%d+):(.*)]])
+        return filename, lnum, col, text
+      end
+    end
+  end)()
+
   -- Gets called only once to parse everything out for the vimgrep, after that looks up directly.
   local parse = function(t)
-    local start, _, filename, lnum, col, text = string.find(t.value, [[([^:]+):(%d+):(%d+):(.*)]])
-
-    -- Handle Windows drive letter (e.g. "C:") at the beginning (if present)
-    if Path.path.sep == "\\" and start == 3 then
-      filename = string.sub(t.value, 1, 3) .. filename
-    end
+    local filename, lnum, col, text = find(t.value)
 
     local ok
     ok, lnum = pcall(tonumber, lnum)


### PR DESCRIPTION
Check if Windows drive letter (e.g. "C:") is present when parsing vimgrep

Fixes #1396

@younger-1 does this work for you?