### PR TITLE
fix(highlight): Use TS built-in is_enabled function

### DIFF
--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -96,25 +96,23 @@ end
 
 local treesitter_attach = function(bufnr, ft)
   local lang = ts_parsers.ft_to_lang(ft)
-  if ts_parsers.has_parser(lang) then
-    local config = ts_configs.get_module "highlight"
-    if vim.tbl_contains(config.disable, lang) then
+  if not ts_configs.is_enabled("highlight", lang, bufnr) then
       return false
-    end
-    for k, v in pairs(config.custom_captures) do
-      vim.treesitter.highlighter.hl_map[k] = v
-    end
-    vim.treesitter.highlighter.new(ts_parsers.get_parser(bufnr, lang))
-    local is_table = type(config.additional_vim_regex_highlighting) == "table"
-    if
-      config.additional_vim_regex_highlighting
-      and (not is_table or vim.tbl_contains(config.additional_vim_regex_highlighting, lang))
-    then
-      vim.api.nvim_buf_set_option(bufnr, "syntax", ft)
-    end
-    return true
   end
-  return false
+
+  local config = ts_configs.get_module "highlight"
+  for k, v in pairs(config.custom_captures) do
+    vim.treesitter.highlighter.hl_map[k] = v
+  end
+  vim.treesitter.highlighter.new(ts_parsers.get_parser(bufnr, lang))
+  local is_table = type(config.additional_vim_regex_highlighting) == "table"
+  if
+    config.additional_vim_regex_highlighting
+    and (not is_table or vim.tbl_contains(config.additional_vim_regex_highlighting, lang))
+  then
+    vim.api.nvim_buf_set_option(bufnr, "syntax", ft)
+  end
+  return true
 end
 
 -- Attach ts highlighter

--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -97,7 +97,7 @@ end
 local treesitter_attach = function(bufnr, ft)
   local lang = ts_parsers.ft_to_lang(ft)
   if not ts_configs.is_enabled("highlight", lang, bufnr) then
-      return false
+    return false
   end
 
   local config = ts_configs.get_module "highlight"


### PR DESCRIPTION
The function just replicated the logic from is_enabled and assumed the
`disable` setting is always a table. This is no longer the case (https://github.com/nvim-treesitter/nvim-treesitter/pull/2009), it can now also be a function.

Do I understand this correctly that the only reason telescope does not use `ts_configs.attach_module` and writes its own `treesitter_attach` is that `attach_module` does not return a boolean indicating success?