### PR TITLE
fix: keep previewer `winid` state updated on layout changes

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -557,6 +557,9 @@ function Picker:recalculate_layout()
       self.preview_win = preview_win
       self.preview_border_win = preview_border_win
       self.preview_border = preview_opts and preview_opts.border
+      if self.previewer and self.previewer.state and self.previewer.state.winid then
+        self.previewer.state.winid = preview_win
+      end
 
       -- Move prompt and results after preview created
       vim.defer_fn(function()


### PR DESCRIPTION
Fixes issue pointed out by Conni [here](https://github.com/nvim-telescope/telescope.nvim/pull/1480#issue-1060554567)

Before:
![preview_winid_pre](https://user-images.githubusercontent.com/35707277/144105807-69f61291-822f-4dc3-b04a-1757584caf32.gif)

After:
![preview_winid_post](https://user-images.githubusercontent.com/35707277/144105853-c917a7d2-6b80-4d60-b840-6f85dbfdc3bd.gif)

