### PR TITLE
fix: dont change highlights when using current_buffer_fuzzy_find

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -487,10 +487,11 @@ files.current_buffer_fuzzy_find = function(opts)
   if ts_ok then
     filetype = ts_parsers.ft_to_lang(filetype)
   end
+  local _, ts_configs = pcall(require, "nvim-treesitter.configs")
 
   local parser_ok, parser = pcall(vim.treesitter.get_parser, bufnr, filetype)
   local query_ok, query = pcall(vim.treesitter.get_query, filetype, "highlights")
-  if parser_ok and query_ok then
+  if ts_configs.is_enabled("highlight", filetype, bufnr) and parser_ok and query_ok then
     local root = parser:parse()[1]:root()
 
     local highlighter = vim.treesitter.highlighter.new(parser)


### PR DESCRIPTION
fix #1504

this happens if parsers are installed but highlight is set to false.
So parsing the buffer with treesitter will automatically apply them to
the buffer but because treesitter highlighting is disabled it will
change the buffer. Its stupid and i dont know why you want parser
installed but highlighting disabled but whatever.

We just dont calculate highlights for people who have highlight set
to false