### PR TITLE
fix: Remove symbol_msg substitution

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -382,7 +382,7 @@ function make_entry.gen_from_lsp_symbols(opts)
 
   return function(entry)
     local filename = entry.filename or vim.api.nvim_buf_get_name(entry.bufnr)
-    local symbol_msg = entry.text:gsub(".* | ", "")
+    local symbol_msg = entry.text
     local symbol_type, symbol_name = symbol_msg:match "%[(.+)%]%s+(.*)"
 
     local ordinal = ""


### PR DESCRIPTION
Because Elixir source code can contain `|`, the removed substitution sometimes broke `lsp_document_symbols()`.

Example:

```
E5108: Error executing lua ...packer/start/telescope.nvim/lua/telescope/make_entry.lua:392: attempt to concatenate local 'symbol_name' (a nil value)
stack traceback:
        ...packer/start/telescope.nvim/lua/telescope/make_entry.lua:392: in function 'entry_maker'
        ...scope.nvim/lua/telescope/finders/async_static_finder.lua:17: in function 'new_table'
        ...acker/start/telescope.nvim/lua/telescope/builtin/lsp.lua:137: in function 'v'
        ...acker/start/telescope.nvim/lua/telescope/builtin/lsp.lua:500: in function 'v'
        ...cker/start/telescope.nvim/lua/telescope/builtin/init.lua:496: in function <...cker/start/telescope.nvim/lua/telescope/builtin/init.lua:467>
        ...ck/packer/start/telescope.nvim/lua/telescope/command.lua:179: in function 'run_command'
        ...ck/packer/start/telescope.nvim/lua/telescope/command.lua:241: in function 'load_command'
        [string ":lua"]:1: in main chunk
```

It is not clear what exactly the removed `gsub` is supposed to do. Not having it doesn't appear to break anything ...

Closes #874