### PR TITLE
chore: add `--strip-cwd-prefix` to `fd`

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -166,7 +166,7 @@ files.find_files = function(opts)
 
   if not find_command then
     if 1 == vim.fn.executable "fd" then
-      find_command = { "fd", "--type", "f" }
+      find_command = { "fd", "--type", "f", "--strip-cwd-prefix" }
       if hidden then
         table.insert(find_command, "--hidden")
       end
@@ -183,7 +183,7 @@ files.find_files = function(opts)
         end
       end
     elseif 1 == vim.fn.executable "fdfind" then
-      find_command = { "fdfind", "--type", "f" }
+      find_command = { "fdfind", "--type", "f", "--strip-cwd-prefix" }
       if hidden then
         table.insert(find_command, "--hidden")
       end


### PR DESCRIPTION
I don't know when exactly this prefix (`./`) started to appear (maybe after `fd v0.8.3`) but I think this only adds noise to the results. So this PR adds `--strip-cwd-prefix` flag to remove the prefix.

Before:
![image](https://user-images.githubusercontent.com/24727447/144382731-818c53f9-7a33-46fd-892c-b4410583a7fc.png)

After:
![image](https://user-images.githubusercontent.com/24727447/144382820-e4d3415d-5f40-4662-9660-4ad889212a94.png)

---

PS: I might need guidance on updating the test :)
