### PR TITLE
feat: chain buitlin commands

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -81,7 +81,15 @@ internal.builtin = function(opts)
     previewer = previewers.builtin.new(opts),
     sorter = conf.generic_sorter(opts),
     attach_mappings = function(_)
-      actions.select_default:replace(actions.run_builtin)
+      actions.select_default:replace(function(prompt_bufnr)
+        local selection = action_state.get_selected_entry()
+        if not selection then
+          print "[telescope] Nothing currently selected"
+          return
+        end
+        opts.next_picker = selection.text
+        actions.run_builtin(prompt_bufnr, opts)
+      end)
       return true
     end,
   }):find()


### PR DESCRIPTION
### Description

Allows chaining/invoking builtin commands by extending `action.run_builtin`

Fixes: #564, #930

Partially fixes: #618, #620, #1357

#### Example

- Select directory and then invoke `live_grep` or `find_files` in that directory, see #1385

#### Other useful examples


* `fuzzy_filter_results`: works by chaining `grep_string` and assuming you have `fzf` as a sorter

https://user-images.githubusercontent.com/59826753/144626240-2b3a8894-ba54-4ee3-a44a-ee9873e61dab.mp4


* `dynamic_filetype`: works by modifying the vimgrep_args passed to `ripgrep` using the filetype under the cursor to either include or exclude it

https://user-images.githubusercontent.com/59826753/144626499-3bdfb102-0b86-4ad5-a1b5-ce60eee2a3a8.mp4

