### PR TITLE
chore: deprecate get_default

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1059,22 +1059,22 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 actions.which_key = function(prompt_bufnr, opts)
   opts = opts or {}
-  opts.max_height = utils.get_default(opts.max_height, 0.4)
-  opts.only_show_current_mode = utils.get_default(opts.only_show_current_mode, true)
-  opts.mode_width = utils.get_default(opts.mode_width, 1)
-  opts.keybind_width = utils.get_default(opts.keybind_width, 7)
-  opts.name_width = utils.get_default(opts.name_width, 30)
-  opts.line_padding = utils.get_default(opts.line_padding, 1)
-  opts.separator = utils.get_default(opts.separator, " -> ")
-  opts.close_with_action = utils.get_default(opts.close_with_action, true)
-  opts.normal_hl = utils.get_default(opts.normal_hl, "TelescopePrompt")
-  opts.border_hl = utils.get_default(opts.border_hl, "TelescopePromptBorder")
-  opts.winblend = utils.get_default(opts.winblend, config.values.winblend)
-  opts.column_padding = utils.get_default(opts.column_padding, "  ")
+  opts.max_height = vim.F.if_nil(opts.max_height, 0.4)
+  opts.only_show_current_mode = vim.F.if_nil(opts.only_show_current_mode, true)
+  opts.mode_width = vim.F.if_nil(opts.mode_width, 1)
+  opts.keybind_width = vim.F.if_nil(opts.keybind_width, 7)
+  opts.name_width = vim.F.if_nil(opts.name_width, 30)
+  opts.line_padding = vim.F.if_nil(opts.line_padding, 1)
+  opts.separator = vim.F.if_nil(opts.separator, " -> ")
+  opts.close_with_action = vim.F.if_nil(opts.close_with_action, true)
+  opts.normal_hl = vim.F.if_nil(opts.normal_hl, "TelescopePrompt")
+  opts.border_hl = vim.F.if_nil(opts.border_hl, "TelescopePromptBorder")
+  opts.winblend = vim.F.if_nil(opts.winblend, config.values.winblend)
+  opts.column_padding = vim.F.if_nil(opts.column_padding, "  ")
 
   -- Assigning into 'opts.column_indent' would override a number with a string and
   -- cause issues with subsequent calls, keep a local copy of the string instead
-  local column_indent = table.concat(utils.repeated_table(utils.get_default(opts.column_indent, 4), " "))
+  local column_indent = table.concat(utils.repeated_table(vim.F.if_nil(opts.column_indent, 4), " "))
 
   -- close on repeated keypress
   local km_bufs = (function()
@@ -1111,9 +1111,9 @@ actions.which_key = function(prompt_bufnr, opts)
 
   local make_display = function(mapping)
     return displayer {
-      { mapping.mode, utils.get_default(opts.mode_hl, "TelescopeResultsConstant") },
-      { mapping.keybind, utils.get_default(opts.keybind_hl, "TelescopeResultsVariable") },
-      { mapping.name, utils.get_default(opts.name_hl, "TelescopeResultsFunction") },
+      { mapping.mode, vim.F.if_nil(opts.mode_hl, "TelescopeResultsConstant") },
+      { mapping.keybind, vim.F.if_nil(opts.keybind_hl, "TelescopeResultsVariable") },
+      { mapping.name, vim.F.if_nil(opts.name_hl, "TelescopeResultsFunction") },
     }
   end
 

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -270,7 +270,7 @@ end
 
 --  TODO: finish docs for opts.show_line
 files.treesitter = function(opts)
-  opts.show_line = utils.get_default(opts.show_line, true)
+  opts.show_line = vim.F.if_nil(opts.show_line, true)
 
   local has_nvim_treesitter, _ = pcall(require, "nvim-treesitter")
   if not has_nvim_treesitter then

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -22,8 +22,8 @@ git.files = function(opts)
     return
   end
 
-  local show_untracked = utils.get_default(opts.show_untracked, false)
-  local recurse_submodules = utils.get_default(opts.recurse_submodules, false)
+  local show_untracked = vim.F.if_nil(opts.show_untracked, false)
+  local recurse_submodules = vim.F.if_nil(opts.recurse_submodules, false)
   if show_untracked and recurse_submodules then
     utils.notify("builtin.git_files", {
       msg = "Git does not support both --others and --recurse-submodules",
@@ -318,7 +318,7 @@ git.status = function(opts)
   end
 
   local gen_new_finder = function()
-    local expand_dir = utils.if_nil(opts.expand_dir, true, opts.expand_dir)
+    local expand_dir = vim.F.if_nil(opts.expand_dir, true)
     local git_cmd = { "git", "status", "-s", "--", "." }
 
     if expand_dir then
@@ -375,7 +375,7 @@ local set_opts_cwd = function(opts)
 
   -- Find root of git directory and remove trailing newline characters
   local git_root, ret = utils.get_os_command_output({ "git", "rev-parse", "--show-toplevel" }, opts.cwd)
-  local use_git_root = utils.get_default(opts.use_git_root, true)
+  local use_git_root = vim.F.if_nil(opts.use_git_root, true)
 
   if ret ~= 0 then
     local in_worktree = utils.get_os_command_output({ "git", "rev-parse", "--is-inside-work-tree" }, opts.cwd)

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -32,7 +32,7 @@ end
 local internal = {}
 
 internal.builtin = function(opts)
-  opts.include_extensions = utils.get_default(opts.include_extensions, false)
+  opts.include_extensions = vim.F.if_nil(opts.include_extensions, false)
 
   local objs = {}
 
@@ -464,7 +464,7 @@ end
 
 internal.oldfiles = function(opts)
   opts = apply_cwd_only_aliases(opts)
-  opts.include_current_session = utils.get_default(opts.include_current_session, true)
+  opts.include_current_session = vim.F.if_nil(opts.include_current_session, true)
 
   local current_buffer = vim.api.nvim_get_current_buf()
   local current_file = vim.api.nvim_buf_get_name(current_buffer)
@@ -610,8 +610,8 @@ internal.vim_options = function(opts)
 end
 
 internal.help_tags = function(opts)
-  opts.lang = utils.get_default(opts.lang, vim.o.helplang)
-  opts.fallback = utils.get_default(opts.fallback, true)
+  opts.lang = vim.F.if_nil(opts.lang, vim.o.helplang)
+  opts.fallback = vim.F.if_nil(opts.fallback, true)
   opts.file_ignore_patterns = {}
 
   local langs = vim.split(opts.lang, ",", true)
@@ -714,7 +714,7 @@ internal.help_tags = function(opts)
 end
 
 internal.man_pages = function(opts)
-  opts.sections = utils.get_default(opts.sections, { "1" })
+  opts.sections = vim.F.if_nil(opts.sections, { "1" })
   assert(vim.tbl_islist(opts.sections), "sections should be a list")
   opts.man_cmd = utils.get_lazy_default(opts.man_cmd, function()
     local is_darwin = vim.loop.os_uname().sysname == "Darwin"

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -186,7 +186,7 @@ lsp.workspace_symbols = function(opts)
       return
     end
 
-    opts.ignore_filename = utils.get_default(opts.ignore_filename, false)
+    opts.ignore_filename = vim.F.if_nil(opts.ignore_filename, false)
 
     pickers.new(opts, {
       prompt_title = "LSP Workspace Symbols",

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -1,7 +1,6 @@
 local strings = require "plenary.strings"
 local deprecated = require "telescope.deprecated"
 local sorters = require "telescope.sorters"
-local if_nil = vim.F.if_nil
 local os_sep = require("plenary.path").path.sep
 local has_win = vim.fn.has "win32" == 1
 
@@ -69,7 +68,7 @@ config.descriptions = {}
 config.pickers = _TelescopeConfigurationPickers
 
 function config.set_pickers(pickers)
-  pickers = if_nil(pickers, {})
+  pickers = vim.F.if_nil(pickers, {})
 
   for k, v in pairs(pickers) do
     config.pickers[k] = v
@@ -877,8 +876,8 @@ append(
 -- @param tele_defaults table: (optional) a table containing all of the defaults
 --    for telescope [defaults to `telescope_defaults`]
 function config.set_defaults(user_defaults, tele_defaults)
-  user_defaults = if_nil(user_defaults, {})
-  tele_defaults = if_nil(tele_defaults, telescope_defaults)
+  user_defaults = vim.F.if_nil(user_defaults, {})
+  tele_defaults = vim.F.if_nil(tele_defaults, telescope_defaults)
 
   -- Check if using layout keywords outside of `layout_config`
   deprecated.options(user_defaults)
@@ -886,8 +885,8 @@ function config.set_defaults(user_defaults, tele_defaults)
   local function get(name, default_val)
     if name == "layout_config" then
       return smarter_depth_2_extend(
-        if_nil(user_defaults[name], {}),
-        vim.tbl_deep_extend("keep", if_nil(config.values[name], {}), if_nil(default_val, {}))
+        vim.F.if_nil(user_defaults[name], {}),
+        vim.tbl_deep_extend("keep", vim.F.if_nil(config.values[name], {}), vim.F.if_nil(default_val, {}))
       )
     end
     if name == "history" or name == "cache_picker" or name == "preview" then
@@ -896,8 +895,8 @@ function config.set_defaults(user_defaults, tele_defaults)
       end
 
       return smarter_depth_2_extend(
-        if_nil(user_defaults[name], {}),
-        vim.tbl_deep_extend("keep", if_nil(config.values[name], {}), if_nil(default_val, {}))
+        vim.F.if_nil(user_defaults[name], {}),
+        vim.tbl_deep_extend("keep", vim.F.if_nil(config.values[name], {}), vim.F.if_nil(default_val, {}))
       )
     end
     return first_non_null(user_defaults[name], config.values[name], default_val)

--- a/lua/telescope/config/resolve.lua
+++ b/lua/telescope/config/resolve.lua
@@ -91,8 +91,6 @@ That's the next step to scrolling.
 
 --]]
 
-local get_default = require("telescope.utils").get_default
-
 local resolver = {}
 local _resolve_map = {}
 
@@ -286,9 +284,9 @@ resolver.win_option = function(val, default)
     end
 
     return {
-      preview = get_default(val.preview, val_to_set),
-      results = get_default(val.results, val_to_set),
-      prompt = get_default(val.prompt, val_to_set),
+      preview = vim.F.if_nil(val.preview, val_to_set),
+      results = vim.F.if_nil(val.results, val_to_set),
+      prompt = vim.F.if_nil(val.prompt, val_to_set),
     }
   end
 end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -754,7 +754,7 @@ function make_entry.gen_from_picker(opts)
     return {
       value = entry,
       text = entry.prompt_title,
-      ordinal = string.format("%s %s", entry.prompt_title, utils.get_default(entry.default_text, "")),
+      ordinal = string.format("%s %s", entry.prompt_title, vim.F.if_nil(entry.default_text, "")),
       display = make_display,
     }
   end
@@ -978,7 +978,7 @@ function make_entry.gen_from_diagnostics(opts)
   end)()
 
   local display_items = {
-    { width = utils.if_nil(signs, 8, 10) },
+    { width = signs ~= nil and 10 or 8 },
     { remaining = true },
   }
   local line_width = vim.F.if_nil(opts.line_width, 0.5)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -24,8 +24,6 @@ local p_window = require "telescope.pickers.window"
 local EntryManager = require "telescope.entry_manager"
 local MultiSelect = require "telescope.pickers.multi"
 
-local get_default = utils.get_default
-
 local truncate = require("plenary.strings").truncate
 local strdisplaywidth = require("plenary.strings").strdisplaywidth
 
@@ -65,26 +63,26 @@ function Picker:new(opts)
   --   pcall(v.clear)
   -- end
 
-  local layout_strategy = get_default(opts.layout_strategy, config.values.layout_strategy)
+  local layout_strategy = vim.F.if_nil(opts.layout_strategy, config.values.layout_strategy)
 
   local obj = setmetatable({
-    prompt_title = get_default(opts.prompt_title, config.values.prompt_title),
-    results_title = get_default(opts.results_title, config.values.results_title),
+    prompt_title = vim.F.if_nil(opts.prompt_title, config.values.prompt_title),
+    results_title = vim.F.if_nil(opts.results_title, config.values.results_title),
     -- either whats passed in by the user or whats defined by the previewer
     preview_title = opts.preview_title,
 
-    prompt_prefix = get_default(opts.prompt_prefix, config.values.prompt_prefix),
-    wrap_results = get_default(opts.wrap_results, config.values.wrap_results),
-    selection_caret = get_default(opts.selection_caret, config.values.selection_caret),
-    entry_prefix = get_default(opts.entry_prefix, config.values.entry_prefix),
-    multi_icon = get_default(opts.multi_icon, config.values.multi_icon),
+    prompt_prefix = vim.F.if_nil(opts.prompt_prefix, config.values.prompt_prefix),
+    wrap_results = vim.F.if_nil(opts.wrap_results, config.values.wrap_results),
+    selection_caret = vim.F.if_nil(opts.selection_caret, config.values.selection_caret),
+    entry_prefix = vim.F.if_nil(opts.entry_prefix, config.values.entry_prefix),
+    multi_icon = vim.F.if_nil(opts.multi_icon, config.values.multi_icon),
 
-    initial_mode = get_default(opts.initial_mode, config.values.initial_mode),
-    debounce = get_default(tonumber(opts.debounce), nil),
+    initial_mode = vim.F.if_nil(opts.initial_mode, config.values.initial_mode),
+    debounce = vim.F.if_nil(tonumber(opts.debounce), nil),
 
     _finder_attached = true,
     default_text = opts.default_text,
-    get_status_text = get_default(opts.get_status_text, config.values.get_status_text),
+    get_status_text = vim.F.if_nil(opts.get_status_text, config.values.get_status_text),
     _on_input_filter_cb = opts.on_input_filter_cb or function() end,
 
     finder = assert(opts.finder, "Finder is required."),
@@ -95,7 +93,7 @@ function Picker:new(opts)
 
     default_selection_index = opts.default_selection_index,
 
-    get_selection_window = get_default(opts.get_selection_window, config.values.get_selection_window),
+    get_selection_window = vim.F.if_nil(opts.get_selection_window, config.values.get_selection_window),
 
     cwd = opts.cwd,
 
@@ -106,32 +104,32 @@ function Picker:new(opts)
         and opts._multi
       or MultiSelect:new(),
 
-    track = get_default(opts.track, false),
+    track = vim.F.if_nil(opts.track, false),
     stats = {},
 
     attach_mappings = opts.attach_mappings,
-    file_ignore_patterns = get_default(opts.file_ignore_patterns, config.values.file_ignore_patterns),
+    file_ignore_patterns = vim.F.if_nil(opts.file_ignore_patterns, config.values.file_ignore_patterns),
 
-    scroll_strategy = get_default(opts.scroll_strategy, config.values.scroll_strategy),
-    sorting_strategy = get_default(opts.sorting_strategy, config.values.sorting_strategy),
-    tiebreak = get_default(opts.tiebreak, config.values.tiebreak),
-    selection_strategy = get_default(opts.selection_strategy, config.values.selection_strategy),
+    scroll_strategy = vim.F.if_nil(opts.scroll_strategy, config.values.scroll_strategy),
+    sorting_strategy = vim.F.if_nil(opts.sorting_strategy, config.values.sorting_strategy),
+    tiebreak = vim.F.if_nil(opts.tiebreak, config.values.tiebreak),
+    selection_strategy = vim.F.if_nil(opts.selection_strategy, config.values.selection_strategy),
 
-    push_cursor_on_edit = get_default(opts.push_cursor_on_edit, false),
-    push_tagstack_on_edit = get_default(opts.push_tagstack_on_edit, false),
+    push_cursor_on_edit = vim.F.if_nil(opts.push_cursor_on_edit, false),
+    push_tagstack_on_edit = vim.F.if_nil(opts.push_tagstack_on_edit, false),
 
     layout_strategy = layout_strategy,
     layout_config = config.smarter_depth_2_extend(opts.layout_config or {}, config.values.layout_config or {}),
 
-    __cycle_layout_list = get_default(opts.cycle_layout_list, config.values.cycle_layout_list),
+    __cycle_layout_list = vim.F.if_nil(opts.cycle_layout_list, config.values.cycle_layout_list),
 
     window = {
-      winblend = get_default(
+      winblend = vim.F.if_nil(
         opts.winblend,
         type(opts.window) == "table" and opts.window.winblend or config.values.winblend
       ),
-      border = get_default(opts.border, type(opts.window) == "table" and opts.window.border or config.values.border),
-      borderchars = get_default(
+      border = vim.F.if_nil(opts.border, type(opts.window) == "table" and opts.window.border or config.values.border),
+      borderchars = vim.F.if_nil(
         opts.borderchars,
         type(opts.window) == "table" and opts.window.borderchars or config.values.borderchars
       ),

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -53,7 +53,6 @@
 
 local resolve = require "telescope.config.resolve"
 local p_window = require "telescope.pickers.window"
-local if_nil = vim.F.if_nil
 
 local get_border_size = function(opts)
   if opts.window.border == false then
@@ -125,7 +124,7 @@ local function validate_layout_config(strategy_name, configuration, values, defa
   local valid_configuration_keys = get_valid_configuration_keys(configuration)
 
   -- If no default_layout_config provided, check Telescope's config values
-  default_layout_config = if_nil(default_layout_config, require("telescope.config").values.layout_config)
+  default_layout_config = vim.F.if_nil(default_layout_config, require("telescope.config").values.layout_config)
 
   local result = {}
   local get_value = function(k)
@@ -263,7 +262,7 @@ local function make_documented_layout(name, layout_config, layout)
       validate_layout_config(
         name,
         layout_config,
-        vim.tbl_deep_extend("keep", if_nil(override_layout, {}), if_nil(self.layout_config, {}))
+        vim.tbl_deep_extend("keep", vim.F.if_nil(override_layout, {}), vim.F.if_nil(self.layout_config, {}))
       )
     )
   end
@@ -320,7 +319,7 @@ layout_strategies.horizontal = make_documented_layout(
       -- Cap over/undersized width (with previewer)
       width, w_space = calc_size_and_spacing(width, max_columns, bs, 2, 4, 1)
 
-      preview.width = resolve.resolve_width(if_nil(layout_config.preview_width, function(_, cols)
+      preview.width = resolve.resolve_width(vim.F.if_nil(layout_config.preview_width, function(_, cols)
         if cols < 150 then
           return math.floor(cols * 0.4)
         elseif cols < 200 then
@@ -588,7 +587,7 @@ layout_strategies.cursor = make_documented_layout(
       -- Cap over/undersized width (with preview)
       width, w_space = calc_size_and_spacing(width, max_columns, bs, 2, 4, 0)
 
-      preview.width = resolve.resolve_width(if_nil(layout_config.preview_width, 2 / 3))(self, width, max_lines)
+      preview.width = resolve.resolve_width(vim.F.if_nil(layout_config.preview_width, 2 / 3))(self, width, max_lines)
       prompt.width = width - preview.width - w_space
       results.width = prompt.width
     else
@@ -694,7 +693,11 @@ layout_strategies.vertical = make_documented_layout(
       -- Cap over/undersized height (with previewer)
       height, h_space = calc_size_and_spacing(height, max_lines, bs, 3, 6, 2)
 
-      preview.height = resolve.resolve_height(if_nil(layout_config.preview_height, 0.5))(self, max_columns, height)
+      preview.height = resolve.resolve_height(vim.F.if_nil(layout_config.preview_height, 0.5))(
+        self,
+        max_columns,
+        height
+      )
     else
       -- Cap over/undersized height (without previewer)
       height, h_space = calc_size_and_spacing(height, max_lines, bs, 2, 4, 1)
@@ -764,8 +767,8 @@ layout_strategies.flex = make_documented_layout(
     horizontal = "Options to pass when switching to horizontal layout",
   }),
   function(self, max_columns, max_lines, layout_config)
-    local flip_columns = if_nil(layout_config.flip_columns, 100)
-    local flip_lines = if_nil(layout_config.flip_lines, 20)
+    local flip_columns = vim.F.if_nil(layout_config.flip_columns, 100)
+    local flip_lines = vim.F.if_nil(layout_config.flip_lines, 20)
 
     if max_columns < flip_columns and max_lines > flip_lines then
       self.__flex_strategy = "vertical"
@@ -851,7 +854,7 @@ layout_strategies.bottom_pane = make_documented_layout(
     local tbln
     max_lines, tbln = calc_tabline(max_lines)
 
-    local height = if_nil(resolve.resolve_height(layout_config.height)(self, max_columns, max_lines), 25)
+    local height = vim.F.if_nil(resolve.resolve_height(layout_config.height)(self, max_columns, max_lines), 25)
     if type(layout_config.height) == "table" and type(layout_config.height.padding) == "number" then
       -- Since bottom_pane only has padding at the top, we only need half as much padding in total
       -- This doesn't match the vim help for `resolve.resolve_height`, but it matches expectations
@@ -874,7 +877,7 @@ layout_strategies.bottom_pane = make_documented_layout(
       -- Cap over/undersized width (with preview)
       local width, w_space = calc_size_and_spacing(max_columns, max_columns, bs, 2, 4, 0)
 
-      preview.width = resolve.resolve_width(if_nil(layout_config.preview_width, 0.5))(self, width, max_lines)
+      preview.width = resolve.resolve_width(vim.F.if_nil(layout_config.preview_width, 0.5))(self, width, max_lines)
       results.width = width - preview.width - w_space
     else
       results.width = prompt.width

--- a/lua/telescope/sorters.lua
+++ b/lua/telescope/sorters.lua
@@ -602,7 +602,7 @@ end
 
 sorters.prefilter = function(opts)
   local sorter = opts.sorter
-  opts.delimiter = util.get_default(opts.delimiter, ":")
+  opts.delimiter = vim.F.if_nil(opts.delimiter, ":")
   sorter._delimiter = opts.delimiter
   sorter.tags = create_tag_set(opts.tag)
   sorter.filter_function = filter_function(opts)

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -20,6 +20,7 @@ utils.get_separator = function()
 end
 
 utils.if_nil = function(x, was_nil, was_not_nil)
+  log.error "telescope.utils.if_nil is deprecated and will be removed. Please use vim.F.if_nil"
   if x == nil then
     return was_nil
   else
@@ -28,6 +29,7 @@ utils.if_nil = function(x, was_nil, was_not_nil)
 end
 
 utils.get_default = function(x, default)
+  log.error "telescope.utils.get_default is deprecated and will be removed. Please use vim.F.if_nil"
   return utils.if_nil(x, default, x)
 end
 
@@ -198,7 +200,7 @@ utils.path_tail = (function()
 end)()
 
 utils.is_path_hidden = function(opts, path_display)
-  path_display = path_display or utils.get_default(opts.path_display, require("telescope.config").values.path_display)
+  path_display = path_display or vim.F.if_nil(opts.path_display, require("telescope.config").values.path_display)
 
   return path_display == nil
     or path_display == "hidden"
@@ -235,7 +237,7 @@ utils.transform_path = function(opts, path)
     return path
   end
 
-  local path_display = utils.get_default(opts.path_display, require("telescope.config").values.path_display)
+  local path_display = vim.F.if_nil(opts.path_display, require("telescope.config").values.path_display)
 
   local transformed_path = path
 


### PR DESCRIPTION
I actually wanna remove it but tj uses it in his configs. So lets throw a bunch of errors for him :rofl: 

I even used his employers software to find the code: https://sourcegraph.com/github.com/tjdevries/config_manager/-/blob/xdg_config/nvim/lua/tj/telescope/custom/live_workspace.lua?L61:28 #ad