### PR TITLE
defaults: change `center` layout default size

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -119,10 +119,10 @@ telescope.setup({opts})                                    *telescope.setup()*
             prompt_position = "top"
           },
           center = {
-            height = 0.9,
+            height = 0.4,
             preview_cutoff = 40,
             prompt_position = "top",
-            width = 0.8
+            width = 0.5
           },
           cursor = {
             height = 0.9,

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -93,8 +93,8 @@ local layout_config_defaults = {
   },
 
   center = {
-    width = 0.8,
-    height = 0.9,
+    width = 0.5,
+    height = 0.4,
     preview_cutoff = 40,
     prompt_position = "top",
   },


### PR DESCRIPTION
Now matches the description and has space for a preview above the central block

Fixes #1481