### PR TITLE
chore: remove dot at the beginning

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -85,8 +85,6 @@ files.live_grep = function(opts)
 
     if search_dirs then
       table.insert(search_list, search_dirs)
-    else
-      table.insert(search_list, ".")
     end
 
     if grep_open_files then
@@ -137,8 +135,6 @@ files.grep_string = function(opts)
     for _, path in ipairs(search_dirs) do
       table.insert(args, vim.fn.expand(path))
     end
-  else
-    table.insert(args, ".")
   end
 
   pickers.new(opts, {


### PR DESCRIPTION
We added this for rg 13.0 release because it was needed but it doesnt
seem to be needed anymore. Weird

This might be due to some changes in neovim or due to changes to jobs.

I'll build 0.5.1 and test it with that right now. If it doesnt work on 0.5.1 we move this PR back after the 0.6 bump.

Edit: also seems to work for 0.5.1 What am i missing.