### PR TITLE
fix concatenate err

### DIFF
--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -18,7 +18,7 @@ lsp.references = function(opts)
 
   vim.lsp.buf_request(0, "textDocument/references", params, function(err, result, _ctx, _config)
     if err then
-      vim.api.nvim_err_writeln("Error when finding references: " .. err)
+      vim.api.nvim_err_writeln("Error when finding references: " .. err.message)
       return
     end
 
@@ -49,7 +49,7 @@ local function list_or_jump(action, title, opts)
   local params = vim.lsp.util.make_position_params()
   vim.lsp.buf_request(0, action, params, function(err, result, _ctx, _config)
     if err then
-      vim.api.nvim_err_writeln("Error when executing " .. action .. " : " .. err)
+      vim.api.nvim_err_writeln("Error when executing " .. action .. " : " .. err.message)
       return
     end
     local flattened_results = {}
@@ -105,7 +105,7 @@ lsp.document_symbols = function(opts)
   local params = vim.lsp.util.make_position_params()
   vim.lsp.buf_request(0, "textDocument/documentSymbol", params, function(err, result, _ctx, _config)
     if err then
-      vim.api.nvim_err_writeln("Error when finding document symbols: " .. err)
+      vim.api.nvim_err_writeln("Error when finding document symbols: " .. err.message)
       return
     end
 
@@ -335,7 +335,7 @@ lsp.workspace_symbols = function(opts)
   local params = { query = opts.query or "" }
   vim.lsp.buf_request(0, "workspace/symbol", params, function(err, server_result, _ctx, _config)
     if err then
-      vim.api.nvim_err_writeln("Error when finding workspace symbols: " .. err)
+      vim.api.nvim_err_writeln("Error when finding workspace symbols: " .. err.message)
       return
     end
 


### PR DESCRIPTION
```
Error executing vim.schedule lua callback: ...acker/start/telescope.nvim/lua/telescope/builtin/lsp.lua:52: attempt to concatenate local 'err' (a table value)
stack traceback:
        ...acker/start/telescope.nvim/lua/telescope/builtin/lsp.lua:52: in function 'handler'
        ...w/Cellar/neovim/0.6.0/share/nvim/runtime/lua/vim/lsp.lua:957: in function 'cb'
        vim.lua:285: in function <vim.lua:285>
```

`err` is a table value for lsp-handler.
https://github.com/neovim/neovim/blob/master/runtime/doc/lsp.txt#L212-L215

lsp log
```
vim/lsp/rpc.lua:451    "rpc.receive"   {  error = {    code = 0,    message = "no packages returned: packages.Load error"  },  id = 11,  jsonrpc = "2.0"}
```