### PR TITLE
feat: Config Option to Use Unix Path Separators 

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -12,7 +12,7 @@ local log = require "telescope.log"
 
 local scan = require "plenary.scandir"
 local Path = require "plenary.path"
-local os_sep = Path.path.sep
+local os_sep = utils.get_separator(conf.use_unix_friendly_paths)
 
 local flatten = vim.tbl_flatten
 local filter = vim.tbl_filter

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -676,6 +676,15 @@ append(
     Default: require("telescope.previewers").buffer_previewer_maker]]
 )
 
+append(
+  "use_unix_friendly_paths",
+  false,
+  [[
+  Boolean if should use unix friendly os seperator. "\\" -> "/"
+
+  Default: false]]
+)
+
 -- @param user_defaults table: a table where keys are the names of options,
 --    and values are the ones the user wants
 -- @param tele_defaults table: (optional) a table containing all of the defaults

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -92,10 +92,12 @@ do
         if not vim.loop.fs_access(retpath, "R", nil) then
           retpath = t.value
         end
-        return retpath
+
+        return utils.transform_path_os_sep(retpath)
       end
 
-      return rawget(t, rawget(lookup_keys, k))
+
+      return utils.transform_path_os_sep(rawget(t, rawget(lookup_keys, k)))
     end
 
     return function(line)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -96,7 +96,6 @@ do
         return utils.transform_path_os_sep(retpath)
       end
 
-
       return utils.transform_path_os_sep(rawget(t, rawget(lookup_keys, k)))
     end
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -248,7 +248,7 @@ utils.transform_path = function(opts, path)
   if path == nil then
     return
   end
-  
+
   path = utils.transform_path_os_sep(path)
 
   if is_uri(path) then

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -8,7 +8,11 @@ local get_status = require("telescope.state").get_status
 
 local utils = {}
 
-utils.get_separator = function()
+utils.get_separator = function(use_unix_friendly_paths)
+  if use_unix_friendly_paths then
+    return "/"
+  end
+
   return Path.path.sep
 end
 
@@ -325,6 +329,17 @@ utils.is_path_hidden = function(opts, path_display)
     or path_display.hidden
 end
 
+utils.transform_path_os_sep = function(filename)
+  local conf = require("telescope.config").values
+  local os_sep = utils.get_separator(conf.use_unix_friendly_paths)
+
+  if not filename then
+    return filename
+  end
+
+  return filename:gsub(Path.path.sep, os_sep)
+end
+
 local is_uri = function(filename)
   return string.match(filename, "^%w+://") ~= nil
 end
@@ -336,6 +351,7 @@ local calc_result_length = function(truncate_len)
 end
 
 utils.transform_path = function(opts, path)
+  path = utils.transform_path_os_sep(path)
   if is_uri(path) then
     return path
   end


### PR DESCRIPTION
I work on Windows and wanted a way to make telescope treat paths with a Unix friendly separator. 