### PR TITLE
fix: `bottom_pane` remove `results` border next to `prompt`

### DIFF
--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -839,7 +839,7 @@ layout_strategies.bottom_pane = make_documented_layout(
       results.line = prompt.line + 1
       preview.line = results.line + bs
       if results.border == true then
-        results.border = {0, 1, 1, 1}
+        results.border = { 0, 1, 1, 1 }
       end
       if type(results.title) == "string" then
         results.title = { { pos = "S", text = results.title } }
@@ -852,7 +852,7 @@ layout_strategies.bottom_pane = make_documented_layout(
         prompt.title = { { pos = "S", text = prompt.title } }
       end
       if results.border == true then
-        results.border = {1, 1, 0, 1}
+        results.border = { 1, 1, 0, 1 }
       end
     else
       error("Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config))

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -838,12 +838,21 @@ layout_strategies.bottom_pane = make_documented_layout(
       prompt.line = max_lines - results.height - (1 + bs) + 1
       results.line = prompt.line + 1
       preview.line = results.line + bs
+      if results.border == true then
+        results.border = {0, 1, 1, 1}
+      end
+      if type(results.title) == "string" then
+        results.title = { { pos = "S", text = results.title } }
+      end
     elseif layout_config.prompt_position == "bottom" then
       results.line = max_lines - results.height - (1 + bs) + 1
       preview.line = results.line
       prompt.line = max_lines - bs
       if type(prompt.title) == "string" then
         prompt.title = { { pos = "S", text = prompt.title } }
+      end
+      if results.border == true then
+        results.border = {1, 1, 0, 1}
       end
     else
       error("Unknown prompt_position: " .. tostring(self.window.prompt_position) .. "\n" .. vim.inspect(layout_config))


### PR DESCRIPTION
@max397574 does this PR fix your issue?

Fixes #1557