### PR TITLE
[ADD] add windows_position option in layout_config

### DIFF
--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -94,6 +94,7 @@ local get_valid_configuration_keys = function(strategy_config)
     -- TEMP: There are a few keys we should say are valid to start with.
     preview_cutoff = true,
     prompt_position = true,
+    window_position = true,
   }
 
   for key in pairs(strategy_config) do
@@ -659,9 +660,17 @@ layout_strategies.vertical = make_documented_layout(
     prompt.height = 1
     results.height = height - preview.height - prompt.height - h_space
 
-    results.col, preview.col, prompt.col = 0, 0, 0 -- all centered
-
+    local width_padding = 0
     local height_padding = math.floor((max_lines - height) / 2)
+
+    local win_pos = layout_config.window_position
+    if win_pos then
+        width_padding = win_pos.x and win_pos.x or width_padding
+        height_padding = win_pos.y and win_pos.y or height_padding
+    end
+
+    results.col, preview.col, prompt.col = width_padding, width_padding, width_padding -- all centered
+
     if not layout_config.mirror then
       preview.line = height_padding + (1 + bs)
       if layout_config.prompt_position == "top" then


### PR DESCRIPTION
Good day to you!

I've added `window_position` to `layout_config`
 currently implemented it for vertical strategy.
 
![image](https://user-images.githubusercontent.com/52028706/145038423-3b1a5112-1455-4a89-bc26-0c1c749ee901.png)

![image](https://user-images.githubusercontent.com/52028706/145038593-9619b255-ce6e-4650-b0e2-084538e72b0e.png)

![image](https://user-images.githubusercontent.com/52028706/145039084-53c47f71-1bdf-4582-bf1b-d0e0d9d17019.png)

 My main goal was to be able create `scratchpad`-like theme, but i've suggested that it could be handy for other themes (layouts)

Please make a review and give advice: is it  worth to be in telescope's core or not?

Thank you!