### PR TITLE
fix: [file_browser] hide "../" when in rootdir

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -309,7 +309,9 @@ files.file_browser = function(opts)
           table.insert(data, typ == "directory" and (entry .. os_sep) or entry)
         end,
       })
-      table.insert(data, 1, ".." .. os_sep)
+      if path ~= os_sep then
+        table.insert(data, 1, ".." .. os_sep)
+      end
 
       local maker = function()
         local mt = {}


### PR DESCRIPTION
Currently `file_browser` will always insert an "up dir" entry (`../`), regardless of where it is in the filesystem

This change suppresses this entry if we are in the root directory (`/`)

Note I do not have access to Windows. I don't think `\` is ever a valid path in Windows, so don't believe this will have any adverse affects on that OS, but I haven't been able to check specifically.