### PR TITLE
feat: multiselect icon

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -184,6 +184,15 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Default: '  '
 
+                                            *telescope.defaults.multi_icon*
+    multi_icon: ~
+        Symbol to add in front of a multi-selected result entry.
+        Replaces final character of |telescope.defaults.selection_caret| and
+        |telescope.defaults.entry_prefix| as appropriate.
+        To have no icon, set to the empty string.
+
+        Default: '+'
+
                                           *telescope.defaults.initial_mode*
     initial_mode: ~
         Determines in which mode telescope starts. Valid Keys:

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -246,6 +246,18 @@ append(
 )
 
 append(
+  "multi_icon",
+  "+",
+  [[
+  Symbol to add in front of a multi-selected result entry.
+  Replaces final character of |telescope.defaults.selection_caret| and
+  |telescope.defaults.entry_prefix| as appropriate.
+  To have no icon, set to the empty string.
+
+  Default: '+']]
+)
+
+append(
   "initial_mode",
   "insert",
   [[

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -976,8 +976,8 @@ function Picker:set_selection(row)
     end
     a.nvim_buf_set_lines(results_bufnr, row, row + 1, false, { display })
 
-    -- don't highlight the ' ' at the end of caret
-    self.highlighter:hi_selection(row, caret:sub(1, -2))
+    -- don't highlight any whitespace at the end of caret
+    self.highlighter:hi_selection(row, caret:match("(.*%S)"))
     self.highlighter:hi_display(row, caret, display_highlights)
     self.highlighter:hi_sorter(row, prompt, display)
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -6,7 +6,6 @@ local async = require "plenary.async"
 local await_schedule = async.util.scheduler
 local channel = require("plenary.async.control").channel
 local popup = require "plenary.popup"
-local strings = require "plenary.strings"
 
 local actions = require "telescope.actions"
 local action_set = require "telescope.actions.set"
@@ -28,7 +27,8 @@ local MultiSelect = require "telescope.pickers.multi"
 
 local get_default = utils.get_default
 
-local charpart = strings.strcharpart
+local truncate = require("plenary.strings").truncate
+local strdisplaywidth = require("plenary.strings").strdisplaywidth
 
 local ns_telescope_matching = a.nvim_create_namespace "telescope_matching"
 local ns_telescope_prompt = a.nvim_create_namespace "telescope_prompt"
@@ -933,7 +933,7 @@ function Picker:set_selection(row)
         t = self.entry_prefix
       end
       if multi and type(self.multi_icon) == "string" then
-        t = strings.truncate(t, strings.strdisplaywidth(t) - strings.strdisplaywidth(self.multi_icon), "") .. self.multi_icon
+        t = truncate(t, strdisplaywidth(t) - strdisplaywidth(self.multi_icon), "") .. self.multi_icon
       end
       return t
     end
@@ -977,7 +977,7 @@ function Picker:set_selection(row)
     a.nvim_buf_set_lines(results_bufnr, row, row + 1, false, { display })
 
     -- don't highlight any whitespace at the end of caret
-    self.highlighter:hi_selection(row, caret:match("(.*%S)"))
+    self.highlighter:hi_selection(row, caret:match "(.*%S)")
     self.highlighter:hi_display(row, caret, display_highlights)
     self.highlighter:hi_sorter(row, prompt, display)
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -71,15 +71,7 @@ function Picker:new(opts)
     prompt_prefix = get_default(opts.prompt_prefix, config.values.prompt_prefix),
     selection_caret = get_default(opts.selection_caret, config.values.selection_caret),
     entry_prefix = get_default(opts.entry_prefix, config.values.entry_prefix),
-    multi_icon = (function()
-      local icon = get_default(opts.multi_icon, config.values.multi_icon)
-      assert(type(icon) == "string", "multi_icon must be a string")
-      if icon ~= "" then
-        return charpart(icon, 0, 1)
-      else
-        return false
-      end
-    end)(),
+    multi_icon = get_default(opts.multi_icon, config.values.multi_icon),
 
     initial_mode = get_default(opts.initial_mode, config.values.initial_mode),
     debounce = get_default(tonumber(opts.debounce), nil),
@@ -940,8 +932,8 @@ function Picker:set_selection(row)
       else
         t = self.entry_prefix
       end
-      if multi and self.multi_icon then
-        t = strings.truncate(t, strings.strdisplaywidth(t) - 1, "") .. self.multi_icon
+      if multi and type(self.multi_icon) == "string" then
+        t = strings.truncate(t, strings.strdisplaywidth(t) - strings.strdisplaywidth(self.multi_icon), "") .. self.multi_icon
       end
       return t
     end

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -94,7 +94,7 @@ function Highlighter:hi_multiselect(row, is_selected)
           "TelescopeMultiIcon",
           row,
           pos - 1,
-          pos
+          pos - 1 + #self.picker.multi_icon
         )
       end
     end

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -84,6 +84,20 @@ function Highlighter:hi_multiselect(row, is_selected)
 
   if is_selected then
     vim.api.nvim_buf_add_highlight(results_bufnr, ns_telescope_multiselection, "TelescopeMultiSelection", row, 0, -1)
+    if self.picker.multi_icon then
+      local line = vim.api.nvim_buf_get_lines(results_bufnr, row, row + 1, false)[1]
+      local pos = line:find(self.picker.multi_icon)
+      if pos and pos <= math.max(#self.picker.selection_caret, #self.picker.entry_prefix) then
+        vim.api.nvim_buf_add_highlight(
+          results_bufnr,
+          ns_telescope_multiselection,
+          "TelescopeMultiIcon",
+          row,
+          pos - 1,
+          pos
+        )
+      end
+    end
   else
     local existing_marks = vim.api.nvim_buf_get_extmarks(
       results_bufnr,

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -12,6 +12,7 @@ let g:loaded_telescope = 1
 highlight default link TelescopeSelection Visual
 highlight default link TelescopeSelectionCaret TelescopeSelection
 highlight default link TelescopeMultiSelection Type
+highlight default link TelescopeMultiIcon Identifier
 
 " "Normal" in the floating windows created by telescope.
 highlight default link TelescopeNormal Normal


### PR DESCRIPTION
Adds an icon next to multi-selected entries in a picker.
Icon defaults to "+". Functionality disabled by setting to "".
The corresponding highlight group is called `TelescopeMultiIcon`.

Demo:
![image](https://user-images.githubusercontent.com/35707277/145119288-9d042d63-5857-4b76-9cb8-77465e1e7fbd.png)

Resolves #1551 