### PR TITLE
chore: deprecation notice for builtin.file_browser

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -288,6 +288,9 @@ local function prepare_match(entry, kind)
 end
 
 files.file_browser = function(opts)
+  vim.api.nvim_err_writeln [[Deprecation notice: file browser will be carved out into a more featureful extension, see:
+https://github.com/nvim-telescope/telescope-file-browser.nvim]]
+
   opts = opts or {}
 
   local is_dir = function(value)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -94,6 +94,7 @@ builtin.fd = builtin.find_files
 ---     - Note: you can create files nested into several directories with `<C-e>`, i.e. `lua/telescope/init.lua` would
 ---       create the file `init.lua` inside of `lua/telescope` and will create the necessary folders (similar to how
 ---       `mkdir -p` would work) if they do not already exist
+---@deprecated Please move to https://github.com/nvim-telescope/telescope-file-browser.nvim
 ---@param opts table: options to pass to the picker
 ---@field cwd string: root dir to browse from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field depth number: file tree depth to display (default: 1)


### PR DESCRIPTION
I'm sure it'll get users to switch. They have to press `<CR>` for the notice to go away :sweat_smile: 