### PR TITLE
fix: transform_path nil input

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -331,6 +331,9 @@ local calc_result_length = function(truncate_len)
 end
 
 utils.transform_path = function(opts, path)
+  if path == nil then
+    return
+  end
   if is_uri(path) then
     return path
   end


### PR DESCRIPTION
Sometimes i get with live_grep:
```
Finder failed with msg:  ...nfig/nvim/plugged/telescope.nvim/lua/telescope/utils.lua:324: bad argument #1 to 'match' (string expected, got nil)
```

This happens when rg runs on a binary file, like a pdf. Then the parsing fails. We should maybe also make sure that we dont do anything if the line parsing fails. Regardless `transform_path` should not error if filepath is nil