### PR TITLE
feat: `center` layout `mirror` option

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1638,6 +1638,9 @@ layout_strategies.horizontal()                *layout_strategies.horizontal()*
         - How tall to make Telescope's entire layout
         - See |resolver.resolve_height()|
       - mirror: Flip the location of the results/prompt and preview windows
+      - prompt_position:
+        - Where to place prompt window.
+        - Available Values: 'bottom', 'top'
       - scroll_speed: The number of lines to scroll through the previewer
       - width:
         - How wide to make Telescope's entire layout
@@ -1648,9 +1651,6 @@ layout_strategies.horizontal()                *layout_strategies.horizontal()*
       - preview_width:
         - Change the width of Telescope's preview window
         - See |resolver.resolve_width()|
-      - prompt_position:
-        - Where to place prompt window.
-        - Available Values: 'bottom', 'top'
 
 
 layout_strategies.center()                        *layout_strategies.center()*
@@ -1681,6 +1681,9 @@ layout_strategies.center()                        *layout_strategies.center()*
         - How tall to make Telescope's entire layout
         - See |resolver.resolve_height()|
       - mirror: Flip the location of the results/prompt and preview windows
+      - prompt_position:
+        - Where to place prompt window.
+        - Available Values: 'bottom', 'top'
       - scroll_speed: The number of lines to scroll through the previewer
       - width:
         - How wide to make Telescope's entire layout
@@ -1688,9 +1691,6 @@ layout_strategies.center()                        *layout_strategies.center()*
 
     `picker.layout_config` unique options:
       - preview_cutoff: When lines are less than this value, the preview will be disabled
-      - prompt_position:
-        - Where to place prompt window.
-        - Available Values: 'bottom', 'top'
 
 
 layout_strategies.cursor()                        *layout_strategies.cursor()*
@@ -1742,6 +1742,9 @@ layout_strategies.vertical()                    *layout_strategies.vertical()*
         - How tall to make Telescope's entire layout
         - See |resolver.resolve_height()|
       - mirror: Flip the location of the results/prompt and preview windows
+      - prompt_position:
+        - Where to place prompt window.
+        - Available Values: 'bottom', 'top'
       - scroll_speed: The number of lines to scroll through the previewer
       - width:
         - How wide to make Telescope's entire layout
@@ -1752,9 +1755,6 @@ layout_strategies.vertical()                    *layout_strategies.vertical()*
       - preview_height:
         - Change the height of Telescope's preview window
         - See |resolver.resolve_height()|
-      - prompt_position:
-        - Where to place prompt window.
-        - Available Values: 'bottom', 'top'
 
 
 layout_strategies.flex()                            *layout_strategies.flex()*
@@ -1769,6 +1769,9 @@ layout_strategies.flex()                            *layout_strategies.flex()*
         - How tall to make Telescope's entire layout
         - See |resolver.resolve_height()|
       - mirror: Flip the location of the results/prompt and preview windows
+      - prompt_position:
+        - Where to place prompt window.
+        - Available Values: 'bottom', 'top'
       - scroll_speed: The number of lines to scroll through the previewer
       - width:
         - How wide to make Telescope's entire layout

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -186,6 +186,7 @@ local shared_options = {
   height = { "How tall to make Telescope's entire layout", "See |resolver.resolve_height()|" },
   mirror = "Flip the location of the results/prompt and preview windows",
   scroll_speed = "The number of lines to scroll through the previewer",
+  prompt_position = { "Where to place prompt window.", "Available Values: 'bottom', 'top'" },
 }
 
 -- Used for generating vim help documentation.
@@ -287,7 +288,6 @@ layout_strategies.horizontal = make_documented_layout(
   vim.tbl_extend("error", shared_options, {
     preview_width = { "Change the width of Telescope's preview window", "See |resolver.resolve_width()|" },
     preview_cutoff = "When columns are less than this value, the preview will be disabled",
-    prompt_position = { "Where to place prompt window.", "Available Values: 'bottom', 'top'" },
   }),
   function(self, max_columns, max_lines, layout_config)
     local initial_options = p_window.get_initial_window_options(self)
@@ -412,7 +412,6 @@ layout_strategies.center = make_documented_layout(
   "center",
   vim.tbl_extend("error", shared_options, {
     preview_cutoff = "When lines are less than this value, the preview will be disabled",
-    prompt_position = { "Where to place prompt window.", "Available Values: 'bottom', 'top'" },
   }),
   function(self, max_columns, max_lines, layout_config)
     local initial_options = p_window.get_initial_window_options(self)
@@ -448,7 +447,7 @@ layout_strategies.center = make_documented_layout(
     prompt.height = 1
     results.height = height - prompt.height - h_space
 
-    local topline = (max_lines / 2) - ((results.height + (2 * bs)) / 2) + 1
+    local topline = math.floor((max_lines / 2) - ((results.height + (2 * bs)) / 2) + 1)
     -- Align the prompt and results so halfway up the screen is
     -- in the middle of this combined block
     if layout_config.prompt_position == "top" then
@@ -464,11 +463,15 @@ layout_strategies.center = make_documented_layout(
       error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
     end
 
-    preview.line = 2
-
-    if self.previewer and max_lines >= layout_config.preview_cutoff then
-      preview.height = math.floor(topline - (3 + bs))
+    if not layout_config.mirror then
+      preview.line = 1 + bs
+      preview.height = topline - (2 * bs + 2)
     else
+      preview.line = topline + (results.height + (2 * bs + 2))
+      preview.height = max_lines - preview.line + (1 - bs)
+    end
+
+    if not (self.previewer and max_lines >= layout_config.preview_cutoff) then
       preview.height = 0
     end
 
@@ -617,7 +620,6 @@ layout_strategies.vertical = make_documented_layout(
   vim.tbl_extend("error", shared_options, {
     preview_cutoff = "When lines are less than this value, the preview will be disabled",
     preview_height = { "Change the height of Telescope's preview window", "See |resolver.resolve_height()|" },
-    prompt_position = { "Where to place prompt window.", "Available Values: 'bottom', 'top'" },
   }),
   function(self, max_columns, max_lines, layout_config)
     local initial_options = p_window.get_initial_window_options(self)
@@ -792,7 +794,6 @@ layout_strategies.bottom_pane = make_documented_layout(
   vim.tbl_extend("error", shared_options, {
     preview_width = { "Change the width of Telescope's preview window", "See |resolver.resolve_width()|" },
     preview_cutoff = "When columns are less than this value, the preview will be disabled",
-    prompt_position = { "Where to place prompt window.", "Available Values: 'bottom', 'top'" },
   }),
   function(self, max_columns, max_lines, layout_config)
     local initial_options = p_window.get_initial_window_options(self)


### PR DESCRIPTION
Adds `mirror` option to `center` layout
This switches the position of the preview window to below the central block, rather than above.