### PR TITLE
Fixed module name for builtin picker, correctly jump to description

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -563,7 +563,7 @@ previewers.builtin = defaulter(function(_)
     end,
 
     define_preview = function(self, entry, status)
-      local module_name = vim.fn.fnamemodify(entry.filename, ":t:r")
+      local module_name = vim.fn.fnamemodify(vim.fn.fnamemodify(entry.filename, ":h"), ":t")
       local text
       if entry.text:sub(1, #module_name) ~= module_name then
         text = module_name .. "." .. entry.text


### PR DESCRIPTION
The module name was being calculated as 'init' but the pickers are all prefixed with 'builtin'.. the directory name for 'builtin', not the 'init.lua' filename.