### PR TITLE
fix: `builtin` only have entries for extension functions

### DIFF
--- a/lua/telescope/_extensions/init.lua
+++ b/lua/telescope/_extensions/init.lua
@@ -43,6 +43,9 @@ extensions.manager = setmetatable({}, {
 ---
 ---         Only the items in `exports` will be exposed on the  resulting
 ---         module that users can access via require('telescope').extensions.foo
+---         Also, any top-level key-value pairs in exports where the value is a function and the
+---         key doesn't start with an underscore will be included when calling the `builtin` picker
+---         with the `include_extensions` option enabled.
 ---
 ---         Other things in the module will not be accessible. This is the public API
 ---         for your extension. Consider not breaking it a lot :laugh:

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -55,11 +55,13 @@ internal.builtin = function(opts)
     title = "Telescope Pickers"
     for ext, funcs in pairs(require("telescope").extensions) do
       for func_name, func_obj in pairs(funcs) do
-        local debug_info = debug.getinfo(func_obj)
-        table.insert(objs, {
-          filename = string.sub(debug_info.source, 2),
-          text = string.format("%s : %s", ext, func_name),
-        })
+        if type(func_obj) == "function" then
+          local debug_info = debug.getinfo(func_obj)
+          table.insert(objs, {
+            filename = string.sub(debug_info.source, 2),
+            text = string.format("%s : %s", ext, func_name),
+          })
+        end
       end
     end
   end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -55,7 +55,8 @@ internal.builtin = function(opts)
     title = "Telescope Pickers"
     for ext, funcs in pairs(require("telescope").extensions) do
       for func_name, func_obj in pairs(funcs) do
-        if type(func_obj) == "function" then
+        -- Only include exported functions whose name doesn't begin with an underscore
+        if type(func_obj) == "function" and string.sub(func_name, 0, 1) ~= "_" then
           local debug_info = debug.getinfo(func_obj)
           table.insert(objs, {
             filename = string.sub(debug_info.source, 2),


### PR DESCRIPTION
`:Telescope builtin include_extensions=true` currently errors when the `telescope-file-browser.nvim` extension is being used, as it exports some stuff as tables (e.g. actions) which breaks `debug.getinfo`. I don't think we want to stop extensions from exporting actions and things, so I've added a check for the `func_obj` actually being a function.

@fdschmidt93 just pinging as an FYI, in case this comes up as an issue over on the `file-browser` repo.

Also, in the case of `file-browser`, I'm not sure if we want both `file_browser` and `picker` to be included, so we could maybe add a check for beginning with a "_" to exclude from the builtin `picker`. This way extension creators can choose which exported functions to include here?