### PR TITLE
chore: remove redundant run_builtin action

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1001,7 +1001,6 @@ builtin.builtin({opts})                                    *builtin.builtin()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {ignore_filename}    (boolean)  dont show filenames (default: true)
         {include_extensions} (boolean)  if true will show the pickers of the
                                         installed extensions (default: false)
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -336,26 +336,6 @@ actions.paste_register = function(prompt_bufnr)
   end
 end
 
-actions.run_builtin = function(prompt_bufnr)
-  local selection = action_state.get_selected_entry()
-  if selection == nil then
-    print "[telescope] Nothing currently selected"
-    return
-  end
-
-  actions._close(prompt_bufnr, true)
-  if string.match(selection.text, " : ") then
-    -- Call appropriate function from extensions
-    local split_string = vim.split(selection.text, " : ")
-    local ext = split_string[1]
-    local func = split_string[2]
-    require("telescope").extensions[ext][func]()
-  else
-    -- Call appropriate telescope builtin
-    require("telescope.builtin")[selection.text]()
-  end
-end
-
 actions.insert_symbol = function(prompt_bufnr)
   local symbol = action_state.get_selected_entry().value[1]
   actions.close(prompt_bufnr)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -215,7 +215,6 @@ builtin.git_stash = require_on_exported_call("telescope.builtin.git").stash
 
 --- Lists all of the community maintained pickers built into Telescope
 ---@param opts table: options to pass to the picker
----@field ignore_filename boolean: dont show filenames (default: true)
 ---@field include_extensions boolean: if true will show the pickers of the installed extensions (default: false)
 builtin.builtin = require_on_exported_call("telescope.builtin.internal").builtin
 

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -31,12 +31,7 @@ end
 
 local internal = {}
 
--- TODO: What the heck should we do for accepting this.
---  vim.fn.setreg("+", "nnoremap $TODO :lua require('telescope.builtin').<whatever>()<CR>")
--- TODO: Can we just do the names instead?
 internal.builtin = function(opts)
-  opts.path_display = utils.get_default(opts.path_display, "hidden")
-  opts.ignore_filename = utils.get_default(opts.ignore_filename, true)
   opts.include_extensions = utils.get_default(opts.include_extensions, false)
 
   local objs = {}
@@ -81,7 +76,27 @@ internal.builtin = function(opts)
     previewer = previewers.builtin.new(opts),
     sorter = conf.generic_sorter(opts),
     attach_mappings = function(_)
-      actions.select_default:replace(actions.run_builtin)
+      actions.select_default:replace(function(_)
+        local selection = action_state.get_selected_entry()
+        if not selection then
+          print "[telescope] Nothing currently selected"
+          return
+        end
+
+        -- we do this to avoid any surprises
+        opts.include_extensions = nil
+
+        if string.match(selection.text, " : ") then
+          -- Call appropriate function from extensions
+          local split_string = vim.split(selection.text, " : ")
+          local ext = split_string[1]
+          local func = split_string[2]
+          require("telescope").extensions[ext][func](opts)
+        else
+          -- Call appropriate telescope builtin
+          require("telescope.builtin")[selection.text](opts)
+        end
+      end)
       return true
     end,
   }):find()


### PR DESCRIPTION
Remove `run_builtin` as it's really not that useful, as per the discussion in https://github.com/nvim-telescope/telescope.nvim/pull/1544#issuecomment-991623542
