### PR TITLE
fix: make keepinsert work with nvim-0.7

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2179,14 +2179,13 @@ actions.close({prompt_bufnr})                      *telescope.actions.close()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions._close({prompt_bufnr}, {keepinsert})      *telescope.actions._close()*
+actions._close({prompt_bufnr})                    *telescope.actions._close()*
     Close the Telescope window and specify if you want to keep insert mode or
     not
 
 
     Parameters: ~
-        {prompt_bufnr} (number)   The prompt bufnr
-        {keepinsert}   (boolean)  Remain in INSERT mode if true
+        {prompt_bufnr} (number)  The prompt bufnr
 
 
 actions.edit_command_line({prompt_bufnr}) *telescope.actions.edit_command_line()*

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2180,8 +2180,9 @@ actions.close({prompt_bufnr})                      *telescope.actions.close()*
 
 
 actions._close({prompt_bufnr})                    *telescope.actions._close()*
-    Close the Telescope window and specify if you want to keep insert mode or
-    not
+    Close the Telescope window, usually used within an action
+    Deprecated and no longer needed, does the same as
+    |telescope.actions.close|. Might be removed in the future
 
 
     Parameters: ~

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -357,6 +357,7 @@ end
 
 --- Close the Telescope window, usually used within an action<br>
 --- Deprecated and no longer needed, does the same as |telescope.actions.close|. Might be removed in the future
+---@deprecated
 ---@param prompt_bufnr number: The prompt bufnr
 actions._close = function(prompt_bufnr)
   actions.close(prompt_bufnr)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -348,17 +348,13 @@ end
 
 --- Close the Telescope window and specify if you want to keep insert mode or not
 ---@param prompt_bufnr number: The prompt bufnr
----@param keepinsert boolean: Remain in INSERT mode if true
-actions._close = function(prompt_bufnr, keepinsert)
+actions._close = function(prompt_bufnr)
   action_state.get_current_history():reset()
   local picker = action_state.get_current_picker(prompt_bufnr)
   local prompt_win = state.get_status(prompt_bufnr).prompt_win
   local original_win_id = picker.original_win_id
 
   actions.close_pum(prompt_bufnr)
-  if not keepinsert then
-    vim.cmd [[stopinsert]]
-  end
 
   vim.api.nvim_win_close(prompt_win, true)
   pcall(vim.cmd, string.format([[silent bdelete! %s]], prompt_bufnr))

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -343,12 +343,6 @@ end
 --- Close the Telescope window, usually used within an action
 ---@param prompt_bufnr number: The prompt bufnr
 actions.close = function(prompt_bufnr)
-  actions._close(prompt_bufnr, false)
-end
-
---- Close the Telescope window and specify if you want to keep insert mode or not
----@param prompt_bufnr number: The prompt bufnr
-actions._close = function(prompt_bufnr)
   action_state.get_current_history():reset()
   local picker = action_state.get_current_picker(prompt_bufnr)
   local prompt_win = state.get_status(prompt_bufnr).prompt_win
@@ -359,6 +353,13 @@ actions._close = function(prompt_bufnr)
   vim.api.nvim_win_close(prompt_win, true)
   pcall(vim.cmd, string.format([[silent bdelete! %s]], prompt_bufnr))
   pcall(a.nvim_set_current_win, original_win_id)
+end
+
+--- Close the Telescope window, usually used within an action<br>
+--- Deprecated and no longer needed, does the same as |telescope.actions.close|. Might be removed in the future
+---@param prompt_bufnr number: The prompt bufnr
+actions._close = function(prompt_bufnr)
+  actions.close(prompt_bufnr)
 end
 
 local set_edit_line = function(prompt_bufnr, fname, prefix, postfix)
@@ -456,7 +457,7 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 actions.insert_symbol_i = function(prompt_bufnr)
   local symbol = action_state.get_selected_entry().value[1]
-  actions._close(prompt_bufnr, true)
+  actions.close(prompt_bufnr)
   vim.schedule(function()
     vim.cmd [[startinsert]]
     vim.api.nvim_put({ symbol }, "", true, true)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -356,14 +356,8 @@ actions._close = function(prompt_bufnr, keepinsert)
   local original_win_id = picker.original_win_id
 
   actions.close_pum(prompt_bufnr)
-
   if not keepinsert then
     vim.cmd [[stopinsert]]
-  elseif vim.fn.has "nvim-0.7" == 1 then
-    -- https://github.com/neovim/neovim/commit/28134f4e78819c2bbf0344326b9d44f21eb0d736
-    vim.schedule(function()
-      vim.cmd [[startinsert]]
-    end)
   end
 
   vim.api.nvim_win_close(prompt_win, true)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -356,8 +356,14 @@ actions._close = function(prompt_bufnr, keepinsert)
   local original_win_id = picker.original_win_id
 
   actions.close_pum(prompt_bufnr)
+
   if not keepinsert then
     vim.cmd [[stopinsert]]
+  elseif vim.fn.has "nvim-0.7" == 1 then
+    -- https://github.com/neovim/neovim/commit/28134f4e78819c2bbf0344326b9d44f21eb0d736
+    vim.schedule(function()
+      vim.cmd [[startinsert]]
+    end)
   end
 
   vim.api.nvim_win_close(prompt_win, true)

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -178,9 +178,10 @@ internal.pickers = function(opts)
       actions.select_default:replace(function(prompt_bufnr)
         local current_picker = action_state.get_current_picker(prompt_bufnr)
         local selection_index = current_picker:get_index(current_picker:get_selection_row())
-        actions._close(prompt_bufnr, cached_pickers[selection_index].initial_mode == "insert")
+        actions.close(prompt_bufnr)
         opts.cache_picker = opts._cache_picker
         opts["cache_index"] = selection_index
+        opts["initial_mode"] = cached_pickers[selection_index].initial_mode
         internal.resume(opts)
       end)
       map("i", "<C-x>", actions.remove_selected_picker)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -438,9 +438,7 @@ function Picker:find()
         vim.cmd [[startinsert!]]
       end)
       if self.default_text then
-        vim.schedule(function()
-          self:set_prompt(self.default_text)
-        end)
+        self:set_prompt(self.default_text)
       end
       if self.initial_mode == "normal" then
         -- otherwise (i) insert mode exitted faster than `picker:set_prompt`; (ii) cursor on wrong pos
@@ -725,9 +723,16 @@ function Picker:delete_selection(delete_cb)
 end
 
 function Picker:set_prompt(str)
-  -- TODO(conni2461): As soon as prompt_buffers are fix use this:
-  -- vim.api.nvim_buf_set_lines(self.prompt_bufnr, 0, 1, false, { str })
-  vim.api.nvim_feedkeys(str, "n", false)
+  if vim.fn.has "nvim-0.7" == 1 then
+    local prompt_text = self.prompt_prefix .. (str or "")
+    vim.api.nvim_buf_set_lines(self.prompt_bufnr, 0, 1, false, { prompt_text })
+    vim.api.nvim_win_set_cursor(self.prompt_win, { 1, #prompt_text })
+    self:_reset_prefix_color()
+  else
+    vim.schedule(function()
+      vim.api.nvim_feedkeys(str, "n", false)
+    end)
+  end
 end
 
 --- Closes the windows for the prompt, results and preview

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -432,13 +432,15 @@ function Picker:find()
     pcall(a.nvim_buf_set_option, prompt_bufnr, "filetype", "TelescopePrompt")
     pcall(a.nvim_buf_set_option, results_bufnr, "filetype", "TelescopeResults")
 
-    -- TODO(async): I wonder if this should actually happen _before_ we nvim_buf_attach.
-    -- This way the buffer would always start with what we think it should when we start the loop.
     if self.initial_mode == "insert" or self.initial_mode == "normal" then
       -- required for set_prompt to work adequately
-      vim.cmd [[startinsert!]]
+      vim.schedule(function()
+        vim.cmd [[startinsert!]]
+      end)
       if self.default_text then
-        self:set_prompt(self.default_text)
+        vim.schedule(function()
+          self:set_prompt(self.default_text)
+        end)
       end
       if self.initial_mode == "normal" then
         -- otherwise (i) insert mode exitted faster than `picker:set_prompt`; (ii) cursor on wrong pos

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1216,7 +1216,7 @@ end
 --- Close all open Telescope pickers
 function Picker:close_existing_pickers()
   for _, prompt_bufnr in ipairs(state.get_existing_prompts()) do
-    pcall(actions._close, prompt_bufnr, true)
+    pcall(actions.close, prompt_bufnr)
   end
 end
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -432,21 +432,18 @@ function Picker:find()
     pcall(a.nvim_buf_set_option, prompt_bufnr, "filetype", "TelescopePrompt")
     pcall(a.nvim_buf_set_option, results_bufnr, "filetype", "TelescopeResults")
 
-    if self.initial_mode == "insert" or self.initial_mode == "normal" then
-      -- required for set_prompt to work adequately
+    if self.default_text then
+      self:set_prompt(self.default_text)
+    end
+    -- if self.initial_mode == "normal" then
+    --   await_schedule(function()
+    --     vim.cmd [[stopinsert]]
+    --   end)
+    if self.initial_mode == "insert" then
       vim.schedule(function()
         vim.cmd [[startinsert!]]
       end)
-      if self.default_text then
-        self:set_prompt(self.default_text)
-      end
-      if self.initial_mode == "normal" then
-        -- otherwise (i) insert mode exitted faster than `picker:set_prompt`; (ii) cursor on wrong pos
-        await_schedule(function()
-          vim.cmd [[stopinsert]]
-        end)
-      end
-    else
+    elseif self.initial_mode ~= "normal" then
       error("Invalid setting for initial_mode: " .. self.initial_mode)
     end
 
@@ -723,16 +720,10 @@ function Picker:delete_selection(delete_cb)
 end
 
 function Picker:set_prompt(str)
-  if vim.fn.has "nvim-0.7" == 1 then
-    local prompt_text = self.prompt_prefix .. (str or "")
-    vim.api.nvim_buf_set_lines(self.prompt_bufnr, 0, 1, false, { prompt_text })
-    vim.api.nvim_win_set_cursor(self.prompt_win, { 1, #prompt_text })
-    self:_reset_prefix_color()
-  else
-    vim.schedule(function()
-      vim.api.nvim_feedkeys(str, "n", false)
-    end)
-  end
+  local prompt_text = self.prompt_prefix .. (str or "")
+  vim.api.nvim_buf_set_lines(self.prompt_bufnr, 0, 1, false, { prompt_text })
+  vim.api.nvim_win_set_cursor(self.prompt_win, { 1, #prompt_text })
+  self:_reset_prefix_color()
 end
 
 --- Closes the windows for the prompt, results and preview

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -440,7 +440,12 @@ function Picker:find()
       vim.schedule(function()
         -- startinsert! did not reliable do `A` no idea why, i even looked at the source code
         -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
-        vim.api.nvim_feedkeys("A", "n", true)
+        local mode = vim.fn.mode()
+        if mode == "n" then
+          vim.api.nvim_feedkeys("A", "n", true)
+        elseif mode == "v" then
+          vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<ESC>A", true, false, true), "n", true)
+        end
       end)
     elseif self.initial_mode ~= "normal" then
       error("Invalid setting for initial_mode: " .. self.initial_mode)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -440,10 +440,7 @@ function Picker:find()
       vim.schedule(function()
         -- startinsert! did not reliable do `A` no idea why, i even looked at the source code
         -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
-        local mode = vim.fn.mode()
-        if mode == "n" then
-          vim.api.nvim_feedkeys("A", "n", true)
-        elseif mode == "v" then
+        if vim.fn.mode() ~= "i" then
           vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<ESC>A", true, false, true), "n", true)
         end
       end)

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -1,5 +1,5 @@
 if !has('nvim-0.7.0')
-  echoerr "Telescope.nvim requires at least nvim-0.7.0. See `:h telescope.changelog-1549`"
+  echoerr "Telescope.nvim requires at least nvim-0.7.0. See `:h telescope.changelog-1851`"
   finish
 end
 


### PR DESCRIPTION
Ensure that `keepinsert` works correctly in `actions._close()` in nvim-0.7 after https://github.com/neovim/neovim/commit/28134f4e78819c2bbf0344326b9d44f21eb0d736

Fixes #1599
