### PR TITLE
fix: too early setup on initial extension access

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -610,6 +610,8 @@ telescope.register_extension({mod})           *telescope.register_extension()*
 
 telescope.load_extension({name})                  *telescope.load_extension()*
     Load an extension.
+    - Notes:
+      - Loading triggers ext setup via the config passed in |telescope.setup|
 
 
     Parameters: ~

--- a/lua/telescope/_extensions/init.lua
+++ b/lua/telescope/_extensions/init.lua
@@ -14,7 +14,6 @@ end
 
 extensions.manager = setmetatable({}, {
   __index = function(t, k)
-    -- See if this extension exists.
 
     local ext = load_extension(k)
     t[k] = ext.exports or {}

--- a/lua/telescope/_extensions/init.lua
+++ b/lua/telescope/_extensions/init.lua
@@ -14,7 +14,6 @@ end
 
 extensions.manager = setmetatable({}, {
   __index = function(t, k)
-
     local ext = load_extension(k)
     t[k] = ext.exports or {}
     extensions._health[k] = ext.health

--- a/lua/telescope/_extensions/init.lua
+++ b/lua/telescope/_extensions/init.lua
@@ -4,18 +4,19 @@ extensions._loaded = {}
 extensions._config = {}
 extensions._health = {}
 
+local load_extension = function(name)
+  local ok, ext = pcall(require, "telescope._extensions." .. name)
+  if not ok then
+    error("This extension doesn't exist or is not installed: " .. name .. "\n" .. ext)
+  end
+  return ext
+end
+
 extensions.manager = setmetatable({}, {
   __index = function(t, k)
     -- See if this extension exists.
-    local ok, ext = pcall(require, "telescope._extensions." .. k)
-    if not ok then
-      error("This extension doesn't exist or is not installed: " .. k .. "\n" .. ext)
-    end
 
-    if ext.setup then
-      ext.setup(extensions._config[k] or {}, require("telescope.config").values)
-    end
-
+    local ext = load_extension(k)
     t[k] = ext.exports or {}
     extensions._health[k] = ext.health
 
@@ -54,7 +55,10 @@ extensions.register = function(mod)
 end
 
 extensions.load = function(name)
-  return extensions.manager[name]
+  local ext = load_extension(name)
+  if ext.setup then
+    ext.setup(extensions._config[name] or {}, require("telescope.config").values)
+  end
 end
 
 extensions.set_config = function(extensions_config)

--- a/lua/telescope/init.lua
+++ b/lua/telescope/init.lua
@@ -93,8 +93,8 @@ function telescope.register_extension(mod)
 end
 
 --- Load an extension.
---- Notes:
---- - Loading triggers ext setup via the config passed in |telescope.setup|
+--- - Notes:
+---   - Loading triggers ext setup via the config passed in |telescope.setup|
 ---@param name string: Name of the extension
 function telescope.load_extension(name)
   return _extensions.load(name)

--- a/lua/telescope/init.lua
+++ b/lua/telescope/init.lua
@@ -93,6 +93,8 @@ function telescope.register_extension(mod)
 end
 
 --- Load an extension.
+--- Notes:
+--- - Loading triggers ext setup via the config passed in |telescope.setup|
 ---@param name string: Name of the extension
 function telescope.load_extension(name)
   return _extensions.load(name)


### PR DESCRIPTION
This is a mundane fix for a stupid issue with extensions. For instance, when trying to set mappings from telescope-file-browser or telescope-hop with extension actions, one `require`s the extensions module prior to setup and then user configuration is not applied.

This is a minimal fix within the existing API. I'm curious, what substantive value does `require "telescope".load_extension $EXTENSION` actually add? Alternatively, we could just invoke set up when the extension config is forwarded.. otherwise any extension within telescope interface just has it's default config.

Generally speaking, this is not the most prettiest fix, but maybe more intended to get the ball rolling on a discussion as I didn't want to break the `load_extension` interface just yet.

Once something along these lines is merged, I'll move forward with deprecating the file browser. Basic remappings should be straightforwardly possible :sweat_smile: 