### PR TITLE
fix: actually generate entries for passed result

### DIFF
--- a/lua/telescope/finders/async_oneshot_finder.lua
+++ b/lua/telescope/finders/async_oneshot_finder.lua
@@ -55,6 +55,11 @@ return function(opts)
       end
 
       if not job_completed then
+        if not vim.tbl_isempty(results) then
+          for _, v in ipairs(results) do
+            process_result(v)
+          end
+        end
         for line in stdout:iter(false) do
           num_results = num_results + 1
 


### PR DESCRIPTION
Fully complete #1461, forgot to process the entry.

~~E: On second thought, it begs the question a bit on whether the entry should be added preprocessed to results or not. Preprocessing makes sense I suppose, in which case we could just close this.~~

E2: Forget what I said, I forgot the difference of `process_result` and preprocessing (or more accurately, why I did this PR :laughing:) because I intermediately thought it just worked. The problem is that on the first rendering the added `results` are not shown because `process_result` is otherwise not called.