### PR TITLE
fix: handle filenames with colons in `live_grep`

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -110,29 +110,9 @@ do
     ordinal = 1,
   }
 
-  local find = (function()
-    if Path.path.sep == "\\" then
-      return function(t)
-        local start, _, filename, lnum, col, text = string.find(t, [[([^:]+):(%d+):(%d+):(.*)]])
-
-        -- Handle Windows drive letter (e.g. "C:") at the beginning (if present)
-        if start == 3 then
-          filename = string.sub(t.value, 1, 3) .. filename
-        end
-
-        return filename, lnum, col, text
-      end
-    else
-      return function(t)
-        local _, _, filename, lnum, col, text = string.find(t, [[([^:]+):(%d+):(%d+):(.*)]])
-        return filename, lnum, col, text
-      end
-    end
-  end)()
-
   -- Gets called only once to parse everything out for the vimgrep, after that looks up directly.
   local parse = function(t)
-    local filename, lnum, col, text = find(t.value)
+    local _, _, filename, lnum, col, text = string.find(t.value, [[(.+):(%d+):(%d+):(.*)]])
 
     local ok
     ok, lnum = pcall(tonumber, lnum)


### PR DESCRIPTION
Fixes #1604
@dagle does this work for you?

---

The only time that I can think of this new regex breaking would be if there are sequences of exclusively digits between colons in the filename or the text. However, I'm not the best with regexes, so it would be good if someone else could have a look at it. 

Do we want to add `^` and `$` to the regex too? Can't find a circumstance where doing this breaks anything, but, again, I'm not the best with regexes 😅

This change also means that we don't need to have separate functions for windows/non-windows users, as I introduced in #1494. So its good that we can simplify the code a bit too 🙂