### PR TITLE
add filter options for diagnostics builtin

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1458,7 +1458,7 @@ builtin.lsp_dynamic_workspace_symbols({opts}) *builtin.lsp_dynamic_workspace_sym
 
 
 builtin.diagnostics({opts})                            *builtin.diagnostics()*
-    Lists diagnostics for current or all open buffers
+    Lists diagnostics
     - Fields:
       - `All severity flags can be passed as `string` or `number` as per
         `:vim.diagnostic.severity:`
@@ -1481,6 +1481,14 @@ builtin.diagnostics({opts})                            *builtin.diagnostics()*
         {severity_bound} (string|number)  keep diagnostics equal or less
                                           severe wrt severity name (string) or
                                           id (number)
+        {root_dir}       (string|boolean) if set to string, get diagnostics only
+                                          for buffers under this directory. If
+                                          set to true, uses current working
+                                          directory.
+        {no_unlisted}    (boolean)        if true, get diagnostics only for
+                                          listed buffers. Useful to exclude
+                                          diagnostics from language servers that
+                                          report diagnostics for whole projects.
         {no_sign}        (boolean)        hide DiagnosticSigns from Results
                                           (default: false)
         {line_width}     (number)         set length of diagnostic entry text

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1458,7 +1458,7 @@ builtin.lsp_dynamic_workspace_symbols({opts}) *builtin.lsp_dynamic_workspace_sym
 
 
 builtin.diagnostics({opts})                            *builtin.diagnostics()*
-    Lists diagnostics
+    Lists diagnostics for current or all open buffers
     - Fields:
       - `All severity flags can be passed as `string` or `number` as per
         `:vim.diagnostic.severity:`

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1458,7 +1458,7 @@ builtin.lsp_dynamic_workspace_symbols({opts}) *builtin.lsp_dynamic_workspace_sym
 
 
 builtin.diagnostics({opts})                            *builtin.diagnostics()*
-    Lists diagnostics for current or all open buffers
+    Lists diagnostics
     - Fields:
       - `All severity flags can be passed as `string` or `number` as per
         `:vim.diagnostic.severity:`
@@ -1471,22 +1471,27 @@ builtin.diagnostics({opts})                            *builtin.diagnostics()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {bufnr}          (string|number)  if nil get diagnostics for all open
-                                          buffers. Use 0 for current buffer
-        {severity}       (string|number)  filter diagnostics by severity name
-                                          (string) or id (number)
-        {severity_limit} (string|number)  keep diagnostics equal or more
-                                          severe wrt severity name (string) or
-                                          id (number)
-        {severity_bound} (string|number)  keep diagnostics equal or less
-                                          severe wrt severity name (string) or
-                                          id (number)
-        {no_sign}        (boolean)        hide DiagnosticSigns from Results
-                                          (default: false)
-        {line_width}     (number)         set length of diagnostic entry text
-                                          in Results
-        {namespace}      (number)         limit your diagnostics to a specific
-                                          namespace
+        {bufnr}          (string|number)   if nil get diagnostics for all open
+                                           buffers. Use 0 for current buffer
+        {severity}       (string|number)   filter diagnostics by severity name
+                                           (string) or id (number)
+        {severity_limit} (string|number)   keep diagnostics equal or more
+                                           severe wrt severity name (string)
+                                           or id (number)
+        {severity_bound} (string|number)   keep diagnostics equal or less
+                                           severe wrt severity name (string)
+                                           or id (number)
+        {root_dir}       (string|boolean)  if set to string, get diagnostics
+                                           only for buffers under this dir
+                                           otherwise cwd
+        {no_unlisted}    (boolean)         if true, get diagnostics only for
+                                           listed buffers
+        {no_sign}        (boolean)         hide DiagnosticSigns from Results
+                                           (default: false)
+        {line_width}     (number)          set length of diagnostic entry text
+                                           in Results
+        {namespace}      (number)          limit your diagnostics to a
+                                           specific namespace
 
 
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1481,14 +1481,6 @@ builtin.diagnostics({opts})                            *builtin.diagnostics()*
         {severity_bound} (string|number)  keep diagnostics equal or less
                                           severe wrt severity name (string) or
                                           id (number)
-        {root_dir}       (string|boolean) if set to string, get diagnostics only
-                                          for buffers under this directory. If
-                                          set to true, uses current working
-                                          directory.
-        {no_unlisted}    (boolean)        if true, get diagnostics only for
-                                          listed buffers. Useful to exclude
-                                          diagnostics from language servers that
-                                          report diagnostics for whole projects.
         {no_sign}        (boolean)        hide DiagnosticSigns from Results
                                           (default: false)
         {line_width}     (number)         set length of diagnostic entry text

--- a/lua/telescope/builtin/diagnostics.lua
+++ b/lua/telescope/builtin/diagnostics.lua
@@ -41,12 +41,7 @@ local diagnostics_to_tbl = function(opts)
     end
   end
 
-  local root_dir
-  if opts.root_dir then
-    root_dir = type(opts.root_dir) == "boolean" and
-      vim.fn.getcwd() or  -- use cwd for `true`
-      opts.root_dir
-  end
+  opts.root_dir = opts.root_dir == true and vim.loop.cwd() or opts.root_dir
 
   local bufnr_name_map = {}
   local filter_diag = function(diagnostic)
@@ -54,10 +49,10 @@ local diagnostics_to_tbl = function(opts)
       bufnr_name_map[diagnostic.bufnr] = vim.api.nvim_buf_get_name(diagnostic.bufnr)
     end
 
-    local root_dir_test = not root_dir or
-      string.sub(bufnr_name_map[diagnostic.bufnr], 1, #root_dir) == root_dir
-    local listed_test = not opts.no_unlisted  or
-      vim.fn.buflisted(diagnostic.bufnr) == 1
+    local root_dir_test = not opts.root_dir or
+      string.sub(bufnr_name_map[diagnostic.bufnr], 1, #opts.root_dir) == opts.root_dir
+    local listed_test = not opts.no_unlisted or
+      vim.api.nvim_buf_get_option(diagnostic.bufnr, "buflisted")
 
     return root_dir_test and listed_test
   end

--- a/lua/telescope/builtin/diagnostics.lua
+++ b/lua/telescope/builtin/diagnostics.lua
@@ -49,10 +49,9 @@ local diagnostics_to_tbl = function(opts)
       bufnr_name_map[diagnostic.bufnr] = vim.api.nvim_buf_get_name(diagnostic.bufnr)
     end
 
-    local root_dir_test = not opts.root_dir or
-      string.sub(bufnr_name_map[diagnostic.bufnr], 1, #opts.root_dir) == opts.root_dir
-    local listed_test = not opts.no_unlisted or
-      vim.api.nvim_buf_get_option(diagnostic.bufnr, "buflisted")
+    local root_dir_test = not opts.root_dir
+      or string.sub(bufnr_name_map[diagnostic.bufnr], 1, #opts.root_dir) == opts.root_dir
+    local listed_test = not opts.no_unlisted or vim.api.nvim_buf_get_option(diagnostic.bufnr, "buflisted")
 
     return root_dir_test and listed_test
   end

--- a/lua/telescope/builtin/diagnostics.lua
+++ b/lua/telescope/builtin/diagnostics.lua
@@ -41,9 +41,12 @@ local diagnostics_to_tbl = function(opts)
     end
   end
 
-  local root_dir = not opts.root_dir or
-    type(opts.root_dir) == "boolean" and vim.fn.getcwd() or  -- use cwd for `true`
-    opts.root_dir
+  local root_dir
+  if opts.root_dir then
+    root_dir = type(opts.root_dir) == "boolean" and
+      vim.fn.getcwd() or  -- use cwd for `true`
+      opts.root_dir
+  end
 
   local bufnr_name_map = {}
   local filter_diag = function(diagnostic)

--- a/lua/telescope/builtin/diagnostics.lua
+++ b/lua/telescope/builtin/diagnostics.lua
@@ -41,13 +41,26 @@ local diagnostics_to_tbl = function(opts)
     end
   end
 
+  local root_dir = not opts.root_dir or
+    type(opts.root_dir) == "boolean" and vim.fn.getcwd() or  -- use cwd for `true`
+    opts.root_dir
+
   local bufnr_name_map = {}
-  local preprocess_diag = function(diagnostic)
+  local filter_diag = function(diagnostic)
     if bufnr_name_map[diagnostic.bufnr] == nil then
       bufnr_name_map[diagnostic.bufnr] = vim.api.nvim_buf_get_name(diagnostic.bufnr)
     end
 
-    local buffer_diag = {
+    local root_dir_test = not root_dir or
+      string.sub(bufnr_name_map[diagnostic.bufnr], 1, #root_dir) == root_dir
+    local listed_test = not opts.no_unlisted  or
+      vim.fn.buflisted(diagnostic.bufnr) == 1
+
+    return root_dir_test and listed_test
+  end
+
+  local preprocess_diag = function(diagnostic)
+    return {
       bufnr = diagnostic.bufnr,
       filename = bufnr_name_map[diagnostic.bufnr],
       lnum = diagnostic.lnum + 1,
@@ -55,11 +68,12 @@ local diagnostics_to_tbl = function(opts)
       text = vim.trim(diagnostic.message:gsub("[\n]", "")),
       type = severities[diagnostic.severity] or severities[1],
     }
-    return buffer_diag
   end
 
   for _, d in ipairs(vim.diagnostic.get(opts.bufnr, diagnosis_opts)) do
-    table.insert(items, preprocess_diag(d))
+    if filter_diag(d) then
+      table.insert(items, preprocess_diag(d))
+    end
   end
 
   -- sort results by bufnr (prioritize cur buf), severity, lnum

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -433,8 +433,8 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 ---@field severity string|number: filter diagnostics by severity name (string) or id (number)
 ---@field severity_limit string|number: keep diagnostics equal or more severe wrt severity name (string) or id (number)
 ---@field severity_bound string|number: keep diagnostics equal or less severe wrt severity name (string) or id (number)
----@field root_dir string|boolean: if set to string, get diagnostics only for buffers under this directory. If set to true, uses current working directory.
----@field no_unlisted boolean: if true, get diagnostics only for listed buffers. Useful to exclude diagnostics from language servers that report diagnostics for whole projects.
+---@field root_dir string|boolean: if set to string, get diagnostics only for buffers under this dir otherwise cwd
+---@field no_unlisted boolean: if true, get diagnostics only for listed buffers
 ---@field no_sign boolean: hide DiagnosticSigns from Results (default: false)
 ---@field line_width number: set length of diagnostic entry text in Results
 ---@field namespace number: limit your diagnostics to a specific namespace

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -433,6 +433,8 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 ---@field severity string|number: filter diagnostics by severity name (string) or id (number)
 ---@field severity_limit string|number: keep diagnostics equal or more severe wrt severity name (string) or id (number)
 ---@field severity_bound string|number: keep diagnostics equal or less severe wrt severity name (string) or id (number)
+---@field root_dir string|boolean: if set to string, get diagnostics only for buffers under this directory. If set to true, uses current working directory.
+---@field no_unlisted boolean: if true, get diagnostics only for listed buffers. Useful to exclude diagnostics from language servers that report diagnostics for whole projects.
 ---@field no_sign boolean: hide DiagnosticSigns from Results (default: false)
 ---@field line_width number: set length of diagnostic entry text in Results
 ---@field namespace number: limit your diagnostics to a specific namespace

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -423,7 +423,7 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 --
 --
 
---- Lists diagnostics for current or all open buffers
+--- Lists diagnostics
 --- - Fields:
 ---   - `All severity flags can be passed as `string` or `number` as per `:vim.diagnostic.severity:`
 --- - Default keymaps:


### PR DESCRIPTION
Adds support for filtering diagnostics by:

1. A root directory. Useful to browse only project-scoped diagnostics.
2. `buflisted` status. Useful to exclude diagnostics from unlisted buffers, which are created by language servers that analyze the entire project/workspace (e.g. `sumneko-lua`).