### PR TITLE
feat: languages table to specify treesitter highlighing

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -497,8 +497,17 @@ telescope.setup({opts})                                    *telescope.setup()*
                               highlighting, which falls back to regex-based highlighting.
                               `true`: treesitter highlighting for all available filetypes
                               `false`: regex-based highlighting for all filetypes
-                              `table`: table of filetypes for which to attach treesitter
-                              highlighting
+                              `table`: following nvim-treesitters highlighting options:
+                                It contains two keys:
+                                  - enable boolean|table: if boolean, enable all ts
+                                                          highlighing with that flag,
+                                                          disable still considered.
+                                                          Containing a list of filetypes,
+                                                          that are enabled, disabled
+                                                          ignored because it doesnt make
+                                                          any sense in this case.
+                                  - disable table: containing a list of filetypes
+                                                   that are disabled
                               Default: true
           - msg_bg_fillchar:  Character to fill background of unpreviewable buffers with
                               Default: "╱"

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -593,8 +593,17 @@ append(
                           highlighting, which falls back to regex-based highlighting.
                           `true`: treesitter highlighting for all available filetypes
                           `false`: regex-based highlighting for all filetypes
-                          `table`: table of filetypes for which to attach treesitter
-                          highlighting
+                          `table`: following nvim-treesitters highlighting options:
+                            It contains two keys:
+                              - enable boolean|table: if boolean, enable all ts
+                                                      highlighing with that flag,
+                                                      disable still considered.
+                                                      Containing a list of filetypes,
+                                                      that are enabled, disabled
+                                                      ignored because it doesnt make
+                                                      any sense in this case.
+                              - disable table: containing a list of filetypes
+                                               that are disabled
                           Default: true
       - msg_bg_fillchar:  Character to fill background of unpreviewable buffers with
                           Default: "╱"

--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -82,12 +82,26 @@ end
 utils.highlighter = function(bufnr, ft, opts)
   opts = opts or {}
   opts.preview = opts.preview or {}
-  opts.preview.treesitter = vim.F.if_nil(
-    opts.preview.treesitter,
-    type(conf.preview) == "table" and conf.preview.treesitter
-  )
-  local ts_highlighting = opts.preview.treesitter == true
-    or type(opts.preview.treesitter) == "table" and vim.tbl_contains(opts.preview.treesitter, ft)
+  opts.preview.treesitter = vim.F.if_nil(opts.preview.treesitter, conf.preview.treesitter)
+  if type(opts.preview.treesitter) == "boolean" then
+    local temp = { enable = opts.preview.treesitter }
+    opts.preview.treesitter = temp
+  end
+
+  local ts_highlighting = (function()
+    if type(opts.preview.treesitter.enable) == "table" then
+      if vim.tbl_contains(opts.preview.treesitter.enable, ft) then
+        return true
+      end
+      return false
+    end
+
+    if vim.tbl_contains(vim.F.if_nil(opts.preview.treesitter.disable, {}), ft) then
+      return false
+    end
+
+    return opts.preview.treesitter.enable == nil or opts.preview.treesitter.enable == true
+  end)()
 
   local ts_success
   if ts_highlighting then


### PR DESCRIPTION
First of all just say that's my first "contribution" to any open source project. I hope with time the contributions are bigger :). This change makes more sense for me that the logic that it's being use now, but maybe not for everyone. Any feedback welcome.

If the languages exists in the config, only the file-types that match with
the ones on the table will be affected by the treesitter boolean.

The config now will look like this:
```lua
defaults = {
        preview = {
            treesitter = false,
            languages = { "perl", "javascript" },
        },
},
```

That will make that only `perl` and `javascript` will use regex for the highlight and any other file-type will use treesitter if possible.