### PR TITLE
feat: adds multiselect counter in prompt status_text

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -332,6 +332,7 @@ append(
 append(
   "get_status_text",
   function(self)
+    local ww = #(self:get_multi_selection())
     local xx = (self.stats.processed or 0) - (self.stats.filtered or 0)
     local yy = self.stats.processed or 0
     if xx == 0 and yy == 0 then
@@ -344,7 +345,11 @@ append(
     -- else
     --   status_icon = "*"
     -- end
-    return string.format("%s / %s", xx, yy)
+    if ww == 0 then
+      return string.format("%s / %s", xx, yy)
+    else
+      return string.format("%s / %s / %s", ww, xx, yy)
+    end
   end,
   [[
   A function that determines what the virtual text looks like.

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -757,6 +757,7 @@ function Picker:add_selection(row)
   local entry = self.manager:get_entry(self:get_index(row))
   self._multi:add(entry)
 
+  self:get_status_updater(self.prompt_win, self.prompt_bufnr)()
   self.highlighter:hi_multiselect(row, true)
 end
 
@@ -766,6 +767,7 @@ function Picker:remove_selection(row)
   local entry = self.manager:get_entry(self:get_index(row))
   self._multi:drop(entry)
 
+  self:get_status_updater(self.prompt_win, self.prompt_bufnr)()
   self.highlighter:hi_multiselect(row, false)
 end
 
@@ -790,6 +792,7 @@ function Picker:toggle_selection(row)
   local entry = self.manager:get_entry(self:get_index(row))
   self._multi:toggle(entry)
 
+  self:get_status_updater(self.prompt_win, self.prompt_bufnr)()
   self.highlighter:hi_multiselect(row, self._multi:is_selected(entry))
 end
 


### PR DESCRIPTION
Adds a counter for the number of entries in the multi-selection.

Example:
![image](https://user-images.githubusercontent.com/35707277/146685044-593f0d86-f819-4e09-b558-3844eee05760.png)

Note: new counter isn't displayed when nothing in the multi-selection