### PR TITLE
fix(actions): force insertmode after inserting symbol

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -369,6 +369,7 @@ actions.insert_symbol_i = function(prompt_bufnr)
   vim.api.nvim_buf_set_text(0, cursor[1] - 1, cursor[2], cursor[1] - 1, cursor[2], { symbol })
   vim.schedule(function()
     vim.api.nvim_win_set_cursor(0, { cursor[1], cursor[2] + #symbol })
+    vim.cmd [[startinsert!]]
   end)
 end
 


### PR DESCRIPTION
required after upstream changes to prompt buffer behavior (see https://github.com/neovim/neovim/commit/28134f4e78819c2bbf0344326b9d44f21eb0d736)

Fixes #1608

(I doubt anyone besides me has ever used this action... @Conni2461)