### PR TITLE
feat: workspace & document diag in title

### DIFF
--- a/lua/telescope/builtin/diagnostics.lua
+++ b/lua/telescope/builtin/diagnostics.lua
@@ -102,7 +102,7 @@ diagnostics.get = function(opts)
 
   opts.path_display = vim.F.if_nil(opts.path_display, "hidden")
   pickers.new(opts, {
-    prompt_title = "Document Diagnostics",
+    prompt_title = opts.bufnr == nil and "Workspace Diagnostics" or "Document Diagnostics",
     finder = finders.new_table {
       results = locations,
       entry_maker = opts.entry_maker or make_entry.gen_from_diagnostics(opts),


### PR DESCRIPTION
This PR is the minimum viable solution to disambiguate between "Workspace" and "Document" diagnostics (ie once `bufnr`) is passed.

Of course we could also add some more info in the prompt title.

One other way I like, which would be a departure from how we've been doing it would be:

* Prompt title: "Diagnostics"
* Results title: "Workspace" or filename (or buf number)

Any thoughts/preferences here? 