### PR TITLE
Prevent an exception when err.message is nil

### DIFF
--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -49,7 +49,7 @@ local function list_or_jump(action, title, opts)
   local params = vim.lsp.util.make_position_params()
   vim.lsp.buf_request(0, action, params, function(err, result, _ctx, _config)
     if err then
-      vim.api.nvim_err_writeln("Error when executing " .. action .. " : " .. err.message)
+      vim.api.nvim_err_writeln("Error when executing " .. action .. " : " .. tostring(err.message))
       return
     end
     local flattened_results = {}


### PR DESCRIPTION
When trying to use go-to-definition using telescope's
LSP helper while Sumneko lua-language-server has not completed loading yet,
it returns an error response which does not have `message`
field.

This error handler tries to log an error by accessing
`message` field which is a `nil`. Concatenating `nil` to a string
throws an exception in Lua. Using `tostring()` prevents that.