### PR TITLE
Fix documentation for lsp_range_code_actions

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1386,7 +1386,9 @@ builtin.lsp_range_code_actions({opts})      *builtin.lsp_range_code_actions()*
 
     Options: ~
         {timeout}    (number)  timeout for the sync call (default: 10000)
-        {start_line} (number)  where the code action ends (default: handled by
+        {start_line} (number)  where the code action starts (default: handled
+                               by :'<,'>Telescope lsp_range_code_actions)
+        {end_line}   (number)  where the code action ends (default: handled by
                                :'<,'>Telescope lsp_range_code_actions)
 
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -400,7 +400,7 @@ builtin.lsp_code_actions = require_on_exported_call("telescope.builtin.lsp").cod
 ---@param opts table: options to pass to the picker
 ---@field timeout number: timeout for the sync call (default: 10000)
 ---@field start_line number: where the code action starts (default: handled by :'<,'>Telescope lsp_range_code_actions)
----@field start_line number: where the code action ends (default: handled by :'<,'>Telescope lsp_range_code_actions)
+---@field end_line number: where the code action ends (default: handled by :'<,'>Telescope lsp_range_code_actions)
 builtin.lsp_range_code_actions = require_on_exported_call("telescope.builtin.lsp").range_code_actions
 
 --- Lists LSP document symbols in the current buffer


### PR DESCRIPTION
The current documentation accidentally used start_line for both fields, making the documentation both incomplete and confusing.
Renaming the second field will bring this in line with the intended documentation, as well as the behaviour of the function.

Hopefully this is the correct file to change, as the docs/telescope.txt seems to be generated from this.