### PR TITLE
reload buffers and syntax-hi after git_reset

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -550,6 +550,11 @@ local git_reset_branch = function(prompt_bufnr, mode)
   else
     print(string.format('Error when resetting to: %s. Git returned: "%s"', selection.value, table.concat(stderr, "  ")))
   end
+  
+  local currentBuff = vim.api.nvim_get_current_buf()
+  vim.cmd("bufdo e")
+  vim.cmd("b" .. currentBuff)
+  vim.cmd("syntax on")
 end
 
 --- Reset to selected git commit using mixed mode


### PR DESCRIPTION
After calling the git_reset function from telescope,
- the buffers do not refresh and do not show the changes that are invoked by the git_reset command. Therefore, ```vim.cmd("bufdo e")``` was added such that buffers are reloading
- ```bufdo e``` will reload all open buffers, but may end up viewing another buffer (and not, as expected, the one that was previously viewed). Therefore, ```vim.cmd("b" ..currentBuff)``` was added to restore the view to the currentBuffer.
- ```bufdo e``` may also remove syntax highlighting (for reasons of speed). Therefore ```vim.cmd("syntax on")``` was added.