### PR TITLE
feat: Add <C-w> to default mappings

### DIFF
--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -34,6 +34,7 @@ mappings.default_mappings = config.values.default_mappings
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
       ["<C-l>"] = actions.complete_tag,
       ["<C-_>"] = actions.which_key, -- keys from pressing <C-/>
+      ["<C-w>"] = { "<c-s-w>", type = "command" },
     },
 
     n = {


### PR DESCRIPTION
As described in https://github.com/nvim-telescope/telescope.nvim/issues/1579, this adds `<C-w>` to the default mappings.