### PR TITLE
Xnorly buffer reload

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -550,6 +550,8 @@ local git_reset_branch = function(prompt_bufnr, mode)
   else
     print(string.format('Error when resetting to: %s. Git returned: "%s"', selection.value, table.concat(stderr, "  ")))
   end
+
+  action_utils.restore_buffers()
 end
 
 --- Reset to selected git commit using mixed mode

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -102,4 +102,11 @@ function utils.get_registered_mappings(prompt_bufnr)
   return ret
 end
 
+function utils.restore_buffers()
+  local currentBuffer = vim.api.nvim_get_current_buf()
+  vim.cmd("bufdo e")
+  vim.cmd("syntax on")
+  vim.cmd("b" .. currentBuffer)
+end
+
 return utils


### PR DESCRIPTION
After undoing commits with telescope's ```git_reset_branch``` function, the buffers do not reload and still show the old state. Therefore I added a ```restore_buffers``` function in actions/utils.lua, that does exactly that:

- reloading all the buffers with ```vim.cmd("bufdo e")```
- turn syntax on again with ```vim.cmd("syntax on")``` (because ```bufdo``` may turn off syntax to increase speed)
- show previously shown buffer with ```vim.cmd("b" .. currentBuff)``` (because with multiple buffers opened, ```bufdo``` will change the view and not return back to the previously shown buffer)

The ```restore_buffers``` function could also be used in other git functions. Which is why I added it to the utils module.
