### PR TITLE
fix: allow `selection_caret` to be entirely whitespace

### DIFF
--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -65,6 +65,7 @@ function Highlighter:hi_sorter(row, prompt, display)
 end
 
 function Highlighter:hi_selection(row, caret)
+  caret = vim.F.if_nil(caret, "")
   local results_bufnr = assert(self.picker.results_bufnr, "Must have a results bufnr")
 
   a.nvim_buf_clear_namespace(results_bufnr, ns_telescope_selection, 0, -1)


### PR DESCRIPTION
@deryrahman @gegoune does this fix your issue?

See [comment](https://github.com/nvim-telescope/telescope.nvim/commit/f285599440fcdbf97a7f44d120d403c80316f576#commitcomment-63007223) for details of problem