### PR TITLE
feat: make results pane of builtin `keymaps` more readable

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -693,6 +693,44 @@ function make_entry.gen_from_registers(_)
   end
 end
 
+function make_entry.gen_from_keymaps(opts)
+  local function get_desc(entry)
+    return entry.desc or entry.rhs or "Lua function"
+  end
+  local function get_lhs(entry)
+    return utils.display_termcodes(entry.lhs)
+  end
+
+  local displayer = require("telescope.pickers.entry_display").create {
+    separator = "▏",
+    items = {
+      { width = 2 },
+      { width = opts.width_lhs },
+      { remaining = true },
+    },
+  }
+  local make_display = function(entry)
+    return displayer {
+      entry.mode,
+      get_lhs(entry),
+      get_desc(entry)
+    }
+  end
+
+  return function(entry)
+    return {
+      mode = entry.mode,
+      lhs = get_lhs(entry),
+      desc = get_desc(entry),
+      --
+      valid = entry ~= "",
+      value = entry,
+      ordinal = entry.mode .. " " .. get_lhs(entry) .. " " .. get_desc(entry),
+      display = make_display
+    }
+  end
+end
+
 function make_entry.gen_from_highlights()
   local make_display = function(entry)
     local display = entry.value

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -713,7 +713,7 @@ function make_entry.gen_from_keymaps(opts)
     return displayer {
       entry.mode,
       get_lhs(entry),
-      get_desc(entry)
+      get_desc(entry),
     }
   end
 
@@ -726,7 +726,7 @@ function make_entry.gen_from_keymaps(opts)
       valid = entry ~= "",
       value = entry,
       ordinal = entry.mode .. " " .. get_lhs(entry) .. " " .. get_desc(entry),
-      display = make_display
+      display = make_display,
     }
   end
 end


### PR DESCRIPTION
Updated the result pane of the builtin picker `keymaps` to be more coherent with some other pickers by using the `|` to seperate information for each entry (e.g. like `commands`, `quickfix`). The width of the middle column is adjusted dynamically so the lhs of the keymap doesn't get cut off.

Before:
![before](https://user-images.githubusercontent.com/62295482/149263801-c6ec1327-59eb-48c8-9b9d-e918216d3c4e.png)

After:
![after](https://user-images.githubusercontent.com/62295482/149263965-a6585e4e-9c8a-4d7c-8acd-8bd02f02eb82.png)

Some feedback if everything is ok, would be nice, as I'm still a bit new to lua.
