### PR TITLE
Update doc to remove file browser

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -792,35 +792,6 @@ builtin.fd()                                                    *builtin.fd()*
     This is an alias for the `find_files` picker
 
 
-
-builtin.file_browser({opts})                          *builtin.file_browser()*
-    Lists files and folders in your current working directory, open files,
-    navigate your filesystem, and create new files and folders
-    - Default keymaps:
-      - `<cr>`: opens the currently selected file, or navigates to the
-        currently selected directory
-      - `<C-e>`: creates new file in current directory, creates new directory
-        if the name contains a trailing '/'
-        - Note: you can create files nested into several directories with
-          `<C-e>`, i.e. `lua/telescope/init.lua` would create the file
-          `init.lua` inside of `lua/telescope` and will create the necessary
-          folders (similar to how `mkdir -p` would work) if they do not already
-          exist
-
-
-    Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}      (string)   root dir to browse from (default: cwd, use
-                              utils.buffer_dir() to search relative to open
-                              buffer)
-        {depth}    (number)   file tree depth to display (default: 1)
-        {dir_icon} (string)   change the icon for a directory. (default: )
-        {hidden}   (boolean)  determines whether to show hidden files or not
-                              (default: false)
-
-
 builtin.treesitter()                                    *builtin.treesitter()*
     Lists function names, variables, and other symbols from treesitter queries
     - Default keymaps:


### PR DESCRIPTION
On the PR #1453 the `file_browser` has been remove from the builtint, it was remove from almost all places but the documentation, so it still part of the help when checked from neovim.