### PR TITLE
feat(rg): add glob and type filter opts by default

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -764,6 +764,11 @@ builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
         {search_dirs}         (table)     directory/directories to search in,
                                           mutually exclusive with
                                           `grep_open_files`
+        {glob_pattern}        (string)    argument to be used with `--glob`,
+                                          e.g. "*.toml", can use the opposite
+                                          "!*.toml"
+        {type_filter}         (string)    argument to be used with `--type`,
+                                          e.g. "rust", see `rg --type-list`
         {additional_args}     (function)  function(opts) which returns a table
                                           of additional arguments to be passed
                                           on

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -72,6 +72,14 @@ files.live_grep = function(opts)
     additional_args = opts.additional_args(opts)
   end
 
+  if opts.type_filter then
+    additional_args[#additional_args + 1] = "--type=" .. opts.type_filter
+  end
+
+  if opts.glob_pattern then
+    additional_args[#additional_args + 1] = "--glob=" .. opts.glob_pattern
+  end
+
   local live_grepper = finders.new_job(function(prompt)
     -- TODO: Probably could add some options for smart case and whatever else rg offers.
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -55,6 +55,8 @@ end
 ---@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
 ---@field search_dirs table: directory/directories to search in, mutually exclusive with `grep_open_files`
+---@field glob_pattern string: argument to be used with `--glob`, e.g. "*.toml", can use the opposite "!*.toml"
+---@field type_filter string: argument to be used with `--type`, e.g. "rust", see `rg --type-list`
 ---@field additional_args function: function(opts) which returns a table of additional arguments to be passed on
 ---@field max_results number: define a upper result value
 ---@field disable_coordinates boolean: don't show the line & row numbers (default: false)


### PR DESCRIPTION
- `glob_pattern` string: argument to be used with `--glob`,
e.g. "*.toml", can use the opposite "!*.toml"
- `type_filter` string: argument to be used with `--type`,
e.g. "rust", see `rg --type-list`

```vim
:Telescope live_grep glob_pattern=!*.txt
:Telescope live_grep type_filter=lua
:Telescope live_grep type_filter=make
```
