### PR TITLE
feat: show a message for unknown command

### DIFF
--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -182,7 +182,10 @@ local function run_command(args)
 
   if rawget(extensions, cmd) then
     extensions[cmd][cmd](opts)
+    return
   end
+
+  print "[Telescope] unknown command"
 end
 
 -- @Summary get extensions sub command


### PR DESCRIPTION
For a week I've been typing `:Telescope lsp_reference` instead of `:Telescope lsp_references` and wondering why it stopped working, then I found out that typo.