### PR TITLE
feat: add configuration options to builtin `keymaps`

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1240,6 +1240,12 @@ builtin.keymaps({opts})                                    *builtin.keymaps()*
     Parameters: ~
         {opts} (table)  options to pass to the picker
 
+    Options: ~
+        {modes}     (table)    a list of short-named keymap modes to search
+                               (default: { "n", "i", "c", "x" })
+        {show_plug} (boolean)  if true, the keymaps for which the lhs contains
+                               "<Plug>" are also shown (default: true)
+
 
 builtin.filetypes({opts})                                *builtin.filetypes()*
     Lists all available filetypes, sets currently open buffer's filetype to

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -314,6 +314,8 @@ builtin.registers = require_on_exported_call("telescope.builtin.internal").regis
 
 --- Lists normal mode keymappings, runs the selected keymap on `<cr>`
 ---@param opts table: options to pass to the picker
+---@field modes table: short names of the keymap modes to show (default: { "n", "i", "c", "x" })
+---@field show_plug boolean: if true, show the keymaps for which the lhs contains "<Plug>" (default: true)
 builtin.keymaps = require_on_exported_call("telescope.builtin.internal").keymaps
 
 --- Lists all available filetypes, sets currently open buffer's filetype to selected filetype in Telescope on `<cr>`

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -314,8 +314,8 @@ builtin.registers = require_on_exported_call("telescope.builtin.internal").regis
 
 --- Lists normal mode keymappings, runs the selected keymap on `<cr>`
 ---@param opts table: options to pass to the picker
----@field modes table: short names of the keymap modes to show (default: { "n", "i", "c", "x" })
----@field show_plug boolean: if true, show the keymaps for which the lhs contains "<Plug>" (default: true)
+---@field modes table: a list of short-named keymap modes to search (default: { "n", "i", "c", "x" })
+---@field show_plug boolean: if true, the keymaps for which the lhs contains "<Plug>" are also shown (default: true)
 builtin.keymaps = require_on_exported_call("telescope.builtin.internal").keymaps
 
 --- Lists all available filetypes, sets currently open buffer's filetype to selected filetype in Telescope on `<cr>`

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -952,8 +952,8 @@ end
 
 -- TODO: make filtering include the mapping and the action
 internal.keymaps = function(opts)
-  opts.modes = utils.get_default(opts.modes, { "n", "i", "c", "x" })
-  opts.show_plug = utils.get_default(opts.show_plug, true)
+  opts.modes = vim.F.if_nil(opts.modes, { "n", "i", "c", "x" })
+  opts.show_plug = vim.F.if_nil(opts.show_plug, true)
 
   local keymap_encountered = {} -- used to make sure no duplicates are inserted into keymaps_table
   local keymaps_table = {}
@@ -967,7 +967,7 @@ internal.keymaps = function(opts)
         keymap_encountered[keymap_key] = true
         if opts.show_plug or not string.find(keymap.lhs, "<Plug>") then
           table.insert(keymaps_table, keymap)
-          max_len_lhs = math.max(max_len_lhs, string.len(utils.display_termcodes(keymap.lhs)))
+          max_len_lhs = math.max(max_len_lhs, #utils.display_termcodes(keymap.lhs))
         end
       end
     end

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -952,18 +952,28 @@ end
 
 -- TODO: make filtering include the mapping and the action
 internal.keymaps = function(opts)
-  local modes = { "n", "i", "c" }
-  local keymaps_table = {}
+  opts.modes = utils.get_default(opts.modes, { "n", "i", "c", "x" })
+  opts.show_plug = utils.get_default(opts.show_plug, true)
 
+  local keymap_encountered = {} -- used to make sure no duplicates are inserted into keymaps_table
+  local keymaps_table = {}
   local max_len_lhs = 0
-  for _, mode in pairs(modes) do
-    local function extract_keymaps(keymaps)
-      for _, keymap in pairs(keymaps) do
-        table.insert(keymaps_table, keymap)
-        max_len_lhs = math.max(max_len_lhs, string.len(keymap.lhs or ""))
+
+  -- helper function to populate keymaps_table and determine max_len_lhs
+  local function extract_keymaps(keymaps)
+    for _, keymap in pairs(keymaps) do
+      local keymap_key = keymap.buffer .. keymap.mode .. keymap.lhs -- should be distinct for every keymap
+      if not keymap_encountered[keymap_key] then
+        keymap_encountered[keymap_key] = true
+        if opts.show_plug or not string.find(keymap.lhs, "<Plug>") then
+          table.insert(keymaps_table, keymap)
+          max_len_lhs = math.max(max_len_lhs, string.len(utils.display_termcodes(keymap.lhs)))
+        end
       end
     end
+  end
 
+  for _, mode in pairs(opts.modes) do
     local global = vim.api.nvim_get_keymap(mode)
     local buf_local = vim.api.nvim_buf_get_keymap(0, mode)
     extract_keymaps(global)


### PR DESCRIPTION
This pull request adds the following:
- Add visual mode to the default keymap modes
- Make the shown keymap modes a configurable option
- Add a configuration option to not show <Plug> keymaps (by default it will show them, which is the same behaviour as before this pull request)
- While implementing this, I found out there are duplicates present in this picker (also present before this pull request) which happens when for example for "!" mode keymaps is added twice because it is both a "i" and "c" mode keymap