### PR TITLE
fix: add opts.bufnr and opts.winnr to builtin picker

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1311,9 +1311,6 @@ builtin.lsp_references({opts})                      *builtin.lsp_references()*
     Parameters: ~
         {opts} (table)  options to pass to the picker
 
-    Options: ~
-        {timeout} (number)  timeout for the sync call (default: 10000)
-
 
 builtin.lsp_definitions({opts})                    *builtin.lsp_definitions()*
     Goto the definition of the word under the cursor, if there's only one,
@@ -1324,8 +1321,6 @@ builtin.lsp_definitions({opts})                    *builtin.lsp_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {timeout}         (number)   timeout for the sync call (default:
-                                     10000)
         {jump_type}       (string)   how to goto definition if there is only
                                      one, values: "tab", "split", "vsplit",
                                      "never"
@@ -1341,8 +1336,6 @@ builtin.lsp_type_definitions({opts})          *builtin.lsp_type_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {timeout}         (number)   timeout for the sync call (default:
-                                     10000)
         {jump_type}       (string)   how to goto definition if there is only
                                      one, values: "tab", "split", "vsplit",
                                      "never"
@@ -1358,8 +1351,6 @@ builtin.lsp_implementations({opts})            *builtin.lsp_implementations()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {timeout}         (number)   timeout for the sync call (default:
-                                     10000)
         {jump_type}       (string)   how to goto implementation if there is
                                      only one, values: "tab", "split",
                                      "vsplit", "never"
@@ -1404,8 +1395,6 @@ builtin.lsp_document_symbols({opts})          *builtin.lsp_document_symbols()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {timeout}           (number)        timeout for the sync call
-                                            (default: 10000)
         {ignore_filename}   (boolean)       dont show filenames (default:
                                             true)
         {show_line}         (boolean)       if true, shows the content of the
@@ -1429,8 +1418,6 @@ builtin.lsp_workspace_symbols({opts})        *builtin.lsp_workspace_symbols()*
     Options: ~
         {query}             (string)        for what to query the workspace
                                             (default: "")
-        {timeout}           (number)        timeout for the sync call
-                                            (default: 10000)
         {ignore_filename}   (boolean)       dont show filenames (default:
                                             false)
         {show_line}         (boolean)       if true, shows the content of the

--- a/lua/telescope/builtin/diagnostics.lua
+++ b/lua/telescope/builtin/diagnostics.lua
@@ -86,6 +86,9 @@ local diagnostics_to_tbl = function(opts)
 end
 
 diagnostics.get = function(opts)
+  if opts.bufnr ~= 0 then
+    opts.bufnr = nil
+  end
   if opts.bufnr == nil then
     opts.path_display = vim.F.if_nil(opts.path_display, {})
   end

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -101,8 +101,6 @@ local get_current_buf_line = function(winnr)
 end
 
 git.bcommits = function(opts)
-  -- local winnr = opts.winnr or vim.api.nvim_get_current_win()
-  -- local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
   opts.current_line = (opts.current_file == nil) and get_current_buf_line(opts.winnr) or nil
   opts.current_file = vim.F.if_nil(opts.current_file, vim.api.nvim_buf_get_name(opts.bufnr))
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -101,8 +101,10 @@ local get_current_buf_line = function(winnr)
 end
 
 git.bcommits = function(opts)
-  opts.current_line = (opts.current_file == nil) and get_current_buf_line(0) or nil
-  opts.current_file = vim.F.if_nil(opts.current_file, vim.fn.expand "%:p")
+  -- local winnr = opts.winnr or vim.api.nvim_get_current_win()
+  -- local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  opts.current_line = (opts.current_file == nil) and get_current_buf_line(opts.winnr) or nil
+  opts.current_file = vim.F.if_nil(opts.current_file, vim.api.nvim_buf_get_name(opts.bufnr))
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
   local git_command = vim.F.if_nil(opts.git_command, { "git", "log", "--pretty=oneline", "--abbrev-commit" })
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -448,6 +448,8 @@ local apply_config = function(mod)
   for k, v in pairs(mod) do
     mod[k] = function(opts)
       opts = opts or {}
+      opts.bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+      opts.winnr = opts.winnr or vim.api.nvim_get_current_win()
       local pconf = pickers_conf[k] or {}
       local defaults = (function()
         if pconf.theme then

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -352,12 +352,10 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.internal").jumpli
 
 --- Lists LSP references for word under the cursor, jumps to reference on `<cr>`
 ---@param opts table: options to pass to the picker
----@field timeout number: timeout for the sync call (default: 10000)
 builtin.lsp_references = require_on_exported_call("telescope.builtin.lsp").references
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field timeout number: timeout for the sync call (default: 10000)
 ---@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
 ---@field ignore_filename boolean: dont show filenames (default: true)
 builtin.lsp_definitions = require_on_exported_call("telescope.builtin.lsp").definitions
@@ -365,14 +363,12 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.lsp").defi
 --- Goto the definition of the type of the word under the cursor, if there's only one,
 --- otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field timeout number: timeout for the sync call (default: 10000)
 ---@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
 ---@field ignore_filename boolean: dont show filenames (default: true)
 builtin.lsp_type_definitions = require("telescope.builtin.lsp").type_definitions
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field timeout number: timeout for the sync call (default: 10000)
 ---@field jump_type string: how to goto implementation if there is only one, values: "tab", "split", "vsplit", "never"
 ---@field ignore_filename boolean: dont show filenames (default: true)
 builtin.lsp_implementations = require_on_exported_call("telescope.builtin.lsp").implementations
@@ -393,7 +389,6 @@ builtin.lsp_range_code_actions = require_on_exported_call("telescope.builtin.lsp
 --- - Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
 ---@param opts table: options to pass to the picker
----@field timeout number: timeout for the sync call (default: 10000)
 ---@field ignore_filename boolean: dont show filenames (default: true)
 ---@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
@@ -405,7 +400,6 @@ builtin.lsp_document_symbols = require_on_exported_call("telescope.builtin.lsp")
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
 ---@param opts table: options to pass to the picker
 ---@field query string: for what to query the workspace (default: "")
----@field timeout number: timeout for the sync call (default: 10000)
 ---@field ignore_filename boolean: dont show filenames (default: false)
 ---@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -62,6 +62,8 @@ internal.builtin = function(opts)
     end
   end
 
+  opts.bufnr = vim.api.nvim_get_current_buf()
+  opts.winnr = vim.api.nvim_get_current_win()
   pickers.new(opts, {
     prompt_title = title,
     finder = finders.new_table {

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -77,7 +77,7 @@ local function list_or_jump(action, title, opts)
       elseif opts.jump_type == "vsplit" then
         vim.cmd "vnew"
       end
-      vim.lsp.util.jump_to_location(flattened_results[1], vim.lsp.get_client_by_id(ctx.client_id).offset_encoding)
+      vim.lsp.util.jump_to_location(flattened_results[1], offset_encoding)
     else
       local locations = vim.lsp.util.locations_to_items(flattened_results, offset_encoding)
       pickers.new(opts, {

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -13,10 +13,10 @@ local utils = require "telescope.utils"
 local lsp = {}
 
 lsp.references = function(opts)
-  local params = vim.lsp.util.make_position_params()
+  local params = vim.lsp.util.make_position_params(opts.winnr)
   params.context = { includeDeclaration = true }
 
-  vim.lsp.buf_request(0, "textDocument/references", params, function(err, result, ctx, _config)
+  vim.lsp.buf_request(opts.bufnr, "textDocument/references", params, function(err, result, _, _)
     if err then
       vim.api.nvim_err_writeln("Error when finding references: " .. err.message)
       return
@@ -24,10 +24,7 @@ lsp.references = function(opts)
 
     local locations = {}
     if result then
-      vim.list_extend(
-        locations,
-        vim.lsp.util.locations_to_items(result, vim.lsp.get_client_by_id(ctx.client_id).offset_encoding) or {}
-      )
+      vim.list_extend(locations, vim.lsp.util.locations_to_items(result) or {})
     end
 
     if vim.tbl_isempty(locations) then
@@ -49,8 +46,8 @@ end
 local function list_or_jump(action, title, opts)
   opts = opts or {}
 
-  local params = vim.lsp.util.make_position_params()
-  vim.lsp.buf_request(0, action, params, function(err, result, ctx, _config)
+  local params = vim.lsp.util.make_position_params(opts.winnr)
+  vim.lsp.buf_request(opts.bufnr, action, params, function(err, result, _, _)
     if err then
       vim.api.nvim_err_writeln("Error when executing " .. action .. " : " .. err.message)
       return
@@ -106,9 +103,8 @@ lsp.implementations = function(opts)
 end
 
 lsp.document_symbols = function(opts)
-  local bufnr = vim.api.nvim_get_current_buf()
-  local params = vim.lsp.util.make_position_params()
-  vim.lsp.buf_request(0, "textDocument/documentSymbol", params, function(err, result, _ctx, _config)
+  local params = vim.lsp.util.make_position_params(opts.winnr)
+  vim.lsp.buf_request(opts.bufnr, "textDocument/documentSymbol", params, function(err, result, _, _)
     if err then
       vim.api.nvim_err_writeln("Error when finding document symbols: " .. err.message)
       return
@@ -119,7 +115,7 @@ lsp.document_symbols = function(opts)
       return
     end
 
-    local locations = vim.lsp.util.symbols_to_items(result or {}, bufnr) or {}
+    local locations = vim.lsp.util.symbols_to_items(result or {}, opts.bufnr) or {}
     locations = utils.filter_symbols(locations, opts)
     if locations == nil then
       -- error message already printed in `utils.filter_symbols`
@@ -127,6 +123,7 @@ lsp.document_symbols = function(opts)
     end
 
     if vim.tbl_isempty(locations) then
+      print "locations table empty"
       return
     end
 
@@ -147,18 +144,14 @@ lsp.document_symbols = function(opts)
 end
 
 lsp.code_actions = function(opts)
-  local params = vim.F.if_nil(opts.params, vim.lsp.util.make_range_params())
+  local params = vim.F.if_nil(opts.params, vim.lsp.util.make_range_params(opts.winnr))
+  local lnum = vim.api.nvim_win_get_cursor(opts.winnr)[1]
 
   params.context = {
-    diagnostics = vim.lsp.diagnostic.get_line_diagnostics(),
+    diagnostics = vim.lsp.diagnostic.get_line_diagnostics(opts.bufnr, lnum - 1),
   }
 
-  local results_lsp, err = vim.lsp.buf_request_sync(
-    0,
-    "textDocument/codeAction",
-    params,
-    vim.F.if_nil(opts.timeout, 10000)
-  )
+  local results_lsp, err = vim.lsp.buf_request_sync(opts.bufnr, "textDocument/codeAction", params, opts.timeout)
 
   if err then
     print("ERROR: " .. err)
@@ -271,10 +264,10 @@ lsp.code_actions = function(opts)
     end
 
   local execute_action = opts.execute_action
-    or function(action, offset_encoding)
+    or function(action, _)
       if action.edit or type(action.command) == "table" then
         if action.edit then
-          vim.lsp.util.apply_workspace_edit(action.edit, offset_encoding)
+          vim.lsp.util.apply_workspace_edit(action.edit)
         end
         if type(action.command) == "table" then
           vim.lsp.buf.execute_command(action.command)
@@ -334,20 +327,19 @@ lsp.code_actions = function(opts)
 end
 
 lsp.range_code_actions = function(opts)
-  opts.params = vim.lsp.util.make_given_range_params({ opts.start_line, 1 }, { opts.end_line, 1 })
+  opts.params = vim.lsp.util.make_given_range_params({ opts.start_line, 1 }, { opts.end_line, 1 }, opts.bufnr)
   lsp.code_actions(opts)
 end
 
 lsp.workspace_symbols = function(opts)
-  local bufnr = vim.api.nvim_get_current_buf()
   local params = { query = opts.query or "" }
-  vim.lsp.buf_request(0, "workspace/symbol", params, function(err, server_result, _ctx, _config)
+  vim.lsp.buf_request(opts.bufnr, "workspace/symbol", params, function(err, server_result, _, _)
     if err then
       vim.api.nvim_err_writeln("Error when finding workspace symbols: " .. err.message)
       return
     end
 
-    local locations = vim.lsp.util.symbols_to_items(server_result or {}, bufnr) or {}
+    local locations = vim.lsp.util.symbols_to_items(server_result or {}, opts.bufnr) or {}
     locations = utils.filter_symbols(locations, opts)
     if locations == nil then
       -- error message already printed in `utils.filter_symbols`
@@ -400,21 +392,19 @@ local function get_workspace_symbols_requester(bufnr, opts)
 end
 
 lsp.dynamic_workspace_symbols = function(opts)
-  local curr_bufnr = vim.api.nvim_get_current_buf()
-
   pickers.new(opts, {
     prompt_title = "LSP Dynamic Workspace Symbols",
     finder = finders.new_dynamic {
       entry_maker = opts.entry_maker or make_entry.gen_from_lsp_symbols(opts),
-      fn = get_workspace_symbols_requester(curr_bufnr, opts),
+      fn = get_workspace_symbols_requester(opts.bufnr, opts),
     },
     previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
   }):find()
 end
 
-local function check_capabilities(feature)
-  local clients = vim.lsp.buf_get_clients(0)
+local function check_capabilities(feature, bufnr)
+  local clients = vim.lsp.buf_get_clients(bufnr)
 
   local supported_client = false
   for _, client in pairs(clients) do
@@ -450,9 +440,10 @@ local function apply_checks(mod)
   for k, v in pairs(mod) do
     mod[k] = function(opts)
       opts = opts or {}
+      opts.timeout = vim.F.if_nil(opts.timeout, 10000)
 
       local feature_name = feature_map[k]
-      if feature_name and not check_capabilities(feature_name) then
+      if feature_name and not check_capabilities(feature_name, opts.bufnr) then
         return
       end
       v(opts)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -536,7 +536,7 @@ function make_entry.gen_from_treesitter(opts)
   return function(entry)
     local ts_utils = require "nvim-treesitter.ts_utils"
     local start_row, start_col, end_row, _ = ts_utils.get_node_range(entry.node)
-    local node_text = ts_utils.get_node_text(entry.node)[1]
+    local node_text = ts_utils.get_node_text(entry.node, bufnr)[1]
     return {
       valid = true,
 
@@ -906,7 +906,7 @@ function make_entry.gen_from_ctags(opts)
   opts = opts or {}
 
   local cwd = vim.fn.expand(opts.cwd or vim.loop.cwd())
-  local current_file = Path:new(vim.fn.expand "%"):normalize(cwd)
+  local current_file = Path:new(vim.api.nvim_buf_get_name(opts.bufnr)):normalize(cwd)
 
   local display_items = {
     { remaining = true },


### PR DESCRIPTION
When buffer/window specific pickers are selected from the `:Telescope builtin` picker, the current buffer & window becomes Telescope itself making many of the pickers practically useless.

This PR sets `opts.bufnr` and `opts.winnr` when `:Telescope builtin` is ran. Buffer and window sensitive pickers can then reference those values when called via the `builtin` picker (if not set, use the current bufnr/winnr via `vim.api.nvim_get_current_buf/win()`).

closes #1678

Considering the builtin picker is probably where many new users try out the various builtin pickers, I think getting all the pickers functional from within the builtin picker is quite important.

Fixes or tweaks to allow for fix:
 - `files.treesitter`
 - `files.current_buffer_fuzzy_find`
 - `files.current_buffer_tags`
 - `git.bcommits`
 - `lsp.references`
 - `lsp.definitions`
 - `lsp.type_definitions`
 - `lsp.implementations`
 - `lsp.document_symbols`
 - `lsp.code_actions`
 - `lsp.range_code_actions`
 - `lsp.workspace_symbols`
 - `lsp.dynamic_workspace_symbols`
 - `diagnostics.get`

I think I got them all.


TODO: 
- [x] `current_buffer_ctags` still needs work in its `make_entry`
 - [x] double check and test all changes
 - [x] clean up