### PR TITLE
Skip path escaping when adding items to quickfix list

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -623,7 +623,7 @@ local entry_to_qf = function(entry)
 
   return {
     bufnr = entry.bufnr,
-    filename = from_entry.path(entry, false),
+    filename = from_entry.path(entry, false, false),
     lnum = vim.F.if_nil(entry.lnum, 1),
     col = vim.F.if_nil(entry.col, 1),
     text = text,

--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -10,8 +10,15 @@ This will provide standard mechanism for accessing information from an entry.
 
 local from_entry = {}
 
-function from_entry.path(entry, validate)
-  local path = entry.path and vim.fn.fnameescape(entry.path) or nil
+function from_entry.path(entry, validate, escape)
+  escape = vim.F.if_nil(escape, true)
+  local path
+  if escape then
+    path = entry.path and vim.fn.fnameescape(entry.path) or nil
+  else
+    path = entry.path
+  end
+
   if path == nil then
     path = entry.filename
   end


### PR DESCRIPTION
# Problem

Items added to the quickfix list should not have their paths escaped because then Neovim can't open them.

My specific case is paths such as `src/routes/api/trackables/[trackable_id]/index.ts`, where the brackets would be escaped when adding to the quickfix list. 

I think #1700 is the same problem but I don't have a Windows box to test on so can't be 100% sure. I did also test this fix on MacOS with a filename containing spaces and it works fine.

# Reproduction

1. Create a file with some escapable character such as a space or `[`.
2. Open neovim in that directory, use a telescope picker to show the file in the list, and hit `<c-q>`.
3. Notice the extra backslashes in the escaped filename in the quickfix list, and that trying to open the file from the quickfix list fails. Neovim tries to open the path containing the backslash instead of the actual path.

# Solution

This PR adds a new parameter `escape` to `from_entry.path`. It defaults to `true` if omitted, but if `false` then the call to `vim.fn.fnameescape` is skipped.

