### PR TITLE
fix: picker `autocommands` doesn't show all autocommands

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -1096,7 +1096,7 @@ internal.autocommands = function(opts)
     end
 
     if current_ft and cmd then
-      source_file = line:match "Last set from ([^%s]*)"
+      source_file = line:match "Last set from (.*) line %d*$" or line:match "Last set from (.*)$"
       source_lnum = line:match "line (%d*)$" or "1"
       if source_file then
         local autocmd = {}

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -1096,7 +1096,8 @@ internal.autocommands = function(opts)
     end
 
     if current_ft and cmd then
-      source_file, source_lnum = line:match "Last set from (.*) line (.*)"
+      source_file = line:match "Last set from ([^%s]*)"
+      source_lnum = line:match "line (%d*)$" or "1"
       if source_file then
         local autocmd = {}
         autocmd.event = current_event


### PR DESCRIPTION
When using this picker I noticed that some autocommands where not showing. From my own setup, calling `:verbose au *` retrieves 4 kinds of metadata (from most common to least common):
1. `Last set from {filepath} line {linenr}`
2. `Last set from anonymous :source`
3. `Last set from anonymous :source line {linenr}`
4. `Last set from {filepath}`

Case 2 and 4 are now also picked up and defaulted to the first line in the document (even tho the `anonymous :source` one doesn't go anywhere)
