### PR TITLE
Change center layout strategy to allow vertical anchoring

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1631,11 +1631,15 @@ layout_strategies.horizontal()                *layout_strategies.horizontal()*
 layout_strategies.center()                        *layout_strategies.center()*
     Centered layout with a combined block of the prompt and results aligned to
     the middle of the screen. The preview window is then placed in the
-    remaining space above. Particularly useful for creating dropdown menus (see
-    |telescope.themes| and |themes.get_dropdown()|`).
+    remaining space above or below, according to `anchor` or `mirror`.
+    Particularly useful for creating dropdown menus (see |telescope.themes| and
+    |themes.get_dropdown()|).
 
-    Note that the `anchor` option can only pin this layout to the left or right
-    edges.
+    Note that vertical anchoring, i.e. `anchor` containing `"N"` or `"S"`, will
+    override `mirror` config. For `"N"` anchoring preview will be placed below
+    prompt/result block. For `"S"` anchoring preview will be placed above
+    prompt/result block. For horizontal only anchoring preview will be placed
+    according to `mirror` config, default is above the prompt/result block.
 
     ┌──────────────────────────────────────────────────┐
     │    ┌────────────────────────────────────────┐    │


### PR DESCRIPTION
Affects `telescope.pickers.layout_strategies.center` that is used by dropdown (`telescope.themes.get_dropdown`) theme, allowing more customization for dropdown theme, i. e. setting it in the top with mirrored preview.

Some may argue that it is already possible to do that with vertical layout, although vertical layout uses fixed height, so toggling preview squeezes the result prompt, while center layout has dynamic height and shows the preview without squeezing the result prompt.

[Example of the initial proposal](https://i.imgur.com/9LHjKT3.gif) (obsolete)

EDIT: 

As discussed (see comments), beyond changing the center layout to allow vertical anchoring, I updated the change to make preview window fill the rest of the screen (which is the original purpose of center layout) and also changed ´anchor´ to override `mirror` behavior as follows:

Vertical anchoring, i.e. `anchor` containing `"N"` or `"S"` will ignore `mirror` config. For `"N"` anchoring preview will be placed below prompt result block. For `"S"` anchoring preview will be placed above prompt result block. For horizontal only anchoring preview will be placed according to `mirror` config, default is above the prompt result block.

![horizontalanchoring](https://i.imgur.com/2qafVBd.gif)