### PR TITLE
fix(action): insert symbol in insert mode

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -360,11 +360,9 @@ end
 actions.insert_symbol_i = function(prompt_bufnr)
   local symbol = action_state.get_selected_entry().value[1]
   actions._close(prompt_bufnr, true)
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  vim.api.nvim_buf_set_text(0, cursor[1] - 1, cursor[2], cursor[1] - 1, cursor[2], { symbol })
   vim.schedule(function()
-    vim.api.nvim_win_set_cursor(0, { cursor[1], cursor[2] + #symbol })
-    vim.cmd [[startinsert!]]
+    vim.cmd [[startinsert]]
+    vim.api.nvim_put({ symbol }, "", true, true)
   end)
 end
 


### PR DESCRIPTION
followup to #1618, ensure insert after cursor

(turns out bang means `A`, not `a`. classic reading fail 🤦🏻 )