### PR TITLE
fix: builtin `autocommands` throws error

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -930,7 +930,9 @@ previewers.autocommands = defaulter(function(_)
       end
 
       vim.api.nvim_buf_add_highlight(self.state.bufnr, ns_previewer, "TelescopePreviewLine", selected_row + 1, 0, -1)
-      vim.api.nvim_win_set_cursor(status.preview_win, { selected_row, 0 })
+      vim.schedule(function()
+        vim.api.nvim_win_set_cursor(status.preview_win, { selected_row, 0 })
+      end)
 
       self.state.last_set_bufnr = self.state.bufnr
     end,

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -930,6 +930,7 @@ previewers.autocommands = defaulter(function(_)
       end
 
       vim.api.nvim_buf_add_highlight(self.state.bufnr, ns_previewer, "TelescopePreviewLine", selected_row + 1, 0, -1)
+      -- set the cursor position after self.state.bufnr is connected to the preview window (which is scheduled in new_buffer_previewer)
       vim.schedule(function()
         vim.api.nvim_win_set_cursor(status.preview_win, { selected_row, 0 })
       end)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -930,7 +930,8 @@ previewers.autocommands = defaulter(function(_)
       end
 
       vim.api.nvim_buf_add_highlight(self.state.bufnr, ns_previewer, "TelescopePreviewLine", selected_row + 1, 0, -1)
-      -- set the cursor position after self.state.bufnr is connected to the preview window (which is scheduled in new_buffer_previewer)
+      -- set the cursor position after self.state.bufnr is connected to the
+      -- preview window (which is scheduled in new_buffer_previewer)
       vim.schedule(function()
         vim.api.nvim_win_set_cursor(status.preview_win, { selected_row, 0 })
       end)


### PR DESCRIPTION
Resolves: #1727

The issue seems to be that this snippet in `new_buffer_previewer` is sometimes scheduled after setting the cursor in the `define_preview` function.

https://github.com/nvim-telescope/telescope.nvim/blob/f262e7d56d37625613c5de0df5a933cccacf13c5/lua/telescope/previewers/buffer_previewer.lua#L366-L370

This will result in an error when going from a small preview buffer to a large preview buffer and trying to set the cursor at the end of the larger buffer, because it will try to set the cursor in the smaller buffer.

I tried to quickly replicate the issue with other previewers using `nvim_win_set_cursor`, but wasn't able to do so, so I didn't change anything to them.

But since this is kinda an easy mistake to make and hard to debug, maybe the `define_preview` function call in `new_buffer_previewer` needs to be scheduled instead or maybe add an util function around `nvim_win_set_cursor` or add something in the docs to be carefull/schedule `nvim_win_set_cursor`. @Conni2461 What do you think?