### PR TITLE
feat: allow user to wrap picker results (#701, #1296)

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -179,6 +179,12 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Default: 0
 
+                                          *telescope.defaults.wrap_results*
+    wrap_results: ~
+        Word wrap the search results
+
+        Default: false
+
                                          *telescope.defaults.prompt_prefix*
     prompt_prefix: ~
         The character(s) that will be shown in front of Telescope's prompt.

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -237,6 +237,15 @@ append(
 )
 
 append(
+  "wrap_results",
+  false,
+  [[
+  Word wrap the search results
+
+  Default: false]]
+)
+
+append(
   "prompt_prefix",
   "> ",
   [[

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -69,6 +69,7 @@ function Picker:new(opts)
     preview_title = opts.preview_title,
 
     prompt_prefix = get_default(opts.prompt_prefix, config.values.prompt_prefix),
+    wrap_results = get_default(opts.wrap_results, config.values.wrap_results),
     selection_caret = get_default(opts.selection_caret, config.values.selection_caret),
     entry_prefix = get_default(opts.entry_prefix, config.values.entry_prefix),
     multi_icon = get_default(opts.multi_icon, config.values.multi_icon),
@@ -314,9 +315,7 @@ function Picker:_create_window(bufnr, popup_opts, nowrap)
   local win, opts = popup.create(what, popup_opts)
 
   a.nvim_win_set_option(win, "winblend", self.window.winblend)
-  if nowrap then
-    a.nvim_win_set_option(win, "wrap", false)
-  end
+  a.nvim_win_set_option(win, "wrap", not nowrap)
   local border_win = opts and opts.border and opts.border.win_id
   if border_win then
     a.nvim_win_set_option(border_win, "winblend", self.window.winblend)
@@ -363,7 +362,7 @@ function Picker:find()
     popup_opts.preview.titlehighlight = "TelescopePreviewTitle"
   end
 
-  local results_win, results_opts, results_border_win = self:_create_window("", popup_opts.results, true)
+  local results_win, results_opts, results_border_win = self:_create_window("", popup_opts.results, not self.wrap_results)
 
   local results_bufnr = a.nvim_win_get_buf(results_win)
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -363,10 +363,10 @@ function Picker:find()
   end
 
   local results_win, results_opts, results_border_win = self:_create_window(
-      "",
-      popup_opts.results,
-      not self.wrap_results
-    )
+    "",
+    popup_opts.results,
+    not self.wrap_results
+  )
 
   local results_bufnr = a.nvim_win_get_buf(results_win)
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -362,7 +362,11 @@ function Picker:find()
     popup_opts.preview.titlehighlight = "TelescopePreviewTitle"
   end
 
-  local results_win, results_opts, results_border_win = self:_create_window("", popup_opts.results, not self.wrap_results)
+  local results_win, results_opts, results_border_win = self:_create_window(
+      "",
+      popup_opts.results,
+      not self.wrap_results
+    )
 
   local results_bufnr = a.nvim_win_get_buf(results_win)
 


### PR DESCRIPTION
Added a config option `wrap_results` to wrap the results in all pickers. Requested in #701  and #1296.

Default option is false. Same as current behavior. If user chooses, they can set this value true in setup call and see the results wrapped.


Unwrapped behavior:
<img width="1440" alt="unwrapped" src="https://user-images.githubusercontent.com/11389059/152654642-d0f02435-3214-4114-b374-38c40df10135.png">

Wrapped behavior:
<img width="1440" alt="wrapped" src="https://user-images.githubusercontent.com/11389059/152654823-df6d30b9-9797-4791-8e90-f194a5c7a080.png">

On a git_commits picker
<img width="1149" alt="image" src="https://user-images.githubusercontent.com/11389059/152654854-a14c75b6-6e6f-4651-a8c3-b1b282113178.png">


