### PR TITLE
feat(spell_suggest): ignore spell setting

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -1154,10 +1154,6 @@ internal.autocommands = function(opts)
 end
 
 internal.spell_suggest = function(opts)
-  if not vim.wo.spell then
-    return false
-  end
-
   local cursor_word = vim.fn.expand "<cword>"
   local suggestions = vim.fn.spellsuggest(cursor_word)
 


### PR DESCRIPTION
`z=` works even when `spell` is not set. I think it would be nice if Telescope would behave the same.

If you think this should be a setting, I'll look into how they work in telescope an add it.