### PR TITLE
feat(lsp): ignore_symbols

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1410,7 +1410,6 @@ builtin.lsp_document_symbols({opts})          *builtin.lsp_document_symbols()*
                                             false)
         {symbols}           (string|table)  filter results by symbol kind(s)
         {ignore_symbols}    (string|table)  list of symbols to ignore
-                                            (default: nil)
         {symbol_highlights} (table)         string -> string. Matches symbol
                                             with hl_group
 
@@ -1435,7 +1434,6 @@ builtin.lsp_workspace_symbols({opts})        *builtin.lsp_workspace_symbols()*
                                             false)
         {symbols}           (string|table)  filter results by symbol kind(s)
         {ignore_symbols}    (string|table)  list of symbols to ignore
-                                            (default: nil)
         {symbol_highlights} (table)         string -> string. Matches symbol
                                             with hl_group
 
@@ -1458,7 +1456,6 @@ builtin.lsp_dynamic_workspace_symbols({opts}) *builtin.lsp_dynamic_workspace_sym
                                             (default: false)
         {symbols}           (string|table)  filter results by symbol kind(s)
         {ignore_symbols}    (string|table)  list of symbols to ignore
-                                            (default: nil)
         {symbol_highlights} (table)         string -> string. Matches symbol
                                             with hl_group
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1409,6 +1409,8 @@ builtin.lsp_document_symbols({opts})          *builtin.lsp_document_symbols()*
                                             line the tag is found on (default:
                                             false)
         {symbols}           (string|table)  filter results by symbol kind(s)
+        {ignore_symbols}    (string|table)  list of symbols to ignore
+                                            (default: nil)
         {symbol_highlights} (table)         string -> string. Matches symbol
                                             with hl_group
 
@@ -1432,6 +1434,8 @@ builtin.lsp_workspace_symbols({opts})        *builtin.lsp_workspace_symbols()*
                                             line the tag is found on (default:
                                             false)
         {symbols}           (string|table)  filter results by symbol kind(s)
+        {ignore_symbols}    (string|table)  list of symbols to ignore
+                                            (default: nil)
         {symbol_highlights} (table)         string -> string. Matches symbol
                                             with hl_group
 
@@ -1453,6 +1457,8 @@ builtin.lsp_dynamic_workspace_symbols({opts}) *builtin.lsp_dynamic_workspace_sym
                                             line the symbol is found on
                                             (default: false)
         {symbols}           (string|table)  filter results by symbol kind(s)
+        {ignore_symbols}    (string|table)  list of symbols to ignore
+                                            (default: nil)
         {symbol_highlights} (table)         string -> string. Matches symbol
                                             with hl_group
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -393,7 +393,7 @@ builtin.lsp_range_code_actions = require_on_exported_call("telescope.builtin.lsp
 ---@field ignore_filename boolean: dont show filenames (default: true)
 ---@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
----@field ignore_symbols string|table: list of symbols to ignore (default: nil)
+---@field ignore_symbols string|table: list of symbols to ignore
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
 builtin.lsp_document_symbols = require_on_exported_call("telescope.builtin.lsp").document_symbols
 
@@ -405,7 +405,7 @@ builtin.lsp_document_symbols = require_on_exported_call("telescope.builtin.lsp")
 ---@field ignore_filename boolean: dont show filenames (default: false)
 ---@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
----@field ignore_symbols string|table: list of symbols to ignore (default: nil)
+---@field ignore_symbols string|table: list of symbols to ignore
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
 builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.lsp").workspace_symbols
 
@@ -416,7 +416,7 @@ builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.lsp"
 ---@field ignore_filename boolean: dont show filenames (default: false)
 ---@field show_line boolean: if true, shows the content of the line the symbol is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
----@field ignore_symbols string|table: list of symbols to ignore (default: nil)
+---@field ignore_symbols string|table: list of symbols to ignore
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
 builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.builtin.lsp").dynamic_workspace_symbols
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -393,6 +393,7 @@ builtin.lsp_range_code_actions = require_on_exported_call("telescope.builtin.lsp
 ---@field ignore_filename boolean: dont show filenames (default: true)
 ---@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
+---@field ignore_symbols string|table: list of symbols to ignore (default: nil)
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
 builtin.lsp_document_symbols = require_on_exported_call("telescope.builtin.lsp").document_symbols
 
@@ -404,6 +405,7 @@ builtin.lsp_document_symbols = require_on_exported_call("telescope.builtin.lsp")
 ---@field ignore_filename boolean: dont show filenames (default: false)
 ---@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
+---@field ignore_symbols string|table: list of symbols to ignore (default: nil)
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
 builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.lsp").workspace_symbols
 
@@ -414,6 +416,7 @@ builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.lsp"
 ---@field ignore_filename boolean: dont show filenames (default: false)
 ---@field show_line boolean: if true, shows the content of the line the symbol is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
+---@field ignore_symbols string|table: list of symbols to ignore (default: nil)
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
 builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.builtin.lsp").dynamic_workspace_symbols
 

--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -64,6 +64,7 @@ local split_keywords = {
   ["sections"] = true,
   ["search_dirs"] = true,
   ["symbols"] = true,
+  ["ignore_symbols"] = true,
 }
 
 -- convert command line string arguments to

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -91,9 +91,23 @@ utils.quickfix_items_to_entries = function(locations)
 end
 
 utils.filter_symbols = function(results, opts)
-  if opts.symbols == nil then
+  local has_ignore = opts.ignore_symbols ~= nil
+  local has_symbols = opts.symbols ~= nil
+
+  if has_symbols and has_ignore then
+    error "Either opts.symbols or opts.ignore_symbols, can't process opposing options at the same time ;)'"
+    return
+  elseif not (has_ignore or has_symbols) then
     return results
+  elseif has_ignore then
+    if type(opts.ignore_symbols) == "string" then
+      opts.ignore_symbols = { opts.ignore_symbols }
+    end
+    return vim.tbl_filter(function(item)
+      return not vim.tbl_contains(opts.ignore_symbols, string.lower(item.kind))
+    end, results)
   end
+
   local valid_symbols = vim.tbl_map(string.lower, vim.lsp.protocol.SymbolKind)
 
   local filtered_symbols = {}

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -93,9 +93,10 @@ end
 utils.filter_symbols = function(results, opts)
   local has_ignore = opts.ignore_symbols ~= nil
   local has_symbols = opts.symbols ~= nil
+  local filtered_symbols
 
   if has_symbols and has_ignore then
-    error "Either opts.symbols or opts.ignore_symbols, can't process opposing options at the same time ;)'"
+    error "Either opts.symbols or opts.ignore_symbols, can't process opposing options at the same time!"
     return
   elseif not (has_ignore or has_symbols) then
     return results
@@ -103,46 +104,33 @@ utils.filter_symbols = function(results, opts)
     if type(opts.ignore_symbols) == "string" then
       opts.ignore_symbols = { opts.ignore_symbols }
     end
-    return vim.tbl_filter(function(item)
+    if type(opts.ignore_symbols) ~= "table" then
+      print "Please pass ignore_symbols as either a string or a list of strings"
+      return
+    end
+
+    opts.ignore_symbols = vim.tbl_map(string.lower, opts.ignore_symbols)
+    filtered_symbols = vim.tbl_filter(function(item)
       return not vim.tbl_contains(opts.ignore_symbols, string.lower(item.kind))
+    end, results)
+  elseif has_symbols then
+    if type(opts.symbols) == "string" then
+      opts.symbols = { opts.symbols }
+    end
+    if type(opts.symbols) ~= "table" then
+      print "Please pass filtering symbols as either a string or a list of strings"
+      return
+    end
+
+    opts.symbols = vim.tbl_map(string.lower, opts.symbols)
+    filtered_symbols = vim.tbl_filter(function(item)
+      return vim.tbl_contains(opts.symbols, string.lower(item.kind))
     end, results)
   end
 
-  local valid_symbols = vim.tbl_map(string.lower, vim.lsp.protocol.SymbolKind)
-
-  local filtered_symbols = {}
-  if type(opts.symbols) == "string" then
-    opts.symbols = string.lower(opts.symbols)
-    if vim.tbl_contains(valid_symbols, opts.symbols) then
-      for _, result in ipairs(results) do
-        if string.lower(result.kind) == opts.symbols then
-          table.insert(filtered_symbols, result)
-        end
-      end
-    else
-      print(string.format("%s is not a valid symbol per `vim.lsp.protocol.SymbolKind`", opts.symbols))
-    end
-  elseif type(opts.symbols) == "table" then
-    opts.symbols = vim.tbl_map(string.lower, opts.symbols)
-    local mismatched_symbols = {}
-    for _, symbol in ipairs(opts.symbols) do
-      if vim.tbl_contains(valid_symbols, symbol) then
-        for _, result in ipairs(results) do
-          if string.lower(result.kind) == symbol then
-            table.insert(filtered_symbols, result)
-          end
-        end
-      else
-        table.insert(mismatched_symbols, symbol)
-        mismatched_symbols = table.concat(mismatched_symbols, ", ")
-        print(string.format("%s are not valid symbols per `vim.lsp.protocol.SymbolKind`", mismatched_symbols))
-      end
-    end
-  else
-    print "Please pass filtering symbols as either a string or a list of strings"
-    return
-  end
-
+  -- TODO(conni2461): If you understand this correctly then we sort the results table based on the bufnr
+  -- If you ask me this should be its own function, that happens after the filtering part and should be
+  -- called in the lsp function directly
   local current_buf = vim.api.nvim_get_current_buf()
   if not vim.tbl_isempty(filtered_symbols) then
     -- filter adequately for workspace symbols
@@ -167,9 +155,15 @@ utils.filter_symbols = function(results, opts)
     end)
     return filtered_symbols
   end
-  -- only account for string|table as function otherwise already printed message and returned nil
-  local symbols = type(opts.symbols) == "string" and opts.symbols or table.concat(opts.symbols, ", ")
-  print(string.format("%s symbol(s) were not part of the query results", symbols))
+
+  -- print message that filtered_symbols is now empty
+  if has_symbols then
+    local symbols = table.concat(opts.symbols, ", ")
+    print(string.format("%s symbol(s) were not part of the query results", symbols))
+  elseif has_ignore then
+    local symbols = table.concat(opts.ignore_symbols, ", ")
+    print(string.format("%s ignore_symbol(s) have removed everything from the query result", symbols))
+  end
 end
 
 utils.path_smart = (function()


### PR DESCRIPTION
#### Purpose 

Adds new option to ignore symbols. Essentially same as `opts.symbols` but only ignores given symbols and doesn't do any checking whether the symbol is valid or not.

extracted from #1449. 
