### PR TITLE
feat: teach git_files to use the current repository

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -878,6 +878,11 @@ builtin.git_files({opts})                                *builtin.git_files()*
         {use_git_root}       (boolean)  if we should use git root as cwd or
                                         the cwd (important for submodule)
                                         (default: true)
+        {use_per_file_cwd}  (boolean)   if true, uses the current file's
+                                        directory as the working directory.
+                                        Results will be in the context
+                                        of the current file's repository.
+                                        (default: false)
         {show_untracked}     (boolean)  if true, adds `--others` flag to
                                         command and shows untracked files
                                         (default: true)


### PR DESCRIPTION
git_files only looks at the current repository, which is limiting
when editing files across several repositories.

A simple solution is to scope the "git ls-files" queries
to the current buffer's directory. This causes Telescope to
discover the git repository in the context of the current
file and return results relevant to that file.

Enable this behavior behind a new "use_per_file_cwd" so that
existing behavior is unchanged.

This is arguably better behavior in general and could be made the
default behavior, but is left as an opt-in feature.