### PR TITLE
fix builtin.autocommands giving error

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -930,11 +930,7 @@ previewers.autocommands = defaulter(function(_)
       end
 
       vim.api.nvim_buf_add_highlight(self.state.bufnr, ns_previewer, "TelescopePreviewLine", selected_row + 1, 0, -1)
-      -- set the cursor position after self.state.bufnr is connected to the
-      -- preview window (which is scheduled in new_buffer_previewer)
-      vim.schedule(function()
-        vim.api.nvim_win_set_cursor(status.preview_win, { selected_row, 0 })
-      end)
+      pcall(vim.api.nvim_win_set_cursor(status.preview_win, { selected_row, 0 }))
 
       self.state.last_set_bufnr = self.state.bufnr
     end,


### PR DESCRIPTION
im `pcall` ing it as per the suggestion of @Conni2461
i also removed the vim.schedule as the other previewers didn't need it too
Fixes: #1754