### PR TITLE
feat: add git_worktrees picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Built-in functions. Ready to be bound to any key you like.
 | `builtin.git_branches`              | Lists all branches with log preview, checkout action `<cr>`, track action `<C-t>` and rebase action`<C-r>` |
 | `builtin.git_status`                | Lists current changes per file with diff preview and add action. (Multi-selection still WIP)               |
 | `builtin.git_stash`                 | Lists stash items in current repository with ability to apply them on `<cr>`                               |
+| `builtin.git_worktress`             | Lists worktrees in current bare repository with ability to change directory on `<cr>`                      |
 
 ### Treesitter Picker
 

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -348,6 +348,29 @@ git.status = function(opts)
   }):find()
 end
 
+git.worktrees = function(opts)
+  opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_worktrees(opts))
+
+  pickers.new(opts, {
+    prompt_title = "Git Worktrees",
+    finder = finders.new_oneshot_job(
+      vim.tbl_flatten {
+        { "git", "worktree", "list" },
+      },
+      opts
+    ),
+    sorter = conf.file_sorter(opts),
+    attach_mappings = function()
+      actions.select_default:replace(function(prompt_bufnr)
+        actions.close(prompt_bufnr)
+        local selection = action_state.get_selected_entry()
+        vim.cmd("cd " .. selection.value)
+      end)
+      return true
+    end,
+  }):find()
+end
+
 local set_opts_cwd = function(opts)
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -192,6 +192,14 @@ builtin.git_status = require_on_exported_call("telescope.builtin.git").status
 ---@field show_branch boolean: if we should display the branch name for git stash entries (default: true)
 builtin.git_stash = require_on_exported_call("telescope.builtin.git").stash
 
+--- Lists worktrees in current bare repository
+--- - Default keymaps:
+---   - `<cr>`: runs `cd` for currently selected worktree
+---@param opts table: options to pass to the picker
+---@field cwd string: specify the path of the repo
+---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
+builtin.git_worktrees = require_on_exported_call("telescope.builtin.git").worktrees
+
 --
 --
 -- Internal and Vim-related Pickers

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -307,6 +307,43 @@ function make_entry.gen_from_git_commits(opts)
   end
 end
 
+function make_entry.gen_from_git_worktrees(opts)
+  opts = opts or {}
+
+  local displayer = entry_display.create {
+    separator = " ",
+    items = {
+      { width = 20 },
+      { remaining = true },
+    },
+  }
+
+  local make_display = function(entry)
+    return displayer {
+      { string.sub(entry.ordinal, 2, -2), "TelescopeResultsIdentifier" },
+      { entry.sha },
+    }
+  end
+
+  return function(entry)
+    if entry == "" then
+      return nil
+    end
+
+    local splitted = utils.max_split(entry)
+    local path = splitted[1]
+    local branch_name = splitted[3]
+    local sha = splitted[2]
+
+    return {
+      value = path,
+      ordinal = branch_name,
+      sha = sha,
+      display = make_display,
+    }
+  end
+end
+
 function make_entry.gen_from_quickfix(opts)
   opts = opts or {}
 


### PR DESCRIPTION
This PR add `git_worktrees` picker to change worktrees in a git bare repository.