### PR TITLE
Number type should be allowed for option keys

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1356,10 +1356,7 @@ pickers.new = function(opts, defaults)
   local result = {}
 
   for k, v in pairs(opts) do
-    assert(
-        type(k) == "string" or type(k) == "number",
-        "Should be string or number, found: " .. type(k)
-    )
+    assert(type(k) == "string" or type(k) == "number", "Should be string or number, found: " .. type(k))
     result[k] = v
   end
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1356,7 +1356,10 @@ pickers.new = function(opts, defaults)
   local result = {}
 
   for k, v in pairs(opts) do
-    assert(type(k) == "string", "Should be string, opts")
+    assert(
+        type(k) == "string" or type(k) == "number",
+        "Should be string or number, found: " .. type(k)
+    )
     result[k] = v
   end
 


### PR DESCRIPTION
Some extensions (e.g. `dap`) use integer numbers for their selector options instead of strings.

Before this commit, the interface for these plugins breaks when using `ui-select` with a stack trace like the following:

```
Error detected while processing function StartDebugger:
line   33:
E5108: Error executing lua .../telescope.nvim/lua/telescope/pickers.lua:1359: Should be string, found: number
stack traceback:
        [C]: in function 'assert'
        .../.vim/bundle/telescope.nvim/lua/telescope/pickers.lua:1359: in function 'new'
        ...e-ui-select.nvim/lua/telescope/_extensions/ui-select.lua:22: in function 'pick_one'
        .../nvim-dap/lua/dap/ui.lua:32: in function 'pick_if_many'
        .../nvim-dap/lua/dap.lua:225: in function 'select_config_and_run'
        .../nvim-dap/lua/dap.lua:551: in function 'continue'
        [string ":lua"]:1: in main chunk
```

Since simply allowing number types for the keys seems to work fine, I don't see a reason why one should allow only strings.