### PR TITLE
Make `make_entry` filename parser non-greedy

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -112,7 +112,7 @@ do
 
   -- Gets called only once to parse everything out for the vimgrep, after that looks up directly.
   local parse = function(t)
-    local _, _, filename, lnum, col, text = string.find(t.value, [[(.+):(%d+):(%d+):(.*)]])
+    local _, _, filename, lnum, col, text = string.find(t.value, [[(..-):(%d+):(%d+):(.*)]])
 
     local ok
     ok, lnum = pcall(tonumber, lnum)


### PR DESCRIPTION
Hi

I was suffering some dire performance around showing `rg` results. I've tracked it down to some large files with unusual content, specifically content with sequences like `2:3:1:0`.

With content like this the initial greedy matching captures more than the filename which went on to cause the poor performance.

This should fix that by making the matcher non-greedy.

## Some Working

### Before
```lua
local line = [[a/file/path:12:99:text with a time (kinda) :08:10: not a real time]]                                                                                                                                                         

local _, _, filename, lnum, col, text = string.find(line, [[(.+):(%d+):(%d+):(.*)]])                                                                                                                                                        

print(filename)  -- "a/file/path:12:99:text with a time (kinda) "                                                                                                                                                                             
print(lnum)  -- "08"                                                                                                                                                                                                                          
print(col)  -- "10"                                                                                                                                                                                                                           
print(text)  -- " not a real time"
```

### After
```lua
local line = [[a/file/path:12:99:text with a time (kinda) :08:10: not a real time]]                                                                                                                                                         

local _, _, filename, lnum, col, text = string.find(line, [[(..-):(%d+):(%d+):(.*)]])                                                                                                                                                        

print(filename)  -- "a/file/path"                                                                                                                                                                                                             
print(lnum)  -- "12"                                                                                                                                                                                                                          
print(col)  -- "99"                                                                                                                                                                                                                           
print(text)  -- "text with a time (kinda) :09:10: not a real time"
```