### PR TITLE
Fix: error on select empty picker entry (#1751)

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -804,6 +804,7 @@ end
 ---@param row number: the number of the chosen row
 function Picker:toggle_selection(row)
   local entry = self.manager:get_entry(self:get_index(row))
+  if entry == nil then return end
   self._multi:toggle(entry)
 
   self:update_prefix(entry, row)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -804,7 +804,9 @@ end
 ---@param row number: the number of the chosen row
 function Picker:toggle_selection(row)
   local entry = self.manager:get_entry(self:get_index(row))
-  if entry == nil then return end
+  if entry == nil then
+    return
+  end
   self._multi:toggle(entry)
 
   self:update_prefix(entry, row)


### PR DESCRIPTION
Checks if the picker entry selected exists before actually selecting it.

Resolves #1751.