### PR TITLE
fix: follow with find command

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -209,7 +209,7 @@ files.find_files = function(opts)
       log.warn "The `no_ignore` key is not available for the `find` command in `find_files`."
     end
     if follow then
-      table.insert(find_command, "-L")
+      table.insert(find_command, 2, "-L")
     end
     if search_dirs then
       table.remove(find_command, 2)


### PR DESCRIPTION
This doesn't work
`$ find . -type f -L`
find: -L: unknown primary or operator
But this works well
`$ find -L.  -type f`