### PR TITLE
fix: prevent double calling of `setup`

### DIFF
--- a/lua/telescope/_extensions/init.lua
+++ b/lua/telescope/_extensions/init.lua
@@ -16,11 +16,7 @@ extensions.manager = setmetatable({}, {
   __index = function(t, k)
     local ext = load_extension(k)
     t[k] = ext.exports or {}
-    if ext.setup then
-      ext.setup(extensions._config[k] or {}, require("telescope.config").values)
-    end
     extensions._health[k] = ext.health
-
     return t[k]
   end,
 })


### PR DESCRIPTION
Minor fix but was previously calling the `setup` function twice upon `require'telescope'.load_extension(...)`