### PR TITLE
docs: fix typo 'grown' in documentation

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -326,7 +326,7 @@ telescope.setup({opts})                                    *telescope.setup()*
                      default: stdpath("data")/telescope_history
           - limit:   The amount of entries that will be written in the
                      history.
-                     Warning: If limit is set to nil it will grown unbound.
+                     Warning: If limit is set to nil it will grow unbound.
                      default: 100
           - handler: A lua function that implements the history.
                      This is meant as a developer setting for extensions to

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -446,7 +446,7 @@ append(
                default: stdpath("data")/telescope_history
     - limit:   The amount of entries that will be written in the
                history.
-               Warning: If limit is set to nil it will grown unbound.
+               Warning: If limit is set to nil it will grow unbound.
                default: 100
     - handler: A lua function that implements the history.
                This is meant as a developer setting for extensions to


### PR DESCRIPTION
In the history section of the documentation description (docs/telescope.txt), the warning line sounds like an incorrect grammar:

    Warning: If limit is set to nil it will grown unbound.