### PR TITLE
Fix a small typo in a LSP error message

### DIFF
--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -171,7 +171,7 @@ lsp.code_actions = function(opts)
   )
 
   if err then
-    utils.notify("builin.lsp_code_actions", {
+    utils.notify("builtin.lsp_code_actions", {
       msg = err,
       level = "ERROR",
     })


### PR DESCRIPTION
Nothing big... just encountered a typo in neovim's status bar. This fixes that.