### PR TITLE
fix tags|btags for all special characters

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -434,10 +434,9 @@ files.tags = function(opts)
             -- un-escape / then escape required
             -- special chars for vim.fn.search()
             -- ] ~ *
-            local scode = selection.scode:gsub([[\/]], "/"):gsub("[%]~*]",
-              function(x)
-                return "\\" .. x
-              end)
+            local scode = selection.scode:gsub([[\/]], "/"):gsub("[%]~*]", function(x)
+              return "\\" .. x
+            end)
 
             vim.cmd "norm! gg"
             vim.fn.search(scode)

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -431,10 +431,13 @@ files.tags = function(opts)
           local selection = action_state.get_selected_entry()
 
           if selection.scode then
-            local scode = string.gsub(selection.scode, "[$]$", "")
-            scode = string.gsub(scode, [[\\]], [[\]])
-            scode = string.gsub(scode, [[\/]], [[/]])
-            scode = string.gsub(scode, "[*]", [[\*]])
+            -- un-escape / then escape required
+            -- special chars for vim.fn.search()
+            -- ] ~ *
+            local scode = selection.scode:gsub([[\/]], "/"):gsub("[%]~*]",
+              function(x)
+                return "\\" .. x
+              end)
 
             vim.cmd "norm! gg"
             vim.fn.search(scode)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -484,10 +484,13 @@ previewers.ctags = defaulter(function(_)
   local determine_jump = function(entry)
     if entry.scode then
       return function(self)
-        local scode = string.gsub(entry.scode, "[$]$", "")
-        scode = string.gsub(scode, [[\\]], [[\]])
-        scode = string.gsub(scode, [[\/]], [[/]])
-        scode = string.gsub(scode, "[*]", [[\*]])
+        -- un-escape / then escape required
+        -- special chars for vim.fn.search()
+        -- ] ~ *
+        local scode = entry.scode:gsub([[\/]], "/"):gsub("[%]~*]",
+          function(x)
+            return "\\" .. x
+          end)
 
         pcall(vim.fn.matchdelete, self.state.hl_id, self.state.winid)
         vim.cmd "norm! gg"

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -487,10 +487,9 @@ previewers.ctags = defaulter(function(_)
         -- un-escape / then escape required
         -- special chars for vim.fn.search()
         -- ] ~ *
-        local scode = entry.scode:gsub([[\/]], "/"):gsub("[%]~*]",
-          function(x)
-            return "\\" .. x
-          end)
+        local scode = entry.scode:gsub([[\/]], "/"):gsub("[%]~*]", function(x)
+          return "\\" .. x
+        end)
 
         pcall(vim.fn.matchdelete, self.state.hl_id, self.state.winid)
         vim.cmd "norm! gg"


### PR DESCRIPTION
This PR fixes both the preview and default action for `tags|btags` when tags contains special characets.

Tested with the below file:
```cpp
#include <stdio.h>

const char s01[] = "[\\[]~$?*|{}()^%-+./'%\"\r\n\t";
const char s02[] = "\\";
const char s03[] = "[";
const char s04[] = "]";
const char s05[] = "~";
const char s06[] = "$";
const char s07[] = "?";
const char s08[] = "*";
const char s09[] = "|";
const char s10[] = "{";
const char s11[] = "}";
const char s12[] = "(";
const char s13[] = ")";
const char s14[] = "^";
const char s15[] = "%";
const char s16[] = "-";
const char s17[] = "+";
const char s18[] = ".";
const char s19[] = "/";
const char s21[] = "\"";
const char s22[] = "'";
const char s23[] = "%";
const char s24[] = "\r";
const char s25[] = "\n";
const char s26[] = "\t";

void f(int x[3], const char s[]="[\\[]~$?*|{}()^%-+./'%\"\r\n\t")
{
}

int main(void)
{
}
```