### PR TITLE
fix: detect binary files before detecting filetype

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -160,7 +160,6 @@ previewers.file_maker = function(filepath, bufnr, opts)
   if opts.use_ft_detect == nil then
     opts.use_ft_detect = true
   end
-  opts.ft = opts.use_ft_detect and pfiletype.detect(filepath)
   if opts.bufname ~= filepath then
     if not vim.in_fast_event() then
       filepath = vim.fn.expand(filepath)
@@ -187,7 +186,7 @@ previewers.file_maker = function(filepath, bufnr, opts)
           end),
         })
       else
-        if opts.preview.check_mime_type == true and has_file and opts.ft == "" then
+        if opts.preview.check_mime_type == true and has_file then
           -- avoid SIGABRT in buffer previewer happening with utils.get_os_command_output
           local output = capture(string.format([[file --mime-type -b "%s"]], filepath))
           local mime_type = vim.split(output, "/")[1]
@@ -222,6 +221,8 @@ previewers.file_maker = function(filepath, bufnr, opts)
             return
           end
         end
+
+        opts.ft = opts.use_ft_detect and pfiletype.detect(filepath)
 
         opts.start_time = vim.loop.hrtime()
         Path:new(filepath):_read_async(vim.schedule_wrap(function(data)


### PR DESCRIPTION
Fixes #1637 for files recognized as binary by `file --mime-type`.

The filetype detection from plenary was run before checking if the file
is binary and if it is over the size limit. Moving the detection after
them fixes most cases of freezing while previewing a large binary file.

---

Note that https://github.com/nvim-lua/plenary.nvim/issues/307 is still needed for large files detected as `text/plain` with no newlines. Still, I think this commit is also useful: why detect the filetype if we later decide not to show a preview after all?