### PR TITLE
Allow results_title and prompt_title to have global default values

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -307,6 +307,21 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Default: false
 
+                                         *telescope.defaults.results_title*
+    results_title: ~
+        Defines the default title of the results window. A false value
+        can be used to hide the title altogether.
+
+        Default: "Results"
+
+                                          *telescope.defaults.prompt_title*
+    prompt_title: ~
+        Defines the default title of the prompt window. A false value
+        can be used to hide the title altogether. Most of the times builtins
+        define a prompt_title which will be prefered over this default.
+
+        Default: "Prompt"
+
                                                *telescope.defaults.history*
     history: ~
         This field handles the configuration for prompt history.

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -423,8 +423,8 @@ append(
   "results_title",
   "Results",
   [[
-	Defines the default title of the results window. A false value can be used to hide
-	the title altogether.
+  Defines the default title of the results window. A false value
+  can be used to hide the title altogether.
 
   Default: "Results"]]
 )
@@ -433,8 +433,9 @@ append(
   "prompt_title",
   "Prompt",
   [[
-	Defines the default title of the prompt window. A false value can be used to hide
-	the title altogether.
+  Defines the default title of the prompt window. A false value
+  can be used to hide the title altogether. Most of the times builtins
+  define a prompt_title which will be prefered over this default.
 
   Default: "Prompt"]]
 )

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -420,6 +420,26 @@ append(
 )
 
 append(
+  "results_title",
+  "Results",
+  [[
+	Defines the default title of the results window. A false value can be used to hide
+	the title altogether.
+
+  Default: "Results"]]
+)
+
+append(
+  "prompt_title",
+  "Prompt",
+  [[
+	Defines the default title of the prompt window. A false value can be used to hide
+	the title altogether.
+
+  Default: "Prompt"]]
+)
+
+append(
   "history",
   {
     path = vim.fn.stdpath "data" .. os_sep .. "telescope_history",

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -64,8 +64,8 @@ function Picker:new(opts)
   local layout_strategy = get_default(opts.layout_strategy, config.values.layout_strategy)
 
   local obj = setmetatable({
-    prompt_title = get_default(opts.prompt_title, "Prompt"),
-    results_title = get_default(opts.results_title, "Results"),
+    prompt_title = get_default(opts.prompt_title, config.values.prompt_title),
+    results_title = get_default(opts.results_title, config.values.results_title),
     -- either whats passed in by the user or whats defined by the previewer
     preview_title = opts.preview_title,
 


### PR DESCRIPTION
Currently both `results_title` and `prompt_title` can only be changed when a picker is executed. This PR makes those fields global so that they can be set in Telescope setup's `defaults` property.