### PR TITLE
Fix calc_result_length can throw

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -202,7 +202,12 @@ end
 
 local calc_result_length = function(truncate_len)
   local status = get_status(vim.api.nvim_get_current_buf())
-  local len = vim.api.nvim_win_get_width(status.results_win) - status.picker.selection_caret:len() - 2
+  local results_win = status.results_win
+  if type(results_win) ~= "number" then
+    return 0
+  end
+
+  local len = vim.api.nvim_win_get_width(results_win) - status.picker.selection_caret:len() - 2
   return type(truncate_len) == "number" and len - truncate_len or len
 end
 


### PR DESCRIPTION
git-worktree extension is throwing an error when this function get executed. 
I think this is because I have the truncate set, and this plugin does not operate on buffer
adding a type check here seems to fix it