### PR TITLE
feat(lsp): added trim option to make_entry.gen_from_quickfix

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1110,6 +1110,7 @@ builtin.quickfix({opts})                        *telescope.builtin.quickfix()*
 
     Options: ~
         {ignore_filename} (boolean)  dont show filenames (default: true)
+        {trim_text}       (boolean)  trim results text (default: false)
 
 
 builtin.loclist({opts})                          *telescope.builtin.loclist()*
@@ -1122,6 +1123,7 @@ builtin.loclist({opts})                          *telescope.builtin.loclist()*
 
     Options: ~
         {ignore_filename} (boolean)  dont show filenames (default: true)
+        {trim_text}       (boolean)  trim results text (default: false)
 
 
 builtin.oldfiles({opts})                        *telescope.builtin.oldfiles()*
@@ -1321,6 +1323,7 @@ builtin.tagstack({opts})                        *telescope.builtin.tagstack()*
 
     Options: ~
         {ignore_filename} (boolean)  dont show filenames (default: true)
+        {trim_text}       (boolean)  trim results text (default: false)
 
 
 builtin.jumplist({opts})                        *telescope.builtin.jumplist()*
@@ -1332,6 +1335,7 @@ builtin.jumplist({opts})                        *telescope.builtin.jumplist()*
 
     Options: ~
         {ignore_filename} (boolean)  dont show filenames (default: true)
+        {trim_text}       (boolean)  trim results text (default: false)
 
 
 builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
@@ -1347,6 +1351,7 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
                                           lsp references (default: true)
         {include_current_line} (boolean)  include current line (default:
                                           false)
+        {trim_text}            (boolean)  trim results text (default: false)
 
 
 builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
@@ -1362,6 +1367,7 @@ builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
                                      one, values: "tab", "split", "vsplit",
                                      "never"
         {ignore_filename} (boolean)  dont show filenames (default: true)
+        {trim_text}       (boolean)  trim results text (default: false)
 
 
 builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
@@ -1377,6 +1383,7 @@ builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
                                      one, values: "tab", "split", "vsplit",
                                      "never"
         {ignore_filename} (boolean)  dont show filenames (default: true)
+        {trim_text}       (boolean)  trim results text (default: false)
 
 
 builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
@@ -1392,6 +1399,7 @@ builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
                                      only one, values: "tab", "split",
                                      "vsplit", "never"
         {ignore_filename} (boolean)  dont show filenames (default: true)
+        {trim_text}       (boolean)  trim results text (default: false)
 
 
 builtin.lsp_code_actions({opts})        *telescope.builtin.lsp_code_actions()*

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -240,11 +240,13 @@ builtin.commands = require_on_exported_call("telescope.builtin.internal").comman
 --- Lists items in the quickfix list, jumps to location on `<cr>`
 ---@param opts table: options to pass to the picker
 ---@field ignore_filename boolean: dont show filenames (default: true)
+---@field trim_text boolean: trim results text (default: false)
 builtin.quickfix = require_on_exported_call("telescope.builtin.internal").quickfix
 
 --- Lists items from the current window's location list, jumps to location on `<cr>`
 ---@param opts table: options to pass to the picker
 ---@field ignore_filename boolean: dont show filenames (default: true)
+---@field trim_text boolean: trim results text (default: false)
 builtin.loclist = require_on_exported_call("telescope.builtin.internal").loclist
 
 --- Lists previously open files, opens on `<cr>`
@@ -337,11 +339,13 @@ builtin.spell_suggest = require_on_exported_call("telescope.builtin.internal").s
 --- Lists the tag stack for the current window, jumps to tag on `<cr>`
 ---@param opts table: options to pass to the picker
 ---@field ignore_filename boolean: dont show filenames (default: true)
+---@field trim_text boolean: trim results text (default: false)
 builtin.tagstack = require_on_exported_call("telescope.builtin.internal").tagstack
 
 --- Lists items from Vim's jumplist, jumps to location on `<cr>`
 ---@param opts table: options to pass to the picker
 ---@field ignore_filename boolean: dont show filenames (default: true)
+---@field trim_text boolean: trim results text (default: false)
 builtin.jumplist = require_on_exported_call("telescope.builtin.internal").jumplist
 
 --
@@ -354,12 +358,14 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.internal").jumpli
 ---@param opts table: options to pass to the picker
 ---@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
 ---@field include_current_line boolean: include current line (default: false)
+---@field trim_text boolean: trim results text (default: false)
 builtin.lsp_references = require_on_exported_call("telescope.builtin.lsp").references
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
 ---@field ignore_filename boolean: dont show filenames (default: true)
+---@field trim_text boolean: trim results text (default: false)
 builtin.lsp_definitions = require_on_exported_call("telescope.builtin.lsp").definitions
 
 --- Goto the definition of the type of the word under the cursor, if there's only one,
@@ -367,12 +373,14 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.lsp").defi
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
 ---@field ignore_filename boolean: dont show filenames (default: true)
+---@field trim_text boolean: trim results text (default: false)
 builtin.lsp_type_definitions = require("telescope.builtin.lsp").type_definitions
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto implementation if there is only one, values: "tab", "split", "vsplit", "never"
 ---@field ignore_filename boolean: dont show filenames (default: true)
+---@field trim_text boolean: trim results text (default: false)
 builtin.lsp_implementations = require_on_exported_call("telescope.builtin.lsp").implementations
 
 --- Lists any LSP actions for the word under the cursor which can be triggered with `<cr>`

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -324,6 +324,10 @@ function make_entry.gen_from_quickfix(opts)
 
     local line_info = { table.concat({ entry.lnum, entry.col }, ":"), "TelescopeResultsLineNr" }
 
+    if opts.trim_text then
+      entry.text = entry.text:gsub("^%s*(.-)%s*$", "%1")
+    end
+
     return displayer {
       line_info,
       entry.text:gsub(".* | ", ""),


### PR DESCRIPTION
Added option to trim results text.
![image](https://user-images.githubusercontent.com/14127958/163179249-fa6f7a92-2870-443d-9f3c-bd9134808da5.png)
![image](https://user-images.githubusercontent.com/14127958/163179316-ddadcdf2-59be-4c90-99ff-be132dedcad6.png)
