### PR TITLE
feat(git): add git_command parameters to all builtin git pickers

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -983,6 +983,8 @@ builtin.git_branches({opts})                          *builtin.git_branches()*
         {use_git_root} (boolean)  if we should use git root as cwd or the cwd
                                   (important for submodule) (default: true)
         {pattern}      (string)   specify the pattern to match all refs
+        {git_command}  (table)    command that will be exectued.
+                                  {"git","for-each-ref","--perl","--format"}
 
 
 builtin.git_status({opts})                              *builtin.git_status()*
@@ -1002,6 +1004,8 @@ builtin.git_status({opts})                              *builtin.git_status()*
         {git_icons}    (table)    string -> string. Matches name with icon
                                   (see source code, make_entry.lua
                                   git_icon_defaults)
+        {git_command}  (table)    command that will be exectued.
+                                  {"git","status","-s","--","."}
 
 
 builtin.git_stash({opts})                                *builtin.git_stash()*
@@ -1019,6 +1023,8 @@ builtin.git_stash({opts})                                *builtin.git_stash()*
                                   (important for submodule) (default: true)
         {show_branch}  (boolean)  if we should display the branch name for git
                                   stash entries (default: true)
+        {git_command}  (table)    command that will be exectued.
+                                  {"git","--no-pager","stash","list"}
 
 
 builtin.builtin({opts})                                    *builtin.builtin()*

--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -82,16 +82,12 @@ end
 git.stash = function(opts)
   opts.show_branch = vim.F.if_nil(opts.show_branch, true)
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_stash(opts))
+  local git_command = vim.F.if_nil(opts.git_command, { "git", "--no-pager", "stash", "list" })
 
   pickers.new(opts, {
     prompt_title = "Git Stash",
     finder = finders.new_oneshot_job(
-      vim.tbl_flatten {
-        "git",
-        "--no-pager",
-        "stash",
-        "list",
-      },
+      vim.tbl_flatten(git_command),
       opts
     ),
     previewer = previewers.git_stash_diff.new(opts),
@@ -193,8 +189,9 @@ git.branches = function(opts)
     .. "%(authorname)"
     .. "%(upstream:lstrip=2)"
     .. "%(committerdate:format-local:%Y/%m/%d %H:%M:%S)"
+  local git_command = vim.F.if_nil(opts.git_command, { "git", "for-each-ref", "--perl", "--format" })
   local output = utils.get_os_command_output(
-    { "git", "for-each-ref", "--perl", "--format", format, opts.pattern },
+    vim.tbl_flatten { git_command, format, opts.pattern },
     opts.cwd
   )
 
@@ -317,13 +314,13 @@ git.status = function(opts)
 
   local gen_new_finder = function()
     local expand_dir = utils.if_nil(opts.expand_dir, true, opts.expand_dir)
-    local git_cmd = { "git", "status", "-s", "--", "." }
+    local git_command = vim.F.if_nil(opts.git_command, { "git", "status", "-s", "--", "." })
 
     if expand_dir then
-      table.insert(git_cmd, #git_cmd - 1, "-u")
+      table.insert(git_command, #git_command - 1, "-u")
     end
 
-    local output = utils.get_os_command_output(git_cmd, opts.cwd)
+    local output = utils.get_os_command_output(git_command, opts.cwd)
 
     if #output == 0 then
       print "No changes found"


### PR DESCRIPTION
Some of the `git_*` pickers have a `git_command`option, while some others don't.

I would like to be able to pass in a different git executable to all commands, so I added the git_command option to all pickers that didn't already have one.