### PR TITLE
docs: add module prefix

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -743,7 +743,7 @@ options you want to use. Here's an example with the live_grep picker:
   })
 <
 
-builtin.live_grep({opts})                                *builtin.live_grep()*
+builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
     Search for a string and get results live as you type (respecting
     .gitignore)
 
@@ -769,7 +769,7 @@ builtin.live_grep({opts})                                *builtin.live_grep()*
                                           (default: false)
 
 
-builtin.grep_string({opts})                            *builtin.grep_string()*
+builtin.grep_string({opts})                  *telescope.builtin.grep_string()*
     Searches for the string under your cursor in your current working directory
 
 
@@ -796,7 +796,7 @@ builtin.grep_string({opts})                            *builtin.grep_string()*
                                           line or row (default: false)
 
 
-builtin.find_files({opts})                              *builtin.find_files()*
+builtin.find_files({opts})                    *telescope.builtin.find_files()*
     Search for files (respecting .gitignore)
 
 
@@ -819,12 +819,12 @@ builtin.find_files({opts})                              *builtin.find_files()*
         {search_dirs}  (table)    directory/directories to search in
 
 
-builtin.fd()                                                    *builtin.fd()*
+builtin.fd()                                          *telescope.builtin.fd()*
     This is an alias for the `find_files` picker
 
 
 
-builtin.treesitter()                                    *builtin.treesitter()*
+builtin.treesitter()                          *telescope.builtin.treesitter()*
     Lists function names, variables, and other symbols from treesitter queries
     - Default keymaps:
       - `<C-l>`: show autocompletion menu to prefilter your query by kind of ts
@@ -841,7 +841,7 @@ builtin.treesitter()                                    *builtin.treesitter()*
                                        hl_group
 
 
-builtin.current_buffer_fuzzy_find({opts}) *builtin.current_buffer_fuzzy_find()*
+builtin.current_buffer_fuzzy_find({opts}) *telescope.builtin.current_buffer_fuzzy_find()*
     Live fuzzy search inside of the currently open buffer
 
 
@@ -853,7 +853,7 @@ builtin.current_buffer_fuzzy_find({opts}) *builtin.current_buffer_fuzzy_find()*
                                       (default: false)
 
 
-builtin.tags({opts})                                          *builtin.tags()*
+builtin.tags({opts})                                *telescope.builtin.tags()*
     Lists tags in current directory with tag location file preview (users are
     required to run ctags -R to generate tags or update when introducing new
     changes)
@@ -874,7 +874,7 @@ builtin.tags({opts})                                          *builtin.tags()*
                                     false)
 
 
-builtin.current_buffer_tags({opts})            *builtin.current_buffer_tags()*
+builtin.current_buffer_tags({opts})  *telescope.builtin.current_buffer_tags()*
     Lists all of the tags for the currently open buffer, with a preview
 
 
@@ -893,7 +893,7 @@ builtin.current_buffer_tags({opts})            *builtin.current_buffer_tags()*
                                     false)
 
 
-builtin.git_files({opts})                                *builtin.git_files()*
+builtin.git_files({opts})                      *telescope.builtin.git_files()*
     Fuzzy search for files tracked by Git. This command lists the output of the
     `git ls-files` command, respects .gitignore, and optionally ignores
     untracked files
@@ -919,7 +919,7 @@ builtin.git_files({opts})                                *builtin.git_files()*
                                         {"git","ls-files","--exclude-standard","--cached"}
 
 
-builtin.git_commits({opts})                            *builtin.git_commits()*
+builtin.git_commits({opts})                  *telescope.builtin.git_commits()*
     Lists commits for current directory with diff preview
     - Default keymaps:
       - `<cr>`: checks out the currently selected commit
@@ -939,7 +939,7 @@ builtin.git_commits({opts})                            *builtin.git_commits()*
                                   {"git","log","--pretty=oneline","--abbrev-commit","--","."}
 
 
-builtin.git_bcommits({opts})                          *builtin.git_bcommits()*
+builtin.git_bcommits({opts})                *telescope.builtin.git_bcommits()*
     Lists commits for current buffer with diff preview
     - Default keymaps or your overriden `select_` keys:
       - `<cr>`: checks out the currently selected commit
@@ -961,7 +961,7 @@ builtin.git_bcommits({opts})                          *builtin.git_bcommits()*
                                   {"git","log","--pretty=oneline","--abbrev-commit"}
 
 
-builtin.git_branches({opts})                          *builtin.git_branches()*
+builtin.git_branches({opts})                *telescope.builtin.git_branches()*
     List branches for current directory, with output from `git log --oneline`
     shown in the preview window
     - Default keymaps:
@@ -985,7 +985,7 @@ builtin.git_branches({opts})                          *builtin.git_branches()*
         {pattern}      (string)   specify the pattern to match all refs
 
 
-builtin.git_status({opts})                              *builtin.git_status()*
+builtin.git_status({opts})                    *telescope.builtin.git_status()*
     Lists git status for current directory
     - Default keymaps:
       - `<Tab>`: stages or unstages the currently selected file
@@ -1004,7 +1004,7 @@ builtin.git_status({opts})                              *builtin.git_status()*
                                   git_icon_defaults)
 
 
-builtin.git_stash({opts})                                *builtin.git_stash()*
+builtin.git_stash({opts})                      *telescope.builtin.git_stash()*
     Lists stash items in current repository
     - Default keymaps:
       - `<cr>`: runs `git apply` for currently selected stash
@@ -1021,7 +1021,7 @@ builtin.git_stash({opts})                                *builtin.git_stash()*
                                   stash entries (default: true)
 
 
-builtin.builtin({opts})                                    *builtin.builtin()*
+builtin.builtin({opts})                          *telescope.builtin.builtin()*
     Lists all of the community maintained pickers built into Telescope
 
 
@@ -1033,7 +1033,7 @@ builtin.builtin({opts})                                    *builtin.builtin()*
                                         installed extensions (default: false)
 
 
-builtin.resume({opts})                                      *builtin.resume()*
+builtin.resume({opts})                            *telescope.builtin.resume()*
     Opens the previous picker in the identical state (incl. multi selections)
     - Notes:
       - Requires `cache_picker` in setup or when having invoked pickers, see
@@ -1048,7 +1048,7 @@ builtin.resume({opts})                                      *builtin.resume()*
                                 recent (default: 1)
 
 
-builtin.pickers({opts})                                    *builtin.pickers()*
+builtin.pickers({opts})                          *telescope.builtin.pickers()*
     Opens a picker over previously cached pickers in their preserved states
     (incl. multi selections)
     - Default keymaps:
@@ -1062,7 +1062,7 @@ builtin.pickers({opts})                                    *builtin.pickers()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.planets({opts})                                    *builtin.planets()*
+builtin.planets({opts})                          *telescope.builtin.planets()*
     Use the telescope...
 
 
@@ -1074,7 +1074,7 @@ builtin.planets({opts})                                    *builtin.planets()*
                                 hidden feature)
 
 
-builtin.symbols({opts})                                    *builtin.symbols()*
+builtin.symbols({opts})                          *telescope.builtin.symbols()*
     Lists symbols inside of `data/telescope-sources/*.json` found in your
     runtime path or found in `stdpath("data")/telescope/symbols/*.json`. The
     second path can be customized. We provide a couple of default symbols which
@@ -1093,7 +1093,7 @@ builtin.symbols({opts})                                    *builtin.symbols()*
                                 this time
 
 
-builtin.commands({opts})                                  *builtin.commands()*
+builtin.commands({opts})                        *telescope.builtin.commands()*
     Lists available plugin/user commands and runs them on `<cr>`
 
 
@@ -1101,7 +1101,7 @@ builtin.commands({opts})                                  *builtin.commands()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.quickfix({opts})                                  *builtin.quickfix()*
+builtin.quickfix({opts})                        *telescope.builtin.quickfix()*
     Lists items in the quickfix list, jumps to location on `<cr>`
 
 
@@ -1112,7 +1112,7 @@ builtin.quickfix({opts})                                  *builtin.quickfix()*
         {ignore_filename} (boolean)  dont show filenames (default: true)
 
 
-builtin.loclist({opts})                                    *builtin.loclist()*
+builtin.loclist({opts})                          *telescope.builtin.loclist()*
     Lists items from the current window's location list, jumps to location on
     `<cr>`
 
@@ -1124,7 +1124,7 @@ builtin.loclist({opts})                                    *builtin.loclist()*
         {ignore_filename} (boolean)  dont show filenames (default: true)
 
 
-builtin.oldfiles({opts})                                  *builtin.oldfiles()*
+builtin.oldfiles({opts})                        *telescope.builtin.oldfiles()*
     Lists previously open files, opens on `<cr>`
 
 
@@ -1136,7 +1136,7 @@ builtin.oldfiles({opts})                                  *builtin.oldfiles()*
         {cwd_only} (boolean)  alias for only_cwd
 
 
-builtin.command_history({opts})                    *builtin.command_history()*
+builtin.command_history({opts})          *telescope.builtin.command_history()*
     Lists commands that were executed recently, and reruns them on `<cr>`
     - Default keymaps:
       - `<C-e>`: open the command line with the text of the currently selected
@@ -1147,7 +1147,7 @@ builtin.command_history({opts})                    *builtin.command_history()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.search_history({opts})                      *builtin.search_history()*
+builtin.search_history({opts})            *telescope.builtin.search_history()*
     Lists searches that were executed recently, and reruns them on `<cr>`
     - Default keymaps:
       - `<C-e>`: open a search window with the text of the currently selected
@@ -1158,7 +1158,7 @@ builtin.search_history({opts})                      *builtin.search_history()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.vim_options({opts})                            *builtin.vim_options()*
+builtin.vim_options({opts})                  *telescope.builtin.vim_options()*
     Lists vim options, allows you to edit the current value on `<cr>`
 
 
@@ -1166,7 +1166,7 @@ builtin.vim_options({opts})                            *builtin.vim_options()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.help_tags({opts})                                *builtin.help_tags()*
+builtin.help_tags({opts})                      *telescope.builtin.help_tags()*
     Lists available help tags and opens a new window with the relevant help
     info on `<cr>`
 
@@ -1180,7 +1180,7 @@ builtin.help_tags({opts})                                *builtin.help_tags()*
                               (default: true)
 
 
-builtin.man_pages({opts})                                *builtin.man_pages()*
+builtin.man_pages({opts})                      *telescope.builtin.man_pages()*
     Lists manpage entries, opens them in a help window on `<cr>`
 
 
@@ -1194,7 +1194,7 @@ builtin.man_pages({opts})                                *builtin.man_pages()*
                                `apropos ""` on linux, `apropos " "` on macos)
 
 
-builtin.reloader({opts})                                  *builtin.reloader()*
+builtin.reloader({opts})                        *telescope.builtin.reloader()*
     Lists lua modules and reloads them on `<cr>`
 
 
@@ -1206,7 +1206,7 @@ builtin.reloader({opts})                                  *builtin.reloader()*
                                (default: dynamic, longest module name)
 
 
-builtin.buffers({opts})                                    *builtin.buffers()*
+builtin.buffers({opts})                          *telescope.builtin.buffers()*
     Lists open buffers in current neovim instance, opens selected buffer on
     `<cr>`
 
@@ -1235,7 +1235,7 @@ builtin.buffers({opts})                                    *builtin.buffers()*
                                            (default: dynamic)
 
 
-builtin.colorscheme({opts})                            *builtin.colorscheme()*
+builtin.colorscheme({opts})                  *telescope.builtin.colorscheme()*
     Lists available colorschemes and applies them on `<cr>`
 
 
@@ -1246,7 +1246,7 @@ builtin.colorscheme({opts})                            *builtin.colorscheme()*
         {enable_preview} (boolean)  if true, will preview the selected color
 
 
-builtin.marks({opts})                                        *builtin.marks()*
+builtin.marks({opts})                              *telescope.builtin.marks()*
     Lists vim marks and their value, jumps to the mark on `<cr>`
 
 
@@ -1254,7 +1254,7 @@ builtin.marks({opts})                                        *builtin.marks()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.registers({opts})                                *builtin.registers()*
+builtin.registers({opts})                      *telescope.builtin.registers()*
     Lists vim registers, pastes the contents of the register on `<cr>`
     - Default keymaps:
       - `<C-e>`: edit the contents of the currently selected register
@@ -1264,7 +1264,7 @@ builtin.registers({opts})                                *builtin.registers()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.keymaps({opts})                                    *builtin.keymaps()*
+builtin.keymaps({opts})                          *telescope.builtin.keymaps()*
     Lists normal mode keymappings, runs the selected keymap on `<cr>`
 
 
@@ -1278,7 +1278,7 @@ builtin.keymaps({opts})                                    *builtin.keymaps()*
                                "<Plug>" are also shown (default: true)
 
 
-builtin.filetypes({opts})                                *builtin.filetypes()*
+builtin.filetypes({opts})                      *telescope.builtin.filetypes()*
     Lists all available filetypes, sets currently open buffer's filetype to
     selected filetype in Telescope on `<cr>`
 
@@ -1287,7 +1287,7 @@ builtin.filetypes({opts})                                *builtin.filetypes()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.highlights({opts})                              *builtin.highlights()*
+builtin.highlights({opts})                    *telescope.builtin.highlights()*
     Lists all available highlights
 
 
@@ -1295,7 +1295,7 @@ builtin.highlights({opts})                              *builtin.highlights()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.autocommands({opts})                          *builtin.autocommands()*
+builtin.autocommands({opts})                *telescope.builtin.autocommands()*
     Lists vim autocommands and goes to their declaration on `<cr>`
 
 
@@ -1303,7 +1303,7 @@ builtin.autocommands({opts})                          *builtin.autocommands()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.spell_suggest({opts})                        *builtin.spell_suggest()*
+builtin.spell_suggest({opts})              *telescope.builtin.spell_suggest()*
     Lists spelling suggestions for the current word under the cursor, replaces
     word with selected suggestion on `<cr>`
 
@@ -1312,7 +1312,7 @@ builtin.spell_suggest({opts})                        *builtin.spell_suggest()*
         {opts} (table)  options to pass to the picker
 
 
-builtin.tagstack({opts})                                  *builtin.tagstack()*
+builtin.tagstack({opts})                        *telescope.builtin.tagstack()*
     Lists the tag stack for the current window, jumps to tag on `<cr>`
 
 
@@ -1323,7 +1323,7 @@ builtin.tagstack({opts})                                  *builtin.tagstack()*
         {ignore_filename} (boolean)  dont show filenames (default: true)
 
 
-builtin.jumplist({opts})                                  *builtin.jumplist()*
+builtin.jumplist({opts})                        *telescope.builtin.jumplist()*
     Lists items from Vim's jumplist, jumps to location on `<cr>`
 
 
@@ -1334,7 +1334,7 @@ builtin.jumplist({opts})                                  *builtin.jumplist()*
         {ignore_filename} (boolean)  dont show filenames (default: true)
 
 
-builtin.lsp_references({opts})                      *builtin.lsp_references()*
+builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
     Lists LSP references for word under the cursor, jumps to reference on
     `<cr>`
 
@@ -1349,7 +1349,7 @@ builtin.lsp_references({opts})                      *builtin.lsp_references()*
                                           false)
 
 
-builtin.lsp_definitions({opts})                    *builtin.lsp_definitions()*
+builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
     Goto the definition of the word under the cursor, if there's only one,
     otherwise show all options in Telescope
 
@@ -1364,7 +1364,7 @@ builtin.lsp_definitions({opts})                    *builtin.lsp_definitions()*
         {ignore_filename} (boolean)  dont show filenames (default: true)
 
 
-builtin.lsp_type_definitions({opts})          *builtin.lsp_type_definitions()*
+builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
     Goto the definition of the type of the word under the cursor, if there's
     only one, otherwise show all options in Telescope
 
@@ -1379,7 +1379,7 @@ builtin.lsp_type_definitions({opts})          *builtin.lsp_type_definitions()*
         {ignore_filename} (boolean)  dont show filenames (default: true)
 
 
-builtin.lsp_implementations({opts})            *builtin.lsp_implementations()*
+builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
     Goto the implementation of the word under the cursor if there's only one,
     otherwise show all options in Telescope
 
@@ -1394,7 +1394,7 @@ builtin.lsp_implementations({opts})            *builtin.lsp_implementations()*
         {ignore_filename} (boolean)  dont show filenames (default: true)
 
 
-builtin.lsp_code_actions({opts})                  *builtin.lsp_code_actions()*
+builtin.lsp_code_actions({opts})        *telescope.builtin.lsp_code_actions()*
     Lists any LSP actions for the word under the cursor which can be triggered
     with `<cr>`
 
@@ -1406,7 +1406,7 @@ builtin.lsp_code_actions({opts})                  *builtin.lsp_code_actions()*
         {timeout} (number)  timeout for the sync call (default: 10000)
 
 
-builtin.lsp_range_code_actions({opts})      *builtin.lsp_range_code_actions()*
+builtin.lsp_range_code_actions({opts}) *telescope.builtin.lsp_range_code_actions()*
     Lists any LSP actions for a given range, that can be triggered with `<cr>`
 
 
@@ -1421,7 +1421,7 @@ builtin.lsp_range_code_actions({opts})      *builtin.lsp_range_code_actions()*
                                :'<,'>Telescope lsp_range_code_actions)
 
 
-builtin.lsp_document_symbols({opts})          *builtin.lsp_document_symbols()*
+builtin.lsp_document_symbols({opts}) *telescope.builtin.lsp_document_symbols()*
     Lists LSP document symbols in the current buffer
     - Default keymaps:
       - `<C-l>`: show autocompletion menu to prefilter your query by type of
@@ -1443,7 +1443,7 @@ builtin.lsp_document_symbols({opts})          *builtin.lsp_document_symbols()*
                                             with hl_group
 
 
-builtin.lsp_workspace_symbols({opts})        *builtin.lsp_workspace_symbols()*
+builtin.lsp_workspace_symbols({opts}) *telescope.builtin.lsp_workspace_symbols()*
     Lists LSP document symbols in the current workspace
     - Default keymaps:
       - `<C-l>`: show autocompletion menu to prefilter your query by type of
@@ -1467,7 +1467,7 @@ builtin.lsp_workspace_symbols({opts})        *builtin.lsp_workspace_symbols()*
                                             with hl_group
 
 
-builtin.lsp_dynamic_workspace_symbols({opts}) *builtin.lsp_dynamic_workspace_symbols()*
+builtin.lsp_dynamic_workspace_symbols({opts}) *telescope.builtin.lsp_dynamic_workspace_symbols()*
     Dynamically lists LSP for all workspace symbols
     - Default keymaps:
       - `<C-l>`: show autocompletion menu to prefilter your query by type of
@@ -1489,7 +1489,7 @@ builtin.lsp_dynamic_workspace_symbols({opts}) *builtin.lsp_dynamic_workspace_sym
                                             with hl_group
 
 
-builtin.diagnostics({opts})                            *builtin.diagnostics()*
+builtin.diagnostics({opts})                  *telescope.builtin.diagnostics()*
     Lists diagnostics
     - Fields:
       - `All severity flags can be passed as `string` or `number` as per
@@ -1535,7 +1535,7 @@ Themes are ways to combine several elements of styling together.
 They are helpful for managing the several different UI aspects for telescope
 and provide a simple interface for users to get a particular "style" of picker.
 
-themes.get_dropdown()                                  *themes.get_dropdown()*
+themes.get_dropdown()                        *telescope.themes.get_dropdown()*
     Dropdown style theme.
 
     Usage:
@@ -1547,7 +1547,7 @@ themes.get_dropdown()                                  *themes.get_dropdown()*
 
 
 
-themes.get_cursor()                                      *themes.get_cursor()*
+themes.get_cursor()                            *telescope.themes.get_cursor()*
     Cursor style theme.
 
     Usage:
@@ -1560,7 +1560,7 @@ themes.get_cursor()                                      *themes.get_cursor()*
 
 
 
-themes.get_ivy()                                            *themes.get_ivy()*
+themes.get_ivy()                                  *telescope.themes.get_ivy()*
     Ivy style theme.
 
     Usage:
@@ -1623,7 +1623,7 @@ most resembles what you want from
 "./lua/telescope/pickers/layout_strategies.lua" in the telescope repo.
 
 
-layout_strategies.horizontal()                *layout_strategies.horizontal()*
+layout_strategies.horizontal()                 *telescope.layout.horizontal()*
     Horizontal layout has two columns, one for the preview and one for the
     prompt and results.
 
@@ -1667,7 +1667,7 @@ layout_strategies.horizontal()                *layout_strategies.horizontal()*
         - See |resolver.resolve_width()|
 
 
-layout_strategies.center()                        *layout_strategies.center()*
+layout_strategies.center()                         *telescope.layout.center()*
     Centered layout with a combined block of the prompt and results aligned to
     the middle of the screen. The preview window is then placed in the
     remaining space above or below, according to `anchor` or `mirror`.
@@ -1717,7 +1717,7 @@ layout_strategies.center()                        *layout_strategies.center()*
       - preview_cutoff: When lines are less than this value, the preview will be disabled
 
 
-layout_strategies.cursor()                        *layout_strategies.cursor()*
+layout_strategies.cursor()                         *telescope.layout.cursor()*
     Cursor layout dynamically positioned below the cursor if possible. If there
     is no place below the cursor it will be placed above.
 
@@ -1740,7 +1740,7 @@ layout_strategies.cursor()                        *layout_strategies.cursor()*
 
 
 
-layout_strategies.vertical()                    *layout_strategies.vertical()*
+layout_strategies.vertical()                     *telescope.layout.vertical()*
     Vertical layout stacks the items on top of each other. Particularly useful
     with thinner windows.
 
@@ -1784,7 +1784,7 @@ layout_strategies.vertical()                    *layout_strategies.vertical()*
         - See |resolver.resolve_height()|
 
 
-layout_strategies.flex()                            *layout_strategies.flex()*
+layout_strategies.flex()                             *telescope.layout.flex()*
     Flex layout swaps between `horizontal` and `vertical` strategies based on
     the window width
      - Supports |layout_strategies.vertical| or |layout_strategies.horizontal|
@@ -1814,7 +1814,7 @@ layout_strategies.flex()                            *layout_strategies.flex()*
       - vertical: Options to pass when switching to vertical layout
 
 
-layout_strategies.bottom_pane()              *layout_strategies.bottom_pane()*
+layout_strategies.bottom_pane()               *telescope.layout.bottom_pane()*
     Bottom pane can be used to create layouts similar to "ivy".
 
     For an easy ivy configuration, see |themes.get_ivy()|
@@ -1827,7 +1827,7 @@ layout_strategies.bottom_pane()              *layout_strategies.bottom_pane()*
 
 Provides "resolver functions" to allow more customisable inputs for options.
 
-resolver.resolve_height()                          *resolver.resolve_height()*
+resolver.resolve_height()                 *telescope.resolve.resolve_height()*
     Converts input to a function that returns the height. The input must take
     one of four forms:
     1. 0 <= number < 1
@@ -1847,7 +1847,7 @@ resolver.resolve_height()                          *resolver.resolve_height()*
 
 
 
-resolver.resolve_width()                            *resolver.resolve_width()*
+resolver.resolve_width()                   *telescope.resolve.resolve_width()*
     Converts input to a function that returns the width. The input must take
     one of four forms:
     1. 0 <= number < 1
@@ -1867,7 +1867,7 @@ resolver.resolve_width()                            *resolver.resolve_width()*
 
 
 
-resolver.resolve_anchor_pos()                  *resolver.resolve_anchor_pos()*
+resolver.resolve_anchor_pos()         *telescope.resolve.resolve_anchor_pos()*
     Calculates the adjustment required to move the picker from the middle of
     the screen to an edge or corner.
     The `anchor` can be any of the following strings:
@@ -1893,41 +1893,39 @@ argument (1) or they can be a custom telescope type called "action" (2).
 (1) The `prompt_bufnr` of a normal function denotes the identifier of your
 picker which can be used to access the picker state. In practice, users most
 commonly access from both picker and global state via the following:
-
 >
--- for utility functions
-local action_state = require "telescope.actions.state"
+  -- for utility functions
+  local action_state = require "telescope.actions.state"
 
-local actions = {}
-actions.do_stuff = function(prompt_bufnr)
-  local current_picker = action_state.get_current_picker(prompt_bufnr) -- picker state
-  local entry = action_state.get_selected_entry()
-end
+  local actions = {}
+  actions.do_stuff = function(prompt_bufnr)
+    local current_picker = action_state.get_current_picker(prompt_bufnr) -- picker state
+    local entry = action_state.get_selected_entry()
+  end
 <
 
 See |telescope.actions.state| for more information.
 
 (2) To transform a module of functions into a module of "action"s, you need to
 do the following:
-
 >
-local transform_mod = require("telescope.actions.mt").transform_mod
+  local transform_mod = require("telescope.actions.mt").transform_mod
 
-local mod = {}
-mod.a1 = function(prompt_bufnr)
-  -- your code goes here
-  -- You can access the picker/global state as described above in (1).
-end
+  local mod = {}
+  mod.a1 = function(prompt_bufnr)
+    -- your code goes here
+    -- You can access the picker/global state as described above in (1).
+  end
 
-mod.a2 = function(prompt_bufnr)
-  -- your code goes here
-end
-mod = transform_mod(mod)
+  mod.a2 = function(prompt_bufnr)
+    -- your code goes here
+  end
+  mod = transform_mod(mod)
 
--- Now the following is possible. This means that actions a2 will be executed
--- after action a1. You can chain as many actions as you want.
-local action = mod.a1 + mod.a2
-action(bufnr)
+  -- Now the following is possible. This means that actions a2 will be executed
+  -- after action a1. You can chain as many actions as you want.
+  local action = mod.a1 + mod.a2
+  action(bufnr)
 <
 
 Another interesing thing to do is that these actions now have functions you can
@@ -1935,7 +1933,7 @@ call. These functions include `:replace(f)`, `:replace_if(f, c)`,
 `replace_map(tbl)` and `enhance(tbl)`. More information on these functions can
 be found in the `developers.md` and `lua/tests/automated/action_spec.lua` file.
 
-actions.move_selection_next({prompt_bufnr})    *actions.move_selection_next()*
+actions.move_selection_next({prompt_bufnr}) *telescope.actions.move_selection_next()*
     Move the selection to the next entry
 
 
@@ -1943,7 +1941,7 @@ actions.move_selection_next({prompt_bufnr})    *actions.move_selection_next()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.move_selection_previous({prompt_bufnr}) *actions.move_selection_previous()*
+actions.move_selection_previous({prompt_bufnr}) *telescope.actions.move_selection_previous()*
     Move the selection to the previous entry
 
 
@@ -1951,7 +1949,7 @@ actions.move_selection_previous({prompt_bufnr}) *actions.move_selection_previous
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.move_selection_worse({prompt_bufnr})  *actions.move_selection_worse()*
+actions.move_selection_worse({prompt_bufnr}) *telescope.actions.move_selection_worse()*
     Move the selection to the entry that has a worse score
 
 
@@ -1959,7 +1957,7 @@ actions.move_selection_worse({prompt_bufnr})  *actions.move_selection_worse()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.move_selection_better({prompt_bufnr}) *actions.move_selection_better()*
+actions.move_selection_better({prompt_bufnr}) *telescope.actions.move_selection_better()*
     Move the selection to the entry that has a better score
 
 
@@ -1967,7 +1965,7 @@ actions.move_selection_better({prompt_bufnr}) *actions.move_selection_better()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.move_to_top({prompt_bufnr})                    *actions.move_to_top()*
+actions.move_to_top({prompt_bufnr})          *telescope.actions.move_to_top()*
     Move to the top of the picker
 
 
@@ -1975,7 +1973,7 @@ actions.move_to_top({prompt_bufnr})                    *actions.move_to_top()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.move_to_middle({prompt_bufnr})              *actions.move_to_middle()*
+actions.move_to_middle({prompt_bufnr})    *telescope.actions.move_to_middle()*
     Move to the middle of the picker
 
 
@@ -1983,7 +1981,7 @@ actions.move_to_middle({prompt_bufnr})              *actions.move_to_middle()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.move_to_bottom({prompt_bufnr})              *actions.move_to_bottom()*
+actions.move_to_bottom({prompt_bufnr})    *telescope.actions.move_to_bottom()*
     Move to the bottom of the picker
 
 
@@ -1991,7 +1989,7 @@ actions.move_to_bottom({prompt_bufnr})              *actions.move_to_bottom()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.add_selection({prompt_bufnr})                *actions.add_selection()*
+actions.add_selection({prompt_bufnr})      *telescope.actions.add_selection()*
     Add current entry to multi select
 
 
@@ -1999,7 +1997,7 @@ actions.add_selection({prompt_bufnr})                *actions.add_selection()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.remove_selection({prompt_bufnr})          *actions.remove_selection()*
+actions.remove_selection({prompt_bufnr}) *telescope.actions.remove_selection()*
     Remove current entry from multi select
 
 
@@ -2007,7 +2005,7 @@ actions.remove_selection({prompt_bufnr})          *actions.remove_selection()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.toggle_selection({prompt_bufnr})          *actions.toggle_selection()*
+actions.toggle_selection({prompt_bufnr}) *telescope.actions.toggle_selection()*
     Toggle current entry status for multi select
 
 
@@ -2015,7 +2013,7 @@ actions.toggle_selection({prompt_bufnr})          *actions.toggle_selection()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.select_all({prompt_bufnr})                      *actions.select_all()*
+actions.select_all({prompt_bufnr})            *telescope.actions.select_all()*
     Multi select all entries.
     - Note: selected entries may include results not visible in the results
       popup.
@@ -2025,7 +2023,7 @@ actions.select_all({prompt_bufnr})                      *actions.select_all()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.drop_all({prompt_bufnr})                          *actions.drop_all()*
+actions.drop_all({prompt_bufnr})                *telescope.actions.drop_all()*
     Drop all entries from the current multi selection.
 
 
@@ -2033,7 +2031,7 @@ actions.drop_all({prompt_bufnr})                          *actions.drop_all()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.toggle_all({prompt_bufnr})                      *actions.toggle_all()*
+actions.toggle_all({prompt_bufnr})            *telescope.actions.toggle_all()*
     Toggle multi selection for all entries.
     - Note: toggled entries may include results not visible in the results
       popup.
@@ -2043,7 +2041,7 @@ actions.toggle_all({prompt_bufnr})                      *actions.toggle_all()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.preview_scrolling_up({prompt_bufnr})  *actions.preview_scrolling_up()*
+actions.preview_scrolling_up({prompt_bufnr}) *telescope.actions.preview_scrolling_up()*
     Scroll the preview window up
 
 
@@ -2051,7 +2049,7 @@ actions.preview_scrolling_up({prompt_bufnr})  *actions.preview_scrolling_up()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.preview_scrolling_down({prompt_bufnr}) *actions.preview_scrolling_down()*
+actions.preview_scrolling_down({prompt_bufnr}) *telescope.actions.preview_scrolling_down()*
     Scroll the preview window down
 
 
@@ -2059,7 +2057,7 @@ actions.preview_scrolling_down({prompt_bufnr}) *actions.preview_scrolling_down()
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.results_scrolling_up({prompt_bufnr})  *actions.results_scrolling_up()*
+actions.results_scrolling_up({prompt_bufnr}) *telescope.actions.results_scrolling_up()*
     Scroll the results window up
 
 
@@ -2067,7 +2065,7 @@ actions.results_scrolling_up({prompt_bufnr})  *actions.results_scrolling_up()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.results_scrolling_down({prompt_bufnr}) *actions.results_scrolling_down()*
+actions.results_scrolling_down({prompt_bufnr}) *telescope.actions.results_scrolling_down()*
     Scroll the results window down
 
 
@@ -2075,7 +2073,7 @@ actions.results_scrolling_down({prompt_bufnr}) *actions.results_scrolling_down()
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.center({prompt_bufnr})                              *actions.center()*
+actions.center({prompt_bufnr})                    *telescope.actions.center()*
     Center the cursor in the window, can be used after selecting a file to edit
     You can just map `actions.select_default + actions.center`
 
@@ -2084,7 +2082,7 @@ actions.center({prompt_bufnr})                              *actions.center()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.select_default({prompt_bufnr})              *actions.select_default()*
+actions.select_default({prompt_bufnr})    *telescope.actions.select_default()*
     Perform default action on selection, usually something like
     `:edit <selection>`
 
@@ -2095,7 +2093,7 @@ actions.select_default({prompt_bufnr})              *actions.select_default()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.select_horizontal({prompt_bufnr})        *actions.select_horizontal()*
+actions.select_horizontal({prompt_bufnr}) *telescope.actions.select_horizontal()*
     Perform 'horizontal' action on selection, usually something like
     `:new <selection>`
 
@@ -2106,7 +2104,7 @@ actions.select_horizontal({prompt_bufnr})        *actions.select_horizontal()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.select_vertical({prompt_bufnr})            *actions.select_vertical()*
+actions.select_vertical({prompt_bufnr})  *telescope.actions.select_vertical()*
     Perform 'vertical' action on selection, usually something like
     `:vnew <selection>`
 
@@ -2117,7 +2115,7 @@ actions.select_vertical({prompt_bufnr})            *actions.select_vertical()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.select_tab({prompt_bufnr})                      *actions.select_tab()*
+actions.select_tab({prompt_bufnr})            *telescope.actions.select_tab()*
     Perform 'tab' action on selection, usually something like
     `:tabedit <selection>`
 
@@ -2128,7 +2126,7 @@ actions.select_tab({prompt_bufnr})                      *actions.select_tab()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.file_edit({prompt_bufnr})                        *actions.file_edit()*
+actions.file_edit({prompt_bufnr})              *telescope.actions.file_edit()*
     Perform file edit on selection, usually something like
     `:edit <selection>`
 
@@ -2137,7 +2135,7 @@ actions.file_edit({prompt_bufnr})                        *actions.file_edit()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.file_split({prompt_bufnr})                      *actions.file_split()*
+actions.file_split({prompt_bufnr})            *telescope.actions.file_split()*
     Perform file split on selection, usually something like
     `:new <selection>`
 
@@ -2146,7 +2144,7 @@ actions.file_split({prompt_bufnr})                      *actions.file_split()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.file_vsplit({prompt_bufnr})                    *actions.file_vsplit()*
+actions.file_vsplit({prompt_bufnr})          *telescope.actions.file_vsplit()*
     Perform file vsplit on selection, usually something like
     `:vnew <selection>`
 
@@ -2155,7 +2153,7 @@ actions.file_vsplit({prompt_bufnr})                    *actions.file_vsplit()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.file_tab({prompt_bufnr})                          *actions.file_tab()*
+actions.file_tab({prompt_bufnr})                *telescope.actions.file_tab()*
     Perform file tab on selection, usually something like
     `:tabedit <selection>`
 
@@ -2164,7 +2162,7 @@ actions.file_tab({prompt_bufnr})                          *actions.file_tab()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.close({prompt_bufnr})                                *actions.close()*
+actions.close({prompt_bufnr})                      *telescope.actions.close()*
     Close the Telescope window, usually used within an action
 
 
@@ -2172,7 +2170,7 @@ actions.close({prompt_bufnr})                                *actions.close()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions._close({prompt_bufnr}, {keepinsert})                *actions._close()*
+actions._close({prompt_bufnr}, {keepinsert})      *telescope.actions._close()*
     Close the Telescope window and specify if you want to keep insert mode or
     not
 
@@ -2182,7 +2180,7 @@ actions._close({prompt_bufnr}, {keepinsert})                *actions._close()*
         {keepinsert}   (boolean)  Remain in INSERT mode if true
 
 
-actions.edit_command_line({prompt_bufnr})        *actions.edit_command_line()*
+actions.edit_command_line({prompt_bufnr}) *telescope.actions.edit_command_line()*
     Set a value in the command line and dont run it, making it editable.
 
 
@@ -2190,7 +2188,7 @@ actions.edit_command_line({prompt_bufnr})        *actions.edit_command_line()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.set_command_line({prompt_bufnr})          *actions.set_command_line()*
+actions.set_command_line({prompt_bufnr}) *telescope.actions.set_command_line()*
     Set a value in the command line and run it
 
 
@@ -2198,7 +2196,7 @@ actions.set_command_line({prompt_bufnr})          *actions.set_command_line()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.edit_search_line({prompt_bufnr})          *actions.edit_search_line()*
+actions.edit_search_line({prompt_bufnr}) *telescope.actions.edit_search_line()*
     Set a value in the search line and dont search for it, making it editable.
 
 
@@ -2206,7 +2204,7 @@ actions.edit_search_line({prompt_bufnr})          *actions.edit_search_line()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.set_search_line({prompt_bufnr})            *actions.set_search_line()*
+actions.set_search_line({prompt_bufnr})  *telescope.actions.set_search_line()*
     Set a value in the search line and search for it
 
 
@@ -2214,7 +2212,7 @@ actions.set_search_line({prompt_bufnr})            *actions.set_search_line()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.edit_register({prompt_bufnr})                *actions.edit_register()*
+actions.edit_register({prompt_bufnr})      *telescope.actions.edit_register()*
     Edit a register
 
 
@@ -2222,7 +2220,7 @@ actions.edit_register({prompt_bufnr})                *actions.edit_register()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.paste_register({prompt_bufnr})              *actions.paste_register()*
+actions.paste_register({prompt_bufnr})    *telescope.actions.paste_register()*
     Paste the selected register into the buffer
 
 
@@ -2230,7 +2228,7 @@ actions.paste_register({prompt_bufnr})              *actions.paste_register()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.insert_symbol({prompt_bufnr})                *actions.insert_symbol()*
+actions.insert_symbol({prompt_bufnr})      *telescope.actions.insert_symbol()*
     Insert a symbol into the current buffer (while switching to normal mode)
 
 
@@ -2238,7 +2236,7 @@ actions.insert_symbol({prompt_bufnr})                *actions.insert_symbol()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.insert_symbol_i({prompt_bufnr})            *actions.insert_symbol_i()*
+actions.insert_symbol_i({prompt_bufnr})  *telescope.actions.insert_symbol_i()*
     Insert a symbol into the current buffer and keeping the insert mode.
 
 
@@ -2246,7 +2244,7 @@ actions.insert_symbol_i({prompt_bufnr})            *actions.insert_symbol_i()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_create_branch({prompt_bufnr})        *actions.git_create_branch()*
+actions.git_create_branch({prompt_bufnr}) *telescope.actions.git_create_branch()*
     Create and checkout a new git branch if it doesn't already exist
 
 
@@ -2254,7 +2252,7 @@ actions.git_create_branch({prompt_bufnr})        *actions.git_create_branch()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_apply_stash({prompt_bufnr})            *actions.git_apply_stash()*
+actions.git_apply_stash({prompt_bufnr})  *telescope.actions.git_apply_stash()*
     Applies an existing git stash
 
 
@@ -2262,7 +2260,7 @@ actions.git_apply_stash({prompt_bufnr})            *actions.git_apply_stash()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_checkout({prompt_bufnr})                  *actions.git_checkout()*
+actions.git_checkout({prompt_bufnr})        *telescope.actions.git_checkout()*
     Checkout an existing git branch
 
 
@@ -2270,7 +2268,7 @@ actions.git_checkout({prompt_bufnr})                  *actions.git_checkout()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_switch_branch({prompt_bufnr})        *actions.git_switch_branch()*
+actions.git_switch_branch({prompt_bufnr}) *telescope.actions.git_switch_branch()*
     Switch to git branch.
     If the branch already exists in local, switch to that. If the branch is
     only in remote, create new branch tracking remote and switch to new one.
@@ -2280,7 +2278,7 @@ actions.git_switch_branch({prompt_bufnr})        *actions.git_switch_branch()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_track_branch({prompt_bufnr})          *actions.git_track_branch()*
+actions.git_track_branch({prompt_bufnr}) *telescope.actions.git_track_branch()*
     Tell git to track the currently selected remote branch in Telescope
 
 
@@ -2288,7 +2286,7 @@ actions.git_track_branch({prompt_bufnr})          *actions.git_track_branch()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_delete_branch({prompt_bufnr})        *actions.git_delete_branch()*
+actions.git_delete_branch({prompt_bufnr}) *telescope.actions.git_delete_branch()*
     Delete the currently selected branch
 
 
@@ -2296,7 +2294,7 @@ actions.git_delete_branch({prompt_bufnr})        *actions.git_delete_branch()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_merge_branch({prompt_bufnr})          *actions.git_merge_branch()*
+actions.git_merge_branch({prompt_bufnr}) *telescope.actions.git_merge_branch()*
     Merge the currently selected branch
 
 
@@ -2304,7 +2302,7 @@ actions.git_merge_branch({prompt_bufnr})          *actions.git_merge_branch()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_rebase_branch({prompt_bufnr})        *actions.git_rebase_branch()*
+actions.git_rebase_branch({prompt_bufnr}) *telescope.actions.git_rebase_branch()*
     Rebase to selected git branch
 
 
@@ -2312,7 +2310,7 @@ actions.git_rebase_branch({prompt_bufnr})        *actions.git_rebase_branch()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_reset_mixed({prompt_bufnr})            *actions.git_reset_mixed()*
+actions.git_reset_mixed({prompt_bufnr})  *telescope.actions.git_reset_mixed()*
     Reset to selected git commit using mixed mode
 
 
@@ -2320,7 +2318,7 @@ actions.git_reset_mixed({prompt_bufnr})            *actions.git_reset_mixed()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_reset_soft({prompt_bufnr})              *actions.git_reset_soft()*
+actions.git_reset_soft({prompt_bufnr})    *telescope.actions.git_reset_soft()*
     Reset to selected git commit using soft mode
 
 
@@ -2328,7 +2326,7 @@ actions.git_reset_soft({prompt_bufnr})              *actions.git_reset_soft()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_reset_hard({prompt_bufnr})              *actions.git_reset_hard()*
+actions.git_reset_hard({prompt_bufnr})    *telescope.actions.git_reset_hard()*
     Reset to selected git commit using hard mode
 
 
@@ -2336,7 +2334,7 @@ actions.git_reset_hard({prompt_bufnr})              *actions.git_reset_hard()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_checkout_current_buffer({prompt_bufnr}) *actions.git_checkout_current_buffer()*
+actions.git_checkout_current_buffer({prompt_bufnr}) *telescope.actions.git_checkout_current_buffer()*
     Checkout a specific file for a given sha
 
 
@@ -2344,7 +2342,7 @@ actions.git_checkout_current_buffer({prompt_bufnr}) *actions.git_checkout_curren
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.git_staging_toggle({prompt_bufnr})      *actions.git_staging_toggle()*
+actions.git_staging_toggle({prompt_bufnr}) *telescope.actions.git_staging_toggle()*
     Stage/unstage selected file
 
 
@@ -2352,7 +2350,7 @@ actions.git_staging_toggle({prompt_bufnr})      *actions.git_staging_toggle()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.send_selected_to_qflist({prompt_bufnr}) *actions.send_selected_to_qflist()*
+actions.send_selected_to_qflist({prompt_bufnr}) *telescope.actions.send_selected_to_qflist()*
     Sends the selected entries to the quickfix list, replacing the previous
     entries.
 
@@ -2361,7 +2359,7 @@ actions.send_selected_to_qflist({prompt_bufnr}) *actions.send_selected_to_qflist
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.add_selected_to_qflist({prompt_bufnr}) *actions.add_selected_to_qflist()*
+actions.add_selected_to_qflist({prompt_bufnr}) *telescope.actions.add_selected_to_qflist()*
     Adds the selected entries to the quickfix list, keeping the previous
     entries.
 
@@ -2370,7 +2368,7 @@ actions.add_selected_to_qflist({prompt_bufnr}) *actions.add_selected_to_qflist()
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.send_to_qflist({prompt_bufnr})              *actions.send_to_qflist()*
+actions.send_to_qflist({prompt_bufnr})    *telescope.actions.send_to_qflist()*
     Sends all entries to the quickfix list, replacing the previous entries.
 
 
@@ -2378,7 +2376,7 @@ actions.send_to_qflist({prompt_bufnr})              *actions.send_to_qflist()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.add_to_qflist({prompt_bufnr})                *actions.add_to_qflist()*
+actions.add_to_qflist({prompt_bufnr})      *telescope.actions.add_to_qflist()*
     Adds all entries to the quickfix list, keeping the previous entries.
 
 
@@ -2386,7 +2384,7 @@ actions.add_to_qflist({prompt_bufnr})                *actions.add_to_qflist()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.send_selected_to_loclist({prompt_bufnr}) *actions.send_selected_to_loclist()*
+actions.send_selected_to_loclist({prompt_bufnr}) *telescope.actions.send_selected_to_loclist()*
     Sends the selected entries to the location list, replacing the previous
     entries.
 
@@ -2395,7 +2393,7 @@ actions.send_selected_to_loclist({prompt_bufnr}) *actions.send_selected_to_locli
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.add_selected_to_loclist({prompt_bufnr}) *actions.add_selected_to_loclist()*
+actions.add_selected_to_loclist({prompt_bufnr}) *telescope.actions.add_selected_to_loclist()*
     Adds the selected entries to the location list, keeping the previous
     entries.
 
@@ -2404,7 +2402,7 @@ actions.add_selected_to_loclist({prompt_bufnr}) *actions.add_selected_to_loclist
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.send_to_loclist({prompt_bufnr})            *actions.send_to_loclist()*
+actions.send_to_loclist({prompt_bufnr})  *telescope.actions.send_to_loclist()*
     Sends all entries to the location list, replacing the previous entries.
 
 
@@ -2412,7 +2410,7 @@ actions.send_to_loclist({prompt_bufnr})            *actions.send_to_loclist()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.add_to_loclist({prompt_bufnr})              *actions.add_to_loclist()*
+actions.add_to_loclist({prompt_bufnr})    *telescope.actions.add_to_loclist()*
     Adds all entries to the location list, keeping the previous entries.
 
 
@@ -2420,7 +2418,7 @@ actions.add_to_loclist({prompt_bufnr})              *actions.add_to_loclist()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.smart_send_to_qflist({prompt_bufnr})  *actions.smart_send_to_qflist()*
+actions.smart_send_to_qflist({prompt_bufnr}) *telescope.actions.smart_send_to_qflist()*
     Sends the selected entries to the quickfix list, replacing the previous
     entries. If no entry was selected, sends all entries.
 
@@ -2429,7 +2427,7 @@ actions.smart_send_to_qflist({prompt_bufnr})  *actions.smart_send_to_qflist()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.smart_add_to_qflist({prompt_bufnr})    *actions.smart_add_to_qflist()*
+actions.smart_add_to_qflist({prompt_bufnr}) *telescope.actions.smart_add_to_qflist()*
     Adds the selected entries to the quickfix list, keeping the previous
     entries. If no entry was selected, adds all entries.
 
@@ -2438,7 +2436,7 @@ actions.smart_add_to_qflist({prompt_bufnr})    *actions.smart_add_to_qflist()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.smart_send_to_loclist({prompt_bufnr}) *actions.smart_send_to_loclist()*
+actions.smart_send_to_loclist({prompt_bufnr}) *telescope.actions.smart_send_to_loclist()*
     Sends the selected entries to the location list, replacing the previous
     entries. If no entry was selected, sends all entries.
 
@@ -2447,7 +2445,7 @@ actions.smart_send_to_loclist({prompt_bufnr}) *actions.smart_send_to_loclist()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.smart_add_to_loclist({prompt_bufnr})  *actions.smart_add_to_loclist()*
+actions.smart_add_to_loclist({prompt_bufnr}) *telescope.actions.smart_add_to_loclist()*
     Adds the selected entries to the location list, keeping the previous
     entries. If no entry was selected, adds all entries.
 
@@ -2456,7 +2454,7 @@ actions.smart_add_to_loclist({prompt_bufnr})  *actions.smart_add_to_loclist()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.complete_tag({prompt_bufnr})                  *actions.complete_tag()*
+actions.complete_tag({prompt_bufnr})        *telescope.actions.complete_tag()*
     Open completion menu containing the tags which can be used to filter the
     results in a faster way
 
@@ -2465,7 +2463,7 @@ actions.complete_tag({prompt_bufnr})                  *actions.complete_tag()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.cycle_history_next({prompt_bufnr})      *actions.cycle_history_next()*
+actions.cycle_history_next({prompt_bufnr}) *telescope.actions.cycle_history_next()*
     Cycle to the next search prompt in the history
 
 
@@ -2473,7 +2471,7 @@ actions.cycle_history_next({prompt_bufnr})      *actions.cycle_history_next()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.cycle_history_prev({prompt_bufnr})      *actions.cycle_history_prev()*
+actions.cycle_history_prev({prompt_bufnr}) *telescope.actions.cycle_history_prev()*
     Cycle to the previous search prompt in the history
 
 
@@ -2481,7 +2479,7 @@ actions.cycle_history_prev({prompt_bufnr})      *actions.cycle_history_prev()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.open_qflist({prompt_bufnr})                    *actions.open_qflist()*
+actions.open_qflist({prompt_bufnr})          *telescope.actions.open_qflist()*
     Open the quickfix list. It makes sense to use this in combination with one
     of the send_to_qflist actions `actions.smart_send_to_qflist +
     actions.open_qflist`
@@ -2491,7 +2489,7 @@ actions.open_qflist({prompt_bufnr})                    *actions.open_qflist()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.open_loclist({prompt_bufnr})                  *actions.open_loclist()*
+actions.open_loclist({prompt_bufnr})        *telescope.actions.open_loclist()*
     Open the location list. It makes sense to use this in combination with one
     of the send_to_loclist actions `actions.smart_send_to_qflist +
     actions.open_qflist`
@@ -2501,7 +2499,7 @@ actions.open_loclist({prompt_bufnr})                  *actions.open_loclist()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.delete_buffer({prompt_bufnr})                *actions.delete_buffer()*
+actions.delete_buffer({prompt_bufnr})      *telescope.actions.delete_buffer()*
     Delete the selected buffer or all the buffers selected using multi
     selection.
 
@@ -2510,7 +2508,7 @@ actions.delete_buffer({prompt_bufnr})                *actions.delete_buffer()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.cycle_previewers_next({prompt_bufnr}) *actions.cycle_previewers_next()*
+actions.cycle_previewers_next({prompt_bufnr}) *telescope.actions.cycle_previewers_next()*
     Cycle to the next previewer if there is one available.
     This action is not mapped on default.
 
@@ -2519,7 +2517,7 @@ actions.cycle_previewers_next({prompt_bufnr}) *actions.cycle_previewers_next()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.cycle_previewers_prev({prompt_bufnr}) *actions.cycle_previewers_prev()*
+actions.cycle_previewers_prev({prompt_bufnr}) *telescope.actions.cycle_previewers_prev()*
     Cycle to the previous previewer if there is one available.
     This action is not mapped on default.
 
@@ -2528,7 +2526,7 @@ actions.cycle_previewers_prev({prompt_bufnr}) *actions.cycle_previewers_prev()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.remove_selected_picker({prompt_bufnr}) *actions.remove_selected_picker()*
+actions.remove_selected_picker({prompt_bufnr}) *telescope.actions.remove_selected_picker()*
     Removes the selected picker in |builtin.pickers|.
     This action is not mapped by default and only intended for
     |builtin.pickers|.
@@ -2538,7 +2536,7 @@ actions.remove_selected_picker({prompt_bufnr}) *actions.remove_selected_picker()
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.which_key({prompt_bufnr})                        *actions.which_key()*
+actions.which_key({prompt_bufnr})              *telescope.actions.which_key()*
     Display the keymaps of registered actions similar to which-key.nvim.
 
     - Notes:
@@ -2557,17 +2555,17 @@ Functions to be used to determine the current state of telescope.
 
 Generally used from within other |telescope.actions|
 
-action_state.get_selected_entry()          *action_state.get_selected_entry()*
+action_state.get_selected_entry() *telescope.actions.state.get_selected_entry()*
     Get the current entry
 
 
 
-action_state.get_current_line()              *action_state.get_current_line()*
+action_state.get_current_line()   *telescope.actions.state.get_current_line()*
     Gets the current line
 
 
 
-action_state.get_current_picker({prompt_bufnr}) *action_state.get_current_picker()*
+action_state.get_current_picker({prompt_bufnr}) *telescope.actions.state.get_current_picker()*
     Gets the current picker
 
 
@@ -2587,7 +2585,7 @@ vertical split, etc. Instead of making users have to overwrite EACH of those
 every time they want to change this behavior, they can instead replace the
 `set` itself and then it will work great and they're done.
 
-action_set.shift_selection({prompt_bufnr}, {change}) *action_set.shift_selection()*
+action_set.shift_selection({prompt_bufnr}, {change}) *telescope.actions.set.shift_selection()*
     Move the current selection of a picker {change} rows. Handles not
     overflowing / underflowing the list.
 
@@ -2597,7 +2595,7 @@ action_set.shift_selection({prompt_bufnr}, {change}) *action_set.shift_selection
         {change}       (number)  The amount to shift the selection by
 
 
-action_set.select({prompt_bufnr}, {type})                *action_set.select()*
+action_set.select({prompt_bufnr}, {type})     *telescope.actions.set.select()*
     Select the current entry. This is the action set to overwrite common
     actions by the user.
 
@@ -2609,7 +2607,7 @@ action_set.select({prompt_bufnr}, {type})                *action_set.select()*
         {type}         (string)  The type of selection to make
 
 
-action_set.edit({prompt_bufnr}, {command})                 *action_set.edit()*
+action_set.edit({prompt_bufnr}, {command})      *telescope.actions.set.edit()*
     Edit a file based on the current selection.
 
 
@@ -2618,7 +2616,7 @@ action_set.edit({prompt_bufnr}, {command})                 *action_set.edit()*
         {command}      (string)  The command to use to open the file.
 
 
-action_set.scroll_previewer({prompt_bufnr}, {direction}) *action_set.scroll_previewer()*
+action_set.scroll_previewer({prompt_bufnr}, {direction}) *telescope.actions.set.scroll_previewer()*
     Scrolls the previewer up or down. Defaults to a half page scroll, but can
     be overridden using the `scroll_speed` option in `layout_config`. See
     |telescope.layout| for more details.
@@ -2629,7 +2627,7 @@ action_set.scroll_previewer({prompt_bufnr}, {direction}) *action_set.scroll_prev
         {direction}    (number)  The direction of the scrolling
 
 
-action_set.scroll_results({prompt_bufnr}, {direction}) *action_set.scroll_results()*
+action_set.scroll_results({prompt_bufnr}, {direction}) *telescope.actions.set.scroll_results()*
     Scrolls the results up or down. Defaults to a half page scroll, but can be
     overridden using the `scroll_speed` option in `layout_config`. See
     |telescope.layout| for more details.
@@ -2646,7 +2644,7 @@ action_set.scroll_results({prompt_bufnr}, {direction}) *action_set.scroll_result
 
 The layout actions are actions to be used to change the layout of a picker.
 
-action_layout.toggle_preview({prompt_bufnr})  *action_layout.toggle_preview()*
+action_layout.toggle_preview({prompt_bufnr}) *telescope.actions.layout.toggle_preview()*
     Toggle preview window.
     - Note: preview window can be toggled even if preview is set to false.
 
@@ -2657,7 +2655,7 @@ action_layout.toggle_preview({prompt_bufnr})  *action_layout.toggle_preview()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-action_layout.toggle_prompt_position({prompt_bufnr}) *action_layout.toggle_prompt_position()*
+action_layout.toggle_prompt_position({prompt_bufnr}) *telescope.actions.layout.toggle_prompt_position()*
     Toggles the `prompt_position` option between "top" and "bottom". Checks if
     `prompt_position` is an option for the current layout.
 
@@ -2668,7 +2666,7 @@ action_layout.toggle_prompt_position({prompt_bufnr}) *action_layout.toggle_promp
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-action_layout.toggle_mirror({prompt_bufnr})    *action_layout.toggle_mirror()*
+action_layout.toggle_mirror({prompt_bufnr}) *telescope.actions.layout.toggle_mirror()*
     Toggles the `mirror` option between `true` and `false`. Checks if `mirror`
     is an option for the current layout.
 
@@ -2679,7 +2677,7 @@ action_layout.toggle_mirror({prompt_bufnr})    *action_layout.toggle_mirror()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-action_layout.cycle_layout_next({prompt_bufnr}) *action_layout.cycle_layout_next()*
+action_layout.cycle_layout_next({prompt_bufnr}) *telescope.actions.layout.cycle_layout_next()*
     Cycles to the next layout in `cycle_layout_list`.
 
     This action is not mapped by default.
@@ -2689,7 +2687,7 @@ action_layout.cycle_layout_next({prompt_bufnr}) *action_layout.cycle_layout_next
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-action_layout.cycle_layout_prev({prompt_bufnr}) *action_layout.cycle_layout_prev()*
+action_layout.cycle_layout_prev({prompt_bufnr}) *telescope.actions.layout.cycle_layout_prev()*
     Cycles to the previous layout in `cycle_layout_list`.
 
     This action is not mapped by default.
@@ -2707,7 +2705,7 @@ Utilities to wrap functions around picker selections and entries.
 
 Generally used from within other |telescope.actions|
 
-utils.map_entries({prompt_bufnr}, {f})                   *utils.map_entries()*
+utils.map_entries({prompt_bufnr}, {f}) *telescope.actions.utils.map_entries()*
     Apply `f` to the entries of the current picker.
     - Notes:
       - Mapped entries may include results not visible in the results popup.
@@ -2738,7 +2736,7 @@ utils.map_entries({prompt_bufnr}, {f})                   *utils.map_entries()*
                                    arguments
 
 
-utils.map_selections({prompt_bufnr}, {f})             *utils.map_selections()*
+utils.map_selections({prompt_bufnr}, {f}) *telescope.actions.utils.map_selections()*
     Apply `f` to the multi selections of the current picker and return a table
     of mapped selections.
     - Notes:
@@ -2769,7 +2767,7 @@ utils.map_selections({prompt_bufnr}, {f})             *utils.map_selections()*
                                    that takes (selection) as a viable argument
 
 
-utils.get_registered_mappings({prompt_bufnr}) *utils.get_registered_mappings()*
+utils.get_registered_mappings({prompt_bufnr}) *telescope.actions.utils.get_registered_mappings()*
     Utility to collect mappings of prompt buffer in array of `{mode, keybind,
     name}`.
 
@@ -2803,7 +2801,7 @@ General usage:
   }
 <
 
-action_generate.which_key({opts})                *action_generate.which_key()*
+action_generate.which_key({opts})     *telescope.actions.generate.which_key()*
     Display the keymaps of registered actions similar to which-key.nvim.
 
     - Floating window:
@@ -2879,7 +2877,7 @@ necessary fields. The more important ones are
 Previewers can be disabled for any builtin or custom picker by doing :Telescope
 find_files previewer=false
 
-previewers.Previewer()                                *previewers.Previewer()*
+previewers.Previewer()                      *telescope.previewers.Previewer()*
     This is the base table all previewers have to implement. It's possible to
     write a wrapper for this because most previewers need to have the same keys
     set. Examples of wrappers are:
@@ -2916,13 +2914,13 @@ previewers.Previewer()                                *previewers.Previewer()*
 
 
 
-previewers.new()                                            *previewers.new()*
+previewers.new()                                  *telescope.previewers.new()*
     A shorthand for creating a new Previewer. The provided table will be
     forwarded to `Previewer:new(...)`
 
 
 
-previewers.new_termopen_previewer()      *previewers.new_termopen_previewer()*
+previewers.new_termopen_previewer() *telescope.previewers.new_termopen_previewer()*
     Is a wrapper around Previewer and helps with creating a new
     `termopen_previewer`.
 
@@ -2952,7 +2950,7 @@ previewers.new_termopen_previewer()      *previewers.new_termopen_previewer()*
 
 
 
-previewers.cat()                                            *previewers.cat()*
+previewers.cat()                                  *telescope.previewers.cat()*
     Provides a `termopen_previewer` which has the ability to display files. It
     will always show the top of the file and has support for `bat`(prioritized)
     and `cat`. Each entry has to provide either the field `path` or `filename`
@@ -2965,7 +2963,7 @@ previewers.cat()                                            *previewers.cat()*
 
 
 
-previewers.vimgrep()                                    *previewers.vimgrep()*
+previewers.vimgrep()                          *telescope.previewers.vimgrep()*
     Provides a `termopen_previewer` which has the ability to display files at
     the provided line. It has support for `bat`(prioritized) and `cat`. Each
     entry has to provide either the field `path` or `filename` and a `lnum`
@@ -2978,7 +2976,7 @@ previewers.vimgrep()                                    *previewers.vimgrep()*
 
 
 
-previewers.qflist()                                      *previewers.qflist()*
+previewers.qflist()                            *telescope.previewers.qflist()*
     Provides a `termopen_previewer` which has the ability to display files at
     the provided line or range. It has support for `bat`(prioritized) and
     `cat`. Each entry has to provide either the field `path` or `filename`,
@@ -2992,7 +2990,7 @@ previewers.qflist()                                      *previewers.qflist()*
 
 
 
-previewers.new_buffer_previewer()          *previewers.new_buffer_previewer()*
+previewers.new_buffer_previewer() *telescope.previewers.new_buffer_previewer()*
     An interface to instantiate a new `buffer_previewer`. That means that the
     content actually lives inside a vim buffer which enables us more control
     over the actual content. For example, we can use `vim.fn.search` to jump to
@@ -3085,7 +3083,7 @@ previewers.new_buffer_previewer()          *previewers.new_buffer_previewer()*
 
 
 
-previewers.buffer_previewer_maker({filepath}, {bufnr}, {opts}) *previewers.buffer_previewer_maker()*
+previewers.buffer_previewer_maker({filepath}, {bufnr}, {opts}) *telescope.previewers.buffer_previewer_maker()*
     A universal way of reading a file into a buffer previewer. It handles async
     reading, cache, highlighting, displaying directories and provides a
     callback which can be used, to jump to a line in the buffer.
@@ -3097,7 +3095,7 @@ previewers.buffer_previewer_maker({filepath}, {bufnr}, {opts}) *previewers.buffe
         {opts}     (table)   keys: `use_ft_detect`, `bufname` and `callback`
 
 
-previewers.vim_buffer_cat()                      *previewers.vim_buffer_cat()*
+previewers.vim_buffer_cat()            *telescope.previewers.vim_buffer_cat()*
     A previewer that is used to display a file. It uses the `buffer_previewer`
     interface and won't jump to the line. To integrate this one into your own
     picker make sure that the field `path` or `filename` is set for each entry.
@@ -3108,7 +3106,7 @@ previewers.vim_buffer_cat()                      *previewers.vim_buffer_cat()*
 
 
 
-previewers.vim_buffer_vimgrep()              *previewers.vim_buffer_vimgrep()*
+previewers.vim_buffer_vimgrep()    *telescope.previewers.vim_buffer_vimgrep()*
     A previewer that is used to display a file and jump to the provided line.
     It uses the `buffer_previewer` interface. To integrate this one into your
     own picker make sure that the field `path` or `filename` and `lnum` is set
@@ -3120,7 +3118,7 @@ previewers.vim_buffer_vimgrep()              *previewers.vim_buffer_vimgrep()*
 
 
 
-previewers.vim_buffer_qflist()                *previewers.vim_buffer_qflist()*
+previewers.vim_buffer_qflist()      *telescope.previewers.vim_buffer_qflist()*
     Is the same as `vim_buffer_vimgrep` and only exist for consistency with
     `term_previewers`.
 
@@ -3131,17 +3129,17 @@ previewers.vim_buffer_qflist()                *previewers.vim_buffer_qflist()*
 
 
 
-previewers.git_branch_log()                      *previewers.git_branch_log()*
+previewers.git_branch_log()            *telescope.previewers.git_branch_log()*
     A previewer that shows a log of a branch as graph
 
 
 
-previewers.git_stash_diff()                      *previewers.git_stash_diff()*
+previewers.git_stash_diff()            *telescope.previewers.git_stash_diff()*
     A previewer that shows a diff of a stash
 
 
 
-previewers.git_commit_diff_to_parent() *previewers.git_commit_diff_to_parent()*
+previewers.git_commit_diff_to_parent() *telescope.previewers.git_commit_diff_to_parent()*
     A previewer that shows a diff of a commit to a parent commit.
     The run command is `git --no-pager diff SHA^! -- $CURRENT_FILE`
 
@@ -3149,7 +3147,7 @@ previewers.git_commit_diff_to_parent() *previewers.git_commit_diff_to_parent()*
 
 
 
-previewers.git_commit_diff_to_head()    *previewers.git_commit_diff_to_head()*
+previewers.git_commit_diff_to_head() *telescope.previewers.git_commit_diff_to_head()*
     A previewer that shows a diff of a commit to head.
     The run command is `git --no-pager diff --cached $SHA -- $CURRENT_FILE`
 
@@ -3157,26 +3155,26 @@ previewers.git_commit_diff_to_head()    *previewers.git_commit_diff_to_head()*
 
 
 
-previewers.git_commit_diff_as_was()      *previewers.git_commit_diff_as_was()*
+previewers.git_commit_diff_as_was() *telescope.previewers.git_commit_diff_as_was()*
     A previewer that shows a diff of a commit as it was.
     The run command is `git --no-pager show $SHA:$CURRENT_FILE` or `git
     --no-pager show $SHA`
 
 
 
-previewers.git_commit_message()              *previewers.git_commit_message()*
+previewers.git_commit_message()    *telescope.previewers.git_commit_message()*
     A previewer that shows the commit message of a diff.
     The run command is `git --no-pager log -n 1 $SHA`
 
 
 
-previewers.git_file_diff()                        *previewers.git_file_diff()*
+previewers.git_file_diff()              *telescope.previewers.git_file_diff()*
     A previewer that shows the current diff of a file. Used in git_status.
     The run command is `git --no-pager diff $FILE`
 
 
 
-previewers.display_content()                    *previewers.display_content()*
+previewers.display_content()          *telescope.previewers.display_content()*
     A deprecated way of displaying content more easily. Was written at a time,
     where the buffer_previewer interface wasn't present. Nowadays it's easier
     to just use this. We will keep it around for backwards compatibility
@@ -3206,7 +3204,7 @@ So you have a history for:
 
 See github.com/nvim-telescope/telescope-smart-history.nvim
 
-histories.History()                                      *histories.History()*
+histories.History()                      *telescope.actions.history.History()*
     Manages prompt history
 
 
@@ -3221,7 +3219,7 @@ histories.History()                                      *histories.History()*
                              Default is #content + 1
 
 
-histories.History:new({opts})                        *histories.History:new()*
+histories.History:new({opts})        *telescope.actions.history.History:new()*
     Create a new History
 
 
@@ -3238,18 +3236,18 @@ histories.History:new({opts})                        *histories.History:new()*
                               will be returned (optional)
 
 
-histories.new()                                              *histories.new()*
+histories.new()                              *telescope.actions.history.new()*
     Shorthand to create a new history
 
 
 
-histories.History:reset()                          *histories.History:reset()*
+histories.History:reset()          *telescope.actions.history.History:reset()*
     Will reset the history index to the default initial state. Will happen
     after the picker closed
 
 
 
-histories.History:append({line}, {picker}, {no_reset}) *histories.History:append()*
+histories.History:append({line}, {picker}, {no_reset}) *telescope.actions.history.History:append()*
     Append a new line to the history
 
 
@@ -3260,7 +3258,7 @@ histories.History:append({line}, {picker}, {no_reset}) *histories.History:append
                               If you don't want to do this set to true
 
 
-histories.History:get_next({line}, {picker})    *histories.History:get_next()*
+histories.History:get_next({line}, {picker}) *telescope.actions.history.History:get_next()*
     Will return the next history item. Can be nil if there are no next items
 
 
@@ -3272,7 +3270,7 @@ histories.History:get_next({line}, {picker})    *histories.History:get_next()*
         string: the next history item
 
 
-histories.History:get_prev({line}, {picker})    *histories.History:get_prev()*
+histories.History:get_prev({line}, {picker}) *telescope.actions.history.History:get_prev()*
     Will return the previous history item. Can be nil if there are no previous
     items
 
@@ -3285,7 +3283,7 @@ histories.History:get_prev({line}, {picker})    *histories.History:get_prev()*
         string: the previous history item
 
 
-histories.get_simple_history()                *histories.get_simple_history()*
+histories.get_simple_history() *telescope.actions.history.get_simple_history()*
     A simple implementation of history.
 
     It will keep one unified history across all pickers.

--- a/lua/telescope/actions/generate.lua
+++ b/lua/telescope/actions/generate.lua
@@ -1,4 +1,5 @@
 ---@tag telescope.actions.generate
+---@config { ["module"] = "telescope.actions.generate" }
 
 ---@brief [[
 --- Module for convenience to override defaults of corresponding |telescope.actions| at |telescope.setup()|.

--- a/lua/telescope/actions/history.lua
+++ b/lua/telescope/actions/history.lua
@@ -4,6 +4,9 @@ local utils = require "telescope.utils"
 
 local uv = vim.loop
 
+---@tag telescope.actions.history
+---@config { ["module"] = "telescope.actions.history" }
+
 ---@brief [[
 --- A base implementation of a prompt history that provides a simple history
 --- and can be replaced with a custom implementation.
@@ -22,7 +25,6 @@ local uv = vim.loop
 ---
 --- See github.com/nvim-telescope/telescope-smart-history.nvim
 ---@brief ]]
----@tag telescope.actions.history
 
 -- TODO(conni2461): currently not present in plenary path only sync.
 -- But sync is just unnecessary here

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1,7 +1,5 @@
 ---@tag telescope.actions
-
--- TODO: Add @module to make it so we can have the prefix.
---@module telescope.actions
+---@config { ["module"] = "telescope.actions" }
 
 ---@brief [[
 --- Actions functions that are useful for people creating their own mappings.
@@ -12,41 +10,39 @@
 --- (1) The `prompt_bufnr` of a normal function denotes the identifier of your
 --- picker which can be used to access the picker state. In practice, users
 --- most commonly access from both picker and global state via the following:
----
 --- <code>
---- -- for utility functions
---- local action_state = require "telescope.actions.state"
+---   -- for utility functions
+---   local action_state = require "telescope.actions.state"
 ---
---- local actions = {}
---- actions.do_stuff = function(prompt_bufnr)
----   local current_picker = action_state.get_current_picker(prompt_bufnr) -- picker state
----   local entry = action_state.get_selected_entry()
---- end
+---   local actions = {}
+---   actions.do_stuff = function(prompt_bufnr)
+---     local current_picker = action_state.get_current_picker(prompt_bufnr) -- picker state
+---     local entry = action_state.get_selected_entry()
+---   end
 --- </code>
 ---
 --- See |telescope.actions.state| for more information.
 ---
 --- (2) To transform a module of functions into a module of "action"s, you need
 --- to do the following:
----
 --- <code>
---- local transform_mod = require("telescope.actions.mt").transform_mod
+---   local transform_mod = require("telescope.actions.mt").transform_mod
 ---
---- local mod = {}
---- mod.a1 = function(prompt_bufnr)
----   -- your code goes here
----   -- You can access the picker/global state as described above in (1).
---- end
+---   local mod = {}
+---   mod.a1 = function(prompt_bufnr)
+---     -- your code goes here
+---     -- You can access the picker/global state as described above in (1).
+---   end
 ---
---- mod.a2 = function(prompt_bufnr)
----   -- your code goes here
---- end
---- mod = transform_mod(mod)
+---   mod.a2 = function(prompt_bufnr)
+---     -- your code goes here
+---   end
+---   mod = transform_mod(mod)
 ---
---- -- Now the following is possible. This means that actions a2 will be executed
---- -- after action a1. You can chain as many actions as you want.
---- local action = mod.a1 + mod.a2
---- action(bufnr)
+---   -- Now the following is possible. This means that actions a2 will be executed
+---   -- after action a1. You can chain as many actions as you want.
+---   local action = mod.a1 + mod.a2
+---   action(bufnr)
 --- </code>
 ---
 --- Another interesing thing to do is that these actions now have functions you

--- a/lua/telescope/actions/layout.lua
+++ b/lua/telescope/actions/layout.lua
@@ -1,4 +1,5 @@
 ---@tag telescope.actions.layout
+---@config { ["module"] = "telescope.actions.layout" }
 
 ---@brief [[
 --- The layout actions are actions to be used to change the layout of a picker.

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -1,4 +1,5 @@
 ---@tag telescope.actions.set
+---@config { ["module"] = "telescope.actions.set" }
 
 ---@brief [[
 --- Telescope action sets are used to provide an interface for managing

--- a/lua/telescope/actions/state.lua
+++ b/lua/telescope/actions/state.lua
@@ -1,4 +1,5 @@
 ---@tag telescope.actions.state
+---@config { ["module"] = "telescope.actions.state" }
 
 ---@brief [[
 --- Functions to be used to determine the current state of telescope.

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -1,4 +1,5 @@
 ---@tag telescope.actions.utils
+---@config { ["module"] = "telescope.actions.utils" }
 
 ---@brief [[
 --- Utilities to wrap functions around picker selections and entries.

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -1,6 +1,6 @@
 ---@tag telescope.builtin
 
----@config { ['field_heading'] = "Options" }
+---@config { ['field_heading'] = "Options", ["module"] = "telescope.builtin" }
 
 ---@brief [[
 --- Telescope Builtins is a collection of community maintained pickers to support common workflows. It can be used as

--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -1,4 +1,5 @@
 ---@tag telescope.command
+---@config { ["module"] = "telescope.command" }
 
 ---@brief [[
 ---

--- a/lua/telescope/config/resolve.lua
+++ b/lua/telescope/config/resolve.lua
@@ -1,4 +1,5 @@
 ---@tag telescope.resolve
+---@config { ["module"] = "telescope.resolve" }
 
 ---@brief [[
 --- Provides "resolver functions" to allow more customisable inputs for options.

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -1,4 +1,5 @@
 ---@tag telescope.layout
+---@config { ["module"] = "telescope.layout" }
 
 ---@brief [[
 --- The layout of telescope pickers can be adjusted using the

--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -1,4 +1,5 @@
 ---@tag telescope.previewers
+---@config { ["module"] = "telescope.previewers" }
 
 ---@brief [[
 --- Provides a Previewer table that has to be implemented by each previewer.

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -4,6 +4,7 @@
 -- local opts = themes.get_dropdown { winblend = 3 }
 
 ---@tag telescope.themes
+---@config { ["module"] = "telescope.themes" }
 
 ---@brief [[
 --- Themes are ways to combine several elements of styling together.


### PR DESCRIPTION
turns out @tjdevries already implemented `module` in tree-sitter-lua some time ago.

Finally `:help telescope.builtin.find_files` is a thing