### PR TITLE
feat: add default hl group for devicons

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -496,7 +496,8 @@ telescope.setup({opts})                                    *telescope.setup()*
 
                                         *telescope.defaults.color_devicons*
     color_devicons: ~
-        Boolean if devicons should be enabled or not.
+        Boolean if devicons should be enabled or not. If set to false, the
+        "TelescopeResultsFileIcon" highlight group is used.
         Hint: Coloring only works if |termguicolors| is enabled.
 
         Default: true

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -650,7 +650,8 @@ append(
   "color_devicons",
   true,
   [[
-  Boolean if devicons should be enabled or not.
+  Boolean if devicons should be enabled or not. If set to false, the
+  "TelescopeResultsFileIcon" highlight group is used.
   Hint: Coloring only works if |termguicolors| is enabled.
 
   Default: true]]

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -437,7 +437,7 @@ utils.transform_devicons = load_once(function()
       if conf.color_devicons then
         return icon_display, icon_highlight
       else
-        return icon_display
+        return icon_display, "TelescopeResultsFileIcon"
       end
     end
   else
@@ -465,7 +465,7 @@ utils.get_devicons = load_once(function()
       if conf.color_devicons then
         return icon, icon_highlight
       else
-        return icon
+        return icon, "TelescopeResultsFileIcon"
       end
     end
   else

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -82,6 +82,7 @@ highlight default link TelescopeResultsIdentifier Identifier
 highlight default link TelescopeResultsNumber Number
 highlight default link TelescopeResultsComment Comment
 highlight default link TelescopeResultsSpecialComment SpecialComment
+highlight default link TelescopeResultsFileIcon Normal
 
 " Used for git status Results highlighting
 highlight default link TelescopeResultsDiffChange DiffChange


### PR DESCRIPTION
Adds the ability to choose the color that is used for rendering the icon when `color_devicons` is set to `false`.

```lua
local colors = require 'gruvbox.colors'

require('telescope').setup {
    defaults = {
        color_devicons = false,
    },
}
vim.api.nvim_set_hl(0, 'TelescopeResultsFileIcon', {fg = colors.neutral_red})
```

![image](https://user-images.githubusercontent.com/319220/163773000-edc77590-71cb-490c-90ac-aa37c7d2938e.png)

_This is ugly but just to illustrate_