### PR TITLE
break: bump minimum required neovim version to 0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
             manager: sudo apt-get
             packages: -y fd-find
           - os: ubuntu-20.04
-            url: https://github.com/neovim/neovim/releases/download/v0.6.0/nvim-linux64.tar.gz
+            url: https://github.com/neovim/neovim/releases/download/v0.7.0/nvim-linux64.tar.gz
             manager: sudo apt-get
             packages: -y fd-find
           - os: macos-10.15
@@ -23,7 +23,7 @@ jobs:
             manager: brew
             packages: fd
           - os: macos-10.15
-            url: https://github.com/neovim/neovim/releases/download/v0.6.0/nvim-macos.tar.gz
+            url: https://github.com/neovim/neovim/releases/download/v0.7.0/nvim-macos.tar.gz
             manager: brew
             packages: fd
     steps:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Telescope Wiki</sub>
 
 This section should guide you to run your first builtin pickers.
 
-[Neovim (v0.6.0)](https://github.com/neovim/neovim/releases/tag/v0.6.0) or the
+[Neovim (v0.7.0)](https://github.com/neovim/neovim/releases/tag/v0.7.0) or the
 latest neovim nightly commit is required for `telescope.nvim` to work.
 
 ### Required dependencies

--- a/doc/telescope_changelog.txt
+++ b/doc/telescope_changelog.txt
@@ -159,5 +159,21 @@ functions. Note that there is no longer a workspace diagnostics. You can only
 get all diagnostics for all open buffers.
 
 
+                                                    *telescope.changelog-1851*
+
+Date: December 10, 2021
+PR: https://github.com/nvim-telescope/telescope.nvim/pull/1851
+
+Telescope requires now Neovim release 0.7.0 or a more recent nightly.
+If you are running Neovim nightly, you need to make sure that you are on the
+LATEST version. Every other commit is not supported. So make sure you build
+the newest nightly before reporting issues.
+In the future, we will adopt a different release strategy. This release
+strategy follows the approach that the latest telescope.nvim master will only
+work with latest Neovim nightly and we will provide tags for specific Neovim
+versions. You can read more about this strategy here:
+https://github.com/nvim-telescope/telescope.nvim/issues/1772
+
+
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -26,8 +26,8 @@
 --- </code>
 ---@brief ]]
 
-if 1 ~= vim.fn.has "nvim-0.6.0" then
-  vim.api.nvim_err_writeln "This plugins requires neovim 0.6.0"
+if 1 ~= vim.fn.has "nvim-0.7.0" then
+  vim.api.nvim_err_writeln "This plugins requires neovim 0.7.0"
   vim.api.nvim_err_writeln "Please update your neovim."
   return
 end

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -1,5 +1,5 @@
-if !has('nvim-0.6.0')
-  echoerr "Telescope.nvim requires at least nvim-0.6.0. See `:h telescope.changelog-1549`"
+if !has('nvim-0.7.0')
+  echoerr "Telescope.nvim requires at least nvim-0.7.0. See `:h telescope.changelog-1549`"
   finish
 end
 


### PR DESCRIPTION
I will most likely merge this this Friday and tag the commit prior to this PR with 0.6.1
After this PR is merged we can look at:
- [ ] #1600 i will fix the remaining things there
- [ ] #1707
- [ ] use of `require "health"` #1868
- [ ] `plugin/telescope.vim` to `plugin/telescope.lua`