### PR TITLE
feat: none strategy & control attachment

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -97,6 +97,7 @@ telescope.setup({opts})                                    *telescope.setup()*
         - "follow"
         - "row"
         - "closest"
+        - "none"
 
                                        *telescope.defaults.scroll_strategy*
     scroll_strategy: ~

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -182,7 +182,8 @@ append(
   - "reset" (default)
   - "follow"
   - "row"
-  - "closest"]]
+  - "closest"
+  - "none"]]
 )
 
 append(

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -82,6 +82,7 @@ function Picker:new(opts)
     initial_mode = get_default(opts.initial_mode, config.values.initial_mode),
     debounce = get_default(tonumber(opts.debounce), nil),
 
+    _finder_attached = true,
     default_text = opts.default_text,
     get_status_text = get_default(opts.get_status_text, config.values.get_status_text),
     _on_input_filter_cb = opts.on_input_filter_cb or function() end,
@@ -499,10 +500,12 @@ function Picker:find()
   -- Register attach
   vim.api.nvim_buf_attach(prompt_bufnr, false, {
     on_lines = function(...)
-      find_id = self:_next_find_id()
+      if self._finder_attached then
+        find_id = self:_next_find_id()
 
-      status_updater { completed = false }
-      self._on_lines(...)
+        status_updater { completed = false }
+        self._on_lines(...)
+      end
     end,
 
     on_detach = function()
@@ -1366,6 +1369,16 @@ function Picker:_do_selection(prompt)
     else
       self:set_selection(self:get_reset_row())
     end
+  elseif selection_strategy == "none" then
+    if self._selection_entry then
+      local old_entry, old_row = self._selection_entry, self._selection_row
+      self:reset_selection() -- required to reset selection before updating prefix
+      if old_row >= 0 then
+        self:update_prefix(old_entry, old_row)
+        self.highlighter:hi_multiselect(old_row, self:is_multi_selected(old_entry))
+      end
+    end
+    return
   else
     error("Unknown selection strategy: " .. selection_strategy)
   end
@@ -1487,6 +1500,11 @@ end
 function Picker:_reset_highlights()
   self.highlighter:clear_display()
   vim.api.nvim_buf_clear_namespace(self.results_bufnr, ns_telescope_matching, 0, -1)
+end
+
+-- Toggles whether finder is attached to prompt buffer input
+function Picker:_toggle_finder_attach()
+  self._finder_attached = not self._finder_attached
 end
 
 function Picker:_detach()


### PR DESCRIPTION
I've recently played a bit around with Emacs magit (blasphemous I know) to see what the fuzz is about (I also started playing with mlua to essentially expose the sync library of [gitui](https://github.com/extrawurst/gitui) which can blow magit diff parsing parallelized out of the water).

Anyways, neither here nor there, but Vertico as a really nicely integrated framework got me thinking whether we can have similar things with telescope (i.e. telescope as `vim.ui.input` with some niceties I suppose). This PR and example code were 20 minutes playing around with the idea (we can polish `attach/detach` later).

Showcase

https://user-images.githubusercontent.com/39233597/164539336-1df5953d-f246-4d91-a52a-9316df4347ee.mp4

Example code

```lua
local builtin = require("telescope.builtin")
local actions = require("telescope.actions")
local action_state = require("telescope.actions.state")

local toggle_attach = function(prompt_bufnr)
  local current_picker = action_state.get_current_picker(prompt_bufnr)
  current_picker.attach = not current_picker.attach
end

local set_prompt = function(prompt_bufnr)
  local value = action_state.get_selected_entry().value
  local current_picker = action_state.get_current_picker(prompt_bufnr)
  current_picker:reset_prompt(value)
end

builtin.find_files({
  selection_strategy = "none",
  attach_mappings = function()
    actions.move_selection_next:enhance({
      pre = function(prompt_bufnr)
        toggle_attach(prompt_bufnr)
      end,
      post = function(prompt_bufnr)
        set_prompt(prompt_bufnr)
        toggle_attach(prompt_bufnr)
      end,
    })
    actions.move_selection_previous:enhance({
      pre = function(prompt_bufnr)
        toggle_attach(prompt_bufnr)
      end,
      post = function(prompt_bufnr)
        set_prompt(prompt_bufnr)
        toggle_attach(prompt_bufnr)
      end,
    })
    return true
  end,
})
```

This PR of course is not per se needed, but enables a `nvim-cmp`-like completion experience from within the prompt. I guess `"none"` is not really controversial and some users may like it anyways, but intermediate detaching like this probably is I suppose a bit more controversial (proper `nvim_buf_detach` apparently is only available via RPC). Primarily putting this up for discussion. I'll probably do some more work around `telescope` for `vim.ui.input` in the next couple of days.

Furthermore, attaching/detaching also could nicely enable uses cases for `telescope-file-browser.nvim` to leverage the prompt for renaming/creating files while being able to glance current results.