### PR TITLE
feat: show assigned function in actions.which_key

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1128,6 +1128,16 @@ actions.which_key = function(prompt_bufnr, opts)
           table.insert(mappings, { mode = v.mode, keybind = v.keybind, name = name })
         end
       end
+    elseif type(v.func) == "function" then
+      if not opts.only_show_current_mode or mode == v.mode then
+        local fname = action_utils._get_anon_function_name(v.func)
+        table.insert(mappings, { mode = v.mode, keybind = v.keybind, name = fname })
+        utils.notify("actions.which_key", {
+          msg = "No name available for anonymous functions.",
+          level = "INFO",
+          once = true,
+        })
+      end
     end
   end
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -477,14 +477,15 @@ end)
 
 --- Telescope Wrapper around vim.notify
 ---@param funname string: name of the function that will be
----@param opts table: opts.level string, opts.msg string
+---@param opts table: opts.level string, opts.msg string, opts.once bool
 utils.notify = function(funname, opts)
+  opts.once = vim.F.if_nil(opts.once, false)
   local level = vim.log.levels[opts.level]
   if not level then
     error("Invalid error level", 2)
   end
-
-  vim.notify(string.format("[telescope.%s]: %s", funname, opts.msg), level, {
+  local notify_fn = opts.once and vim.notify_once or vim.notify
+  notify_fn(string.format("[telescope.%s]: %s", funname, opts.msg), level, {
     title = "telescope.nvim",
   })
 end


### PR DESCRIPTION
Out of laziness, I now left `action_mt` docs out, because their main purpose otherwise (apart from originally for `which_key`) I suppose is sufficiently described in `:h telescope.actions`

Works as intended in my tests. If you don't like it @Conni2461 , it's totally fine :sweat_smile:  felt like a challenge and my experiments are running on GPUs now anyways.

Closes #1869 

My test code

```lua
local builtin = require("telescope.builtin")
local actions = require("telescope.actions")
local action_state = require("telescope.actions.state")

local M = {}

M.print_prompt = function(prompt_bufnr)
  local current_picker = action_state.get_current_picker(prompt_bufnr)
  current_picker:_get_prompt(value)
  print(prompt)
end

function print_value(prompt_bufnr)
  local value = action_state.get_current_history().value
  print(value)
end

local say_hi = function(prompt_bufnr)
  print("hi")
end

builtin.find_files({
  attach_mappings = function(prompt_buf, map)
    map("i", "X", function()
      print("test")
    end)
    map("i", "p", M.set_prompt)
    map("i", "P", print_value)
    map("i", "H", say_hi)
    map("i", "O", require "fds.utils".resize)
    return true
  end,
})
```

![image](https://user-images.githubusercontent.com/39233597/164717235-fa647f18-4177-4ac0-af42-3c446396f0f1.png)
