### PR TITLE
fix(which_key): get full path & handle funcrefs in tables

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1131,12 +1131,16 @@ actions.which_key = function(prompt_bufnr, opts)
     elseif type(v.func) == "function" then
       if not opts.only_show_current_mode or mode == v.mode then
         local fname = action_utils._get_anon_function_name(v.func)
+        -- telescope.setup mappings might result in function names that reflect the keys
+        fname = fname:lower() == v.keybind:lower() and "<anonymous>" or fname
         table.insert(mappings, { mode = v.mode, keybind = v.keybind, name = fname })
-        utils.notify("actions.which_key", {
-          msg = "No name available for anonymous functions.",
-          level = "INFO",
-          once = true,
-        })
+        if fname == "<anonymous>" then
+          utils.notify("actions.which_key", {
+            msg = "No name available for anonymous functions.",
+            level = "INFO",
+            once = true,
+          })
+        end
       end
     end
   end


### PR DESCRIPTION
Some fixups :sweat_smile: 

1. Rightfully trigger notification only if we have `"<anonymous>"`
2. Get full `source` path
3. Clean up table assignment functions (ie `["<C-a>"] = function(...)`) 

(1) Apologies Conni, I too quickly moved the notification last minute inside the loop (in my tests it was always rightfully triggered when it may not be) and (2) we have to get the full path via `source` as paths were otherwise truncated after 60 chars.

As per lua [docs](https://www.lua.org/pil/23.1.html)

> source --- Where the function was defined. If the function was defined in a string (through loadstring), source is that string. If the function was defined in a file, source is the file name prefixed with a `@´.

So, that's why `gsub("@", "")`.

Lastly, (3) is unfortunate because of how mappings are typically handled in `telescope.setup` with anonymous functions. It then for right reasons sadly pops up like this

![image](https://user-images.githubusercontent.com/39233597/164791368-b459e24f-313d-4eff-85df-07a9fca1bbd8.png)

I've now addressed this to show `"<anonymous>"` if "function name" equals the keys and tested it to work correctly.