### PR TITLE
feat: quickfixhistory picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Built-in functions. Ready to be bound to any key you like.
 | `builtin.marks`                     | Lists vim marks and their value                                                                                                                             |
 | `builtin.colorscheme`               | Lists available colorschemes and applies them on `<cr>`                                                                                                     |
 | `builtin.quickfix`                  | Lists items in the quickfix list                                                                                                                            |
+| `builtin.quickfixhistory`           | Lists all quickfix lists in your history and open them with `builtin.quickfix`                                                                              |
 | `builtin.loclist`                   | Lists items from the current window's location list                                                                                                         |
 | `builtin.jumplist`                  | Lists Jump List entries                                                                                                                                     |
 | `builtin.vim_options`               | Lists vim options, allows you to edit the current value on `<cr>`                                                                                           |

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1117,6 +1117,17 @@ builtin.quickfix({opts})                        *telescope.builtin.quickfix()*
     Options: ~
         {ignore_filename} (boolean)  dont show filenames (default: true)
         {trim_text}       (boolean)  trim results text (default: false)
+        {nr}              (number)   specify the quickfix list number
+
+
+builtin.quickfixhistory({opts})          *telescope.builtin.quickfixhistory()*
+    Lists all quickfix lists in your history and open them with
+    `builtin.quickfix`. It seems that neovim only keeps the full history for 10
+    lists
+
+
+    Parameters: ~
+        {opts} (table)  options to pass to the picker
 
 
 builtin.loclist({opts})                          *telescope.builtin.loclist()*

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -800,6 +800,7 @@ local send_selected_to_qf = function(prompt_bufnr, mode, target)
     vim.fn.setloclist(picker.original_win_id, qf_entries, mode)
   else
     vim.fn.setqflist(qf_entries, mode)
+    vim.fn.setqflist({}, "a", { title = picker.prompt_title })
   end
 end
 
@@ -818,6 +819,7 @@ local send_all_to_qf = function(prompt_bufnr, mode, target)
     vim.fn.setloclist(picker.original_win_id, qf_entries, mode)
   else
     vim.fn.setqflist(qf_entries, mode)
+    vim.fn.setqflist({}, "a", { title = picker.prompt_title })
   end
 end
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -794,13 +794,15 @@ local send_selected_to_qf = function(prompt_bufnr, mode, target)
     table.insert(qf_entries, entry_to_qf(entry))
   end
 
+  local prompt = picker:_get_prompt()
   actions.close(prompt_bufnr)
 
   if target == "loclist" then
     vim.fn.setloclist(picker.original_win_id, qf_entries, mode)
   else
+    local qf_title = string.format([[%s (%s)]], picker.prompt_title, prompt)
     vim.fn.setqflist(qf_entries, mode)
-    vim.fn.setqflist({}, "a", { title = picker.prompt_title })
+    vim.fn.setqflist({}, "a", { title = qf_title })
   end
 end
 
@@ -813,13 +815,15 @@ local send_all_to_qf = function(prompt_bufnr, mode, target)
     table.insert(qf_entries, entry_to_qf(entry))
   end
 
+  local prompt = picker:_get_prompt()
   actions.close(prompt_bufnr)
 
   if target == "loclist" then
     vim.fn.setloclist(picker.original_win_id, qf_entries, mode)
   else
     vim.fn.setqflist(qf_entries, mode)
-    vim.fn.setqflist({}, "a", { title = picker.prompt_title })
+    local qf_title = string.format([[%s (%s)]], picker.prompt_title, prompt)
+    vim.fn.setqflist({}, "a", { title = qf_title })
   end
 end
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -241,7 +241,13 @@ builtin.commands = require_on_exported_call("telescope.builtin.internal").comman
 ---@param opts table: options to pass to the picker
 ---@field ignore_filename boolean: dont show filenames (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field nr number: specify the quickfix list number
 builtin.quickfix = require_on_exported_call("telescope.builtin.internal").quickfix
+
+--- Lists all quickfix lists in your history and open them with `builtin.quickfix`. It seems that neovim
+--- only keeps the full history for 10 lists
+---@param opts table: options to pass to the picker
+builtin.quickfixhistory = require_on_exported_call("telescope.builtin.internal").quickfixhistory
 
 --- Lists items from the current window's location list, jumps to location on `<cr>`
 ---@param opts table: options to pass to the picker

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -359,7 +359,9 @@ internal.commands = function(opts)
 end
 
 internal.quickfix = function(opts)
-  local locations = vim.fn.getqflist()
+  opts = opts or {}
+  local qf_identifier = opts.id or vim.F.if_nil(opts.nr, "$")
+  local locations = vim.fn.getqflist({ [opts.id and "id" or "nr"] = qf_identifier, items = true }).items
 
   if vim.tbl_isempty(locations) then
     return
@@ -373,6 +375,65 @@ internal.quickfix = function(opts)
     },
     previewer = conf.qflist_previewer(opts),
     sorter = conf.generic_sorter(opts),
+  }):find()
+end
+
+internal.quickfixhistory = function(opts)
+  opts = opts or {}
+  local qflists = {}
+  for i = 1, 10 do -- (n)vim keeps at most 10 quickfix lists in full
+    local qflist = vim.fn.getqflist { nr = i, all = true }
+    if not qflist or (type(qflist) == "table" and vim.tbl_isempty(qflist.items)) then
+      break
+    end
+    table.insert(qflists, qflist)
+  end
+  local entry_maker = opts.make_entry
+    or function(entry)
+      return {
+        value = entry.title or "Untitled",
+        ordinal = entry.title or "Untitled",
+        display = entry.title or "Untitled",
+        nr = entry.nr,
+        id = entry.id,
+      }
+    end
+  local qf_entry_maker = make_entry.gen_from_quickfix(opts)
+  pickers.new(opts, {
+    prompt_title = "Quickfix History",
+    finder = finders.new_table {
+      results = qflists,
+      entry_maker = entry_maker,
+    },
+    previewer = previewers.new_buffer_previewer {
+      dyn_title = function(_, entry)
+        return entry.title
+      end,
+
+      get_buffer_by_name = function(_, entry)
+        return "quickfixlist_" .. tostring(entry.nr)
+      end,
+
+      define_preview = function(self, entry)
+        local qflist = vim.fn.getqflist({ nr = entry.nr, items = true }).items
+        local entries = vim.tbl_map(function(i)
+          return qf_entry_maker(i):display()
+        end, qflist)
+        if self.state.bufname then
+          return
+        end
+        vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, entries)
+      end,
+    },
+    sorter = conf.generic_sorter(opts),
+    attach_mappings = function(_, _)
+      action_set.select:replace(function(prompt_bufnr)
+        local nr = action_state.get_selected_entry().nr
+        actions.close(prompt_bufnr)
+        internal.quickfix { nr = nr }
+      end)
+      return true
+    end,
   }):find()
 end
 


### PR DESCRIPTION
Closes #1877 

Quick showcase for accessibility of PR

1. Showing quickfix history is empty (`:chistory`)
2. Sending some builtin pickers to quickfix list
3. Launching `quickfixhistory` (in lack of better name, in mood to make quick tele PR)

https://user-images.githubusercontent.com/39233597/164985535-7d32b9f2-5b7e-4967-9618-15e8b0064be1.mp4

I'm aware that we are not necessarily interested in builtins, but I think this one would make a rare exception since it deeply relates to `(n)vim` builtin features made more accessible via telescope.

@Conni2461 it seems to work well, but I unfortunately underutilize the qflist. The qflist generally is weird (there is `id`s for more than 10 qflists? But in practice only 10 lists keep the full history? But only tried creating more than 10 lists once, maybe I made a mistake/overlooked something), maybe there is also edge cases I haven't yet covered.

Once I have your sign off, I'll add docs and related things.