### PR TITLE
feat: add support for builtin.commands to show buffer commands.

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1101,6 +1101,9 @@ builtin.commands({opts})                        *telescope.builtin.commands()*
     Parameters: ~
         {opts} (table)  options to pass to the picker
 
+    Options: ~
+        {show_buf_command} (boolean) show buf local command. (default: true)
+
 
 builtin.quickfix({opts})                        *telescope.builtin.quickfix()*
     Lists items in the quickfix list, jumps to location on `<cr>`

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -314,8 +314,18 @@ internal.commands = function(opts)
         local command_iter = vim.api.nvim_get_commands {}
         local commands = {}
 
+        local need_buf_command = vim.F.if_nil(opts.show_buf_command, true)
+
         for _, cmd in pairs(command_iter) do
           table.insert(commands, cmd)
+        end
+
+        if need_buf_command then
+            local buf_command_iter = vim.api.nvim_buf_get_commands(0, {})
+            buf_command_iter[true] = nil -- remove the redundant entry
+            for _, cmd in pairs(buf_command_iter) do
+                table.insert(commands, cmd)
+            end
         end
 
         return commands


### PR DESCRIPTION
`builtin.keymaps` show the buffer local keymap and global keymaps both.
`builtin.commands` should follow the same as the keymap as the buffer local commands should also be shown in the picker