### PR TITLE
docs: add 'https://' prefix to smart history link

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -3184,7 +3184,7 @@ So you have a history for:
 - live_grep project_2
 - etc
 
-See github.com/nvim-telescope/telescope-smart-history.nvim
+See https://github.com/nvim-telescope/telescope-smart-history.nvim
 
 histories.History()                      *telescope.actions.history.History()*
     Manages prompt history

--- a/lua/telescope/actions/history.lua
+++ b/lua/telescope/actions/history.lua
@@ -23,7 +23,7 @@ local uv = vim.loop
 --- - live_grep   project_2
 --- - etc
 ---
---- See github.com/nvim-telescope/telescope-smart-history.nvim
+--- See https://github.com/nvim-telescope/telescope-smart-history.nvim
 ---@brief ]]
 
 -- TODO(conni2461): currently not present in plenary path only sync.


### PR DESCRIPTION
This link didn't have an HTTPS prefix so it wasn't clickable. The other
link to 'telescope-smart-history.nvim' is clickable.