### PR TITLE
fix(finder): don't trigger twice w/ inital_mode="insert"

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -440,10 +440,7 @@ function Picker:find()
         -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
         local mode = vim.api.nvim_get_mode().mode
         if mode ~= "i" then
-          if mode ~= "n" then
-            vim.api.nvim_input "<ESC>"
-          end
-          vim.api.nvim_input "A"
+          vim.api.nvim_input(mode ~= "n" and "<ESC>A" or "A")
         end
       end)
     elseif self.initial_mode ~= "normal" then

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -438,8 +438,12 @@ function Picker:find()
       vim.schedule(function()
         -- startinsert! did not reliable do `A` no idea why, i even looked at the source code
         -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
-        if vim.fn.mode() ~= "i" then
-          vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<ESC>A", true, false, true), "n", true)
+        local mode = vim.api.nvim_get_mode().mode
+        if mode ~= "i" then
+          if mode ~= "n" then
+            vim.api.nvim_input "<ESC>"
+          end
+          vim.api.nvim_input "A"
         end
       end)
     elseif self.initial_mode ~= "normal" then

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -438,9 +438,9 @@ function Picker:find()
       vim.schedule(function()
         -- startinsert! did not reliable do `A` no idea why, i even looked at the source code
         -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
-        local mode = vim.api.nvim_get_mode().mode
+        local mode = a.nvim_get_mode().mode
         if mode ~= "i" then
-          vim.api.nvim_input(mode ~= "n" and "<ESC>A" or "A")
+          a.nvim_input(mode ~= "n" and "<ESC>A" or "A")
         end
       end)
     elseif self.initial_mode ~= "normal" then

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -438,7 +438,7 @@ function Picker:find()
       vim.schedule(function()
         -- startinsert! did not reliable do `A` no idea why, i even looked at the source code
         -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
-        local mode = a.nvim_get_mode().mode
+        local mode = vim.fn.mode()
         if mode ~= "i" then
           a.nvim_input(mode ~= "n" and "<ESC>A" or "A")
         end


### PR DESCRIPTION
Closes https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/128

Sorry guys, but `initial_mode="insert"` wants another rodeo.

It seems to work appropriately with visual and insert mode in my tests, but can you please also take this once for a spin as I'm aware at least some of you have use cases that would stress test this? That would be very much appreciated :)

`nvim_input` seems to appropriately fit into the event-loop of the finder rather than `nvim_feedkeys`.

@Conni2461 @kylo252 @clason 

E: Summary

+ This fixes that finder loop currently is triggered twice with `initial_mode="insert"` (relevant for `on_complete` callbacks)
- Requires users haven't remapped `<ESC>` and `A` to anything materially otherwise what they are doing by default