### PR TITLE
Set tagstack when we jump with lsp in telescope

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -133,12 +133,19 @@ action_set.edit = function(prompt_bufnr, command)
   local picker = action_state.get_current_picker(prompt_bufnr)
   require("telescope.actions").close(prompt_bufnr)
   local win_id = picker.get_selection_window(picker, entry)
-  if win_id ~= 0 and a.nvim_get_current_win() ~= win_id then
-    vim.api.nvim_set_current_win(win_id)
-  end
 
   if picker.push_cursor_on_edit then
     vim.cmd "normal! m'"
+  end
+
+  if picker.push_tagstack_on_edit then
+    local from = { vim.fn.bufnr "%", vim.fn.line ".", vim.fn.col ".", 0 }
+    local items = { { tagname = vim.fn.expand "<cword>", from = from } }
+    vim.fn.settagstack(vim.fn.win_getid(), { items = items }, "t")
+  end
+
+  if win_id ~= 0 and a.nvim_get_current_win() ~= win_id then
+    vim.api.nvim_set_current_win(win_id)
   end
 
   if entry_bufnr then

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -1042,6 +1042,7 @@ internal.marks = function(opts)
     previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),
     push_cursor_on_edit = true,
+    push_tagstack_on_edit = true,
   }):find()
 end
 

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -5,7 +5,6 @@ local finders = require "telescope.finders"
 local make_entry = require "telescope.make_entry"
 local pickers = require "telescope.pickers"
 local utils = require "telescope.utils"
-local action_set = require "telescope.actions.set"
 
 local lsp = {}
 
@@ -39,9 +38,6 @@ lsp.references = function(opts)
       return
     end
 
-	local from = {vim.fn.bufnr('%'), vim.fn.line('.'), vim.fn.col('.'), 0}
-	local items = {{tagname=vim.fn.expand('<cword>'), from=from}}
-	local win = vim.fn.win_getid()
     pickers.new(opts, {
       prompt_title = "LSP References",
       finder = finders.new_table {
@@ -49,15 +45,9 @@ lsp.references = function(opts)
         entry_maker = opts.entry_maker or make_entry.gen_from_quickfix(opts),
       },
       previewer = conf.qflist_previewer(opts),
-	  attach_mappings = function(prompt_bufnr)
-		  actions.select_default:replace(function()
-			vim.fn.settagstack(win, {items=items}, 't')
-			action_set.select(prompt_bufnr, "default")
-		  end)
-		  return true
-	  end,
       sorter = conf.generic_sorter(opts),
       push_cursor_on_edit = true,
+      push_tagstack_on_edit = true,
     }):find()
   end)
 end
@@ -96,9 +86,6 @@ local function list_or_jump(action, title, opts)
       vim.lsp.util.jump_to_location(flattened_results[1], offset_encoding)
     else
       local locations = vim.lsp.util.locations_to_items(flattened_results, offset_encoding)
-	  local from = {vim.fn.bufnr('%'), vim.fn.line('.'), vim.fn.col('.'), 0}
-	  local items = {{tagname=vim.fn.expand('<cword>'), from=from}}
-	  local win = vim.fn.win_getid()
       pickers.new(opts, {
         prompt_title = title,
         finder = finders.new_table {
@@ -106,14 +93,9 @@ local function list_or_jump(action, title, opts)
           entry_maker = opts.entry_maker or make_entry.gen_from_quickfix(opts),
         },
         previewer = conf.qflist_previewer(opts),
-		attach_mappings = function(prompt_bufnr)
-			actions.select_default:replace(function()
-				vim.fn.settagstack(win, {items=items}, 't')
-				action_set.select(prompt_bufnr, "default")
-			end)
-			return true
-		end,
         sorter = conf.generic_sorter(opts),
+        push_cursor_on_edit = true,
+        push_tagstack_on_edit = true,
       }):find()
     end
   end)
@@ -175,6 +157,7 @@ lsp.document_symbols = function(opts)
         sorter = conf.generic_sorter(opts),
       },
       push_cursor_on_edit = true,
+      push_tagstack_on_edit = true,
     }):find()
   end)
 end

--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -5,6 +5,7 @@ local finders = require "telescope.finders"
 local make_entry = require "telescope.make_entry"
 local pickers = require "telescope.pickers"
 local utils = require "telescope.utils"
+local action_set = require "telescope.actions.set"
 
 local lsp = {}
 
@@ -38,6 +39,9 @@ lsp.references = function(opts)
       return
     end
 
+	local from = {vim.fn.bufnr('%'), vim.fn.line('.'), vim.fn.col('.'), 0}
+	local items = {{tagname=vim.fn.expand('<cword>'), from=from}}
+	local win = vim.fn.win_getid()
     pickers.new(opts, {
       prompt_title = "LSP References",
       finder = finders.new_table {
@@ -45,6 +49,13 @@ lsp.references = function(opts)
         entry_maker = opts.entry_maker or make_entry.gen_from_quickfix(opts),
       },
       previewer = conf.qflist_previewer(opts),
+	  attach_mappings = function(prompt_bufnr)
+		  actions.select_default:replace(function()
+			vim.fn.settagstack(win, {items=items}, 't')
+			action_set.select(prompt_bufnr, "default")
+		  end)
+		  return true
+	  end,
       sorter = conf.generic_sorter(opts),
       push_cursor_on_edit = true,
     }):find()
@@ -85,6 +96,9 @@ local function list_or_jump(action, title, opts)
       vim.lsp.util.jump_to_location(flattened_results[1], offset_encoding)
     else
       local locations = vim.lsp.util.locations_to_items(flattened_results, offset_encoding)
+	  local from = {vim.fn.bufnr('%'), vim.fn.line('.'), vim.fn.col('.'), 0}
+	  local items = {{tagname=vim.fn.expand('<cword>'), from=from}}
+	  local win = vim.fn.win_getid()
       pickers.new(opts, {
         prompt_title = title,
         finder = finders.new_table {
@@ -92,6 +106,13 @@ local function list_or_jump(action, title, opts)
           entry_maker = opts.entry_maker or make_entry.gen_from_quickfix(opts),
         },
         previewer = conf.qflist_previewer(opts),
+		attach_mappings = function(prompt_bufnr)
+			actions.select_default:replace(function()
+				vim.fn.settagstack(win, {items=items}, 't')
+				action_set.select(prompt_bufnr, "default")
+			end)
+			return true
+		end,
         sorter = conf.generic_sorter(opts),
       }):find()
     end

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -117,6 +117,7 @@ function Picker:new(opts)
     selection_strategy = get_default(opts.selection_strategy, config.values.selection_strategy),
 
     push_cursor_on_edit = get_default(opts.push_cursor_on_edit, false),
+    push_tagstack_on_edit = get_default(opts.push_tagstack_on_edit, false),
 
     layout_strategy = layout_strategy,
     layout_config = config.smarter_depth_2_extend(opts.layout_config or {}, config.values.layout_config or {}),


### PR DESCRIPTION
Atm telescope doesn't populate the tagstack making it confusing when you jump with a telescope function, where it populates the tagstack if there is only 1 item.