### PR TITLE
Feat: add support for builtin.commands to show buffer commands (update).

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1103,6 +1103,9 @@ builtin.commands({opts})                        *telescope.builtin.commands()*
     Parameters: ~
         {opts} (table)  options to pass to the picker
 
+    Options: ~
+        {show_buf_command} (boolean)  show buf local command (Default: true)
+
 
 builtin.quickfix({opts})                        *telescope.builtin.quickfix()*
     Lists items in the quickfix list, jumps to location on `<cr>`

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -234,6 +234,7 @@ builtin.symbols = require_on_exported_call("telescope.builtin.internal").symbols
 
 --- Lists available plugin/user commands and runs them on `<cr>`
 ---@param opts table: options to pass to the picker
+---@field show_buf_command boolean: show buf local command (Default: true)
 builtin.commands = require_on_exported_call("telescope.builtin.internal").commands
 
 --- Lists items in the quickfix list, jumps to location on `<cr>`

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -318,6 +318,15 @@ internal.commands = function(opts)
           table.insert(commands, cmd)
         end
 
+        local need_buf_command = vim.F.if_nil(opts.show_buf_command, true)
+
+        if need_buf_command then
+          local buf_command_iter = vim.api.nvim_buf_get_commands(0, {})
+          buf_command_iter[true] = nil -- remove the redundant entry
+          for _, cmd in pairs(buf_command_iter) do
+            table.insert(commands, cmd)
+          end
+        end
         return commands
       end)(),
 


### PR DESCRIPTION
`builtin.commands` should keep the same with `builtin.keymap`: show buffer local commands.