### PR TITLE
fix(actions): don't exec pre or post if replaced

### DIFF
--- a/lua/telescope/actions/mt.lua
+++ b/lua/telescope/actions/mt.lua
@@ -57,7 +57,7 @@ action_mt.create = function()
         if t._static_pre[action_name] then
           t._static_pre[action_name](...)
         end
-        if t._pre[action_name] then
+        if vim.tbl_isempty(t._replacements) and t._pre[action_name] then
           t._pre[action_name](...)
         end
 
@@ -71,7 +71,7 @@ action_mt.create = function()
         if t._static_post[action_name] then
           t._static_post[action_name](...)
         end
-        if t._post[action_name] then
+        if vim.tbl_isempty(t._replacements) and t._post[action_name] then
           t._post[action_name](...)
         end
       end


### PR DESCRIPTION
As per `action_mt` docs 

```lua
...
--- an action is metatable which allows replacement(prepend or append) of the function
---@class Action
---@field _func table<string, function>: the original action function
---@field _static_pre table<string, function>: will allways run before the function even if its replaced
---@field _pre table<string, function>: the functions that will run before the action
---@field _replacements table<string, function>: the function that replaces this action
---@field _static_post table<string, function>: will allways run after the function even if its replaced
---@field _post table<string, function>: the functions that will run after the action

```

which implies `_{pre, post}` should not run if replaced (as opposed to `_static_{pre, post}`)

```lua
local builtin = require "telescope.builtin"
local actions = require "telescope.actions"
local action_state = require "telescope.actions.state"

builtin.find_files {
  attach_mappings = function(_, _)
    actions.select_vertical:enhance({
      pre = function()
        vim.notify("Should not happen", vim.log.levels.WARN)
      end,
      post = function()
        vim.notify("Should not happen", vim.log.levels.WARN)
      end
    })
    actions.select_vertical:replace(function()
      vim.notify(action_state.get_selected_entry().value, vim.log.levels.INFO)
    end)
    return true
  end
}
```
should not launch notifications "should not happen" since the `action.select_vertical` actually has been replaced.