### PR TITLE
fix(pickers): misc inital_mode setting fixes

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -436,11 +436,11 @@ function Picker:find()
 
     if self.initial_mode == "insert" then
       vim.schedule(function()
-        -- startinsert! did not reliable do `A` no idea why, i even looked at the source code
         -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
+        -- vim.cmd doesn't schedule appropriately, bypass with `nvim_input` (echon to clear "startinsert" msg)
         local mode = vim.fn.mode()
         if mode ~= "i" then
-          a.nvim_input(mode ~= "n" and "<ESC>A" or "A")
+          a.nvim_input(mode ~= "n" and "<ESC>:startinsert!|echon ''<CR>" or ":startinsert!|echon ''<CR>")
         end
       end)
     elseif self.initial_mode ~= "normal" then

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -434,16 +434,22 @@ function Picker:find()
       self:set_prompt(self.default_text)
     end
 
+    local mode = vim.fn.mode()
     if self.initial_mode == "insert" then
       vim.schedule(function()
         -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
-        -- vim.cmd doesn't schedule appropriately, bypass with `nvim_input` (echon to clear "startinsert" msg)
-        local mode = vim.fn.mode()
+        -- vim.cmd doesn't schedule appropriately, bypass with `nvim_input`
+        -- echon to clear "startinsert" msg & histdel('cmd', -1) to not pollute command history with startinsert
         if mode ~= "i" then
-          a.nvim_input(mode ~= "n" and "<ESC>:startinsert!|echon ''<CR>" or ":startinsert!|echon ''<CR>")
+          local cmd = ":startinsert!|call histdel('cmd', -1)|echon ''<CR>"
+          a.nvim_input(mode ~= "n" and "<ESC>" .. cmd or cmd)
         end
       end)
-    elseif self.initial_mode ~= "normal" then
+    elseif self.initial_mode == "normal" then
+      if mode ~= "n" then
+        vim.schedule_wrap(a.nvim_input)("<ESC>")
+      end
+    else
       error("Invalid setting for initial_mode: " .. self.initial_mode)
     end
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -434,21 +434,23 @@ function Picker:find()
       self:set_prompt(self.default_text)
     end
 
-    local mode = vim.fn.mode()
-    if self.initial_mode == "insert" then
+    if vim.tbl_contains({ "insert", "normal" }, self.initial_mode) then
       vim.schedule(function()
-        -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
-        -- vim.cmd doesn't schedule appropriately, bypass with `nvim_input`
-        -- echon to clear "startinsert" msg & histdel('cmd', -1) to not pollute command history with startinsert
-        if mode ~= "i" then
-          local cmd = ":startinsert!|call histdel('cmd', -1)|echon ''<CR>"
-          a.nvim_input(mode ~= "n" and "<ESC>" .. cmd or cmd)
+        local mode = vim.fn.mode()
+        if self.initial_mode == "normal" then
+          if mode ~= "n" then
+            a.nvim_input "<ESC>"
+          end
+        else
+          -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
+          -- vim.cmd doesn't schedule appropriately, bypass with `nvim_input`
+          -- histdel('cmd', -1) to not pollute command history with startinsert & echon to clear "startinsert" msg
+          if mode ~= "i" then
+            local cmd = ":startinsert!|call histdel('cmd', -1)|echon ''<CR>"
+            a.nvim_input(mode ~= "n" and "<ESC>" .. cmd or cmd)
+          end
         end
       end)
-    elseif self.initial_mode == "normal" then
-      if mode ~= "n" then
-        vim.schedule_wrap(a.nvim_input)("<ESC>")
-      end
     else
       error("Invalid setting for initial_mode: " .. self.initial_mode)
     end


### PR DESCRIPTION
Um, yeah, not gonna lie, this is satirically stupid but seems to work.

Importantly, this does not work appropriately if startinsert is invoked otherwise (`vim.cmd` or `vim.fn.execute`)

I think we can rely on `<ESC>` though :laughing:

Fixes:
- Code cleanup between initial modes `"normal"` and `"insert"`
- `initial_mode="normal"` wouldn't function properly if original mode was not `"normal"`
- `initial_mode="insert"`: raw input `startinsert!` to avoid `A` which might be mapped otherwise and cannot be fed with `nvim_feedkeys` (see code comments)

Closes #1894 