### PR TITLE
fix: termopen previewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,14 +334,14 @@ Built-in functions. Ready to be bound to any key you like.
 
 ## Previewers
 
-| Previewers                         | Description                                                     |
-|------------------------------------|-----------------------------------------------------------------|
-| `previewers.vim_buffer_cat.new`    | Default previewer for files. Uses vim buffers                   |
-| `previewers.vim_buffer_vimgrep.new`| Default previewer for grep and similar. Uses vim buffers        |
-| `previewers.vim_buffer_qflist.new` | Default previewer for qflist. Uses vim buffers                  |
-| `previewers.cat.new`               | Deprecated previewer for files. Uses `cat`/`bat`                |
-| `previewers.vimgrep.new`           | Deprecated previewer for grep and similar. Uses `cat`/`bat`     |
-| `previewers.qflist.new`            | Deprecated previewer for qflist. Uses `cat`/`bat`               |
+| Previewers                         | Description                                               |
+|------------------------------------|-----------------------------------------------------------|
+| `previewers.vim_buffer_cat.new`    | Default previewer for files. Uses vim buffers             |
+| `previewers.vim_buffer_vimgrep.new`| Default previewer for grep and similar. Uses vim buffers  |
+| `previewers.vim_buffer_qflist.new` | Default previewer for qflist. Uses vim buffers            |
+| `previewers.cat.new`               | Terminal previewer for files. Uses `cat`/`bat`            |
+| `previewers.vimgrep.new`           | Terminal previewer for grep and similar. Uses `cat`/`bat` |
+| `previewers.qflist.new`            | Terminal previewer for qflist. Uses `cat`/`bat`           |
 
 The default previewers are from now on `vim_buffer_` previewers. They use vim
 buffers for displaying files and use tree-sitter or regex for file highlighting.

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2932,9 +2932,6 @@ previewers.new_termopen_previewer() *telescope.previewers.new_termopen_previewer
     Furthermore, it will forward all `config.set_env` environment variables to
     that terminal process.
 
-    While this interface is a good start, it was replaced with the way more
-    flexible `buffer_previewer` and is now deprecated.
-
 
 
 previewers.cat()                                  *telescope.previewers.cat()*

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -345,13 +345,11 @@ end
 actions.close = function(prompt_bufnr)
   action_state.get_current_history():reset()
   local picker = action_state.get_current_picker(prompt_bufnr)
-  local prompt_win = state.get_status(prompt_bufnr).prompt_win
   local original_win_id = picker.original_win_id
 
   actions.close_pum(prompt_bufnr)
 
-  vim.api.nvim_win_close(prompt_win, true)
-  pcall(vim.cmd, string.format([[silent bdelete! %s]], prompt_bufnr))
+  require("telescope.pickers").on_close_prompt(prompt_bufnr)
   pcall(a.nvim_set_current_win, original_win_id)
 end
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -731,23 +731,15 @@ end
 ---@param status table: table containing information on the picker
 --- and associated windows. Generally obtained from `state.get_status`
 function Picker.close_windows(status)
-  local prompt_win = status.prompt_win
-  local results_win = status.results_win
-  local preview_win = status.preview_win
+  utils.win_delete("results_win", status.results_win, true, true)
+  utils.win_delete("preview_win", status.preview_win, true, true)
 
-  local prompt_border_win = status.prompt_border_win
-  local results_border_win = status.results_border_win
-  local preview_border_win = status.preview_border_win
-
-  utils.win_delete("results_win", results_win, true, true)
-  utils.win_delete("preview_win", preview_win, true, true)
-
-  utils.win_delete("prompt_border_win", prompt_border_win, true, true)
-  utils.win_delete("results_border_win", results_border_win, true, true)
-  utils.win_delete("preview_border_win", preview_border_win, true, true)
+  utils.win_delete("prompt_border_win", status.prompt_border_win, true, true)
+  utils.win_delete("results_border_win", status.results_border_win, true, true)
+  utils.win_delete("preview_border_win", status.preview_border_win, true, true)
 
   vim.defer_fn(function()
-    utils.win_delete("prompt_win", prompt_win, true)
+    utils.win_delete("prompt_win", status.prompt_win, true)
   end, 10)
 
   state.clear_status(status.prompt_bufnr)
@@ -1468,6 +1460,11 @@ function pickers.on_close_prompt(prompt_bufnr)
 
   picker.close_windows(status)
   mappings.clear(prompt_bufnr)
+  vim.api.nvim_clear_autocmds {
+    group = "PickerInsert",
+    event = "BufLeave",
+    buffer = prompt_bufnr,
+  }
 end
 
 function pickers.on_resize_window(prompt_bufnr)

--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -95,9 +95,6 @@ end
 ---
 --- Furthermore, it will forward all `config.set_env` environment variables to
 --- that terminal process.
----
---- While this interface is a good start, it was replaced with the way more
---- flexible `buffer_previewer` and is now deprecated.
 previewers.new_termopen_previewer = term_previewer.new_termopen_previewer
 
 --- Provides a `termopen_previewer` which has the ability to display files.


### PR DESCRIPTION
fix #1804

- fixes the buffer leaking
- cleanup termopen previewer
  - [x] we can now reuse buffers similar to buffer_previewer, should still do that
  - [x] mark as no longer deprecated, after these fixes they are fine to use. with no more leaking
- fix teardown for termopen_previewer

CC @bluz71 can you test this. And i am very sorry for the long wait