### PR TITLE
use upstreamed get_node_text() instead of nvim-treesitter's deprecated one

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -540,7 +540,7 @@ function make_entry.gen_from_treesitter(opts)
   return function(entry)
     local ts_utils = require "nvim-treesitter.ts_utils"
     local start_row, start_col, end_row, _ = ts_utils.get_node_range(entry.node)
-    local node_text = ts_utils.get_node_text(entry.node, bufnr)[1]
+    local node_text = vim.treesitter.get_node_text(entry.node, bufnr)
     return {
       valid = true,
 


### PR DESCRIPTION
Currently `:Telescope treesitter` shows this warning:
`nvim-treesitter.ts_utils.get_node_text is deprecated: use vim.treesitter.query.get_node_text`

This PR changes it to use the upstreamed function (which was added in 2020 https://github.com/neovim/neovim/commit/d7b12e58dfc7303dbc06381a9bedd5c3539d5413)