### PR TITLE
feat: goto next/previous entry from last picker

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1921,7 +1921,9 @@ call. These functions include `:replace(f)`, `:replace_if(f, c)`,
 be found in the `developers.md` and `lua/tests/automated/action_spec.lua` file.
 
 actions.move_selection_next({prompt_bufnr}) *telescope.actions.move_selection_next()*
-    Move the selection to the next entry
+    Move the selection to the next entry for (last) open(ed) picker.
+    - Note: requires caching to access entries from previous pickers, see 
+      |telescope.defaults.cache_picker|
 
 
     Parameters: ~
@@ -1930,6 +1932,8 @@ actions.move_selection_next({prompt_bufnr}) *telescope.actions.move_selection_ne
 
 actions.move_selection_previous({prompt_bufnr}) *telescope.actions.move_selection_previous()*
     Move the selection to the previous entry
+    - Note: requires caching to access entries from previous pickers, see 
+      |telescope.defaults.cache_picker|
 
 
     Parameters: ~

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -75,13 +75,15 @@ local actions = setmetatable({}, {
   end,
 })
 
---- Move the selection to the next entry
+--- Move the selection to the next entry for (last) open(ed) picker.
+--- - Note: requires caching to access entries from previous pickers, see  |telescope.defaults.cache_picker|
 ---@param prompt_bufnr number: The prompt bufnr
 actions.move_selection_next = function(prompt_bufnr)
   action_set.shift_selection(prompt_bufnr, 1)
 end
 
 --- Move the selection to the previous entry
+--- - Note: requires caching to access entries from previous pickers, see  |telescope.defaults.cache_picker|
 ---@param prompt_bufnr number: The prompt bufnr
 actions.move_selection_previous = function(prompt_bufnr)
   action_set.shift_selection(prompt_bufnr, -1)
@@ -242,10 +244,10 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 actions.select_default = {
   pre = function(prompt_bufnr)
-    action_state.get_current_history():append(
-      action_state.get_current_line(),
-      action_state.get_current_picker(prompt_bufnr)
-    )
+    local current_picker = action_state.get_current_picker(prompt_bufnr)
+    if current_picker then
+      action_state.get_current_history():append(action_state.get_current_line(), current_picker)
+    end
   end,
   action = function(prompt_bufnr)
     return action_set.select(prompt_bufnr, "default")


### PR DESCRIPTION
40 mins of a bit of telescope hacking :)

Closes #1701 

Now you can

```lua
local actions = require "telescope.actions"
-- also works for actions.move_selection_previous
local select_next = actions.move_selection_next + actions.select_default
-- .. launch picker
select_next() -- go to next result of last picker
```

e: goes without saying but this is ulow prio :sweat_smile: 