### PR TITLE
Revert "fix(pickers): misc inital_mode setting fixes"

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -434,24 +434,16 @@ function Picker:find()
       self:set_prompt(self.default_text)
     end
 
-    if vim.tbl_contains({ "insert", "normal" }, self.initial_mode) then
+    if self.initial_mode == "insert" then
       vim.schedule(function()
+        -- startinsert! did not reliable do `A` no idea why, i even looked at the source code
+        -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
         local mode = vim.fn.mode()
-        if self.initial_mode == "normal" then
-          if mode ~= "n" then
-            a.nvim_input "<ESC>"
-          end
-        else
-          -- Example: live_grep -> type something -> quit -> Telescope pickers -> resume -> cursor of by one
-          -- vim.cmd doesn't schedule appropriately, bypass with `nvim_input`
-          -- histdel('cmd', -1) to not pollute command history with startinsert & echon to clear "startinsert" msg
-          if mode ~= "i" then
-            local cmd = ":startinsert!|call histdel('cmd', -1)|echon ''<CR>"
-            a.nvim_input(mode ~= "n" and "<ESC>" .. cmd or cmd)
-          end
+        if mode ~= "i" then
+          a.nvim_input(mode ~= "n" and "<ESC>A" or "A")
         end
       end)
-    else
+    elseif self.initial_mode ~= "normal" then
       error("Invalid setting for initial_mode: " .. self.initial_mode)
     end
 


### PR DESCRIPTION
Reverts nvim-telescope/telescope.nvim#1895

Many more people have issues when trying to circumvent `A`.

Sorry @yutkat -- I'll do my best to fix your problem soon in a more universal way.