### PR TITLE
feat(entry_display): expose prompt_bufnr opt

### DIFF
--- a/lua/telescope/pickers/entry_display.lua
+++ b/lua/telescope/pickers/entry_display.lua
@@ -6,6 +6,7 @@ local entry_display = {}
 entry_display.truncate = strings.truncate
 
 entry_display.create = function(configuration)
+  configuration.prompt_bufnr = vim.F.if_nil(configuration.prompt_bufnr, vim.api.nvim_get_current_buf())
   local generator = {}
   for _, v in ipairs(configuration.items) do
     if v.width then
@@ -13,7 +14,7 @@ entry_display.create = function(configuration)
       local width
       table.insert(generator, function(item)
         if width == nil then
-          local status = state.get_status(vim.api.nvim_get_current_buf())
+          local status = state.get_status(configuration.prompt_bufnr)
           local s = {}
           s[1] = vim.api.nvim_win_get_width(status.results_win) - #status.picker.selection_caret
           s[2] = vim.api.nvim_win_get_height(status.results_win)

--- a/lua/telescope/pickers/entry_display.lua
+++ b/lua/telescope/pickers/entry_display.lua
@@ -6,7 +6,6 @@ local entry_display = {}
 entry_display.truncate = strings.truncate
 
 entry_display.create = function(configuration)
-  configuration.prompt_bufnr = vim.F.if_nil(configuration.prompt_bufnr, vim.api.nvim_get_current_buf())
   local generator = {}
   for _, v in ipairs(configuration.items) do
     if v.width then
@@ -14,7 +13,7 @@ entry_display.create = function(configuration)
       local width
       table.insert(generator, function(item)
         if width == nil then
-          local status = state.get_status(configuration.prompt_bufnr)
+          local status = state.get_status(vim.F.if_nil(configuration.prompt_bufnr, vim.api.nvim_get_current_buf()))
           local s = {}
           s[1] = vim.api.nvim_win_get_width(status.results_win) - #status.picker.selection_caret
           s[2] = vim.api.nvim_win_get_height(status.results_win)


### PR DESCRIPTION
@Conni2461 do you mind this diff? b/c https://github.com/nvim-telescope/telescope-file-browser.nvim/pull/118 needs this in scenarios in which `vim.ui.input` intermittently leaves prompt buf. Then I hope that PR is done, it will make interaction a lot more smoother.

A bit stupid, but simplest fix.