### PR TITLE
get mark list from opts.bufnr instead of using :marks

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -993,11 +993,10 @@ internal.colorscheme = function(opts)
 end
 
 internal.marks = function(opts)
-  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
   local local_marks = {
-    items = vim.fn.getmarklist(bufnr),
+    items = vim.fn.getmarklist(opts.bufnr),
     name_func = function(_, line)
-      return vim.api.nvim_buf_get_lines(bufnr, line - 1, line, false)[1]
+      return vim.api.nvim_buf_get_lines(opts.bufnr, line - 1, line, false)[1]
     end,
   }
   local global_marks = {
@@ -1009,7 +1008,7 @@ internal.marks = function(opts)
   }
   local marks_table = {}
   local marks_others = {}
-  local bufname = vim.api.nvim_buf_get_name(bufnr)
+  local bufname = vim.api.nvim_buf_get_name(opts.bufnr)
   for _, cnf in ipairs { local_marks, global_marks } do
     for _, v in ipairs(cnf.items) do
       -- strip the first single quote character
@@ -1024,7 +1023,7 @@ internal.marks = function(opts)
         col = col,
         filename = v.file or bufname,
       }
-      -- non alphanumeric markers goes to last
+      -- non alphanumeric marks goes to last
       if mark:match "%w" then
         table.insert(marks_table, row)
       else

--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -993,11 +993,46 @@ internal.colorscheme = function(opts)
 end
 
 internal.marks = function(opts)
-  local marks = vim.api.nvim_exec("marks", true)
-  local marks_table = vim.fn.split(marks, "\n")
-
-  -- Pop off the header.
-  table.remove(marks_table, 1)
+  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  local local_marks = {
+    items = vim.fn.getmarklist(bufnr),
+    name_func = function(_, line)
+      return vim.api.nvim_buf_get_lines(bufnr, line - 1, line, false)[1]
+    end,
+  }
+  local global_marks = {
+    items = vim.fn.getmarklist(),
+    name_func = function(mark, _)
+      -- get buffer name if it is opened, otherwise get file name
+      return vim.api.nvim_get_mark(mark, {})[4]
+    end,
+  }
+  local marks_table = {}
+  local marks_others = {}
+  local bufname = vim.api.nvim_buf_get_name(bufnr)
+  for _, cnf in ipairs { local_marks, global_marks } do
+    for _, v in ipairs(cnf.items) do
+      -- strip the first single quote character
+      local mark = string.sub(v.mark, 2, 3)
+      local _, lnum, col, _ = unpack(v.pos)
+      local name = cnf.name_func(mark, lnum)
+      -- same format to :marks command
+      local line = string.format("%s %6d %4d %s", mark, lnum, col - 1, name)
+      local row = {
+        line = line,
+        lnum = lnum,
+        col = col,
+        filename = v.file or bufname,
+      }
+      -- non alphanumeric markers goes to last
+      if mark:match "%w" then
+        table.insert(marks_table, row)
+      else
+        table.insert(marks_others, row)
+      end
+    end
+  end
+  marks_table = vim.fn.extend(marks_table, marks_others)
 
   pickers.new(opts, {
     prompt_title = "Marks",

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -635,20 +635,15 @@ function make_entry.gen_from_apropos(opts)
 end
 
 function make_entry.gen_from_marks(_)
-  return function(line)
-    local split_value = utils.max_split(line, "%s+", 4)
-
-    local mark_value = split_value[1]
-    local cursor_position = vim.fn.getpos("'" .. mark_value)
-
+  return function(item)
     return {
-      value = line,
-      ordinal = line,
-      display = line,
-      lnum = cursor_position[2],
-      col = cursor_position[3],
-      start = cursor_position[2],
-      filename = vim.api.nvim_buf_get_name(cursor_position[1]),
+      value = item.line,
+      ordinal = item.line,
+      display = item.line,
+      lnum = item.lnum,
+      col = item.col,
+      start = item.lnum,
+      filename = item.filename,
     }
   end
 end


### PR DESCRIPTION
`:marks` command shows local marks for current buffer and global marks.
However, current buffer is not identical to original buffer when called from `builtin.builtin`, so it won't show buffer local marks.
This P-R uses `vim.fn.getmarklist()` to mimic the behavior of `:marks` command.