### PR TITLE
fix: correctly use nvim-web-devicons

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -179,10 +179,14 @@ end)()
 
 utils.path_tail = (function()
   local os_sep = utils.get_separator()
-  local match_string = "[^" .. os_sep .. "]*$"
 
   return function(path)
-    return string.match(path, match_string)
+    for i = #path, 1, -1 do
+      if path:sub(i, i) == os_sep then
+        return path:sub(i + 1, -1)
+      end
+    end
+    return path
   end
 end)()
 
@@ -431,7 +435,7 @@ utils.transform_devicons = load_once(function()
         return display
       end
 
-      local icon, icon_highlight = devicons.get_icon(filename, string.match(filename, "%a+$"), { default = true })
+      local icon, icon_highlight = devicons.get_icon(utils.path_tail(filename), nil, { default = true })
       local icon_display = (icon or " ") .. " " .. (display or "")
 
       if conf.color_devicons then
@@ -461,7 +465,7 @@ utils.get_devicons = load_once(function()
         return ""
       end
 
-      local icon, icon_highlight = devicons.get_icon(filename, string.match(filename, "%a+$"), { default = true })
+      local icon, icon_highlight = devicons.get_icon(utils.path_tail(filename), nil, { default = true })
       if conf.color_devicons then
         return icon, icon_highlight
       else


### PR DESCRIPTION
Before:
![wrong_icons](https://user-images.githubusercontent.com/88047141/168467121-48bf2368-3f57-42a0-a9aa-1887e82ef852.png)

After:
![correct_icons](https://user-images.githubusercontent.com/88047141/168467132-2eaacc7f-a780-49f5-9d86-f5415df01db2.png)

Telescope integration with `nvim-web-devicons` used to work well with most files but not with files like `.bashrc`, `.zshrc`, `CMakeLists.txt` because their extension is different from their filetypes.
Other plugins like barbar, NvimTree and feline display these icons correctly

Also when calling `get_icon` the `extension` parameter is set to `nil` because extension is already computed by `nvim-web-devicons`: https://github.com/kyazdani42/nvim-web-devicons/blob/cde67b5d5427daeecfd7c77cf02ded23a26980bb/lua/nvim-web-devicons.lua#L1531-L1532
