### PR TITLE
chore: cleanup autocmd builtin

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -1170,95 +1170,44 @@ internal.highlights = function(opts)
 end
 
 internal.autocommands = function(opts)
-  local autocmd_table = {}
-
-  local pattern = {}
-  pattern.BUFFER = "<buffer=%d+>"
-  pattern.EVENT = "[%a]+"
-  pattern.GROUP = "[%a%d_:]+"
-  pattern.INDENT = "^%s%s%s%s" -- match indentation of 4 spaces
-
-  local event, group, ft_pat, cmd, source_file, source_lnum
-  local current_event, current_group, current_ft
-
-  local inner_loop = function(line)
-    -- capture group and event
-    group, event = line:match("^(" .. pattern.GROUP .. ")%s+(" .. pattern.EVENT .. ")")
-    -- ..or just an event
-    if event == nil then
-      event = line:match("^(" .. pattern.EVENT .. ")")
-    end
-
-    if event then
-      group = group or "<anonymous>"
-      if event ~= current_event or group ~= current_group then
-        current_event = event
-        current_group = group
-      end
-      return
-    end
-
-    -- non event/group lines
-    ft_pat = line:match(pattern.INDENT .. "(%S+)")
-    if ft_pat then
-      if ft_pat:match "^%d+" then
-        ft_pat = "<buffer=" .. ft_pat .. ">"
-      end
-      current_ft = ft_pat
-
-      -- is there a command on the same line?
-      cmd = line:match(pattern.INDENT .. "%S+%s+(.+)")
-
-      return
-    end
-
-    if current_ft and cmd == nil then
-      -- trim leading spaces
-      cmd = line:gsub("^%s+", "")
-      return
-    end
-
-    if current_ft and cmd then
-      source_file = line:match "Last set from (.*) line %d*$" or line:match "Last set from (.*)$"
-      source_lnum = line:match "line (%d*)$" or "1"
-      if source_file then
-        local autocmd = {}
-        autocmd.event = current_event
-        autocmd.group = current_group
-        autocmd.ft_pattern = current_ft
-        autocmd.command = cmd
-        autocmd.source_file = source_file
-        autocmd.source_lnum = source_lnum
-        table.insert(autocmd_table, autocmd)
-
-        cmd = nil
-      end
-    end
-  end
-
-  local cmd_output = vim.fn.execute("verb autocmd *", "silent")
-  for line in cmd_output:gmatch "[^\r\n]+" do
-    inner_loop(line)
-  end
-
+  local autocmds = vim.api.nvim_get_autocmds {}
+  table.sort(autocmds, function(lhs, rhs)
+    return lhs.event < rhs.event
+  end)
   pickers.new(opts, {
     prompt_title = "autocommands",
     finder = finders.new_table {
-      results = autocmd_table,
+      results = autocmds,
       entry_maker = opts.entry_maker or make_entry.gen_from_autocommands(opts),
     },
     previewer = previewers.autocommands.new(opts),
     sorter = conf.generic_sorter(opts),
     attach_mappings = function(prompt_bufnr)
-      action_set.select:replace(function(_, type)
+      action_set.select:replace_if(function()
         local selection = action_state.get_selected_entry()
         if selection == nil then
-          utils.__warn_no_selection "builtin.autocommands"
-          return
+          return false
         end
-
+        local val = selection.value
+        local output = vim.fn.execute(
+          "verb autocmd " .. val.group_name .. " " .. val.event .. " " .. val.pattern,
+          "silent"
+        )
+        for line in output:gmatch "[^\r\n]+" do
+          local source_file = line:match "Last set from (.*) line %d*$" or line:match "Last set from (.*)$"
+          if source_file and source_file ~= "Lua" then
+            selection.filename = source_file
+            local source_lnum = line:match "line (%d*)$" or "1"
+            selection.lnum = tonumber(source_lnum)
+            selection.col = 1
+            return false
+          end
+        end
+        return true
+      end, function()
+        local selection = action_state.get_selected_entry()
         actions.close(prompt_bufnr)
-        vim.cmd(action_state.select_key_to_edit_key(type) .. " " .. selection.value)
+        print("You selected autocmd: " .. vim.inspect(selection.value))
       end)
 
       return true

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1054,26 +1054,24 @@ function make_entry.gen_from_autocommands(_)
 
   local make_display = function(entry)
     return displayer {
-      { entry.event, "vimAutoEvent" },
-      { entry.group, "vimAugroup" },
-      { entry.ft_pattern, "vimAutoCmdSfxList" },
-      entry.command,
+      { entry.value.event, "vimAutoEvent" },
+      { entry.value.group_name, "vimAugroup" },
+      { entry.value.pattern, "vimAutoCmdSfxList" },
+      entry.value.command,
     }
   end
 
-  -- TODO: <action> dump current filtered items to buffer
   return function(entry)
+    local group_name = vim.F.if_nil(entry.group_name, "<anonymous>")
     return {
-      event = entry.event,
-      group = entry.group,
-      ft_pattern = entry.ft_pattern,
-      command = entry.command,
-      value = string.format("+%d %s", entry.source_lnum, entry.source_file),
-      source_file = entry.source_file,
-      source_lnum = entry.source_lnum,
+      value = {
+        event = entry.event,
+        group_name = group_name,
+        pattern = entry.pattern,
+        command = entry.command,
+      },
       --
-      valid = true,
-      ordinal = entry.event .. " " .. entry.group .. " " .. entry.ft_pattern .. " " .. entry.command,
+      ordinal = entry.event .. " " .. group_name .. " " .. entry.pattern .. " " .. entry.command,
       display = make_display,
     }
   end

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -877,12 +877,12 @@ previewers.autocommands = defaulter(function(_)
     end,
 
     get_buffer_by_name = function(_, entry)
-      return entry.group
+      return entry.value.group_name
     end,
 
     define_preview = function(self, entry, status)
       local results = vim.tbl_filter(function(x)
-        return x.group == entry.group
+        return x.value.group_name == entry.value.group_name
       end, status.picker.finder.results)
 
       if self.state.last_set_bufnr then
@@ -890,9 +890,9 @@ previewers.autocommands = defaulter(function(_)
       end
 
       local selected_row = 0
-      if self.state.bufname ~= entry.group then
+      if self.state.bufname ~= entry.value.group_name then
         local display = {}
-        table.insert(display, string.format(" augroup: %s - [ %d entries ]", entry.group, #results))
+        table.insert(display, string.format(" augroup: %s - [ %d entries ]", entry.value.group_name, #results))
         -- TODO: calculate banner width/string in setup()
         -- TODO: get column characters to be the same HL group as border
         table.insert(display, string.rep("─", vim.fn.getwininfo(status.preview_win)[1].width))
@@ -901,7 +901,10 @@ previewers.autocommands = defaulter(function(_)
           if item == entry then
             selected_row = idx
           end
-          table.insert(display, string.format("  %-14s▏%-08s %s", item.event, item.ft_pattern, item.command))
+          table.insert(
+            display,
+            string.format("  %-14s▏%-08s %s", item.value.event, item.value.ft_pattern, item.value.command)
+          )
         end
 
         vim.api.nvim_buf_set_option(self.state.bufnr, "filetype", "vim")


### PR DESCRIPTION
This is so much cleaner, but we no longer have the source file and linenumber where the autocmd was defined. Currently we get the information with `verbose` and open the appropriate file on `<CR>`

I dont see an open other than parsing `verbose autocmd` again on `<CR>` or removing it or patching neovim. `help nvim_get_option_info()` also returns

```
                • last_set_sid: Last set script id (if any)
                • last_set_linenr: line number where option was set
```

So i dont think it is that wrong to include it (maybe hide behind a verbose option) 