### PR TITLE
fix(resume): previewer if toggled

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -144,6 +144,11 @@ internal.resume = function(opts)
     picker.cache_picker.disabled = true
   end
   opts.cache_picker = nil
+  picker.previewer = picker.all_previewers
+  if picker.hidden_previewer then
+    picker.hidden_previewer = nil
+    opts.previewer = vim.F.if_nil(opts.previewer, false)
+  end
   pickers.new(opts, picker):find()
 end
 


### PR DESCRIPTION
close #1755 

Copying over `all_previewers` to `previewer`, so it works if multiple previewers are set. Also set `opts.previewer = false` If previewer was previously hidden

CC @fdschmidt93 