### PR TITLE
Add support for no-ignore-parent option in find_files.

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -878,19 +878,22 @@ builtin.find_files({opts})                    *telescope.builtin.find_files()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}          (string)   root dir to search from (default: cwd, use
-                                  utils.buffer_dir() to search relative to
-                                  open buffer)
-        {find_command} (table)    command line arguments for `find_files` to
-                                  use for the search, overrides default:
-                                  config
-        {follow}       (boolean)  if true, follows symlinks (i.e. uses `-L`
-                                  flag for the `find` command)
-        {hidden}       (boolean)  determines whether to show hidden files or
-                                  not (default: false)
-        {no_ignore}    (boolean)  show files ignored by .gitignore, .ignore,
-                                  etc. (default: false)
-        {search_dirs}  (table)    directory/directories to search in
+        {cwd}              (string)   root dir to search from (default: cwd,
+                                      use utils.buffer_dir() to search
+                                      relative to open buffer)
+        {find_command}     (table)    command line arguments for `find_files`
+                                      to use for the search, overrides
+                                      default: config
+        {follow}           (boolean)  if true, follows symlinks (i.e. uses
+                                      `-L` flag for the `find` command)
+        {hidden}           (boolean)  determines whether to show hidden files
+                                      or not (default: false)
+        {no_ignore}        (boolean)  show files ignored by .gitignore,
+                                      .ignore, etc. (default: false)
+        {no_ignore_parent} (boolean)  show files ignored by .gitignore,
+                                      .ignore, etc. in parent dirs. (default:
+                                      false)
+        {search_dirs}      (table)    directory/directories to search in
 
 
 builtin.fd()                                          *telescope.builtin.fd()*

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -181,6 +181,7 @@ files.find_files = function(opts)
   local command = find_command[1]
   local hidden = opts.hidden
   local no_ignore = opts.no_ignore
+  local no_ignore_parent = opts.no_ignore_parent
   local follow = opts.follow
   local search_dirs = opts.search_dirs
 
@@ -196,6 +197,9 @@ files.find_files = function(opts)
     end
     if no_ignore then
       table.insert(find_command, "--no-ignore")
+    end
+    if no_ignore_parent then
+      table.insert(find_command, "--no-ignore-parent")
     end
     if follow then
       table.insert(find_command, "-L")
@@ -216,6 +220,9 @@ files.find_files = function(opts)
     if no_ignore ~= nil then
       log.warn "The `no_ignore` key is not available for the `find` command in `find_files`."
     end
+    if no_ignore_parent ~= nil then
+      log.warn "The `no_ignore_parent` key is not available for the `find` command in `find_files`."
+    end
     if follow then
       table.insert(find_command, 2, "-L")
     end
@@ -231,6 +238,9 @@ files.find_files = function(opts)
     end
     if no_ignore ~= nil then
       log.warn "The `no_ignore` key is not available for the Windows `where` command in `find_files`."
+    end
+    if no_ignore_parent ~= nil then
+      log.warn "The `no_ignore_parent` key is not available for the Windows `where` command in `find_files`."
     end
     if follow ~= nil then
       log.warn "The `follow` key is not available for the Windows `where` command in `find_files`."

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -81,6 +81,7 @@ builtin.grep_string = require_on_exported_call("telescope.builtin.files").grep_s
 ---@field follow boolean: if true, follows symlinks (i.e. uses `-L` flag for the `find` command)
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
 ---@field no_ignore boolean: show files ignored by .gitignore, .ignore, etc. (default: false)
+---@field no_ignore_parent boolean: show files ignored by .gitignore, .ignore, etc. in parent directories. (default: false)
 ---@field search_dirs table: directory/directories to search in
 builtin.find_files = require_on_exported_call("telescope.builtin.files").find_files
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -81,7 +81,7 @@ builtin.grep_string = require_on_exported_call("telescope.builtin.files").grep_s
 ---@field follow boolean: if true, follows symlinks (i.e. uses `-L` flag for the `find` command)
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
 ---@field no_ignore boolean: show files ignored by .gitignore, .ignore, etc. (default: false)
----@field no_ignore_parent boolean: show files ignored by .gitignore, .ignore, etc. in parent directories. (default: false)
+---@field no_ignore_parent boolean: show files ignored by .gitignore, .ignore, etc. in parent dirs. (default: false)
 ---@field search_dirs table: directory/directories to search in
 builtin.find_files = require_on_exported_call("telescope.builtin.files").find_files
 


### PR DESCRIPTION
`ripgrep`, `fd` and `find` all support the `no-ignore` option, which doesn't obey ignore files present in the local directory. This is currently exposed in the API for `find_files`. A similar option, `no-ignore-parent`, allows the underlying program to not obey ignore files in parent directories.

This adds support for the latter, and covers the cases of other programs that do not support this option.