### PR TITLE
fix: executing commands with arguments in case of remapping :

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -349,7 +349,7 @@ internal.commands = function(opts)
           vim.cmd(cmd)
         else
           vim.cmd [[stopinsert]]
-          vim.fn.feedkeys(cmd)
+          vim.fn.feedkeys(cmd, "n")
         end
       end)
 


### PR DESCRIPTION
fix #1971 .