### PR TITLE
feat: add `no_wildignore` option to `find_files`

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -200,7 +200,12 @@ files.find_files = function(opts)
     end
     if not no_wildignore then
       for _, ignore_pattern in pairs(vim.opt.wildignore:get()) do
-        table.insert(find_command, "--exclude")
+        if command == "rg" then
+          table.insert(find_command, "--glob")
+          ignore_pattern = "!" .. ignore_pattern
+        else
+          table.insert(find_command, "--exclude")
+        end
         table.insert(find_command, ignore_pattern)
       end
     end

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -200,9 +200,9 @@ files.find_files = function(opts)
     end
     if not no_wildignore then
       for _, ignore_pattern in pairs(vim.opt.wildignore:get()) do
-        table.insert(find_command, { "--exclude", ignore_pattern })
+        table.insert(find_command, "--exclude")
+        table.insert(find_command, ignore_pattern)
       end
-      find_command = flatten(find_command)
     end
     if follow then
       table.insert(find_command, "-L")
@@ -226,14 +226,15 @@ files.find_files = function(opts)
     if not no_wildignore then
       local wildignore = vim.opt.wildignore:get()
       local wildignore_end = #wildignore
-      table.insert(find_command, { "-not", "(" })
+      table.insert(find_command, "-not")
+      table.insert(find_command, "(")
       for idx, ignore_pattern in pairs(wildignore) do
-        table.insert(find_command, { "-path", ignore_pattern })
+        table.insert(find_command, "-path")
+        table.insert(find_command, ignore_pattern)
         if idx ~= wildignore_end then
           table.insert(find_command, "-or")
         end
       end
-      find_command = flatten(find_command)
       table.insert(find_command, ")")
     end
     if follow then

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -231,16 +231,18 @@ files.find_files = function(opts)
     if not no_wildignore then
       local wildignore = vim.opt.wildignore:get()
       local wildignore_end = #wildignore
-      table.insert(find_command, "-not")
-      table.insert(find_command, "(")
-      for idx, ignore_pattern in pairs(wildignore) do
-        table.insert(find_command, "-path")
-        table.insert(find_command, ignore_pattern)
-        if idx ~= wildignore_end then
-          table.insert(find_command, "-or")
+      if wildignore_end ~= 0 then
+        table.insert(find_command, "-not")
+        table.insert(find_command, "(")
+        for idx, ignore_pattern in pairs(wildignore) do
+          table.insert(find_command, "-path")
+          table.insert(find_command, ignore_pattern)
+          if idx ~= wildignore_end then
+            table.insert(find_command, "-or")
+          end
         end
+        table.insert(find_command, ")")
       end
-      table.insert(find_command, ")")
     end
     if follow then
       table.insert(find_command, 2, "-L")

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -236,6 +236,7 @@ files.find_files = function(opts)
         table.insert(find_command, "(")
         for idx, ignore_pattern in pairs(wildignore) do
           table.insert(find_command, "-path")
+          ignore_pattern = "*" .. ignore_pattern .. "*"
           table.insert(find_command, ignore_pattern)
           if idx ~= wildignore_end then
             table.insert(find_command, "-or")

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -81,6 +81,7 @@ builtin.grep_string = require_on_exported_call("telescope.builtin.files").grep_s
 ---@field follow boolean: if true, follows symlinks (i.e. uses `-L` flag for the `find` command)
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
 ---@field no_ignore boolean: show files ignored by .gitignore, .ignore, etc. (default: false)
+---@field no_wildignore boolean: show files ignored by 'wildignore' option (default: false)
 ---@field search_dirs table: directory/directories to search in
 builtin.find_files = require_on_exported_call("telescope.builtin.files").find_files
 


### PR DESCRIPTION
This PR makes `telescope.builtin.find_files` respect the `'wildignore'` vim option by default, unless the user overrides it by setting `no_wildignore` to `true`.

## Motivation

`telescope.builtin.find_files` hides hidden files (`*/.*`) by default, but sometimes I want to show hidden files, for example configuration files like `.eslintrc`, `.prettierrc`, `.travis.yml`, etc. But setting `hidden` to `true` shows files in `.git` first and foremost, which shoves aside the files I actually want to work with. (`.gitignore` typically does not include `.git` since it is ignored by git anyway.)

![Screen Shot 2022-05-27 at 11 07 04 AM](https://user-images.githubusercontent.com/38332081/170737195-753c573f-809a-465a-8235-2c69c155ade9.png)

## Solution

The solution I propose is to respect the user's `'wildignore'` by default and allow them to override it by passing `no_wildignore = true` to `telescope.builtin.find_files`.

One possible solution would be instead to hide files in `.git` by default regardless of what `hidden` is set to, and possibly supply a `git` option to disable this behavior. Here are a few reasons why I think respecting `'wildignore'` by default is better:

- Hiding `.git` when `hidden` is `true` might be confusing to users
- `'wildignore'` is empty by default, so no weird behavior unless the user overrides it
- `'wildignore'` offers more flexibility
- `'wildignore'` exists in vanilla vim and is already respected by vim functions such as `expand()`, `glob()`, and `globpath()`; this orthogonality multiplies the utility of the concept the user already knows

![Screen Shot 2022-05-27 at 11 37 07 AM](https://user-images.githubusercontent.com/38332081/170741789-d3aa8a10-a194-4531-b54a-52e7dcd37807.png)

I'm new to writing lua and vim/neovim plugins in general, so feedback is appreciated!