### PR TITLE
fix: error in action.close when picker.original_win_id is not valid

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -345,13 +345,13 @@ end
 actions.close = function(prompt_bufnr)
   local picker = action_state.get_current_picker(prompt_bufnr)
   local original_win_id = picker.original_win_id
-  local original_cursor = a.nvim_win_get_cursor(original_win_id)
+  local cursor_valid, original_cursor = pcall(a.nvim_win_get_cursor, original_win_id)
 
   actions.close_pum(prompt_bufnr)
 
   require("telescope.pickers").on_close_prompt(prompt_bufnr)
   pcall(a.nvim_set_current_win, original_win_id)
-  if a.nvim_get_mode().mode == "i" and picker._original_mode ~= "i" then
+  if cursor_valid and a.nvim_get_mode().mode == "i" and picker._original_mode ~= "i" then
     pcall(a.nvim_win_set_cursor, original_win_id, { original_cursor[1], original_cursor[2] + 1 })
   end
 end


### PR DESCRIPTION
A concrete scenario that leads to an error can be found in [this issue](https://github.com/jedrzejboczar/toggletasks.nvim/issues/3#issuecomment-1144574061), but in short: if `picker.original_win_id` has already been closed and is no longer valid, an error occurs inside `actions.close` when calling `nvim_win_get_cursor`. This PR just wraps the call using `pcall`.