### PR TITLE
[Bugfix] Pass user opts to planets picker

### DIFF
--- a/lua/telescope/builtin/internal.lua
+++ b/lua/telescope/builtin/internal.lua
@@ -205,7 +205,7 @@ internal.planets = function(opts)
     end
   end
 
-  pickers.new({
+  pickers.new(opts, {
     prompt_title = "Planets",
     finder = finders.new_table {
       results = acceptable_files,


### PR DESCRIPTION
User options are not passed to the planets picker. 

So if I do something like `:lua require"telescope.builtin".planets({ layout_strategy = 'vertical' })`. 
I still get default `horizontal` layout strategy. 

The fix seems to be pretty straight forward. 