### PR TITLE
fix: health for neovim nightly

### DIFF
--- a/lua/telescope/health.lua
+++ b/lua/telescope/health.lua
@@ -1,4 +1,4 @@
-local health = require "health"
+local health = vim.health or require "health"
 local extension_module = require "telescope._extensions"
 local extension_info = require("telescope").extensions
 local is_win = vim.api.nvim_call_function("has", { "win32" }) == 1


### PR DESCRIPTION
The `health` module was moved to `vim.health` in neovim/neovim#18720