### PR TITLE
feat(actions): add select_preview_*

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -303,6 +303,34 @@ actions.select_tab = {
   end,
 }
 
+--- Open the current previewer in the current window
+---
+---@param prompt_bufnr number: The prompt bufnr
+actions.select_preview_default = function(prompt_bufnr, opts)
+  return action_set.select_preview(prompt_bufnr, "default", opts)
+end
+
+--- Open the current previewer in a horizontal split
+---
+---@param prompt_bufnr number: The prompt bufnr
+actions.select_preview_horizontal = function(prompt_bufnr, opts)
+  return action_set.select_preview(prompt_bufnr, "horizontal", opts)
+end
+
+--- Open the current previewer in a vertical split
+---
+---@param prompt_bufnr number: The prompt bufnr
+actions.select_preview_vertical = function(prompt_bufnr, opts)
+  return action_set.select_preview(prompt_bufnr, "vertical", opts)
+end
+
+--- Open the current previewer in a new tab
+---
+---@param prompt_bufnr number: The prompt bufnr
+actions.select_preview_tab = function(prompt_bufnr, opts)
+  return action_set.select_preview(prompt_bufnr, "tab", opts)
+end
+
 -- TODO: consider adding float!
 -- https://github.com/nvim-telescope/telescope.nvim/issues/365
 

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -212,6 +212,36 @@ action_set.scroll_results = function(prompt_bufnr, direction)
   action_set.shift_selection(prompt_bufnr, math.floor(speed) * direction)
 end
 
+--- Select the current previewer and open it in a new scratch buffer.
+---
+---@param prompt_bufnr number: The prompt bufnr
+---@param type string: The type of selection to make
+--          Valid types include: "default", "horizontal", "vertical", "tabedit"
+action_set.select_preview = function(prompt_bufnr, type, opts)
+  opts = opts or {}
+  opts.ft = utils.get_default(opts.ft, nil)
+
+  local picker = action_state.get_current_picker(prompt_bufnr) -- picker state
+
+  -- copy previewer content in new buffer
+  local preview_bufnr = picker.previewer.state.bufnr
+  local lines = vim.api.nvim_buf_get_lines(preview_bufnr, 0, -1, false)
+  local new_bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(new_bufnr, 0, -1, true, lines)
+
+  -- set context mark for jumplist
+  pcall(vim.api.nvim_set_current_win, picker.original_win_id)
+  vim.cmd "normal! m'"
+
+  -- open new buffer
+  edit_buffer(action_state.select_key_to_edit_key(type), new_bufnr)
+  if opts.ft == nil then
+    vim.cmd "filetype detect"
+  else
+    vim.api.nvim_buf_set_option(new_bufnr, 'filetype', opts.ft)
+  end
+end
+
 -- ==================================================
 -- Transforms modules and sets the corect metatables.
 -- ==================================================

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -222,6 +222,13 @@ action_set.select_preview = function(prompt_bufnr, type, opts)
   opts.ft = utils.get_default(opts.ft, nil)
 
   local picker = action_state.get_current_picker(prompt_bufnr) -- picker state
+  if picker.previewer.state == nil then
+    utils.notify("action_set.select_preview", {
+      msg = "There is no previewer open",
+      level = "ERROR",
+    })
+    return
+  end
 
   -- copy previewer content in new buffer
   local preview_bufnr = picker.previewer.state.bufnr


### PR DESCRIPTION
@fdschmidt93 this is what we talked about in https://github.com/nvim-telescope/telescope.nvim/issues/1978

In short: it copies the lines of the preview in a scratch buffer.
I decided not to go with the `keep_last_buf` method (https://github.com/nvim-telescope/telescope.nvim/issues/1978#issuecomment-1141717644) as it would have required to implement `keep_last_buffer` for each previewer.

What do you think ?

For info, I tested it with git commits previews and file previews.
Everything works fine.

Regarding filetype detection : it sometimes cannot detect it with content only.
A way to make it work would be to call plenary with the filename extension.
IMO, this is a not realistic usecase as `select_*` would be more useful when dealing with files.
Also, `ft` can be forced with `opts`.