### PR TITLE
feat(tags): process tagfiles on the fly

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -417,20 +417,11 @@ files.tags = function(opts)
     })
     return
   end
-
-  local results = {}
-  for _, ctags_file in ipairs(tagfiles) do
-    for line in Path:new(vim.fn.expand(ctags_file, true)):iter() do
-      results[#results + 1] = line
-    end
-  end
+  opts.entry_maker = utils.get_default(opts.entry_maker, make_entry.gen_from_ctags(opts))
 
   pickers.new(opts, {
     prompt_title = "Tags",
-    finder = finders.new_table {
-      results = results,
-      entry_maker = opts.entry_maker or make_entry.gen_from_ctags(opts),
-    },
+    finder = finders.new_oneshot_job(flatten {"cat", tagfiles}, opts),
     previewer = previewers.ctags.new(opts),
     sorter = conf.generic_sorter(opts),
     attach_mappings = function()

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -410,6 +410,9 @@ end
 
 files.tags = function(opts)
   local tagfiles = opts.ctags_file and { opts.ctags_file } or vim.fn.tagfiles()
+  for i,ctags_file in ipairs(tagfiles) do
+    tagfiles[i] = vim.fn.expand(ctags_file, true)
+  end
   if vim.tbl_isempty(tagfiles) then
     utils.notify("builtin.tags", {
       msg = "No tags file found. Create one with ctags -R",

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -410,7 +410,7 @@ end
 
 files.tags = function(opts)
   local tagfiles = opts.ctags_file and { opts.ctags_file } or vim.fn.tagfiles()
-  for i,ctags_file in ipairs(tagfiles) do
+  for i, ctags_file in ipairs(tagfiles) do
     tagfiles[i] = vim.fn.expand(ctags_file, true)
   end
   if vim.tbl_isempty(tagfiles) then
@@ -420,11 +420,11 @@ files.tags = function(opts)
     })
     return
   end
-  opts.entry_maker = utils.get_default(opts.entry_maker, make_entry.gen_from_ctags(opts))
+  opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_ctags(opts))
 
   pickers.new(opts, {
     prompt_title = "Tags",
-    finder = finders.new_oneshot_job(flatten {"cat", tagfiles}, opts),
+    finder = finders.new_oneshot_job(flatten { "cat", tagfiles }, opts),
     previewer = previewers.ctags.new(opts),
     sorter = conf.generic_sorter(opts),
     attach_mappings = function()


### PR DESCRIPTION
This allow to start grepping before having to preprocess all the tagfiles entries.

Can be interested if the tag we are looking for is at the beginning of the tagfile.
Still issues of refresh (https://github.com/nvim-telescope/telescope.nvim/issues/1981).

The `Path:new(vim.fn.expand(ctags_file, true)):iter()` performance hit was not as big as when I first tried to implement it.
This could be because I was on a local machine with a SSD, or that the repo I was using previously used a bunch of hardlink.