### PR TITLE
feat(rg): pass multiple globs to rg by default

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -821,26 +821,28 @@ builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}                 (string)    root dir to search from (default:
-                                          cwd, use utils.buffer_dir() to
-                                          search relative to open buffer)
-        {grep_open_files}     (boolean)   if true, restrict search to open
-                                          files only, mutually exclusive with
-                                          `search_dirs`
-        {search_dirs}         (table)     directory/directories/files to
-                                          search, mutually exclusive with
-                                          `grep_open_files`
-        {glob_pattern}        (string)    argument to be used with `--glob`,
-                                          e.g. "*.toml", can use the opposite
-                                          "!*.toml"
-        {type_filter}         (string)    argument to be used with `--type`,
-                                          e.g. "rust", see `rg --type-list`
-        {additional_args}     (function)  function(opts) which returns a table
-                                          of additional arguments to be passed
-                                          on
-        {max_results}         (number)    define a upper result value
-        {disable_coordinates} (boolean)   don't show the line & row numbers
-                                          (default: false)
+        {cwd}                 (string)        root dir to search from
+                                              (default: cwd, use
+                                              utils.buffer_dir() to search
+                                              relative to open buffer)
+        {grep_open_files}     (boolean)       if true, restrict search to open
+                                              files only, mutually exclusive
+                                              with `search_dirs`
+        {search_dirs}         (table)         directory/directories/files to
+                                              search, mutually exclusive with
+                                              `grep_open_files`
+        {glob_pattern}        (string|table)  argument to be used with
+                                              `--glob`, e.g. "*.toml", can use
+                                              the opposite "!*.toml"
+        {type_filter}         (string)        argument to be used with
+                                              `--type`, e.g. "rust", see `rg
+                                              --type-list`
+        {additional_args}     (function)      function(opts) which returns a
+                                              table of additional arguments to
+                                              be passed on
+        {max_results}         (number)        define a upper result value
+        {disable_coordinates} (boolean)       don't show the line & row
+                                              numbers (default: false)
 
 
 builtin.grep_string({opts})                  *telescope.builtin.grep_string()*

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -76,8 +76,12 @@ files.live_grep = function(opts)
     additional_args[#additional_args + 1] = "--type=" .. opts.type_filter
   end
 
-  if opts.glob_pattern then
+  if type(opts.glob_pattern) == "string" then
     additional_args[#additional_args + 1] = "--glob=" .. opts.glob_pattern
+  elseif type(opts.glob_pattern) == "table" then
+    for i = 1, #opts.glob_pattern do
+      additional_args[#additional_args + 1] = "--glob=" .. opts.glob_pattern[i]
+    end
   end
 
   local live_grepper = finders.new_job(function(prompt)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -55,7 +55,7 @@ end
 ---@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
 ---@field search_dirs table: directory/directories/files to search, mutually exclusive with `grep_open_files`
----@field glob_pattern string: argument to be used with `--glob`, e.g. "*.toml", can use the opposite "!*.toml"
+---@field glob_pattern string|table: argument to be used with `--glob`, e.g. "*.toml", can use the opposite "!*.toml"
 ---@field type_filter string: argument to be used with `--type`, e.g. "rust", see `rg --type-list`
 ---@field additional_args function: function(opts) which returns a table of additional arguments to be passed on
 ---@field max_results number: define a upper result value


### PR DESCRIPTION
ripgrep supports multiple `--glob` flags. 
This gives us the ability to do interesting queries. A simple example will be: search in all `lua` files that are not in test directory.  
This query in telescope will look like this
```:lua require"telescope.builtin".live_grep{ glob_pattern = {"*.lua", "!**/test/**/*"} }```
