### PR TITLE
fix: block autocommands when setting preview buffer

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -333,7 +333,7 @@ previewers.new_buffer_previewer = function(opts)
       -- Push in another buffer so the last one will not be cleaned up
       if preview_window_id then
         local bufnr = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_win_set_buf(preview_window_id, bufnr)
+        utils.win_set_buf_noautocmd(preview_window_id, bufnr)
       end
     end
 
@@ -358,14 +358,14 @@ previewers.new_buffer_previewer = function(opts)
     if opts.get_buffer_by_name and get_bufnr_by_bufname(self, opts.get_buffer_by_name(self, entry)) then
       self.state.bufname = opts.get_buffer_by_name(self, entry)
       self.state.bufnr = get_bufnr_by_bufname(self, self.state.bufname)
-      vim.api.nvim_win_set_buf(status.preview_win, self.state.bufnr)
+      utils.win_set_buf_noautocmd(status.preview_win, self.state.bufnr)
     else
       local bufnr = vim.api.nvim_create_buf(false, true)
       set_bufnr(self, bufnr)
 
       vim.schedule(function()
         if vim.api.nvim_buf_is_valid(bufnr) then
-          vim.api.nvim_win_set_buf(status.preview_win, bufnr)
+          utils.win_set_buf_noautocmd(status.preview_win, bufnr)
         end
       end)
 

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -192,12 +192,12 @@ previewers.new_termopen_previewer = function(opts)
     local prev_bufnr = get_bufnr_by_bufentry(self, entry)
     if prev_bufnr then
       self.state.termopen_bufnr = prev_bufnr
-      vim.api.nvim_win_set_buf(status.preview_win, self.state.termopen_bufnr)
+      utils.win_set_buf_noautocmd(status.preview_win, self.state.termopen_bufnr)
       self.state.termopen_id = term_ids[self.state.termopen_bufnr]
     else
       local bufnr = vim.api.nvim_create_buf(false, true)
       set_bufnr(self, bufnr)
-      vim.api.nvim_win_set_buf(status.preview_win, bufnr)
+      utils.win_set_buf_noautocmd(status.preview_win, bufnr)
 
       local term_opts = {
         cwd = opts.cwd or vim.loop.cwd(),

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -410,6 +410,13 @@ function utils.get_os_command_output(cmd, cwd)
   return stdout, ret, stderr
 end
 
+function utils.win_set_buf_noautocmd(win, buf)
+  local save_ei = vim.o.eventignore
+  vim.o.eventignore = "all"
+  vim.api.nvim_win_set_buf(win, buf)
+  vim.o.eventignore = save_ei
+end
+
 local load_once = function(f)
   local resolved = nil
   return function(...)


### PR DESCRIPTION
Telescope creates most floating windows with `noautocmd = true`, so
these windows do not trigger autocommands, but preview buffer is set in
window using `nvim_win_set_buf()`, which triggers buffer autocommands.
This may be unwanted, so block them using `'eventignore'`.