### PR TITLE
fix: Error caused by the invalid options in create_autocmd for vimdiff

### DIFF
--- a/lua/telescope/builtin/git.lua
+++ b/lua/telescope/builtin/git.lua
@@ -156,11 +156,10 @@ git.bcommits = function(opts)
         vim.cmd "diffthis"
 
         vim.api.nvim_create_autocmd("WinClosed", {
-          event = "WinClosed",
           buffer = bufnr,
           nested = true,
           once = true,
-          function()
+          callback = function()
             vim.api.nvim_buf_delete(bufnr, { force = true })
           end,
         })


### PR DESCRIPTION
Fix this "Invalid key: 1" error when we open a diff in vertical/horizontal/tab in the builtin `git_commits` and `git_bcommits`.

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/11582667/173920382-f5f7991a-6ffb-4db1-906c-3aaa8e74f480.png">

Thank you.