### PR TITLE
fix: grep_string crashes when string has newline

### DIFF
--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -124,6 +124,8 @@ files.grep_string = function(opts)
   local word_match = opts.word_match
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_vimgrep(opts)
 
+  local title_word = word:gsub("\n", "\\n")
+
   local additional_args = {}
   if opts.additional_args ~= nil and type(opts.additional_args) == "function" then
     additional_args = opts.additional_args(opts)
@@ -144,7 +146,7 @@ files.grep_string = function(opts)
   end
 
   pickers.new(opts, {
-    prompt_title = "Find Word (" .. word .. ")",
+    prompt_title = "Find Word (" .. title_word .. ")",
     finder = finders.new_oneshot_job(args, opts),
     previewer = conf.grep_previewer(opts),
     sorter = conf.generic_sorter(opts),


### PR DESCRIPTION
# Description

This fixes #2023  by addressing the specific crash I was running in to. The generic solution of cleaning up windows on crashes probably would need fixing on the Pleanary side.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Manual test: `:lua require("telescope.builtin").grep_string( { search = "a\nb" } ) `

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.8.0-dev+436-g279bc71f3                                                                                                                                                                                                                                                  
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3                                                                                                                                                                                                                                                              
Compilation: /usr/bin/cc -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -DNVIM_TS_HAS_SET_MATCH_LIMIT -DNVIM_TS_HAS_SET_ALLOCATOR -O2 -g -Og -g -Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion -Wdouble-promotion -Wmissing-noreturn -Wmissing-format-attribute -Wmissing-prototypes -Wimplicit-fallthrough -Wsuggest-attribute=pure -Wsuggest-attribute=const -Wsuggest-attribute=malloc -Wsuggest-attribute=cold -Wvla -fstack-protector-strong -fno-common -fdiagnostics-color=always -DINCLUDE_GENERATED_DECLARATIONS -D_GNU_SOURCE -DNVIM_MSGPACK_HAS_FLOAT32 -DNVIM_UNIBI_HAS_VAR_FROM -DMIN_LOG_LEVEL=3 (-I flags removed, in my homedir)
Compiled by bob_twinkles@HOSTNAME_HIDDEN

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/home/rkoser/.local/share/nvim"

Run :checkhealth for more info
```
* Operating system and version:
Ubuntu 20.04 / NixOS unstable.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
