### PR TITLE
feat: search_file option for builtin fd command

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -899,6 +899,7 @@ builtin.find_files({opts})                    *telescope.builtin.find_files()*
                                              (default: false)
         {search_dirs}      (table)           directory/directories/files to
                                              search
+        {search_file}      (string)          specify a filename to search for
 
 
 builtin.fd()                                          *telescope.builtin.fd()*

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -224,7 +224,6 @@ files.find_files = function(opts)
     end
     if search_file then
       if command == "rg" then
-        table.insert(find_command, "--files")
         table.insert(find_command, "-g")
         table.insert(find_command, "*" .. search_file .. "*")
       else
@@ -517,4 +516,3 @@ local function apply_checks(mod)
 end
 
 return apply_checks(files)
-

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -201,6 +201,7 @@ files.find_files = function(opts)
   local no_ignore_parent = opts.no_ignore_parent
   local follow = opts.follow
   local search_dirs = opts.search_dirs
+  local search_file = opts.search_file
 
   if search_dirs then
     for k, v in pairs(search_dirs) do
@@ -221,8 +222,17 @@ files.find_files = function(opts)
     if follow then
       table.insert(find_command, "-L")
     end
+    if search_file then
+      if command == "rg" then
+        table.insert(find_command, "--files")
+        table.insert(find_command, "-g")
+        table.insert(find_command, "*" .. search_file .. "*")
+      else
+        table.insert(find_command, search_file)
+      end
+    end
     if search_dirs then
-      if command ~= "rg" then
+      if command ~= "rg" and not search_file then
         table.insert(find_command, ".")
       end
       for _, v in pairs(search_dirs) do
@@ -264,6 +274,9 @@ files.find_files = function(opts)
     end
     if search_dirs ~= nil then
       log.warn "The `search_dirs` key is not available for the Windows `where` command in `find_files`."
+    end
+    if search_file ~= nil then
+      log.warn "The `search_file` key is not available for the Windows `where` command in `find_files`."
     end
   end
 
@@ -504,3 +517,4 @@ local function apply_checks(mod)
 end
 
 return apply_checks(files)
+

--- a/lua/telescope/builtin/files.lua
+++ b/lua/telescope/builtin/files.lua
@@ -252,6 +252,10 @@ files.find_files = function(opts)
     if follow then
       table.insert(find_command, 2, "-L")
     end
+    if search_file then
+      table.insert(find_command, "-name")
+      table.insert(find_command, "*" .. search_file .. "*")
+    end
     if search_dirs then
       table.remove(find_command, 2)
       for _, v in pairs(search_dirs) do

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -83,6 +83,7 @@ builtin.grep_string = require_on_exported_call("telescope.builtin.files").grep_s
 ---@field no_ignore boolean: show files ignored by .gitignore, .ignore, etc. (default: false)
 ---@field no_ignore_parent boolean: show files ignored by .gitignore, .ignore, etc. in parent dirs. (default: false)
 ---@field search_dirs table: directory/directories/files to search
+---@field search_file string: specify a filename to search for
 builtin.find_files = require_on_exported_call("telescope.builtin.files").find_files
 
 --- This is an alias for the `find_files` picker


### PR DESCRIPTION
# Description

This option offers a simple way to reduce results for a find_files search without taking away functionalities.
The behavior is similar the `grep _ string` functionally but in this case we are searching for file names.

To give just a small example but one most people here should be able to relate we could take the scope of one personal nvim config. Often it contains several files with similar names like `lsp*` or `git*`. With this commit one could use the `search_file` option to show and overview his files with a `lsp*` / `git*` name and then use the given functionalites as usual to preview and further search the results.

For me personally, such an option solves several use cases where I want to list a specific set of files with a keymap.

## Type of change

- New feature (non-breaking change which adds functionality)
