### PR TITLE
fix: filereadable should check for 1 or 0

### DIFF
--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -30,7 +30,7 @@ function from_entry.path(entry, validate, escape)
     return
   end
 
-  if validate and not vim.fn.filereadable(path) then
+  if validate and vim.fn.filereadable(path) == 0 then
     return
   end
 


### PR DESCRIPTION
# Description

`vim.fn.filereadable` returns 1/0 which should be checked explicitly.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Manually test: `:Telescope current_buffer_fuzzy_find`

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.8.0-dev+519-g6f6286e4f
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by ustc1314@pop-os

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/local/share/nvim"

Run :checkhealth for more info
```
* Operating system and version:
```
Pop OS 21.04
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
