### PR TITLE
chore: make to fuzzy refine easily configurable

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2811,6 +2811,16 @@ actions.which_key({prompt_bufnr})              *telescope.actions.which_key()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
+actions.to_fuzzy_refine({prompt_bufnr})  *telescope.actions.to_fuzzy_refine()*
+    Move from a none fuzzy search to a fuzzy one
+    This action is meant to be used in live_grep and
+    lsp_dynamic_workspace_symbols
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
 
 ================================================================================
                                                        *telescope.actions.state*

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -54,7 +54,7 @@
 
 local a = vim.api
 
-local config = require "telescope.config"
+local conf = require("telescope.config").values
 local state = require "telescope.state"
 local utils = require "telescope.utils"
 local popup = require "plenary.popup"
@@ -1073,7 +1073,7 @@ actions.which_key = function(prompt_bufnr, opts)
   opts.close_with_action = vim.F.if_nil(opts.close_with_action, true)
   opts.normal_hl = vim.F.if_nil(opts.normal_hl, "TelescopePrompt")
   opts.border_hl = vim.F.if_nil(opts.border_hl, "TelescopePromptBorder")
-  opts.winblend = vim.F.if_nil(opts.winblend, config.values.winblend)
+  opts.winblend = vim.F.if_nil(opts.winblend, conf.winblend)
   opts.column_padding = vim.F.if_nil(opts.column_padding, "  ")
 
   -- Assigning into 'opts.column_indent' would override a number with a string and
@@ -1271,6 +1271,28 @@ actions.which_key = function(prompt_bufnr, opts)
       })
     end)
   end
+end
+
+--- Move from a none fuzzy search to a fuzzy one<br>
+--- This action is meant to be used in live_grep and lsp_dynamic_workspace_symbols
+---@param prompt_bufnr number: The prompt bufnr
+actions.to_fuzzy_refine = function(prompt_bufnr)
+  local line = action_state.get_current_line()
+  local prefix = (function()
+    local title = action_state.get_current_picker(prompt_bufnr).prompt_title
+    if title == "Live Grep" then
+      return "Find Word"
+    elseif title == "LSP Dynamic Workspace Symbols" then
+      return "LSP Workspace Symbols"
+    else
+      return "Fuzzy over"
+    end
+  end)()
+
+  require("telescope.actions.generate").refine(prompt_bufnr, {
+    prompt_title = string.format("%s (%s)", prefix, line),
+    sorter = conf.generic_sorter {},
+  })
 end
 
 -- ==================================================

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -1,5 +1,6 @@
 local action_state = require "telescope.actions.state"
 local action_set = require "telescope.actions.set"
+local actions = require "telescope.actions"
 local finders = require "telescope.finders"
 local make_entry = require "telescope.make_entry"
 local pickers = require "telescope.pickers"
@@ -112,13 +113,7 @@ files.live_grep = function(opts)
     -- and then we could get the highlight positions directly.
     sorter = sorters.highlighter_only(opts),
     attach_mappings = function(_, map)
-      map("i", "<c-space>", function(prompt_bufnr)
-        local line = action_state.get_current_line()
-        require("telescope.actions.generate").refine(prompt_bufnr, {
-          prompt_title = "Find Word (" .. line .. ")",
-          sorter = conf.generic_sorter(opts),
-        })
-      end)
+      map("i", "<c-space>", actions.to_fuzzy_refine)
       return true
     end,
   }):find()

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -1,5 +1,5 @@
 local channel = require("plenary.async.control").channel
-local action_state = require "telescope.actions.state"
+local actions = require "telescope.actions"
 local sorters = require "telescope.sorters"
 local conf = require("telescope.config").values
 local finders = require "telescope.finders"
@@ -318,13 +318,7 @@ lsp.dynamic_workspace_symbols = function(opts)
     previewer = conf.qflist_previewer(opts),
     sorter = sorters.highlighter_only(opts),
     attach_mappings = function(_, map)
-      map("i", "<c-space>", function(prompt_bufnr)
-        local line = action_state.get_current_line()
-        require("telescope.actions.generate").refine(prompt_bufnr, {
-          prompt_title = "LSP Workspace Symbols (" .. line .. ")",
-          sorter = conf.generic_sorter(opts),
-        })
-      end)
+      map("i", "<c-space>", actions.to_fuzzy_refine)
       return true
     end,
   }):find()


### PR DESCRIPTION
CC @clason 


```lua
telescope.setup {
  -- defaults = { },
  pickers = {
    live_grep = {
      mappings = {
        i = { ["<c-f>"] = actions.to_fuzzy_refine },
      },
    },
  },
  -- extensions = { },
}
```