### PR TITLE
fix(from_entry): treat directories as valid paths

### DIFF
--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -30,7 +30,9 @@ function from_entry.path(entry, validate, escape)
     return
   end
 
-  if validate and vim.fn.filereadable(path) == 0 then
+  -- only 0 if neither filereadable nor directory
+  local invalid = vim.fn.filereadable(path) + vim.fn.isdirectory(path)
+  if validate and invalid == 0 then
     return
   end
 


### PR DESCRIPTION
# Description

#2030 broke `ls` preview for directories.

`vim.fn.filereadable` returns `0` for folders. Thus, when `validate` is `true` like for our buffer previewers, `nil` rather than directory paths are returned.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Before**

Open `telescope-file-browser.nvim` and see no preview for directories

**After**

See buffer preview for directories

**Configuration**:
irrelevant

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
