### PR TITLE
fix: `entry_display.create` expects items to be a table not a number

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -413,7 +413,7 @@ function make_entry.gen_from_quickfix(opts)
     { remaining = true },
   }
   if hidden then
-    items[1] = 8
+    items[1] = { width = 8 }
   end
   if not show_line then
     table.remove(items, 1)


### PR DESCRIPTION
# Description
Fixes #2037  

## Type of change
Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration
Following the steps from the issue report with and without this fix.
- I've tested with the following commands: `quickfix`, `lsp_implementations` and `lsp_references`.

**Configuration**:
NVIM v0.7.2
Build type: Release
LuaJIT 2.1.0-beta3

* Operating system and version:
macOS: 12.4