### PR TITLE
feat: grep_open_files for builtin.grep_string

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -866,8 +866,12 @@ builtin.grep_string({opts})                  *telescope.builtin.grep_string()*
                                           cwd, use utils.buffer_dir() to
                                           search relative to open buffer)
         {search}              (string)    the query to search
+        {grep_open_files}     (boolean)   if true, restrict search to open
+                                          files only, mutually exclusive with
+                                          `search_dirs`
         {search_dirs}         (table)     directory/directories/files to
-                                          search
+                                          search, mutually exclusive with
+                                          `grep_open_files`
         {use_regex}           (boolean)   if true, special characters won't be
                                           escaped, allows for using regex
                                           (default: false)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -66,7 +66,8 @@ builtin.live_grep = require_on_exported_call("telescope.builtin.__files").live_g
 ---@param opts table: options to pass to the picker
 ---@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field search string: the query to search
----@field search_dirs table: directory/directories/files to search
+---@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
+---@field search_dirs table: directory/directories/files to search, mutually exclusive with `grep_open_files`
 ---@field use_regex boolean: if true, special characters won't be escaped, allows for using regex (default: false)
 ---@field word_match string: can be set to `-w` to enable exact word matches
 ---@field additional_args function: function(opts) which returns a table of additional arguments to be passed on


### PR DESCRIPTION
# Description

Allows fuzzy finding over all open buffers. Same as `grep_open_files` for `live_grep`

Fixes #1357

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)