### PR TITLE
fix(path_display): allow function on path_display 

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -204,9 +204,7 @@ utils.is_path_hidden = function(opts, path_display)
 
   return path_display == nil
     or path_display == "hidden"
-    or type(path_display) ~= "table"
-    or vim.tbl_contains(path_display, "hidden")
-    or path_display.hidden
+    or type(path_display) == "table" and (vim.tbl_contains(path_display, "hidden") or path_display.hidden)
 end
 
 local is_uri = function(filename)


### PR DESCRIPTION
# Description
Fixes #2042 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration
I have tested with all documented allowed values for **path_display**:
- `{"hidden"}, {hidden = 1}, "hidden"`: hides all the path (empty).
- `{"tail"}, {tail = 1}`: only the filename.
- `{"absolute"}, {absolute = 1}`: shows the absolute path.
- `{"shorten"}, {shorten = 2}`: shows only the defined number of chars of every dir on the path.
- Invalid values tested (3, "invalid_string", true): fallsback to the default value "absolute" with a warning log that `'path_display' must be either a function or a table`.


**Configuration**:
* Neovim version (nvim --version):
NVIM v0.7.2
Build type: Release
LuaJIT 2.1.0-beta3

* Operating system and version:
macOS 12.4

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)