### PR TITLE
fix: also map <C-/> for which-key

### DIFF
--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -33,6 +33,7 @@ mappings.default_mappings = config.values.default_mappings
       ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
       ["<M-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
       ["<C-l>"] = actions.complete_tag,
+      ["<C-/>"] = actions.which_key,
       ["<C-_>"] = actions.which_key, -- keys from pressing <C-/>
       ["<C-w>"] = { "<c-s-w>", type = "command" },
     },


### PR DESCRIPTION
# Description

Some terminals send <kbd>Ctrl + /</kbd> as `<C-/>`, not `<C-_>`. Map both to the `which_key` action to cover these cases.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

In kitty, press <kbd>C-V</kbd><kbd>C-/</kbd> in Insert mode and note that `<C-/>` is inserted into the buffer, not `<C-_>`. Pressing <kbd>C-/</kbd> in the telescope prompt simply inserts a `/` character. With this change, pressing <kbd>C-/</kbd> in the telescope prompt shows the which-key output, as expected.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
