### PR TITLE
feat(make_entry) allow replacement symbol_type string

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -515,6 +515,7 @@ function make_entry.gen_from_lsp_symbols(opts)
     items = display_items,
   }
   local type_highlight = vim.F.if_nil(opts.symbol_highlights or lsp_type_highlight)
+  local type_transform = opts.type_transform or function(type_str) return type_str:lower() end
 
   local make_display = function(entry)
     local msg
@@ -526,14 +527,14 @@ function make_entry.gen_from_lsp_symbols(opts)
     if hidden then
       return displayer {
         entry.symbol_name,
-        { entry.symbol_type:lower(), type_highlight[entry.symbol_type] },
+        { type_transform(entry.symbol_type), type_highlight[entry.symbol_type] },
         msg,
       }
     else
       return displayer {
         utils.transform_path(opts, entry.filename),
         entry.symbol_name,
-        { entry.symbol_type:lower(), type_highlight[entry.symbol_type] },
+        { type_transform(entry.symbol_type), type_highlight[entry.symbol_type] },
         msg,
       }
     end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -515,7 +515,9 @@ function make_entry.gen_from_lsp_symbols(opts)
     items = display_items,
   }
   local type_highlight = vim.F.if_nil(opts.symbol_highlights or lsp_type_highlight)
-  local type_transform = opts.type_transform or function(type_str) return type_str:lower() end
+  local type_transform = opts.type_transform or function(type_str)
+    return type_str:lower()
+  end
 
   local make_display = function(entry)
     local msg


### PR DESCRIPTION
# Description

Minor change to allow replacing symbol type names (variable, function, etc.) via function. No posted issue addressed, I just like having symbols there for easier recognition.

Wasn't too sure on where you would document this, so I didn't for now.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Not much to test since it's a simple string replacement.

- [x] Relevant LSP Pickers used with and without config option type_transform

**Configuration**:
* Neovim version (nvim --version): 0.72
* Operating system and version: Fedora 36

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation (lua annotations)
