### PR TITLE
fix: whichkey mode width options typo

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -243,8 +243,8 @@ end
 actions.select_default = {
   pre = function(prompt_bufnr)
     action_state
-        .get_current_history()
-        :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
+      .get_current_history()
+      :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
   end,
   action = function(prompt_bufnr)
     return action_set.select(prompt_bufnr, "default")
@@ -259,8 +259,8 @@ actions.select_default = {
 actions.select_horizontal = {
   pre = function(prompt_bufnr)
     action_state
-        .get_current_history()
-        :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
+      .get_current_history()
+      :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
   end,
   action = function(prompt_bufnr)
     return action_set.select(prompt_bufnr, "horizontal")
@@ -275,8 +275,8 @@ actions.select_horizontal = {
 actions.select_vertical = {
   pre = function(prompt_bufnr)
     action_state
-        .get_current_history()
-        :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
+      .get_current_history()
+      :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
   end,
   action = function(prompt_bufnr)
     return action_set.select(prompt_bufnr, "vertical")
@@ -291,8 +291,8 @@ actions.select_vertical = {
 actions.select_tab = {
   pre = function(prompt_bufnr)
     action_state
-        .get_current_history()
-        :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
+      .get_current_history()
+      :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
   end,
   action = function(prompt_bufnr)
     return action_set.select(prompt_bufnr, "tab")
@@ -1166,12 +1166,13 @@ actions.which_key = function(prompt_bufnr, opts)
   end)
 
   local entry_width = #opts.column_padding
-      + opts.mode_width
-      + opts.keybind_width
-      + opts.name_width
-      + (3 * #opts.separator)
+    + opts.mode_width
+    + opts.keybind_width
+    + opts.name_width
+    + (3 * #opts.separator)
   local num_total_columns = math.floor((vim.o.columns - #column_indent) / entry_width)
-  opts.num_rows = math.min(math.ceil(#mappings / num_total_columns), resolver.resolve_height(opts.max_height)(_, _, vim.o.lines))
+  opts.num_rows =
+    math.min(math.ceil(#mappings / num_total_columns), resolver.resolve_height(opts.max_height)(_, _, vim.o.lines))
   local total_available_entries = opts.num_rows * num_total_columns
   local winheight = opts.num_rows + 2 * opts.line_padding
 
@@ -1185,7 +1186,7 @@ actions.which_key = function(prompt_bufnr, opts)
   local results_row = win_central_row(picker.results_win)
   local preview_row = picker.preview_win and win_central_row(picker.preview_win) or results_row
   local prompt_pos = prompt_row < 0.4 * vim.o.lines
-      or prompt_row < 0.6 * vim.o.lines and results_row + preview_row < vim.o.lines
+    or prompt_row < 0.6 * vim.o.lines and results_row + preview_row < vim.o.lines
 
   local modes = { n = "Normal", i = "Insert" }
   local title_mode = opts.only_show_current_mode and modes[mode] .. " Mode " or ""

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -243,8 +243,8 @@ end
 actions.select_default = {
   pre = function(prompt_bufnr)
     action_state
-      .get_current_history()
-      :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
+        .get_current_history()
+        :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
   end,
   action = function(prompt_bufnr)
     return action_set.select(prompt_bufnr, "default")
@@ -259,8 +259,8 @@ actions.select_default = {
 actions.select_horizontal = {
   pre = function(prompt_bufnr)
     action_state
-      .get_current_history()
-      :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
+        .get_current_history()
+        :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
   end,
   action = function(prompt_bufnr)
     return action_set.select(prompt_bufnr, "horizontal")
@@ -275,8 +275,8 @@ actions.select_horizontal = {
 actions.select_vertical = {
   pre = function(prompt_bufnr)
     action_state
-      .get_current_history()
-      :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
+        .get_current_history()
+        :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
   end,
   action = function(prompt_bufnr)
     return action_set.select(prompt_bufnr, "vertical")
@@ -291,8 +291,8 @@ actions.select_vertical = {
 actions.select_tab = {
   pre = function(prompt_bufnr)
     action_state
-      .get_current_history()
-      :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
+        .get_current_history()
+        :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
   end,
   action = function(prompt_bufnr)
     return action_set.select(prompt_bufnr, "tab")
@@ -1103,7 +1103,7 @@ actions.which_key = function(prompt_bufnr, opts)
   local displayer = entry_display.create {
     separator = opts.separator,
     items = {
-      { width = opts.mode_with },
+      { width = opts.mode_width },
       { width = opts.keybind_width },
       { width = opts.name_width },
     },
@@ -1166,13 +1166,12 @@ actions.which_key = function(prompt_bufnr, opts)
   end)
 
   local entry_width = #opts.column_padding
-    + opts.mode_width
-    + opts.keybind_width
-    + opts.name_width
-    + (3 * #opts.separator)
+      + opts.mode_width
+      + opts.keybind_width
+      + opts.name_width
+      + (3 * #opts.separator)
   local num_total_columns = math.floor((vim.o.columns - #column_indent) / entry_width)
-  opts.num_rows =
-    math.min(math.ceil(#mappings / num_total_columns), resolver.resolve_height(opts.max_height)(_, _, vim.o.lines))
+  opts.num_rows = math.min(math.ceil(#mappings / num_total_columns), resolver.resolve_height(opts.max_height)(_, _, vim.o.lines))
   local total_available_entries = opts.num_rows * num_total_columns
   local winheight = opts.num_rows + 2 * opts.line_padding
 
@@ -1186,7 +1185,7 @@ actions.which_key = function(prompt_bufnr, opts)
   local results_row = win_central_row(picker.results_win)
   local preview_row = picker.preview_win and win_central_row(picker.preview_win) or results_row
   local prompt_pos = prompt_row < 0.4 * vim.o.lines
-    or prompt_row < 0.6 * vim.o.lines and results_row + preview_row < vim.o.lines
+      or prompt_row < 0.6 * vim.o.lines and results_row + preview_row < vim.o.lines
 
   local modes = { n = "Normal", i = "Insert" }
   local title_mode = opts.only_show_current_mode and modes[mode] .. " Mode " or ""


### PR DESCRIPTION
# Description

Fixes typo in which_key options actions/init.lua , was 
```lua
      { width = opts.mode_with },
```
now is
```lua
      { width = opts.mode_width },
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ran locally, ran make test.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
