### PR TITLE
fix: move the moon behind show_moon option (…

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1117,6 +1117,8 @@ builtin.planets({opts})                          *telescope.builtin.planets()*
     Options: ~
         {show_pluto} (boolean)  we love pluto (default: false, because its a
                                 hidden feature)
+        {show_moon}  (boolean)  we love the moon (default: false, because its
+                                a hidden feature)
 
 
 builtin.symbols({opts})                          *telescope.builtin.symbols()*

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -208,6 +208,7 @@ end
 
 internal.planets = function(opts)
   local show_pluto = opts.show_pluto or false
+  local show_moon = opts.show_moon or false
 
   local sourced_file = require("plenary.debug_utils").sourced_filepath()
   local base_directory = vim.fn.fnamemodify(sourced_file, ":h:h:h:h")
@@ -215,7 +216,7 @@ internal.planets = function(opts)
   local globbed_files = vim.fn.globpath(base_directory .. "/data/memes/planets/", "*", true, true)
   local acceptable_files = {}
   for _, v in ipairs(globbed_files) do
-    if show_pluto or not v:find "pluto" then
+    if (show_pluto or not v:find "pluto") and (show_moon or not v:find "moon") then
       table.insert(acceptable_files, vim.fn.fnamemodify(v, ":t"))
     end
   end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -228,6 +228,7 @@ builtin.pickers = require_on_exported_call("telescope.builtin.__internal").picke
 --- Use the telescope...
 ---@param opts table: options to pass to the picker
 ---@field show_pluto boolean: we love pluto (default: false, because its a hidden feature)
+---@field show_moon boolean: we love the moon (default: false, because its a hidden feature)
 builtin.planets = require_on_exported_call("telescope.builtin.__internal").planets
 
 --- Lists symbols inside of `data/telescope-sources/*.json` found in your runtime path


### PR DESCRIPTION
…#2072)

# Description

- Addressed the issue in #2072 and moved the moon behind show_moon option
- Also added documentation alongside it

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

Manual testing by setting `show_moon` and `show_pluto` to be true.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.7.0
* Operating system and version: macOS 12.2.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
