### PR TITLE
fix: previewer if cwd is not curr dir

### DIFF
--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -25,9 +25,15 @@ function from_entry.path(entry, validate, escape)
   end
 
   -- only 0 if neither filereadable nor directory
-  local invalid = vim.fn.filereadable(path) + vim.fn.isdirectory(path)
-  if validate and invalid == 0 then
-    return
+  if validate then
+    -- We need to expand for filereadable and isdirectory
+    -- TODO(conni2461): we are not going to return the expanded path because
+    --                  this would lead to cache misses in the perviewer.
+    --                  Requires overall refactoring in previewer interface
+    local expanded = vim.fn.expand(path)
+    if (vim.fn.filereadable(expanded) + vim.fn.isdirectory(expanded)) == 0 then
+      return
+    end
   end
   if escape then
     return vim.fn.fnameescape(path)


### PR DESCRIPTION
path needs to be expanded for filereadable and isdirectory

fix #2077

Edit: this might be a bad fix with the get_buffer_by_name in mind. Because get_buffer_by_name doesn't validate (i think) and normal does, causing a problem that the result might be difficult and we get a cache miss.