### PR TITLE
fix(which_key): only get telescope mappings

### DIFF
--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -96,8 +96,11 @@ function utils.get_registered_mappings(prompt_bufnr)
   for _, mode in ipairs { "n", "i" } do
     local mode_mappings = vim.api.nvim_buf_get_keymap(prompt_bufnr, mode)
     for _, mapping in ipairs(mode_mappings) do
-      local funcid = findnth(mapping.rhs, 2)
-      table.insert(ret, { mode = mode, keybind = mapping.lhs, func = __TelescopeKeymapStore[prompt_bufnr][funcid] })
+      -- ensure only telescope mappings
+      if mapping.rhs and string.find(mapping.rhs, [[require%('telescope.mappings'%).execute_keymap]]) then
+        local funcid = findnth(mapping.rhs, 2)
+        table.insert(ret, { mode = mode, keybind = mapping.lhs, func = __TelescopeKeymapStore[prompt_bufnr][funcid] })
+      end
     end
   end
   return ret


### PR DESCRIPTION
# Description

Change `action_utils.get_registered_mappings` to only capture mappings attached to prompt via `telescope` interfaces, as the interface would break otherwise currently anyway (and it's unclear whether other mappings should be showing up.. because then you'd attach them via telescope). 

Fixes #2087 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- Having installed `nvim-surround` (and reproduce with original issue)
- Observing no errors

**Configuration**:

See above

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
