### PR TITLE
0.1.x

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -381,8 +381,12 @@ local set_opts_cwd = function(opts)
     opts.cwd = vim.fn.expand(opts.cwd)
   else
     opts.cwd = vim.loop.cwd()
-  end
-
+		if opts.use_buffer_path then
+			local buffer_filename = vim.api.nvim_buf_get_name(opts.bufnr)
+  		local buffer_path = buffer_filename:match("(.*[/\\])")
+			opts.cwd = buffer_path
+		end
+	end
   -- Find root of git directory and remove trailing newline characters
   local git_root, ret = utils.get_os_command_output({ "git", "rev-parse", "--show-toplevel" }, opts.cwd)
   local use_git_root = vim.F.if_nil(opts.use_git_root, true)

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -384,7 +384,9 @@ local set_opts_cwd = function(opts)
 		if opts.use_buffer_path then
 			local buffer_filename = vim.api.nvim_buf_get_name(opts.bufnr)
   		local buffer_path = buffer_filename:match("(.*[/\\])")
-			opts.cwd = buffer_path
+			if buffer_path then
+				opts.cwd = buffer_path
+			end
 		end
 	end
   -- Find root of git directory and remove trailing newline characters

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -135,6 +135,7 @@ builtin.current_buffer_tags = require_on_exported_call("telescope.builtin.__file
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
+---@field use_buffer_path boolean: if we should use the current buffer path as cwd (important if you use repo tool) (default: false) 
 ---@field show_untracked boolean: if true, adds `--others` flag to command and shows untracked files (default: false)
 ---@field recurse_submodules boolean: if true, adds the `--recurse-submodules` flag to command (default: false)
 ---@field git_command table: command that will be exectued. {"git","ls-files","--exclude-standard","--cached"}
@@ -149,6 +150,7 @@ builtin.git_files = require_on_exported_call("telescope.builtin.__git").files
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
+---@field use_buffer_path boolean: if we should use the current buffer path as cwd (important if you use repo tool) (default: false) 
 ---@field git_command table: command that will be exectued. {"git","log","--pretty=oneline","--abbrev-commit","--","."}
 builtin.git_commits = require_on_exported_call("telescope.builtin.__git").commits
 
@@ -161,6 +163,7 @@ builtin.git_commits = require_on_exported_call("telescope.builtin.__git").commit
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
+---@field use_buffer_path boolean: if we should use the current buffer path as cwd (important if you use repo tool) (default: false) 
 ---@field current_file string: specify the current file that should be used for bcommits (default: current buffer)
 ---@field git_command table: command that will be exectued. {"git","log","--pretty=oneline","--abbrev-commit"}
 builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcommits
@@ -176,6 +179,7 @@ builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcomm
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
+---@field use_buffer_path boolean: if we should use the current buffer path as cwd (important if you use repo tool) (default: false) 
 ---@field pattern string: specify the pattern to match all refs
 builtin.git_branches = require_on_exported_call("telescope.builtin.__git").branches
 
@@ -186,6 +190,7 @@ builtin.git_branches = require_on_exported_call("telescope.builtin.__git").branc
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
+---@field use_buffer_path boolean: if we should use the current buffer path as cwd (important if you use repo tool) (default: false) 
 ---@field git_icons table: string -> string. Matches name with icon (see source code, make_entry.lua git_icon_defaults)
 builtin.git_status = require_on_exported_call("telescope.builtin.__git").status
 
@@ -195,6 +200,7 @@ builtin.git_status = require_on_exported_call("telescope.builtin.__git").status
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
+---@field use_buffer_path boolean: if we should use the current buffer path as cwd (important if you use repo tool) (default: false) 
 ---@field show_branch boolean: if we should display the branch name for git stash entries (default: true)
 builtin.git_stash = require_on_exported_call("telescope.builtin.__git").stash
 


### PR DESCRIPTION
# Description
This is feature is helpfull when working on projects that use the repo tool. 
In this type of projects, is a common practice that you start nvim from the project root directory that contains several subdirs corresponding to all the git repos that belongs to the project.

By letting telescope find the git root directory based on the current buffer path it's very easy to move across all the git projects

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
In order to test the new parameter create a project structure as shown below:
```
test_repo/
├── proj_a
│   └── proj_a_sample.c
└── proj_b
    └── proj_b_sample.c

```
`proj_a` and `proj_b` folders must be git repositories. Therefore you should run:
```bash
test_repo$ cd proj_a && git init && git add . && git commit -m "initial commit" && cd -
test_repo$ cd proj_b && git init && git add . && git commit -m "initial commit" && cd -
```
Configure telescope plugin in your init.lua as follows:
```lua
-- configure telescope
require('telescope').setup({
  extensions = {
    fzf = {
      fuzzy = true,
      override_generic_sorter = true,
      override_file_sorter = true,
      case_mode = "smart_case"
    }
  },
  pickers = {
    git_commits = {
      use_buffer_path = true
    },
    git_bcommits = {
      use_buffer_path = true
    },
    git_branches = {
      use_buffer_path = true
    },
    git_status = {
      use_buffer_path = true
    },
    git_stash = {
      use_buffer_path = true
    },
    git_files = {
      use_buffer_path = true
    }
  }
})
```
To test if everything is working start nvim at test_repo level
Once in nvim open proj_a_sample.c and run Telescope git_commits. You should now see the project A commits
Repeat the same procedure but for the proj_b_sample.c. In this case, you should see the project B commits

**Configuration**:
* Neovim version (nvim --version): v0.7.2
* Operating system and version: Linux Ubuntu 5.15.0-41-generic #44~20.04.1-Ubuntu SMP Fri Jun 24 13:27:29 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
