### PR TITLE
fix(resolve): Check val not nil in resolve funcs

### DIFF
--- a/lua/telescope/config/resolve.lua
+++ b/lua/telescope/config/resolve.lua
@@ -139,7 +139,7 @@ end] = function(_, val)
 end
 
 _resolve_map[function(val)
-  return type(val) == "table" and val[1] >= 0 and val[1] < 1 and val["max"] ~= nil
+  return type(val) == "table" and val["max"] ~= nil and val[1] ~= nil and val[1] >= 0 and val[1] < 1
 end] =
   function(selector, val)
     return function(...)
@@ -149,7 +149,7 @@ end] =
   end
 
 _resolve_map[function(val)
-  return type(val) == "table" and val[1] >= 0 and val[1] < 1 and val["min"] ~= nil
+  return type(val) == "table" and val["min"] ~= nil and val[1] ~= nil and val[1] >= 0 and val[1] < 1
 end] =
   function(selector, val)
     return function(...)


### PR DESCRIPTION
# Description

We did not check `val ~= nil` in the resolve functions, so config like `{ nil, max = 30 }` will throw a nil error. Also, if the config is `{
padding = _ }`, the logic relies on the function handling the padding is iterated before the one handling min/max in the map, which is not always guaranteed.

Fix the bug by adding nil check in the function handling min/max. Close

Fixes #2091

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
