### PR TITLE
Use extmarks for highlighting and carets

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -799,7 +799,6 @@ function Picker:add_selection(row)
   local entry = self.manager:get_entry(self:get_index(row))
   self._multi:add(entry)
 
-  self:update_prefix(entry, row)
   self:get_status_updater(self.prompt_win, self.prompt_bufnr)()
   self.highlighter:hi_multiselect(row, true)
 end
@@ -810,7 +809,6 @@ function Picker:remove_selection(row)
   local entry = self.manager:get_entry(self:get_index(row))
   self._multi:drop(entry)
 
-  self:update_prefix(entry, row)
   self:get_status_updater(self.prompt_win, self.prompt_bufnr)()
   self.highlighter:hi_multiselect(row, false)
 end
@@ -839,7 +837,6 @@ function Picker:toggle_selection(row)
   end
   self._multi:toggle(entry)
 
-  self:update_prefix(entry, row)
   self:get_status_updater(self.prompt_win, self.prompt_bufnr)()
   self.highlighter:hi_multiselect(row, self._multi:is_selected(entry))
 end
@@ -987,7 +984,6 @@ function Picker:set_selection(row)
       self._selection_entry = entry
 
       if old_row >= 0 then
-        self:update_prefix(old_entry, old_row)
         self.highlighter:hi_multiselect(old_row, self:is_multi_selected(old_entry))
       end
     else
@@ -1046,25 +1042,7 @@ function Picker:update_prefix(entry, row)
     return t
   end
 
-  local line = vim.api.nvim_buf_get_lines(self.results_bufnr, row, row + 1, false)[1]
-  if not line then
-    log.trace(string.format("no line found at row %d in buffer %d", row, self.results_bufnr))
-    return
-  end
-
-  local old_caret = string.sub(line, 0, #prefix(true)) == prefix(true) and prefix(true)
-    or string.sub(line, 0, #prefix(true, true)) == prefix(true, true) and prefix(true, true)
-    or string.sub(line, 0, #prefix(false)) == prefix(false) and prefix(false)
-    or string.sub(line, 0, #prefix(false, true)) == prefix(false, true) and prefix(false, true)
-  if old_caret == false then
-    log.warn(string.format("can't identify old caret in line: %s", line))
-    return
-  end
-
-  local pre = prefix(entry == self._selection_entry, self:is_multi_selected(entry))
-  -- Only change the first couple characters, nvim_buf_set_text leaves the existing highlights
-  -- a.nvim_buf_set_text(self.results_bufnr, row, 0, row, #old_caret, { pre })
-  return pre
+  return prefix(entry == self._selection_entry, self:is_multi_selected(entry))
 end
 
 --- Refresh the previewer based on the current `status` of the picker
@@ -1164,7 +1142,6 @@ function Picker:entry_adder(index, entry, _, insert)
     if display_highlights then
       self.highlighter:hi_display(row, prefix, display_highlights)
     end
-    self:update_prefix(entry, row)
     self:highlight_one_row(self.results_bufnr, self:_get_prompt(), display, row)
   end
 
@@ -1371,7 +1348,6 @@ function Picker:_do_selection(prompt)
       local old_entry, old_row = self._selection_entry, self._selection_row
       self:reset_selection() -- required to reset selection before updating prefix
       if old_row >= 0 then
-        self:update_prefix(old_entry, old_row)
         self.highlighter:hi_multiselect(old_row, self:is_multi_selected(old_entry))
       end
     end

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -262,43 +262,6 @@ function Picker:clear_extra_rows(results_bufnr)
   log.trace("Clearing:", worst_line)
 end
 
---- Highlight the entry corresponding to the given row
----@param results_bufnr number: the buffer number of the results buffer
----@param prompt table: table with information about the prompt buffer
----@param display string: the text corresponding to the given row
----@param row number: the number of the chosen row
-function Picker:highlight_one_row(results_bufnr, prompt, display, row)
-  if not self.sorter.highlighter then
-    return
-  end
-
-  local highlights = self.sorter:highlighter(prompt, display)
-
-  if highlights then
-    for _, hl in ipairs(highlights) do
-      local highlight, start, finish
-      if type(hl) == "table" then
-        highlight = hl.highlight or "TelescopeMatching"
-        start = hl.start
-        finish = hl.finish or hl.start
-      elseif type(hl) == "number" then
-        highlight = "TelescopeMatching"
-        start = hl
-        finish = hl
-      else
-        error "Invalid higlighter fn"
-      end
-
-      self:_increment "highlights"
-
-      vim.api.nvim_buf_add_highlight(results_bufnr, ns_telescope_matching, highlight, row, start - 1, finish)
-    end
-  end
-
-  local entry = self.manager:get_entry(self:get_index(row))
-  self.highlighter:hi_multiselect(row, self:is_multi_selected(entry))
-end
-
 --- Check if the given row number can be selected
 ---@param row number: the number of the chosen row in the results buffer
 ---@return boolean
@@ -1142,7 +1105,7 @@ function Picker:entry_adder(index, entry, _, insert)
     if display_highlights then
       self.highlighter:hi_display(row, prefix, display_highlights)
     end
-    self:highlight_one_row(self.results_bufnr, self:_get_prompt(), display, row)
+    self.highlighter:hi_sorter(row, self:_get_prompt(), display)
   end
 
   if not set_ok then

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1063,7 +1063,7 @@ function Picker:update_prefix(entry, row)
 
   local pre = prefix(entry == self._selection_entry, self:is_multi_selected(entry))
   -- Only change the first couple characters, nvim_buf_set_text leaves the existing highlights
-  a.nvim_buf_set_text(self.results_bufnr, row, 0, row, #old_caret, { pre })
+  -- a.nvim_buf_set_text(self.results_bufnr, row, 0, row, #old_caret, { pre })
   return pre
 end
 

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -9,9 +9,10 @@ local ns_telescope_entry = a.nvim_create_namespace "telescope_entry"
 local ns_telescope_matching = a.nvim_create_namespace "telescope_matching"
 
 -- Priorities for extmark highlights. Example: Treesitter is set to 100
+local SELECTION_MULTISELECT_PRIORITY = 100
 local DISPLAY_HIGHLIGHTS_PRIORITY = 110
-local SELECTION_HIGHLIGHTS_PRIORITY = 120
-local SORTER_HIGHLIGHTS_PRIORITY = 130
+local SELECTION_HIGHLIGHTS_PRIORITY = 130
+local SORTER_HIGHLIGHTS_PRIORITY = 140
 
 local Highlighter = {}
 Highlighter.__index = Highlighter
@@ -61,7 +62,6 @@ end
 
 function Highlighter:hi_sorter(row, prompt, display)
   local picker = self.picker
-  local sorter = picker.sorter
   if not picker.sorter or not picker.sorter.highlighter then
     return
   end
@@ -71,7 +71,7 @@ function Highlighter:hi_sorter(row, prompt, display)
     return
   end
 
-  local sorter_highlights = sorter:highlighter(prompt, display)
+  local sorter_highlights = picker.sorter:highlighter(prompt, display)
 
   if sorter_highlights then
     for _, hl in ipairs(sorter_highlights) do
@@ -105,7 +105,8 @@ function Highlighter:hi_selection(row, caret)
   a.nvim_buf_clear_namespace(results_bufnr, ns_telescope_selection, 0, -1)
 
   -- Skip if there is nothing on the actual line
-  if a.nvim_buf_get_lines(results_bufnr, row, row + 1, false)[1] == "" then
+  local line = a.nvim_buf_get_lines(results_bufnr, row, row + 1, false)[1]
+  if line == nil or line == "" then
     return
   end
 
@@ -140,7 +141,7 @@ function Highlighter:hi_multiselect(row, is_selected)
   a.nvim_buf_clear_namespace(results_bufnr, ns_telescope_multiselection, row, row + 1)
 
   local line = a.nvim_buf_get_lines(results_bufnr, row, row + 1, false)[1]
-  if not line then
+  if line == nil or line == "" then
     return
   end
 
@@ -160,6 +161,7 @@ function Highlighter:hi_multiselect(row, is_selected)
     a.nvim_buf_set_extmark(results_bufnr, ns_telescope_multiselection, row, offset, {
       end_col = #line,
       hl_group = "TelescopeMultiSelection",
+      priority = SELECTION_MULTISELECT_PRIORITY,
     })
   end
 end

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -128,7 +128,6 @@ function Highlighter:hi_selection(row, caret)
     hl_group = "TelescopeSelection",
     priority = SELECTION_HIGHLIGHTS_PRIORITY,
   })
-
 end
 
 function Highlighter:hi_multiselect(row, is_selected)

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -93,7 +93,7 @@ function Highlighter:hi_sorter(row, prompt, display)
         end_col = finish,
         hl_group = highlight,
         priority = SORTER_HIGHLIGHTS_PRIORITY,
-        strict = false
+        strict = false,
       })
     end
   end
@@ -161,7 +161,7 @@ function Highlighter:hi_multiselect(row, is_selected)
     -- highlight the text after the multi_icon
     a.nvim_buf_set_extmark(results_bufnr, ns_telescope_multiselection, row, offset, {
       end_col = #line,
-      hl_group = "TelescopeMultiSelection"
+      hl_group = "TelescopeMultiSelection",
     })
   end
 end

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -1,5 +1,4 @@
 local a = vim.api
-local log = require "telescope.log"
 local conf = require("telescope.config").values
 
 local highlights = {}
@@ -46,7 +45,7 @@ function Highlighter:hi_display(row, prefix, display_highlights)
     })
   end
 end
-  
+
 function Highlighter:clear_display()
   if
     not self
@@ -104,7 +103,7 @@ function Highlighter:hi_selection(row, caret)
   local results_bufnr = assert(self.picker.results_bufnr, "Must have a results bufnr")
 
   a.nvim_buf_clear_namespace(results_bufnr, ns_telescope_selection, 0, -1)
-  
+
   -- Skip if there is nothing on the actual line
   if a.nvim_buf_get_lines(results_bufnr, row, row + 1, false)[1] == "" then
     return

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -109,36 +109,36 @@ end
 function Highlighter:hi_multiselect(row, is_selected)
   local results_bufnr = assert(self.picker.results_bufnr, "Must have a results bufnr")
 
-  local multi_icon = self.picker.multi_icon 
-  local offset = #multi_icon -- TODO: Get a real offset here
-  vim.api.nvim_buf_set_extmark(results_bufnr, ns_telescope_multiselection, row, offset, {
-    virt_text = { { multi_icon, "TelescopeMultiIcon" } },
-    virt_text_pos = "overlay",
-    end_col = offset,
-    hl_group = "TelescopeMultiIcon",
-    -- priority = ???,
-  })
+  if not a.nvim_buf_is_valid(results_bufnr) then
+    return
+  end
+
+  a.nvim_buf_clear_namespace(results_bufnr, ns_telescope_multiselection, row, row + 1)
+
+  local line = a.nvim_buf_get_lines(results_bufnr, row, row + 1, false)[1]
+  if not line then
+    return
+  end
 
   if is_selected then
-    vim.api.nvim_buf_add_highlight(results_bufnr, ns_telescope_multiselection, "TelescopeMultiSelection", row, 0, -1)
-    if self.picker.multi_icon then
-      local line = vim.api.nvim_buf_get_lines(results_bufnr, row, row + 1, false)[1]
-      local pos = line:find(self.picker.multi_icon)
-      if pos and pos <= math.max(#self.picker.selection_caret, #self.picker.entry_prefix) then
+    local multi_icon = self.picker.multi_icon 
+    local offset = #multi_icon -- TODO: Get a real offset here
+    a.nvim_buf_set_extmark(results_bufnr, ns_telescope_multiselection, row, offset, {
+      virt_text = { { multi_icon, "TelescopeMultiIcon" } },
+      virt_text_pos = "overlay",
+      end_col = offset,
+      hl_group = "TelescopeMultiIcon",
+      -- priority = ???,
+    })
 
-
-        -- vim.api.nvim_buf_add_highlight(
-        --   results_bufnr,
-        --   ns_telescope_multiselection,
-        --   "TelescopeMultiIcon",
-        --   row,
-        --   pos - 1,
-        --   pos - 1 + #self.picker.multi_icon
-        -- )
-      end
-    end
+    -- highlight the text after the multi_icon
+    -- TODO: test with multi-byte prefixes
+    a.nvim_buf_set_extmark(results_bufnr, ns_telescope_multiselection, row, offset, {
+      end_col = #line,
+      hl_group = "TelescopeMultiSelection"
+    })
   else
-    local existing_marks = vim.api.nvim_buf_get_extmarks(
+    local existing_marks = a.nvim_buf_get_extmarks(
       results_bufnr,
       ns_telescope_multiselection,
       { row, 0 },
@@ -151,7 +151,6 @@ function Highlighter:hi_multiselect(row, is_selected)
     if #existing_marks > 0 then
       log.trace("Clearing highlight multi select row: ", row)
 
-      vim.api.nvim_buf_clear_namespace(results_bufnr, ns_telescope_multiselection, row, row + 1)
     end
   end
 end

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -118,6 +118,7 @@ function Highlighter:hi_selection(row, caret)
     virt_text_pos = "overlay",
     end_col = offset,
     hl_group = "TelescopeSelectionCaret",
+    hl_mode = "combine",
     priority = SELECTION_HIGHLIGHTS_PRIORITY,
     strict = true,
   })
@@ -153,10 +154,16 @@ function Highlighter:hi_multiselect(row, is_selected)
       virt_text = { { multi_icon, "TelescopeMultiIcon" } },
       virt_text_pos = "overlay",
       end_col = offset,
+      hl_mode = "combine",
       hl_group = "TelescopeMultiIcon",
       priority = SELECTION_HIGHLIGHTS_PRIORITY,
     })
-
+    -- highlight the caret
+    a.nvim_buf_set_extmark(results_bufnr, ns_telescope_multiselection, row, 0, {
+      end_col = #self.picker.selection_caret,
+      hl_group = "TelescopeMultiSelection",
+      priority = SELECTION_MULTISELECT_PRIORITY,
+    })
     -- highlight the text after the multi_icon
     a.nvim_buf_set_extmark(results_bufnr, ns_telescope_multiselection, row, offset, {
       end_col = #line,

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -110,7 +110,7 @@ function Highlighter:hi_selection(row, caret)
     return
   end
 
-  local offset = #caret -- TODO: Don't have an offset yet, may need to add one. Need to know if we can derive it from the caret or not
+  local offset = #caret
 
   -- Highlight the caret
   a.nvim_buf_set_extmark(results_bufnr, ns_telescope_selection, row, 0, {
@@ -148,7 +148,7 @@ function Highlighter:hi_multiselect(row, is_selected)
 
   if is_selected then
     local multi_icon = self.picker.multi_icon
-    local offset = #multi_icon -- TODO: Get a real offset here
+    local offset = #multi_icon
 
     a.nvim_buf_set_extmark(results_bufnr, ns_telescope_multiselection, row, offset, {
       virt_text = { { multi_icon, "TelescopeMultiIcon" } },
@@ -159,7 +159,6 @@ function Highlighter:hi_multiselect(row, is_selected)
     })
 
     -- highlight the text after the multi_icon
-    -- TODO: test with multi-byte prefixes
     a.nvim_buf_set_extmark(results_bufnr, ns_telescope_multiselection, row, offset, {
       end_col = #line,
       hl_group = "TelescopeMultiSelection"

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -8,6 +8,11 @@ local ns_telescope_selection = a.nvim_create_namespace "telescope_selection"
 local ns_telescope_multiselection = a.nvim_create_namespace "telescope_multiselection"
 local ns_telescope_entry = a.nvim_create_namespace "telescope_entry"
 
+-- Priorities for extmark highlights. Example: Treesitter is set to 100
+local DISPLAY_HIGHLIGHTS_PRIORITY = 110
+local SORTER_HIGHLIGHTS_PRIORITY = 120
+local SELECTION_HIGHLIGHTS_PRIORITY = 130
+
 local Highlighter = {}
 Highlighter.__index = Highlighter
 
@@ -25,19 +30,19 @@ function Highlighter:hi_display(row, prefix, display_highlights)
   end
 
   local results_bufnr = assert(self.picker.results_bufnr, "Must have a results bufnr")
+  if not a.nvim_buf_is_valid(results_bufnr) then
+    return
+  end
 
   a.nvim_buf_clear_namespace(results_bufnr, ns_telescope_entry, row, row + 1)
-  local len_prefix = #prefix
 
   for _, hl_block in ipairs(display_highlights) do
-    a.nvim_buf_add_highlight(
-      results_bufnr,
-      ns_telescope_entry,
-      hl_block[2],
-      row,
-      len_prefix + hl_block[1][1],
-      len_prefix + hl_block[1][2]
-    )
+    a.nvim_buf_set_extmark(results_bufnr, ns_telescope_entry, row, #prefix + hl_block[1][1], {
+      end_col = #prefix + hl_block[1][2],
+      hl_group = hl_block[2],
+      priority = DISPLAY_HIGHLIGHTS_PRIORITY,
+      strict = false,
+    })
   end
 end
 
@@ -69,15 +74,6 @@ function Highlighter:hi_selection(row, caret)
   local results_bufnr = assert(self.picker.results_bufnr, "Must have a results bufnr")
 
   a.nvim_buf_clear_namespace(results_bufnr, ns_telescope_selection, 0, -1)
-  -- a.nvim_buf_add_highlight(results_bufnr, ns_telescope_selection, "TelescopeSelectionCaret", row, 0, #caret)
-
-  -- a.nvim_buf_set_extmark(
-  --   results_bufnr,
-  --   ns_telescope_selection,
-  --   row,
-  --   #caret,
-  --   { end_line = row + 1, hl_eol = conf.hl_result_eol, hl_group = "TelescopeSelection" }
-  -- )
   
   -- Skip if there is nothing on the actual line
   if a.nvim_buf_get_lines(results_bufnr, row, row + 1, false)[1] == "" then
@@ -92,7 +88,7 @@ function Highlighter:hi_selection(row, caret)
     virt_text_pos = "overlay",
     end_col = offset,
     hl_group = "TelescopeSelectionCaret",
-    -- priority = TODO:,
+    priority = SELECTION_HIGHLIGHTS_PRIORITY,
     strict = true,
   })
 
@@ -101,7 +97,7 @@ function Highlighter:hi_selection(row, caret)
     end_line = row + 1,
     hl_eol = conf.hl_result_eol,
     hl_group = "TelescopeSelection",
-    -- priority = ???
+    priority = SELECTION_HIGHLIGHTS_PRIORITY,
   })
 
 end
@@ -121,14 +117,14 @@ function Highlighter:hi_multiselect(row, is_selected)
   end
 
   if is_selected then
-    local multi_icon = self.picker.multi_icon 
+    local multi_icon = self.picker.multi_icon
     local offset = #multi_icon -- TODO: Get a real offset here
     a.nvim_buf_set_extmark(results_bufnr, ns_telescope_multiselection, row, offset, {
       virt_text = { { multi_icon, "TelescopeMultiIcon" } },
       virt_text_pos = "overlay",
       end_col = offset,
       hl_group = "TelescopeMultiIcon",
-      -- priority = ???,
+      priority = SELECTION_HIGHLIGHTS_PRIORITY,
     })
 
     -- highlight the text after the multi_icon
@@ -137,21 +133,6 @@ function Highlighter:hi_multiselect(row, is_selected)
       end_col = #line,
       hl_group = "TelescopeMultiSelection"
     })
-  else
-    local existing_marks = a.nvim_buf_get_extmarks(
-      results_bufnr,
-      ns_telescope_multiselection,
-      { row, 0 },
-      { row, -1 },
-      {}
-    )
-
-    -- This is still kind of weird to me, since it seems like I'm erasing stuff
-    -- when I shouldn't... Perhaps it's about the gravity of the extmark?
-    if #existing_marks > 0 then
-      log.trace("Clearing highlight multi select row: ", row)
-
-    end
   end
 end
 

--- a/lua/tests/automated/pickers/find_files_spec.lua
+++ b/lua/tests/automated/pickers/find_files_spec.lua
@@ -26,7 +26,7 @@ describe("builtin.find_files", function()
         runner.picker('find_files', 'README.md', {
           post_typed = {
             { "> README.md", GetPrompt },
-            { "> README.md", GetBestResult },
+            { "  README.md", GetBestResult },
           },
           post_close = {
             { 'README.md', GetFile },
@@ -112,7 +112,7 @@ describe("builtin.find_files", function()
           {
             {
               "  lua/tests/fixtures/file_a.txt",
-              "> lua/tests/fixtures/file_abc.txt",
+              "  lua/tests/fixtures/file_abc.txt",
             }, GetResults
           },
         },


### PR DESCRIPTION
# Description

Pulled out as a subset of the changes from #1491

This PR uses extmarks and virtual text instead of typical highlighting and text replacement to consolidate the highlight/rendering logic to `highlights.lua`. This should give us more flexibility in the future when we want to improve rendering of telescope.

## Type of change

Please delete options that are not relevant.

- Internal Changes

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] All the tests in `lua/tests/automated/`

**Configuration**:
* Neovim version (nvim --version): NVIM v0.7.2
* Operating system and version: macOS 12.3.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
