### PR TITLE
Fix error due to concatenating table to string

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -58,7 +58,7 @@ end
 local function call_hierarchy(opts, method, title, direction, item)
   vim.lsp.buf_request(opts.bufnr, method, { item = item }, function(err, result)
     if err then
-      vim.api.nvim_err_writeln("Error handling " .. title .. ": " .. err)
+      vim.api.nvim_err_writeln("Error handling " .. title .. ": " .. err.message)
       return
     end
 


### PR DESCRIPTION


# Description

This pr fixes a bug that lead to an error because we tried to
concatenate a table (`err`) to a string. Now we concatenate
`err.message` (a string) to the string.

Fixes #2098 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Due to the simplicity of the change I only did a manual test.

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.8.0-dev-699-gcbfae548e8
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
Compilation: /usr/bin/cc -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions     -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security     -fstack-clash-protection -fcf-protection -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=1 -DNVIM_TS_HAS_SET_MATCH_LIMIT -DNVIM_TS_HAS_SET_ALLOCATOR -O2 -g -Og -g -Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion -Wdouble-promotion -Wmissing-noreturn -Wmissing-format-attribute -Wmissing-prototypes -Wimplicit-fallthrough -Wvla -fstack-protector-strong -fno-common -fdiagnostics-color=auto -DINCLUDE_GENERATED_DECLARATIONS -D_GNU_SOURCE -DNVIM_MSGPACK_HAS_FLOAT32 -DNVIM_UNIBI_HAS_VAR_FROM -DMIN_LOG_LEVEL=3 -I/home/chris/pkgs/neovim-git/src/build/cmake.config -I/home/chris/pkgs/neovim-git/src/neovim-git/src -I/usr/include -I/home/chris/pkgs/neovim-git/src/build/src/nvim/auto -I/home/chris/pkgs/neovim-git/src/build/include
Compiled by chris@archie-work

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/share/nvim"

Run :checkhealth for more info
```

* Operating system and version:
```
Linux archie-work 5.18.14-arch1-1 #1 SMP PREEMPT_DYNAMIC Sat, 23 Jul 2022 11:46:17 +0000 x86_64 GNU/Linux
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
