### PR TITLE
default entry_maker not set properly

### DIFF
--- a/lua/telescope/finders.lua
+++ b/lua/telescope/finders.lua
@@ -44,7 +44,7 @@ function JobFinder:new(opts)
   assert(not opts.static, "`static` should be used with finder.new_oneshot_job")
 
   local obj = setmetatable({
-    entry_maker = opts.entry_maker or make_entry.gen_from_string,
+    entry_maker = opts.entry_maker or make_entry.gen_from_string(opts),
     fn_command = opts.fn_command,
     cwd = opts.cwd,
     writer = opts.writer,
@@ -122,7 +122,7 @@ function DynamicFinder:new(opts)
   local obj = setmetatable({
     curr_buf = opts.curr_buf,
     fn = opts.fn,
-    entry_maker = opts.entry_maker or make_entry.gen_from_string,
+    entry_maker = opts.entry_maker or make_entry.gen_from_string(opts),
   }, self)
 
   return obj
@@ -180,7 +180,7 @@ finders.new_oneshot_job = function(command_list, opts)
   local command = table.remove(command_list, 1)
 
   return async_oneshot_finder {
-    entry_maker = opts.entry_maker or make_entry.gen_from_string(),
+    entry_maker = opts.entry_maker or make_entry.gen_from_string(opts),
 
     cwd = opts.cwd,
     maximum_results = opts.maximum_results,

--- a/lua/telescope/finders/async_job_finder.lua
+++ b/lua/telescope/finders/async_job_finder.lua
@@ -6,7 +6,7 @@ local log = require "telescope.log"
 
 return function(opts)
   log.trace("Creating async_job:", opts)
-  local entry_maker = opts.entry_maker or make_entry.gen_from_string()
+  local entry_maker = opts.entry_maker or make_entry.gen_from_string(opts)
 
   local fn_command = function(prompt)
     local command_list = opts.command_generator(prompt)

--- a/lua/telescope/finders/async_oneshot_finder.lua
+++ b/lua/telescope/finders/async_oneshot_finder.lua
@@ -9,7 +9,7 @@ local await_count = 1000
 return function(opts)
   opts = opts or {}
 
-  local entry_maker = opts.entry_maker or make_entry.gen_from_string
+  local entry_maker = opts.entry_maker or make_entry.gen_from_string(opts)
   local cwd = opts.cwd
   local env = opts.env
   local fn_command = assert(opts.fn_command, "Must pass `fn_command`")

--- a/lua/telescope/finders/async_static_finder.lua
+++ b/lua/telescope/finders/async_static_finder.lua
@@ -10,7 +10,7 @@ return function(opts)
     input_results = opts.results
   end
 
-  local entry_maker = opts.entry_maker or make_entry.gen_from_string()
+  local entry_maker = opts.entry_maker or make_entry.gen_from_string(opts)
 
   local results = {}
   for k, v in ipairs(input_results) do


### PR DESCRIPTION
# Description

Not setting entry_maker explicitly should fallback gracefully, Currently, it doesn't work, because
it's being set to make_entry.gen_from_string and make_entry.gen_from_string is entry_maker factory.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran a script:

```lua
  pickers.new(opts, {
    finder = finders.new_dynamic({fn=function(_)
      return {"a","b","c"}
    end}):find()
```

**Configuration**:
* Neovim version 0.7.2
* Operating system and version: Ubuntu 20.04

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
