### PR TITLE
fix(buffer_previewer): terminal path validation

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -462,13 +462,18 @@ previewers.vimgrep = defaulter(function(opts)
     end,
 
     define_preview = function(self, entry, status)
-      local p = from_entry.path(entry, true)
-      if p == nil or p == "" then
-        return
+      -- bypass path validation for terminal buffers that don't have appropriate path
+      local has_buftype = vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= ""
+      local p
+      if not has_buftype then
+        p = from_entry.path(entry, true)
+        if p == nil or p == "" then
+          return
+        end
       end
 
       -- Workaround for unnamed buffer when using builtin.buffer
-      if entry.bufnr and (p == "[No Name]" or vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= "") then
+      if entry.bufnr and (p == "[No Name]" or has_buftype) then
         local lines = vim.api.nvim_buf_get_lines(entry.bufnr, 0, -1, false)
         vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
         jump_to_line(self, self.state.bufnr, entry.lnum)


### PR DESCRIPTION
# Description

Recent regression of path validation affects terminal buffer preview as terminal buffers always return invalid paths.

Fixes # (issue)

Reddit issue @siduck

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Create terminal buffer and open `:Telescope buffers`. It now shows up again.

**Configuration**:
Irrelevant

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

