### PR TITLE
Expand tilde in path because path in filereadable and isdirectory is used as is

### DIFF
--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -24,6 +24,7 @@ function from_entry.path(entry, validate, escape)
     return
   end
 
+  path = vim.fn.fnamemodify(path, ":p")
   -- only 0 if neither filereadable nor directory
   local invalid = vim.fn.filereadable(path) + vim.fn.isdirectory(path)
   if validate and invalid == 0 then


### PR DESCRIPTION
# Description
For pickers that can generate entries with absolute paths containing a tilde, the previewer will fail.
This is because ~ isn't expanded in filereadable and isdirectory and take the path at face value.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have tested this on some previewers that uses from_entry
- [x] vimgrep
- [x] git_file_diff

And now the pickers give the correct preview.