### PR TITLE
Fix to find_files to force color=never

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -181,11 +181,11 @@ files.find_files = function(opts)
       end
       return opts.find_command
     elseif 1 == vim.fn.executable "rg" then
-      return { "rg", "--files" }
+      return { "rg", "--files", "--color", "never" }
     elseif 1 == vim.fn.executable "fd" then
-      return { "fd", "--type", "f" }
+      return { "fd", "--type", "f", "--color", "never" }
     elseif 1 == vim.fn.executable "fdfind" then
-      return { "fdfind", "--type", "f" }
+      return { "fdfind", "--type", "f", "--color", "never" }
     elseif 1 == vim.fn.executable "find" and vim.fn.has "win32" == 0 then
       return { "find", ".", "-type", "f" }
     elseif 1 == vim.fn.executable "where" then


### PR DESCRIPTION
# Description

```find_files``` currently returns syntax color characters appended to file names, breaking ability within telescope to open a file from find_files and breaking syntax highlighting in find_files

Fixes #2128

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Test A - Manual - Ran:
``` lua require("telescope.builtin").find_files { find_command = { "rg", "--color=never", "--files" }, }``` which does not include the extra characters. 

**Configuration**:
* Neovim version (nvim --version): 
NVIM v0.8.0-dev
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
* Operating system and version:
macOS 12.5
# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
