### PR TITLE
Add drop command for buffers

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -67,6 +67,7 @@ end
 local edit_buffer
 do
   local map = {
+    drop = "drop",
     edit = "buffer",
     new = "sbuffer",
     vnew = "vert sbuffer",

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -79,7 +79,11 @@ do
     if command == nil then
       error "There was no associated buffer command"
     end
-    vim.cmd(string.format("%s %d", command, bufnr))
+    if command ~= "drop" then
+      vim.cmd(string.format("%s %d", command, bufnr))
+    else
+      vim.cmd(string.format("%s %s", command, vim.api.nvim_buf_get_name(bufnr)))
+    end
   end
 end
 


### PR DESCRIPTION
# Description

Adds vim's `drop` command for opening buffers:

> :dr[op] [[++opt]](https://vimhelp.org/editing.txt.html#%5B%2B%2Bopt%5D) [[+cmd]](https://vimhelp.org/editing.txt.html#%5B%2Bcmd%5D) [{file}](https://vimhelp.org/editing.txt.html#%7Bfile%7D) ..
                Edit the first [{file}](https://vimhelp.org/editing.txt.html#%7Bfile%7D) in [a](https://vimhelp.org/insert.txt.html#a) window.
                [-](https://vimhelp.org/motion.txt.html#-) If the file [is](https://vimhelp.org/motion.txt.html#is) [a](https://vimhelp.org/insert.txt.html#a)lready open in a [window](https://vimhelp.org/windows.txt.html#window) change to that
                  window.
                [-](https://vimhelp.org/motion.txt.html#-) If the file [is](https://vimhelp.org/motion.txt.html#is) not open in [a](https://vimhelp.org/insert.txt.html#a) [window](https://vimhelp.org/windows.txt.html#window) edit the file in the
                  current window.  If the current buffer can't be [abandon](https://vimhelp.org/editing.txt.html#abandon)ed,
                  the [window](https://vimhelp.org/windows.txt.html#window) [is](https://vimhelp.org/motion.txt.html#is) split first.
                [-](https://vimhelp.org/motion.txt.html#-) Windows that are not in the argument [list](https://vimhelp.org/eval.txt.html#list) or are not full
                  width will be closed if possible.
                The [argument-list](https://vimhelp.org/editing.txt.html#argument-list) [is](https://vimhelp.org/motion.txt.html#is) set, like with the [:next](https://vimhelp.org/editing.txt.html#%3Anext) command.
                The purpose of th[is](https://vimhelp.org/motion.txt.html#is) command is that [it](https://vimhelp.org/motion.txt.html#it) c[a](https://vimhelp.org/insert.txt.html#a)n be used from [a](https://vimhelp.org/insert.txt.html#a)
                program that wants Vim to edit another file, e.g., a debugger.
                When using the [:tab](https://vimhelp.org/tabpage.txt.html#%3Atab) modifier each argument [is](https://vimhelp.org/motion.txt.html#is) opened in [a](https://vimhelp.org/insert.txt.html#a)
                [tab](https://vimhelp.org/intro.txt.html#tab) page.  The last [window](https://vimhelp.org/windows.txt.html#window) [is](https://vimhelp.org/motion.txt.html#is) used if it's empty.
                Also see [++opt](https://vimhelp.org/editing.txt.html#%2B%2Bopt) and [+cmd](https://vimhelp.org/editing.txt.html#%2Bcmd)[.](https://vimhelp.org/repeat.txt.html#.)

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Added a call to `require"telescope.actions.set".edit(bufnr, "drop")` for my buffers mapping.
- Executed mapping on a selected buffer in the Telescope buffers list.

**Configuration**:
* Neovim version (nvim --version): v0.7.2
* Operating system and version: Windows 11

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
