### PR TITLE
feat(picker): command history filter

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1213,6 +1213,10 @@ builtin.command_history({opts})          *telescope.builtin.command_history()*
     Parameters: ~
         {opts} (table)  options to pass to the picker
 
+    Options: ~
+        {filter_fn} (function)  filter fn(cmd:string). true if the history
+                                command should be presented.
+
 
 builtin.search_history({opts})            *telescope.builtin.search_history()*
     Lists searches that were executed recently, and reruns them on `<cr>`

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -544,10 +544,20 @@ internal.command_history = function(opts)
   local history_list = vim.split(history_string, "\n")
 
   local results = {}
+  local filter_fn = opts.filter_fn
+
   for i = #history_list, 3, -1 do
     local item = history_list[i]
     local _, finish = string.find(item, "%d+ +")
-    table.insert(results, string.sub(item, finish + 1))
+    local cmd = string.sub(item, finish + 1)
+
+    if filter_fn then
+      if filter_fn(cmd) then
+        table.insert(results, cmd)
+      end
+    else
+      table.insert(results, cmd)
+    end
   end
 
   pickers

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -276,6 +276,7 @@ builtin.oldfiles = require_on_exported_call("telescope.builtin.__internal").oldf
 --- - Default keymaps:
 ---   - `<C-e>`: open the command line with the text of the currently selected result populated in it
 ---@param opts table: options to pass to the picker
+---@field filter_fn function: filter fn(cmd:string). true if the history command should be presented.
 builtin.command_history = require_on_exported_call("telescope.builtin.__internal").command_history
 
 --- Lists searches that were executed recently, and reruns them on `<cr>`


### PR DESCRIPTION
# Description

I've recently start using command history. For sometime I was a bit annoyed of unrelevant commands
like edit/write and others (most likely only used once)

I've considered using lua patterns, however, logical `or` isn't a thing. Additionally, passing a list of lua patterns and checking each pattern for each command history entry felt tedious.

This PR introduce a new optional function to filter command history items.

For example, in my configurations

~~~lua
local command_history_ignore = vim.regex "edit\\|Move\\|write\\|Write\\|e\\s\\|lua\\sI("
overrides.command_history = minimal {
  prompt_prefix = "CMDHistory> ",
  filter_fn = function(item)
    if #item < 3 then
      return false
    else
      return not command_history_ignore:match_str(item)
    end
  end,
}
~~~
## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
