### PR TITLE
Update documentation for git_files and live_grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,9 +270,9 @@ Built-in functions. Ready to be bound to any key you like.
 | Functions                           | Description                                                                                                                       |
 |-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | `builtin.find_files`                | Lists files in your current working directory, respects .gitignore                                                                |
-| `builtin.git_files`                 | Fuzzy search through the output of `git ls-files` command, respects .gitignore, optionally ignores untracked files                |
+| `builtin.git_files`                 | Fuzzy search through the output of `git ls-files` command, respects .gitignore                                                    |
 | `builtin.grep_string`               | Searches for the string under your cursor in your current working directory                                                       |
-| `builtin.live_grep`                 | Search for a string in your current working directory and get results live as you type (respecting .gitignore)                    |
+| `builtin.live_grep`                 | Search for a string in your current working directory and get results live as you type, respects .gitignore                       |
 
 ### Vim Pickers
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -765,8 +765,7 @@ options you want to use. Here's an example with the live_grep picker:
 <
 
 builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
-    Search for a string and get results live as you type (respecting
-    .gitignore)
+    Search for a string and get results live as you type, respects .gitignore
 
 
     Parameters: ~
@@ -938,8 +937,7 @@ builtin.current_buffer_tags({opts})  *telescope.builtin.current_buffer_tags()*
 
 builtin.git_files({opts})                      *telescope.builtin.git_files()*
     Fuzzy search for files tracked by Git. This command lists the output of the
-    `git ls-files` command, respects .gitignore, and optionally ignores
-    untracked files
+    `git ls-files` command, respects .gitignore
     - Default keymaps:
       - `<cr>`: opens the currently selected file
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -45,7 +45,7 @@ end
 --
 --
 
---- Search for a string and get results live as you type (respecting .gitignore)
+--- Search for a string and get results live as you type, respects .gitignore
 ---@param opts table: options to pass to the picker
 ---@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
@@ -123,8 +123,8 @@ builtin.current_buffer_tags = require_on_exported_call("telescope.builtin.__file
 --
 --
 
---- Fuzzy search for files tracked by Git. This command lists the output of the `git ls-files` command, respects
---- .gitignore, and optionally ignores untracked files
+--- Fuzzy search for files tracked by Git. This command lists the output of the `git ls-files` command,
+--- respects .gitignore
 --- - Default keymaps:
 ---   - `<cr>`: opens the currently selected file
 ---@param opts table: options to pass to the picker


### PR DESCRIPTION
# Description

- Updating the documentation for `git_files` to match the work done in [PR#842](https://github.com/nvim-telescope/telescope.nvim/pull/842/files).
- Updating the documentation for `live_grep` to match the pattern of the other pickers.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Just searched code base for any documentation that was out of data for `git_files`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
