### PR TITLE
feat(sorters): add highlighter to fuzzy_with_index_bias

### DIFF
--- a/lua/telescope/sorters.lua
+++ b/lua/telescope/sorters.lua
@@ -430,6 +430,7 @@ sorters.fuzzy_with_index_bias = function(opts)
         return math.min(math.pow(entry.index, 0.25), 2) * base_score
       end
     end,
+    highlighter = fuzzy_sorter.highlighter,
   }
 end
 


### PR DESCRIPTION
# Description

`sorters.fuzzy_with_index_bias` was missing highlighter.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

^ I guess it's one of the above? 🤷🏼‍♂️

# How Has This Been Tested?

- [ ] Any picker using `sorters.fuzzy_with_index_bias` should now highlight matched parts

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
