### PR TITLE
Feature: new builtin picker `tabpages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Built-in functions. Ready to be bound to any key you like.
 | Functions                           | Description                                                                                                                                                 |
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `builtin.buffers`                   | Lists open buffers in current neovim instance                                                                                                               |
+| `builtin.tabpages`                  | Lists open windows in each tabpage in current neovim instance, opens selected window on `<cr>`
 | `builtin.oldfiles`                  | Lists previously open files                                                                                                                                 |
 | `builtin.commands`                  | Lists available plugin/user commands and runs them on `<cr>`                                                                                                |
 | `builtin.tags`                      | Lists tags in current directory with tag location file preview (users are required to run ctags -R to generate tags or update when introducing new changes) |

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1302,6 +1302,15 @@ builtin.buffers({opts})                          *telescope.builtin.buffers()*
                                            (default: dynamic)
 
 
+builtin.tabpages({opts})                        *telescope.builtin.tabpages()*
+    Lists open windows in each tabpage in current neovim instance, opens
+    selected window on `<cr>`
+
+
+    Parameters: ~
+        {opts} (table)  options to pass to the picker
+
+
 builtin.colorscheme({opts})                  *telescope.builtin.colorscheme()*
     Lists available colorschemes and applies them on `<cr>`
 

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -920,17 +920,36 @@ internal.tabpages = function(opts)
     return
   end
 
+  local isValidBuffer = function(b)
+    if 1 ~= vim.fn.buflisted(b) then
+      return false
+    end
+    -- only hide unloaded buffers if opts.show_all_buffers is false, keep them listed if true or nil
+    if opts.show_all_buffers == false and not vim.api.nvim_buf_is_loaded(b) then
+      return false
+    end
+    if opts.ignore_current_buffer and b == vim.api.nvim_get_current_buf() then
+      return false
+    end
+    if opts.cwd_only and not string.find(vim.api.nvim_buf_get_name(b), vim.loop.cwd(), 1, true) then
+      return false
+    end
+    return true
+  end
+
   local tabpages = {}
   for tabidx, tabnr in ipairs(tabnrs) do
     for _, bufnr in ipairs(vim.fn.tabpagebuflist(tabnr)) do
-      local flag = bufnr == vim.fn.bufnr "" and "%" or (bufnr == vim.fn.bufnr "#" and "#" or " ")
-      local element = {
-        tabidx = tabidx,
-        bufnr = bufnr,
-        flag = flag,
-        info = vim.fn.getbufinfo(bufnr)[1],
-      }
-      table.insert(tabpages, element)
+      if isValidBuffer(bufnr) then
+        local flag = bufnr == vim.fn.bufnr "" and "%" or (bufnr == vim.fn.bufnr "#" and "#" or " ")
+        local element = {
+          tabidx = tabidx,
+          bufnr = bufnr,
+          flag = flag,
+          info = vim.fn.getbufinfo(bufnr)[1],
+        }
+        table.insert(tabpages, element)
+      end
     end
   end
 

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -920,34 +920,34 @@ internal.tabpages = function(opts)
     return
   end
 
-  local tabpages = {}
+  local wins = {}
   for tabidx, tabnr in ipairs(tabnrs) do
     for _, winnr in ipairs(vim.api.nvim_tabpage_list_wins(tabnr)) do
       local bufnr = vim.api.nvim_win_get_buf(winnr)
       if vim.fn.buflisted(bufnr) == 1 then
         local flag = bufnr == vim.fn.bufnr "" and "%" or (bufnr == vim.fn.bufnr "#" and "#" or " ")
-        local element = {
+        local win = {
           tabidx = tabidx,
           winnr = winnr,
           bufnr = bufnr,
           flag = flag,
           info = vim.fn.getbufinfo(bufnr)[1],
         }
-        table.insert(tabpages, element)
+        table.insert(wins, win)
       end
     end
   end
 
-  if not opts.bufnr_width then
-    local max_bufnr = math.max(unpack(tabnrs))
-    opts.bufnr_width = #tostring(max_bufnr)
+  if not opts.tabidx_width then
+    local max_tabidx = #tabnrs
+    opts.tabidx_width = #tostring(max_tabidx)
   end
 
   pickers
       .new(opts, {
         prompt_title = "Tabpages",
         finder = finders.new_table {
-          results = tabpages,
+          results = wins,
           entry_maker = opts.entry_maker or make_entry.gen_from_tabpage(opts),
         },
         previewer = conf.grep_previewer(opts),

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -920,28 +920,11 @@ internal.tabpages = function(opts)
     return
   end
 
-  local isValidBuffer = function(b)
-    if 1 ~= vim.fn.buflisted(b) then
-      return false
-    end
-    -- only hide unloaded buffers if opts.show_all_buffers is false, keep them listed if true or nil
-    if opts.show_all_buffers == false and not vim.api.nvim_buf_is_loaded(b) then
-      return false
-    end
-    if opts.ignore_current_buffer and b == vim.api.nvim_get_current_buf() then
-      return false
-    end
-    if opts.cwd_only and not string.find(vim.api.nvim_buf_get_name(b), vim.loop.cwd(), 1, true) then
-      return false
-    end
-    return true
-  end
-
   local tabpages = {}
   for tabidx, tabnr in ipairs(tabnrs) do
     for _, winnr in ipairs(vim.api.nvim_tabpage_list_wins(tabnr)) do
       local bufnr = vim.api.nvim_win_get_buf(winnr)
-      if isValidBuffer(bufnr) then
+      if vim.fn.buflisted(bufnr) == 1 then
         local flag = bufnr == vim.fn.bufnr "" and "%" or (bufnr == vim.fn.bufnr "#" and "#" or " ")
         local element = {
           tabidx = tabidx,

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -925,7 +925,7 @@ internal.tabpages = function(opts)
   for tabidx, tabnr in ipairs(tabnrs) do
     -- in each tabpage, iterate through each window
     for _, winnr in ipairs(vim.api.nvim_tabpage_list_wins(tabnr)) do
-      -- then get the corresponding buffer number inside that window 
+      -- then get the corresponding buffer number inside that window
       local bufnr = vim.api.nvim_win_get_buf(winnr)
       -- if a window is holding a listed buffer, it will be added and shown in picker
       -- if multiple windows are holding the same buffer, multiple rows will be shown
@@ -949,27 +949,29 @@ internal.tabpages = function(opts)
   end
 
   pickers
-      .new(opts, {
-        prompt_title = "Tabpages",
-        finder = finders.new_table {
-          results = wins,
-          entry_maker = opts.entry_maker or make_entry.gen_from_tabpage(opts),
-        },
-        previewer = conf.grep_previewer(opts),
-        sorter = conf.generic_sorter(opts),
-        attach_mappings = function(prompt_bufnr)
-          -- default action on <cr> is switch to that tabpage and focus to that window
-          actions.select_default:replace(function()
-            local selection = action_state.get_selected_entry()
-            if selection == nil then return end
-            actions.close(prompt_bufnr)
-            vim.api.nvim_set_current_win(selection.winnr)
-          end)
+    .new(opts, {
+      prompt_title = "Tabpages",
+      finder = finders.new_table {
+        results = wins,
+        entry_maker = opts.entry_maker or make_entry.gen_from_tabpage(opts),
+      },
+      previewer = conf.grep_previewer(opts),
+      sorter = conf.generic_sorter(opts),
+      attach_mappings = function(prompt_bufnr)
+        -- default action on <cr> is switch to that tabpage and focus to that window
+        actions.select_default:replace(function()
+          local selection = action_state.get_selected_entry()
+          if selection == nil then
+            return
+          end
+          actions.close(prompt_bufnr)
+          vim.api.nvim_set_current_win(selection.winnr)
+        end)
 
-          return true
-        end,
-      })
-      :find()
+        return true
+      end,
+    })
+    :find()
 end
 
 internal.colorscheme = function(opts)

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -943,6 +943,16 @@ internal.tabpages = function(opts)
     end
   end
 
+  -- selection index defaults to 1, then try to set it to the current window
+  local default_selection_index = 1
+  local current_winnr = vim.api.nvim_get_current_win()
+  for i, win in ipairs(wins) do
+    if win.winnr == current_winnr then
+      default_selection_index = i
+      break
+    end
+  end
+
   if not opts.tabidx_width then
     local max_tabidx = #tabnrs
     opts.tabidx_width = #tostring(max_tabidx)
@@ -957,6 +967,7 @@ internal.tabpages = function(opts)
       },
       previewer = conf.grep_previewer(opts),
       sorter = conf.generic_sorter(opts),
+      default_selection_index = default_selection_index,
       attach_mappings = function(prompt_bufnr)
         -- default action on <cr> is switch to that tabpage and focus to that window
         actions.select_default:replace(function()

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -921,9 +921,14 @@ internal.tabpages = function(opts)
   end
 
   local wins = {}
+  -- iterate through each tabpage for the current vim instance
   for tabidx, tabnr in ipairs(tabnrs) do
+    -- in each tabpage, iterate through each window
     for _, winnr in ipairs(vim.api.nvim_tabpage_list_wins(tabnr)) do
+      -- then get the corresponding buffer number inside that window 
       local bufnr = vim.api.nvim_win_get_buf(winnr)
+      -- if a window is holding a listed buffer, it will be added and shown in picker
+      -- if multiple windows are holding the same buffer, multiple rows will be shown
       if vim.fn.buflisted(bufnr) == 1 then
         local flag = bufnr == vim.fn.bufnr "" and "%" or (bufnr == vim.fn.bufnr "#" and "#" or " ")
         local win = {
@@ -953,6 +958,7 @@ internal.tabpages = function(opts)
         previewer = conf.grep_previewer(opts),
         sorter = conf.generic_sorter(opts),
         attach_mappings = function(prompt_bufnr)
+          -- default action on <cr> is switch to that tabpage and focus to that window
           actions.select_default:replace(function()
             local selection = action_state.get_selected_entry()
             if selection == nil then return end

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -912,6 +912,75 @@ internal.buffers = function(opts)
     :find()
 end
 
+internal.tabpages = function(opts)
+  opts = apply_cwd_only_aliases(opts)
+  local bufnrs = filter(function(b)
+    if 1 ~= vim.fn.buflisted(b) then
+      return false
+    end
+    -- only hide unloaded buffers if opts.show_all_buffers is false, keep them listed if true or nil
+    if opts.show_all_buffers == false and not vim.api.nvim_buf_is_loaded(b) then
+      return false
+    end
+    if opts.ignore_current_buffer and b == vim.api.nvim_get_current_buf() then
+      return false
+    end
+    if opts.cwd_only and not string.find(vim.api.nvim_buf_get_name(b), vim.loop.cwd(), 1, true) then
+      return false
+    end
+    return true
+  end, vim.api.nvim_list_bufs())
+  if not next(bufnrs) then
+    return
+  end
+  if opts.sort_mru then
+    table.sort(bufnrs, function(a, b)
+      return vim.fn.getbufinfo(a)[1].lastused > vim.fn.getbufinfo(b)[1].lastused
+    end)
+  end
+
+  local tabpages = {}
+  local default_selection_idx = 1
+  for _, bufnr in ipairs(bufnrs) do
+    local flag = bufnr == vim.fn.bufnr "" and "%" or (bufnr == vim.fn.bufnr "#" and "#" or " ")
+
+    if opts.sort_lastused and not opts.ignore_current_buffer and flag == "#" then
+      default_selection_idx = 2
+    end
+
+    local element = {
+      bufnr = bufnr,
+      flag = flag,
+      info = vim.fn.getbufinfo(bufnr)[1],
+    }
+
+    if opts.sort_lastused and (flag == "#" or flag == "%") then
+      local idx = ((tabpages[1] ~= nil and tabpages[1].flag == "%") and 2 or 1)
+      table.insert(tabpages, idx, element)
+    else
+      table.insert(tabpages, element)
+    end
+  end
+
+  if not opts.bufnr_width then
+    local max_bufnr = math.max(unpack(bufnrs))
+    opts.bufnr_width = #tostring(max_bufnr)
+  end
+
+  pickers
+    .new(opts, {
+      prompt_title = "Tabpages",
+      finder = finders.new_table {
+        results = tabpages,
+        entry_maker = opts.entry_maker or make_entry.gen_from_buffer(opts),
+      },
+      previewer = conf.grep_previewer(opts),
+      sorter = conf.generic_sorter(opts),
+      default_selection_index = default_selection_idx,
+    })
+    :find()
+end
+
 internal.colorscheme = function(opts)
   local before_background = vim.o.background
   local before_color = vim.api.nvim_exec("colorscheme", true)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -316,6 +316,8 @@ builtin.reloader = require_on_exported_call("telescope.builtin.__internal").relo
 ---@field bufnr_width number: Defines the width of the buffer numbers in front of the filenames  (default: dynamic)
 builtin.buffers = require_on_exported_call("telescope.builtin.__internal").buffers
 
+--- Lists open windows in each tabpage in current neovim instance, opens selected window on `<cr>`
+---@param opts table: options to pass to the picker
 builtin.tabpages = require_on_exported_call("telescope.builtin.__internal").tabpages
 
 --- Lists available colorschemes and applies them on `<cr>`

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -316,6 +316,8 @@ builtin.reloader = require_on_exported_call("telescope.builtin.__internal").relo
 ---@field bufnr_width number: Defines the width of the buffer numbers in front of the filenames  (default: dynamic)
 builtin.buffers = require_on_exported_call("telescope.builtin.__internal").buffers
 
+builtin.tabpages = require_on_exported_call("telescope.builtin.__internal").tabpages
+
 --- Lists available colorschemes and applies them on `<cr>`
 ---@param opts table: options to pass to the picker
 ---@field enable_preview boolean: if true, will preview the selected color

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -641,7 +641,7 @@ function make_entry.gen_from_tabpage(opts)
   local displayer = entry_display.create {
     separator = " ",
     items = {
-      { width = opts.bufnr_width },
+      { width = opts.tabidx_width },
       { width = 4 },
       { width = icon_width },
       { remaining = true },
@@ -651,8 +651,8 @@ function make_entry.gen_from_tabpage(opts)
   local cwd = vim.fn.expand(opts.cwd or vim.loop.cwd())
 
   local make_display = function(entry)
-    -- bufnr_width + modes + icon + 3 spaces + : + lnum
-    opts.__prefix = opts.bufnr_width + 4 + icon_width + 3 + 1 + #tostring(entry.lnum)
+    -- tabidx_width + modes + icon + 3 spaces + : + lnum
+    opts.__prefix = opts.tabidx_width + 4 + icon_width + 3 + 1 + #tostring(entry.lnum)
     local display_bufname = utils.transform_path(opts, entry.filename)
     local icon, hl_group = utils.get_devicons(entry.filename, disable_devicons)
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -677,7 +677,7 @@ function make_entry.gen_from_tabpage(opts)
 
     return make_entry.set_default_entry_mt({
       value = bufname,
-      ordinal = entry.bufnr .. " : " .. bufname,
+      ordinal = entry.tabidx .. " : " .. bufname,
       display = make_display,
 
       tabidx = entry.tabidx,

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -655,6 +655,7 @@ function make_entry.gen_from_tabpage(opts)
     opts.__prefix = opts.bufnr_width + 4 + icon_width + 3 + 1 + #tostring(entry.lnum)
     local display_bufname = utils.transform_path(opts, entry.filename)
     local icon, hl_group = utils.get_devicons(entry.filename, disable_devicons)
+
     return displayer {
       { entry.tabidx, "TelescopeResultsNumber" },
       { entry.indicator, "TelescopeResultsComment" },
@@ -680,6 +681,8 @@ function make_entry.gen_from_tabpage(opts)
       display = make_display,
 
       tabidx = entry.tabidx,
+      winnr = entry.winnr,
+
       bufnr = entry.bufnr,
       filename = bufname,
       -- account for potentially stale lnum as getbufinfo might not be updated or from resuming buffers picker

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -627,6 +627,68 @@ function make_entry.gen_from_buffer(opts)
   end
 end
 
+function make_entry.gen_from_tabpage(opts)
+  opts = opts or {}
+
+  local disable_devicons = opts.disable_devicons
+
+  local icon_width = 0
+  if not disable_devicons then
+    local icon, _ = utils.get_devicons("fname", disable_devicons)
+    icon_width = strings.strdisplaywidth(icon)
+  end
+
+  local displayer = entry_display.create {
+    separator = " ",
+    items = {
+      { width = opts.bufnr_width },
+      { width = 4 },
+      { width = icon_width },
+      { remaining = true },
+    },
+  }
+
+  local cwd = vim.fn.expand(opts.cwd or vim.loop.cwd())
+
+  local make_display = function(entry)
+    -- bufnr_width + modes + icon + 3 spaces + : + lnum
+    opts.__prefix = opts.bufnr_width + 4 + icon_width + 3 + 1 + #tostring(entry.lnum)
+    local display_bufname = utils.transform_path(opts, entry.filename)
+    local icon, hl_group = utils.get_devicons(entry.filename, disable_devicons)
+    return displayer {
+      { entry.tabidx, "TelescopeResultsNumber" },
+      { entry.indicator, "TelescopeResultsComment" },
+      { icon, hl_group },
+      display_bufname .. ":" .. entry.lnum,
+    }
+  end
+
+  return function(entry)
+    local bufname = entry.info.name ~= "" and entry.info.name or "[No Name]"
+    -- if bufname is inside the cwd, trim that part of the string
+    bufname = Path:new(bufname):normalize(cwd)
+
+    local hidden = entry.info.hidden == 1 and "h" or "a"
+    local readonly = vim.api.nvim_buf_get_option(entry.bufnr, "readonly") and "=" or " "
+    local changed = entry.info.changed == 1 and "+" or " "
+    local indicator = entry.flag .. hidden .. readonly .. changed
+    local line_count = vim.api.nvim_buf_line_count(entry.bufnr)
+
+    return make_entry.set_default_entry_mt({
+      value = bufname,
+      ordinal = entry.bufnr .. " : " .. bufname,
+      display = make_display,
+
+      tabidx = entry.tabidx,
+      bufnr = entry.bufnr,
+      filename = bufname,
+      -- account for potentially stale lnum as getbufinfo might not be updated or from resuming buffers picker
+      lnum = entry.info.lnum ~= 0 and math.max(math.min(entry.info.lnum, line_count), 1) or 1,
+      indicator = indicator,
+    }, opts)
+  end
+end
+
 function make_entry.gen_from_treesitter(opts)
   opts = opts or {}
 


### PR DESCRIPTION
# Description

This PR suggests to add a builtin picker `tabpages`. This picker is similar to the `buffers` picker, but its focus is on tabpages and windows instead. When a neovim user is having many split windows in different tabpages, switching between them using the buffers picker is usually difficult. Instead, by using the new `tabpages` picker, user should be able to switch to the specific window on a specific tabpage. I found this picker very useful when using neovim as an IDE, where different tabpages are usually holding different file types (e.g. js, css, json files on separate tabpages). In this case, switching by the buffers picker will mess up the workspace, and tabpages picker can speed up file switching and preserving the workspace layout.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Tested on multiple split windows over multiple tabpages
- [x] Tested on Manjaro Linux and MacOS

**Configuration**:
* Neovim version (nvim --version): v0.8.0-dev-nightly-6-gbb7853a62
* Operating system and version: Manjaro Ruah 21.3.7 / MacOS 12.5

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
