### PR TITLE
Allow table as additional args in live grep and grep string

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -772,28 +772,28 @@ builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}                 (string)        root dir to search from
-                                              (default: cwd, use
-                                              utils.buffer_dir() to search
-                                              relative to open buffer)
-        {grep_open_files}     (boolean)       if true, restrict search to open
-                                              files only, mutually exclusive
-                                              with `search_dirs`
-        {search_dirs}         (table)         directory/directories/files to
-                                              search, mutually exclusive with
-                                              `grep_open_files`
-        {glob_pattern}        (string|table)  argument to be used with
-                                              `--glob`, e.g. "*.toml", can use
-                                              the opposite "!*.toml"
-        {type_filter}         (string)        argument to be used with
-                                              `--type`, e.g. "rust", see `rg
-                                              --type-list`
-        {additional_args}     (function)      function(opts) which returns a
-                                              table of additional arguments to
-                                              be passed on
-        {max_results}         (number)        define a upper result value
-        {disable_coordinates} (boolean)       don't show the line & row
-                                              numbers (default: false)
+        {cwd}                 (string)          root dir to search from
+                                                (default: cwd, use
+                                                utils.buffer_dir() to search
+                                                relative to open buffer)
+        {grep_open_files}     (boolean)         if true, restrict search to
+                                                open files only, mutually
+                                                exclusive with `search_dirs`
+        {search_dirs}         (table)           directory/directories/files to
+                                                search, mutually exclusive
+                                                with `grep_open_files`
+        {glob_pattern}        (string|table)    argument to be used with
+                                                `--glob`, e.g. "*.toml", can
+                                                use the opposite "!*.toml"
+        {type_filter}         (string)          argument to be used with
+                                                `--type`, e.g. "rust", see `rg
+                                                --type-list`
+        {additional_args}     (function|table)  additional arguments to be
+                                                passed on. Can be fn(opts) ->
+                                                tbl
+        {max_results}         (number)          define a upper result value
+        {disable_coordinates} (boolean)         don't show the line & row
+                                                numbers (default: false)
 
 
 builtin.grep_string({opts})                  *telescope.builtin.grep_string()*
@@ -804,28 +804,30 @@ builtin.grep_string({opts})                  *telescope.builtin.grep_string()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}                 (string)    root dir to search from (default:
-                                          cwd, use utils.buffer_dir() to
-                                          search relative to open buffer)
-        {search}              (string)    the query to search
-        {grep_open_files}     (boolean)   if true, restrict search to open
-                                          files only, mutually exclusive with
-                                          `search_dirs`
-        {search_dirs}         (table)     directory/directories/files to
-                                          search, mutually exclusive with
-                                          `grep_open_files`
-        {use_regex}           (boolean)   if true, special characters won't be
-                                          escaped, allows for using regex
-                                          (default: false)
-        {word_match}          (string)    can be set to `-w` to enable exact
-                                          word matches
-        {additional_args}     (function)  function(opts) which returns a table
-                                          of additional arguments to be passed
-                                          on
-        {disable_coordinates} (boolean)   don't show the line and row numbers
-                                          (default: false)
-        {only_sort_text}      (boolean)   only sort the text, not the file,
-                                          line or row (default: false)
+        {cwd}                 (string)          root dir to search from
+                                                (default: cwd, use
+                                                utils.buffer_dir() to search
+                                                relative to open buffer)
+        {search}              (string)          the query to search
+        {grep_open_files}     (boolean)         if true, restrict search to
+                                                open files only, mutually
+                                                exclusive with `search_dirs`
+        {search_dirs}         (table)           directory/directories/files to
+                                                search, mutually exclusive
+                                                with `grep_open_files`
+        {use_regex}           (boolean)         if true, special characters
+                                                won't be escaped, allows for
+                                                using regex (default: false)
+        {word_match}          (string)          can be set to `-w` to enable
+                                                exact word matches
+        {additional_args}     (function|table)  additional arguments to be
+                                                passed on. Can be fn(opts) ->
+                                                tbl
+        {disable_coordinates} (boolean)         don't show the line and row
+                                                numbers (default: false)
+        {only_sort_text}      (boolean)         only sort the text, not the
+                                                file, line or row (default:
+                                                false)
 
 
 builtin.find_files({opts})                    *telescope.builtin.find_files()*

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -138,8 +138,12 @@ files.grep_string = function(opts)
   local search = opts.use_regex and word or escape_chars(word)
 
   local additional_args = {}
-  if opts.additional_args ~= nil and type(opts.additional_args) == "function" then
-    additional_args = opts.additional_args(opts)
+  if opts.additional_args ~= nil then
+    if type(opts.additional_args) == "function" then
+      additional_args = opts.additional_args(opts)
+    elseif type(opts.additional_args) == "table" then
+      additional_args = opts.additional_args
+    end
   end
 
   if search == "" then

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -76,8 +76,12 @@ files.live_grep = function(opts)
   end
 
   local additional_args = {}
-  if opts.additional_args ~= nil and type(opts.additional_args) == "function" then
-    additional_args = opts.additional_args(opts)
+  if opts.additional_args ~= nil then
+    if type(opts.additional_args) == "function" then
+      additional_args = opts.additional_args(opts)
+    elseif type(opts.additional_args) == "table" then
+      additional_args = opts.additional_args
+    end
   end
 
   if opts.type_filter then

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -52,7 +52,7 @@ end
 ---@field search_dirs table: directory/directories/files to search, mutually exclusive with `grep_open_files`
 ---@field glob_pattern string|table: argument to be used with `--glob`, e.g. "*.toml", can use the opposite "!*.toml"
 ---@field type_filter string: argument to be used with `--type`, e.g. "rust", see `rg --type-list`
----@field additional_args function: function(opts) which returns a table of additional arguments to be passed on
+---@field additional_args function|table: additional arguments to be passed on. Can be fn(opts) -> tbl
 ---@field max_results number: define a upper result value
 ---@field disable_coordinates boolean: don't show the line & row numbers (default: false)
 builtin.live_grep = require_on_exported_call("telescope.builtin.__files").live_grep

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -65,7 +65,7 @@ builtin.live_grep = require_on_exported_call("telescope.builtin.__files").live_g
 ---@field search_dirs table: directory/directories/files to search, mutually exclusive with `grep_open_files`
 ---@field use_regex boolean: if true, special characters won't be escaped, allows for using regex (default: false)
 ---@field word_match string: can be set to `-w` to enable exact word matches
----@field additional_args function: function(opts) which returns a table of additional arguments to be passed on
+---@field additional_args function|table: additional arguments to be passed on. Can be fn(opts) -> tbl
 ---@field disable_coordinates boolean: don't show the line and row numbers (default: false)
 ---@field only_sort_text boolean: only sort the text, not the file, line or row (default: false)
 builtin.grep_string = require_on_exported_call("telescope.builtin.__files").grep_string


### PR DESCRIPTION
# Description

Currently you need to wrap additional arguments for live grep (and grep string) in a function that returns a table. This PR allows using just a table too.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Minimal config:
```lua
require 'telescope'.setup {
  defaults = {
    vimgrep_arguments = { 'rg', '--column' }
  }
}
```

Have hidden and non-hidden files in the current working directory. Open live grep with the options specified in the following tests. 
Search for a hidden file to test if telescope used the specified options for grepping.

- [x] Using a function for additional args still works
```lua
require 'telescope.builtin'.live_grep {
  additional_args = function(opts) return { '--hidden' } end
}
```
- [x] Using a table for additional args now works
```lua
require 'telescope.builtin'.live_grep {
  additional_args = { '--hidden' }
}
```
Test are identical for grep_string.

**Configuration**:
* Neovim version (nvim --version): v0.8.0-dev-788-g0fdf59ac9
* Operating system and version: arch linux 5.19.1-arch2-1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
