### PR TITLE
fix: pickers: Redraw telescope picker always when screen is resized

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -494,7 +494,6 @@ function Picker:find()
     buffer = prompt_bufnr,
     group = "PickerInsert",
     nested = true,
-    once = true,
     callback = function()
       require("telescope.pickers").on_resize_window(prompt_bufnr)
     end,


### PR DESCRIPTION
# Description

Resize telescope picker everytime screen is resized. Currently it set adds once in autocmd opts it triggers only one time


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Open `Telescope find_files`, resize multiple times, it should properly resize

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
