### PR TITLE
feat: added support for tabdrop

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2470,6 +2470,28 @@ actions.select_tab({prompt_bufnr})            *telescope.actions.select_tab()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
+actions.select_drop({prompt_bufnr})          *telescope.actions.select_drop()*
+    Perform 'drop' action on selection, usually something like
+    `:drop <selection>`
+
+    i.e. open the selection in a window
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.select_tab_drop({prompt_bufnr})  *telescope.actions.select_tab_drop()*
+    Perform 'tab drop' action on selection, usually something like
+    `:tab drop <selection>`
+
+    i.e. open the selection in a new tab
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
 actions.file_edit({prompt_bufnr})              *telescope.actions.file_edit()*
     Perform file edit on selection, usually something like
     `:edit <selection>`

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -299,6 +299,23 @@ actions.select_tab = {
   end,
 }
 
+--- Perform 'drop' action on selection, usually something like<br>
+---`:drop <selection>`
+---
+--- i.e. open the selection in a new tab
+---@param prompt_bufnr number: The prompt bufnr
+actions.select_drop = {
+  pre = function(prompt_bufnr)
+    action_state.get_current_history():append(
+      action_state.get_current_line(),
+      action_state.get_current_picker(prompt_bufnr)
+    )
+  end,
+  action = function(prompt_bufnr)
+    return action_set.select(prompt_bufnr, "drop")
+  end,
+}
+
 --- Perform 'tab drop' action on selection, usually something like<br>
 ---`:tab drop <selection>`
 ---

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -329,7 +329,7 @@ actions.select_tab_drop = {
     )
   end,
   action = function(prompt_bufnr)
-    return action_set.select(prompt_bufnr, "tab drop")
+    return action_set.select(prompt_bufnr, "tab_drop")
   end,
 }
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -329,7 +329,7 @@ actions.select_tab_drop = {
     )
   end,
   action = function(prompt_bufnr)
-    return action_set.select(prompt_bufnr, "tab_drop")
+    return action_set.select(prompt_bufnr, "tab drop")
   end,
 }
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -302,7 +302,7 @@ actions.select_tab = {
 --- Perform 'drop' action on selection, usually something like<br>
 ---`:drop <selection>`
 ---
---- i.e. open the selection in a new tab
+--- i.e. open the selection in a window
 ---@param prompt_bufnr number: The prompt bufnr
 actions.select_drop = {
   pre = function(prompt_bufnr)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -306,10 +306,9 @@ actions.select_tab = {
 ---@param prompt_bufnr number: The prompt bufnr
 actions.select_drop = {
   pre = function(prompt_bufnr)
-    action_state.get_current_history():append(
-      action_state.get_current_line(),
-      action_state.get_current_picker(prompt_bufnr)
-    )
+    action_state
+      .get_current_history()
+      :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
   end,
   action = function(prompt_bufnr)
     return action_set.select(prompt_bufnr, "drop")
@@ -323,10 +322,9 @@ actions.select_drop = {
 ---@param prompt_bufnr number: The prompt bufnr
 actions.select_tab_drop = {
   pre = function(prompt_bufnr)
-    action_state.get_current_history():append(
-      action_state.get_current_line(),
-      action_state.get_current_picker(prompt_bufnr)
-    )
+    action_state
+      .get_current_history()
+      :append(action_state.get_current_line(), action_state.get_current_picker(prompt_bufnr))
   end,
   action = function(prompt_bufnr)
     return action_set.select(prompt_bufnr, "tab drop")

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -299,6 +299,23 @@ actions.select_tab = {
   end,
 }
 
+--- Perform 'tab drop' action on selection, usually something like<br>
+---`:tab drop <selection>`
+---
+--- i.e. open the selection in a new tab
+---@param prompt_bufnr number: The prompt bufnr
+actions.select_tab_drop = {
+  pre = function(prompt_bufnr)
+    action_state.get_current_history():append(
+      action_state.get_current_line(),
+      action_state.get_current_picker(prompt_bufnr)
+    )
+  end,
+  action = function(prompt_bufnr)
+    return action_set.select(prompt_bufnr, "tab drop")
+  end,
+}
+
 -- TODO: consider adding float!
 -- https://github.com/nvim-telescope/telescope.nvim/issues/365
 

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -68,6 +68,7 @@ local edit_buffer
 do
   local map = {
     drop = "drop",
+    ["tab drop"] = "tab drop",
     edit = "buffer",
     new = "sbuffer",
     vnew = "vert sbuffer",
@@ -79,7 +80,7 @@ do
     if command == nil then
       error "There was no associated buffer command"
     end
-    if command ~= "drop" then
+    if command ~= "drop" and command ~= "tab drop" then
       vim.cmd(string.format("%s %d", command, bufnr))
     else
       vim.cmd(string.format("%s %s", command, vim.api.nvim_buf_get_name(bufnr)))

--- a/lua/telescope/actions/state.lua
+++ b/lua/telescope/actions/state.lua
@@ -34,7 +34,7 @@ local select_to_edit_map = {
   vertical = "vnew",
   tab = "tabedit",
   drop = "drop",
-  ["tab drop"] = "tab drop",
+  ["tab_drop"] = "tab drop",
 }
 function action_state.select_key_to_edit_key(type)
   return select_to_edit_map[type]

--- a/lua/telescope/actions/state.lua
+++ b/lua/telescope/actions/state.lua
@@ -34,7 +34,7 @@ local select_to_edit_map = {
   vertical = "vnew",
   tab = "tabedit",
   drop = "drop",
-  tab_drop = "tab drop",
+  ["tab drop"] = "tab drop",
 }
 function action_state.select_key_to_edit_key(type)
   return select_to_edit_map[type]

--- a/lua/telescope/actions/state.lua
+++ b/lua/telescope/actions/state.lua
@@ -34,7 +34,7 @@ local select_to_edit_map = {
   vertical = "vnew",
   tab = "tabedit",
   drop = "drop",
-  ["tab_drop"] = "tab drop",
+  tab_drop = "tab drop",
 }
 function action_state.select_key_to_edit_key(type)
   return select_to_edit_map[type]

--- a/lua/telescope/actions/state.lua
+++ b/lua/telescope/actions/state.lua
@@ -33,6 +33,7 @@ local select_to_edit_map = {
   horizontal = "new",
   vertical = "vnew",
   tab = "tabedit",
+  drop = "drop",
   ["tab drop"] = "tab drop",
 }
 function action_state.select_key_to_edit_key(type)

--- a/lua/telescope/actions/state.lua
+++ b/lua/telescope/actions/state.lua
@@ -33,6 +33,7 @@ local select_to_edit_map = {
   horizontal = "new",
   vertical = "vnew",
   tab = "tabedit",
+  ["tab drop"] = "tab drop",
 }
 function action_state.select_key_to_edit_key(type)
   return select_to_edit_map[type]


### PR DESCRIPTION
# Description

This PR adds support for the `tab` modifier of `drop` to open a file in a new tab if it is not currently open in an existing window. Existing functionality did not support the `tab` modifier, so this would always replace the existing window, which was not what was desired for me.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] I referenced `actions.select_tab_drop` in a keymap, and then executed this keymap while Telescope was open for `git_files`

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
