### PR TITLE
fix: remove un-needed check

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -858,9 +858,7 @@ function config.set_defaults(user_defaults, tele_defaults)
     assert(description, "Config values must always have a description")
 
     config.values[name] = get(name, default_val)
-    if description then
-      config.descriptions[name] = strings.dedent(description)
-    end
+    config.descriptions[name] = strings.dedent(description)
   end
 
   for key, info in pairs(tele_defaults) do


### PR DESCRIPTION
# Description
Removing an "if" that is is checking a condition previously tested by the assert().

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Not really tested. Only started the plugin.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.8.0-dev-701-g2a9c9371b 
* Operating system and version: Windows/WSL-Ubuntu 20.04

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
