### PR TITLE
fix(preview): update buffer previewer to upstream changes

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -409,8 +409,12 @@ files.current_buffer_fuzzy_find = function(opts)
         return obj
       end,
     })
+
+    -- update to changes on Neovim master, see https://github.com/neovim/neovim/pull/19931
+    -- TODO(clason): remove when dropping support for Neovim 0.7
+    local on_nvim_master = vim.fn.has "nvim-0.8" == 1
     for id, node in query:iter_captures(root, opts.bufnr, 0, -1) do
-      local hl = highlighter_query:_get_hl_from_capture(id)
+      local hl = on_nvim_master and query.captures[id] or highlighter_query:_get_hl_from_capture(id)
       if hl and type(hl) ~= "number" then
         local row1, col1, row2, col2 = node:range()
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -26,11 +26,6 @@
 --- </code>
 ---@brief ]]
 
-if 1 ~= vim.fn.has "nvim-0.7.0" then
-  vim.api.nvim_err_writeln "Telescope.nvim requires at least nvim-0.7.0. See `:h telescope.changelog-1851`"
-  return
-end
-
 local builtin = {}
 
 -- Ref: https://github.com/tjdevries/lazy.nvim


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/19931 removed `_get_hl_from_capture(id)` since captures are now implicitly mapped to highlight groups with the same name.

Fixes #2149

(PSA: "Neovim master" always means "latest HEAD" -- this will intentionally break on older nightlies.)