### PR TITLE
fix: check for window before scrolling previewer

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -185,13 +185,13 @@ end
 --      Valid directions include: "1", "-1"
 action_set.scroll_previewer = function(prompt_bufnr, direction)
   local previewer = action_state.get_current_picker(prompt_bufnr).previewer
+  local status = state.get_status(prompt_bufnr)
 
-  -- Check if we actually have a previewer
-  if type(previewer) ~= "table" or previewer.scroll_fn == nil then
+  -- Check if we actually have a previewer and a preview window
+  if type(previewer) ~= "table" or previewer.scroll_fn == nil or status.preview_win == nil then
     return
   end
 
-  local status = state.get_status(prompt_bufnr)
   local default_speed = vim.api.nvim_win_get_height(status.preview_win) / 2
   local speed = status.picker.layout_config.scroll_speed or default_speed
 


### PR DESCRIPTION
# Description

This avoids an error when scrolling the preview window but the window is not visible (e.g. due to a screen resize).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually: 
- `:Telescope help_tags` (preview window is shown)
- make the Neovim window smaller so the preview window disappears
- press `<C-d>` to scroll the preview window

Observe no more error. Before this fix, the following error was shown:
```
E5108: Error executing lua ...acker/start/telescope.nvim/lua/telescope/actions/set.lua:195: Expected Lua number     stack traceback:                                                                                                    
        [C]: in function 'nvim_win_get_height'                                                                      
        ...acker/start/telescope.nvim/lua/telescope/actions/set.lua:195: in function 'run_replace_or_original'      
        ...packer/start/telescope.nvim/lua/telescope/actions/mt.lua:65: in function 'scroll_previewer'              
        ...cker/start/telescope.nvim/lua/telescope/actions/init.lua:216: in function 'run_replace_or_original'      
        ...packer/start/telescope.nvim/lua/telescope/actions/mt.lua:65: in function 'key_func'                      
        ...k/packer/start/telescope.nvim/lua/telescope/mappings.lua:341: in function 'execute_keymap'               
        [string ":lua"]:1: in main chunk   
```

**Configuration**:
* Neovim version (nvim --version): NVIM v0.8.0-dev-1020-gea10e0c10  
* Operating system and version: Linux Mint 20.2

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
