### PR TITLE
fix(lsp): don't include current line in lsp_references if current_line=false

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -25,7 +25,7 @@ lsp.references = function(opts)
     local locations = {}
     if result then
       local results = vim.lsp.util.locations_to_items(result, vim.lsp.get_client_by_id(ctx.client_id).offset_encoding)
-      if include_current_line then
+      if not include_current_line then
         locations = vim.tbl_filter(function(v)
           -- Remove current line from result
           return not (v.filename == filepath and v.lnum == lnum)


### PR DESCRIPTION
# Description

Does what it says on the tin really. The current line was being included in the `lsp_references` output, even though `current_line` was `false`. Setting `current_line` to `true` removes the current line.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran both `Telescope lsp_references current_line=false` and `Telescope lsp_references current_line=false` and verified that the current line was included / excluded correctly.

**Configuration**:
* Neovim version (nvim --version): 0.8.0-dev
* Operating system and version: Ubuntu 18.04.6 LTS x86_64

# Checklist:

- [✅] My code follows the style guidelines of this project (stylua)
- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] I have made corresponding changes to the documentation (lua annotations)
