### PR TITLE
fix: builtin register picker better sorting

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -7,7 +7,6 @@ local Path = require "plenary.path"
 local pickers = require "telescope.pickers"
 local previewers = require "telescope.previewers"
 local p_window = require "telescope.pickers.window"
-local sorters = require "telescope.sorters"
 local state = require "telescope.state"
 local utils = require "telescope.utils"
 

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1089,9 +1089,7 @@ internal.registers = function(opts)
         results = registers_table,
         entry_maker = opts.entry_maker or make_entry.gen_from_registers(opts),
       },
-			-- levenshtein doesn't seem to work with ordinal = register content
-			-- so changed to get_generic_fuzzy_sorter
-      sorter = sorters.get_generic_fuzzy_sorter(),
+      sorter = conf.generic_sorter(opts),
       attach_mappings = function(_, map)
         actions.select_default:replace(actions.paste_register)
         map("i", "<C-e>", actions.edit_register)

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1089,8 +1089,9 @@ internal.registers = function(opts)
         results = registers_table,
         entry_maker = opts.entry_maker or make_entry.gen_from_registers(opts),
       },
-      -- use levenshtein as n-gram doesn't support <2 char matches
-      sorter = sorters.get_levenshtein_sorter(),
+			-- levenshtein doesn't seem to work with ordinal = register content
+			-- so changed to get_generic_fuzzy_sorter
+      sorter = sorters.get_generic_fuzzy_sorter(),
       attach_mappings = function(_, map)
         actions.select_default:replace(actions.paste_register)
         map("i", "<C-e>", actions.edit_register)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -792,10 +792,11 @@ function make_entry.gen_from_registers(opts)
   end
 
   return function(entry)
+    local contents = vim.fn.getreg(entry)
     return make_entry.set_default_entry_mt({
       value = entry,
-      ordinal = vim.fn.getreg(entry),
-      content = vim.fn.getreg(entry),
+      ordinal = contents,
+      content = contents,
       display = make_display,
     }, opts)
   end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -794,7 +794,7 @@ function make_entry.gen_from_registers(opts)
   return function(entry)
     return make_entry.set_default_entry_mt({
       value = entry,
-      ordinal = entry,
+      ordinal = vim.fn.getreg(entry),
       content = vim.fn.getreg(entry),
       display = make_display,
     }, opts)


### PR DESCRIPTION
Now using `:Telescope registers` will sort with register content.

# Description

Default `:Telescope registers` does weird stuff like sorting with register names. Change the ordinal to sort on the basis of content of the registers.

This will be much better than the default behaviour I think.

Fixes #(996)
https://github.com/nvim-telescope/telescope.nvim/issues/996

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

😅. I ran it a few times.

**Configuration**:

- Neovim version (v0.8.0-dev-1132-g37a71d1f2):
- Operating system and version: manjaro

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
