### PR TITLE
fix: checktime when git checkout

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -592,6 +592,7 @@ actions.git_checkout = function(prompt_bufnr)
       msg = string.format("Checked out: %s", selection.value),
       level = "INFO",
     })
+    vim.cmd "checktime"
   else
     utils.notify("actions.git_checkout", {
       msg = string.format(
@@ -781,6 +782,7 @@ actions.git_checkout_current_buffer = function(prompt_bufnr)
   end
   actions.close(prompt_bufnr)
   utils.get_os_command_output({ "git", "checkout", selection.value, "--", selection.file }, cwd)
+  vim.cmd "checktime"
 end
 
 --- Stage/unstage selected file


### PR DESCRIPTION
# Description

When perform action `git checkout`, run `checktime` for current buffer to get the new content.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
