### PR TITLE
Search with register name and content in builtin register picker.

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -795,7 +795,7 @@ function make_entry.gen_from_registers(opts)
     local contents = vim.fn.getreg(entry)
     return make_entry.set_default_entry_mt({
       value = entry,
-      ordinal = contents,
+      ordinal = string.format("%s %s", entry, contents),
       content = contents,
       display = make_display,
     }, opts)


### PR DESCRIPTION
# Description

Currently sorting in builtin register picker will sort with the content of the registers only. But searching over registers names is also useful.

Now it will sort over register names and register content


## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


**Configuration**:
* Neovim version (nvim --version) NVIM v0.8.0-dev-1132-g37a71d1f2
* Operating system and version: manjaro

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
