### PR TITLE
feat(git): notify when not in a git repo instead of error

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -392,7 +392,11 @@ local set_opts_cwd = function(opts)
     local in_bare = utils.get_os_command_output({ "git", "rev-parse", "--is-bare-repository" }, opts.cwd)
 
     if in_worktree[1] ~= "true" and in_bare[1] ~= "true" then
-      error(opts.cwd .. " is not a git directory")
+      utils.notify("builtin.git", {
+        msg = opts.cwd .. " is not a git directory",
+        level = "ERROR",
+      })
+      return false
     elseif in_worktree[1] ~= "true" and in_bare[1] == "true" then
       opts.is_bare = true
     end
@@ -401,6 +405,8 @@ local set_opts_cwd = function(opts)
       opts.cwd = git_root[1]
     end
   end
+
+  return true
 end
 
 local function apply_checks(mod)
@@ -408,8 +414,10 @@ local function apply_checks(mod)
     mod[k] = function(opts)
       opts = vim.F.if_nil(opts, {})
 
-      set_opts_cwd(opts)
-      v(opts)
+      local ok = set_opts_cwd(opts)
+      if ok then
+        v(opts)
+      end
     end
   end
 


### PR DESCRIPTION
# Description

Fixes #2180

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] git_files in git repo: works as before
- [x] git_files outside git repo: notification pops-up, Telescope prompt does not show up, no more error

**Configuration**:
* Neovim version (nvim --version): NVIM v0.8.0-dev-1200-gf9228577e
* Operating system and version: Linux Manjaro 22

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
