### PR TITLE
fix: selected icon highlight with color_devicons to false

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -556,7 +556,7 @@ telescope.setup({opts})                                    *telescope.setup()*
                                         *telescope.defaults.color_devicons*
     color_devicons: ~
         Boolean if devicons should be enabled or not. If set to false, the
-        "TelescopeResultsFileIcon" highlight group is used.
+        text highlight group is used.
         Hint: Coloring only works if |termguicolors| is enabled.
 
         Default: true

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -665,7 +665,7 @@ append(
   true,
   [[
   Boolean if devicons should be enabled or not. If set to false, the
-  "TelescopeResultsFileIcon" highlight group is used.
+  text highlight group is used.
   Hint: Coloring only works if |termguicolors| is enabled.
 
   Default: true]]

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -452,7 +452,7 @@ utils.transform_devicons = load_once(function()
       if conf.color_devicons then
         return icon_display, icon_highlight
       else
-        return icon_display, "TelescopeResultsFileIcon"
+        return icon_display, nil
       end
     end
   else
@@ -480,7 +480,7 @@ utils.get_devicons = load_once(function()
       if conf.color_devicons then
         return icon, icon_highlight
       else
-        return icon, "TelescopeResultsFileIcon"
+        return icon, nil
       end
     end
   else

--- a/plugin/telescope.lua
+++ b/plugin/telescope.lua
@@ -82,7 +82,6 @@ local highlights = {
   TelescopeResultsNumber = { default = true, link = "Number" },
   TelescopeResultsComment = { default = true, link = "Comment" },
   TelescopeResultsSpecialComment = { default = true, link = "SpecialComment" },
-  TelescopeResultsFileIcon = { default = true, link = "Normal" },
 
   -- Used for git status Results highlighting
   TelescopeResultsDiffChange = { default = true, link = "DiffChange" },


### PR DESCRIPTION
# Description
The background color is off on selected text

![image](https://user-images.githubusercontent.com/319220/193759245-ae9a9ae8-154e-4c79-a149-c69e5ae8be56.png)

## Type of change
- Bug fix 

![image](https://user-images.githubusercontent.com/319220/193760120-e3d02d37-1f41-4a76-a1b7-6a046e605e55.png)


# How Has This Been Tested?
Locally

**Configuration**:
* Neovim version (nvim --version): `NVIM v0.9.0-dev-16-g56998feeb`
* Operating system and version: Arch Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
