### PR TITLE
Change builtin.diagnostics highlight groups to DiagnosticSign...

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1132,7 +1132,7 @@ function make_entry.gen_from_diagnostics(opts)
     local pos = string.format("%4d:%2d", entry.lnum, entry.col)
     local line_info = {
       (signs and signs[entry.type] .. " " or "") .. pos,
-      "Diagnostic" .. entry.type,
+      "DiagnosticSign" .. entry.type,
     }
 
     return displayer {


### PR DESCRIPTION
# Description

Change `builtin.diagnostics`'s highlight groups to `DiagnosticSign...`

Fixes #2182

## Type of change

- Enhancement

# How Has This Been Tested?

I've been running this locally for a week.

Colorscheme: [gruvbox-material](https://github.com/sainnhe/gruvbox-material)

* Before:
![image](https://user-images.githubusercontent.com/13317164/194699310-4dd3fed8-9c45-41c7-954e-aa20d2139c6f.png)


* After:
![image](https://user-images.githubusercontent.com/13317164/194699315-00dd0c74-66d4-4117-ac05-bc8aa49984e5.png)

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.0-dev-43-g6cd643dbf
* Operating system and version: archlinux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
