### PR TITLE
Add jump_type option for lsp_references

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1420,6 +1420,9 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
                                           lsp references (default: true)
         {include_current_line} (boolean)  include current line (default:
                                           false)
+        {jump_type}            (string)   how to goto reference if there is
+                                          only one, values: "tab", "split",
+                                          "vsplit", "never"
         {fname_width}          (number)   defines the width of the filename
                                           section (default: 30)
         {show_line}            (boolean)  show results text (default: true)

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -39,6 +39,20 @@ lsp.references = function(opts)
       return
     end
 
+    if #locations == 1 and opts.jump_type ~= "never" then
+      if opts.jump_type == "tab" then
+        vim.cmd "tabedit"
+      elseif opts.jump_type == "split" then
+        vim.cmd "new"
+      elseif opts.jump_type == "vsplit" then
+        vim.cmd "vnew"
+      end
+      -- jump to location
+      vim.api.nvim_win_set_buf(0, opts.bufnr)
+      vim.api.nvim_win_set_cursor(0, { locations[1].lnum, locations[1].col - 1 })
+      return
+    end
+
     pickers
       .new(opts, {
         prompt_title = "LSP References",

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -372,6 +372,7 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@param opts table: options to pass to the picker
 ---@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
 ---@field include_current_line boolean: include current line (default: false)
+---@field jump_type string: how to goto reference if there is only one, values: "tab", "split", "vsplit", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)


### PR DESCRIPTION
# Description

Add `jump_type` option to `lsp_references`, since it already exists for other lsp pickers, like `lsp_definitions`.
But the main reason is it was annoying when I know there is only 1 reference, use `lsp_references` and I still get the picker opened instead of immediately jumping to the only reference.

Fixes #2189 (probably)

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

(for all tests `lsp_references = require 'telescope.builtin'.lsp_references`)

- [x] Test A:
```py
def foo(): # cursor is here, `lsp_references {}` jumps to the only result
  foo()
```

- [x] Test B:
```py
def foo(): # cursor is here, `lsp_references { jump_type = 'never' }` opens the picker with 1 result
  foo()
```

- [x] Test C:
```py
def foo(): # cursor is here, `lsp_references { jump_type = 'split' }` splits the window and opens the result
  foo()
```

- [x] Test D:
```py
def bar(): # cursor is here, `lsp_references {}` opens the picker with 2 results
  bar()
  bar()
```


**Configuration**:
* Neovim version (nvim --version): v0.8.0-dev-1093-g982fef601
* Operating system and version: Arch Linux 6.0.5-arch1-1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
