### PR TITLE
feat: the parameter "map" of attach_mappings can be list of modes to create mapping on multiple modes

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1775,6 +1775,11 @@ ordered from the lowest priority to the highest priority.
       map("i", "asdf", function(_prompt_bufnr)
         print "You typed asdf"
       end)
+
+      map({"i", "n"}, "<C-r>", function(_prompt_bufnr)
+        print "You typed <C-r>"
+      end)
+
       -- needs to return true if you want to map default_mappings and
       -- false if not
       return true

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -71,9 +71,9 @@ git.commits = function(opts)
       sorter = conf.file_sorter(opts),
       attach_mappings = function(_, map)
         actions.select_default:replace(actions.git_checkout)
-        map({"i", "n"}, "<c-r>m", actions.git_reset_mixed)
-        map({"i", "n"}, "<c-r>s", actions.git_reset_soft)
-        map({"i", "n"}, "<c-r>h", actions.git_reset_hard)
+        map({ "i", "n" }, "<c-r>m", actions.git_reset_mixed)
+        map({ "i", "n" }, "<c-r>s", actions.git_reset_soft)
+        map({ "i", "n" }, "<c-r>h", actions.git_reset_hard)
         return true
       end,
     })
@@ -290,12 +290,12 @@ git.branches = function(opts)
       sorter = conf.file_sorter(opts),
       attach_mappings = function(_, map)
         actions.select_default:replace(actions.git_checkout)
-        map({"i", "n"}, "<c-t>", actions.git_track_branch)
-        map({"i", "n"}, "<c-r>", actions.git_rebase_branch)
-        map({"i", "n"}, "<c-a>", actions.git_create_branch)
-        map({"i", "n"}, "<c-s>", actions.git_switch_branch)
-        map({"i", "n"}, "<c-d>", actions.git_delete_branch)
-        map({"i", "n"}, "<c-y>", actions.git_merge_branch)
+        map({ "i", "n" }, "<c-t>", actions.git_track_branch)
+        map({ "i", "n" }, "<c-r>", actions.git_rebase_branch)
+        map({ "i", "n" }, "<c-a>", actions.git_create_branch)
+        map({ "i", "n" }, "<c-s>", actions.git_switch_branch)
+        map({ "i", "n" }, "<c-d>", actions.git_delete_branch)
+        map({ "i", "n" }, "<c-y>", actions.git_merge_branch)
         return true
       end,
     })
@@ -354,7 +354,7 @@ git.status = function(opts)
           end,
         }
 
-        map({"i", "n"}, "<tab>", actions.git_staging_toggle)
+        map({ "i", "n" }, "<tab>", actions.git_staging_toggle)
         return true
       end,
     })

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -71,12 +71,9 @@ git.commits = function(opts)
       sorter = conf.file_sorter(opts),
       attach_mappings = function(_, map)
         actions.select_default:replace(actions.git_checkout)
-        map("i", "<c-r>m", actions.git_reset_mixed)
-        map("n", "<c-r>m", actions.git_reset_mixed)
-        map("i", "<c-r>s", actions.git_reset_soft)
-        map("n", "<c-r>s", actions.git_reset_soft)
-        map("i", "<c-r>h", actions.git_reset_hard)
-        map("n", "<c-r>h", actions.git_reset_hard)
+        map({"i", "n"}, "<c-r>m", actions.git_reset_mixed)
+        map({"i", "n"}, "<c-r>s", actions.git_reset_soft)
+        map({"i", "n"}, "<c-r>h", actions.git_reset_hard)
         return true
       end,
     })
@@ -293,23 +290,12 @@ git.branches = function(opts)
       sorter = conf.file_sorter(opts),
       attach_mappings = function(_, map)
         actions.select_default:replace(actions.git_checkout)
-        map("i", "<c-t>", actions.git_track_branch)
-        map("n", "<c-t>", actions.git_track_branch)
-
-        map("i", "<c-r>", actions.git_rebase_branch)
-        map("n", "<c-r>", actions.git_rebase_branch)
-
-        map("i", "<c-a>", actions.git_create_branch)
-        map("n", "<c-a>", actions.git_create_branch)
-
-        map("i", "<c-s>", actions.git_switch_branch)
-        map("n", "<c-s>", actions.git_switch_branch)
-
-        map("i", "<c-d>", actions.git_delete_branch)
-        map("n", "<c-d>", actions.git_delete_branch)
-
-        map("i", "<c-y>", actions.git_merge_branch)
-        map("n", "<c-y>", actions.git_merge_branch)
+        map({"i", "n"}, "<c-t>", actions.git_track_branch)
+        map({"i", "n"}, "<c-r>", actions.git_rebase_branch)
+        map({"i", "n"}, "<c-a>", actions.git_create_branch)
+        map({"i", "n"}, "<c-s>", actions.git_switch_branch)
+        map({"i", "n"}, "<c-d>", actions.git_delete_branch)
+        map({"i", "n"}, "<c-y>", actions.git_merge_branch)
         return true
       end,
     })
@@ -368,8 +354,7 @@ git.status = function(opts)
           end,
         }
 
-        map("i", "<tab>", actions.git_staging_toggle)
-        map("n", "<tab>", actions.git_staging_toggle)
+        map({"i", "n"}, "<tab>", actions.git_staging_toggle)
         return true
       end,
     })

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -198,7 +198,7 @@ internal.pickers = function(opts)
           opts["initial_mode"] = cached_pickers[selection_index].initial_mode
           internal.resume(opts)
         end)
-        map({"i", "n"}, "<C-x>", actions.remove_selected_picker)
+        map({ "i", "n" }, "<C-x>", actions.remove_selected_picker)
         return true
       end,
     })
@@ -555,8 +555,8 @@ internal.command_history = function(opts)
       sorter = conf.generic_sorter(opts),
 
       attach_mappings = function(_, map)
-        map({"i", "n"}, "<CR>", actions.set_command_line)
-        map({"i", "n"}, "<C-e>", actions.edit_command_line)
+        map({ "i", "n" }, "<CR>", actions.set_command_line)
+        map({ "i", "n" }, "<C-e>", actions.edit_command_line)
 
         -- TODO: Find a way to insert the text... it seems hard.
         -- map('i', '<C-i>', actions.insert_value, { expr = true })
@@ -585,8 +585,8 @@ internal.search_history = function(opts)
       sorter = conf.generic_sorter(opts),
 
       attach_mappings = function(_, map)
-        map({"i", "n"}, "<CR>", actions.set_search_line)
-        map({"i", "n"}, "<C-e>", actions.edit_search_line)
+        map({ "i", "n" }, "<CR>", actions.set_search_line)
+        map({ "i", "n" }, "<C-e>", actions.edit_search_line)
 
         -- TODO: Find a way to insert the text... it seems hard.
         -- map('i', '<C-i>', actions.insert_value, { expr = true })
@@ -1086,7 +1086,7 @@ internal.registers = function(opts)
       sorter = conf.generic_sorter(opts),
       attach_mappings = function(_, map)
         actions.select_default:replace(actions.paste_register)
-        map({"i", "n"}, "<C-e>", actions.edit_register)
+        map({ "i", "n" }, "<C-e>", actions.edit_register)
 
         return true
       end,

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -198,8 +198,7 @@ internal.pickers = function(opts)
           opts["initial_mode"] = cached_pickers[selection_index].initial_mode
           internal.resume(opts)
         end)
-        map("i", "<C-x>", actions.remove_selected_picker)
-        map("n", "<C-x>", actions.remove_selected_picker)
+        map({"i", "n"}, "<C-x>", actions.remove_selected_picker)
         return true
       end,
     })
@@ -556,10 +555,8 @@ internal.command_history = function(opts)
       sorter = conf.generic_sorter(opts),
 
       attach_mappings = function(_, map)
-        map("i", "<CR>", actions.set_command_line)
-        map("n", "<CR>", actions.set_command_line)
-        map("n", "<C-e>", actions.edit_command_line)
-        map("i", "<C-e>", actions.edit_command_line)
+        map({"i", "n"}, "<CR>", actions.set_command_line)
+        map({"i", "n"}, "<C-e>", actions.edit_command_line)
 
         -- TODO: Find a way to insert the text... it seems hard.
         -- map('i', '<C-i>', actions.insert_value, { expr = true })
@@ -588,10 +585,8 @@ internal.search_history = function(opts)
       sorter = conf.generic_sorter(opts),
 
       attach_mappings = function(_, map)
-        map("i", "<CR>", actions.set_search_line)
-        map("n", "<CR>", actions.set_search_line)
-        map("n", "<C-e>", actions.edit_search_line)
-        map("i", "<C-e>", actions.edit_search_line)
+        map({"i", "n"}, "<CR>", actions.set_search_line)
+        map({"i", "n"}, "<C-e>", actions.edit_search_line)
 
         -- TODO: Find a way to insert the text... it seems hard.
         -- map('i', '<C-i>', actions.insert_value, { expr = true })
@@ -1091,7 +1086,7 @@ internal.registers = function(opts)
       sorter = conf.generic_sorter(opts),
       attach_mappings = function(_, map)
         actions.select_default:replace(actions.paste_register)
-        map("i", "<C-e>", actions.edit_register)
+        map({"i", "n"}, "<C-e>", actions.edit_register)
 
         return true
       end,

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -112,6 +112,11 @@
 ---       map("i", "asdf", function(_prompt_bufnr)
 ---         print "You typed asdf"
 ---       end)
+---
+---       map({"i", "n"}, "<C-r>", function(_prompt_bufnr)
+---         print "You typed <C-r>"
+---       end)
+---
 ---       -- needs to return true if you want to map default_mappings and
 ---       -- false if not
 ---       return true

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -284,12 +284,16 @@ end
 mappings.apply_keymap = function(prompt_bufnr, attach_mappings, buffer_keymap)
   local applied_mappings = { n = {}, i = {} }
 
-  local map = function(mode, key_bind, key_func, opts)
-    mode = string.lower(mode)
-    local key_bind_internal = a.nvim_replace_termcodes(key_bind, true, true, true)
-    applied_mappings[mode][key_bind_internal] = true
+  local map = function(modes, key_bind, key_func, opts)
+    if type(modes) == "string" then modes = { modes } end
 
-    telescope_map(prompt_bufnr, mode, key_bind, key_func, opts)
+    for _, mode in pairs(modes) do
+      mode = string.lower(mode)
+      local key_bind_internal = a.nvim_replace_termcodes(key_bind, true, true, true)
+      applied_mappings[mode][key_bind_internal] = true
+
+      telescope_map(prompt_bufnr, mode, key_bind, key_func, opts)
+    end
   end
 
   if attach_mappings then

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -285,7 +285,9 @@ mappings.apply_keymap = function(prompt_bufnr, attach_mappings, buffer_keymap)
   local applied_mappings = { n = {}, i = {} }
 
   local map = function(modes, key_bind, key_func, opts)
-    if type(modes) == "string" then modes = { modes } end
+    if type(modes) == "string" then
+      modes = { modes }
+    end
 
     for _, mode in pairs(modes) do
       mode = string.lower(mode)


### PR DESCRIPTION
# Description

like vim.keymap.set

Example:

```lua
attach_mappings = function(prompt_bufnr, map)
  map({ 'i', 'n' }, '<C-r>', function() end)
end
```

and refactor: merge map("i") and map("n") into map({"i", "n"}) in telescope/builtin

## Type of change

- New feature (non-breaking change which adds functionality)

**Configuration**:
* Neovim version (nvim --version):

NVIM v0.8.0
Build type: Release
LuaJIT 2.1.0-beta3

* Operating system and version:

MacOS 12.2 (Apple M1 Pro)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)

