### PR TITLE
fix(actions): support commands with special chars

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -394,13 +394,14 @@ end
 
 local set_edit_line = function(prompt_bufnr, fname, prefix, postfix)
   postfix = vim.F.if_nil(postfix, "")
+  postfix = a.nvim_replace_termcodes(postfix, true, false, true)
   local selection = action_state.get_selected_entry()
   if selection == nil then
     utils.__warn_no_selection(fname)
     return
   end
   actions.close(prompt_bufnr)
-  a.nvim_feedkeys(a.nvim_replace_termcodes(prefix .. selection.value .. postfix, true, false, true), "t", true)
+  a.nvim_feedkeys(prefix .. selection.value .. postfix, "n", true)
 end
 
 --- Set a value in the command line and dont run it, making it editable.


### PR DESCRIPTION
# Description

It is inconvenient that commands containing strings such as `<CR>` cannot be edited using `<C-e>`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Execute a command containing `<CR>` (e.g. `nnoremap <CR> <CR>`) to add it to the history, select the command in `Telescope command_history`, and press `<C-e>`.
This PR makes correctly enter the four characters `<CR>` into the cmdline.

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
