### PR TITLE
Fixes not changing files when request only returns 1 result

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -48,8 +48,13 @@ lsp.references = function(opts)
         vim.cmd "vnew"
       end
       -- jump to location
-      vim.api.nvim_win_set_buf(0, opts.bufnr)
-      vim.api.nvim_win_set_cursor(0, { locations[1].lnum, locations[1].col - 1 })
+      local location = locations[1]
+      local bufnr = opts.bufnr
+      if location.filename then
+        bufnr = vim.uri_to_bufnr(vim.uri_from_fname(location.filename))
+      end
+      vim.api.nvim_win_set_buf(0, bufnr)
+      vim.api.nvim_win_set_cursor(0, { location.lnum, location.col - 1 })
       return
     end
 


### PR DESCRIPTION
# Description

When using `telescope.lsp_references` and there are only 2 references (the one where the cursor is on, and another one), telescope will try to jump to the other location without showing a picker. But if the reference is in another file, it will just put the cursor in the correct row/column, but it will stay in the same buffer/file.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I called `telescope.lsp_reference` on a symbol that has 2 references, the one where the cursor is, and one in a different file. After this change, it jumps to the other file, before the change, it did not.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.0-dev-5e1687e-dirty
* Operating system and version: Archlinux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
