### PR TITLE
Allow `entry_maker` to return a flag to denote entries type

### DIFF
--- a/lua/telescope/finders/async_job_finder.lua
+++ b/lua/telescope/finders/async_job_finder.lua
@@ -57,8 +57,14 @@ return function(opts)
     }
 
     for line in stdout:iter(true) do
-      if process_result(entry_maker(line)) then
-        return
+      local entries, consider_multiple = entry_maker(line)
+      if not consider_multiple then
+        entries = { entries }
+      end
+      for _, entry in ipairs(entries) do
+        if process_result(entry) then
+          return
+        end
       end
     end
 


### PR DESCRIPTION
# Description
What the tittle says.

This is useful when one is creating a live_grep like picker that makes a request to some url that returns a single json array with multiple entries. From the perspective of the oneshot job, the json is on a single line and has to be considered as a single entry, however this might not be what we actually want. Instead, we might want to parse the json and return *multiple* entries. For instance:
source line : "{someArray: [1, 2, 3]}" -> wanted entries : 1, 2, 3

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

I tested this with `curl` as a command that makes request to an http endpoint that returns a json. Also tested other pickers like live_grep, find_files, lsp pickers etc.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Test A
- [ ] Test B

**Configuration**:
* Neovim version (nvim --version):
```
nvim --version
NVIM v0.9.0-dev-213+gcc5b7368d
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
Compilation: /usr/bin/cc -DNVIM_TS_HAS_SET_MATCH_LIMIT -DNVIM_TS_HAS_SET_ALLOCATOR -O2 -g -Og -g -Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion -Wdouble-promotion -Wmissing-noreturn -Wmissing-format-attribute -Wmissing-prototypes -Wimplicit-fallthrough -Wvla -fstack-protector-strong -fno-common -fdiagnostics-color=auto -DINCLUDE_GENERATED_DECLARATIONS -D_GNU_SOURCE -DNVIM_MSGPACK_HAS_FLOAT32 -DNVIM_UNIBI_HAS_VAR_FROM -DMIN_LOG_LEVEL=3 -I/home/dsych/.local/source/neovim/build/cmake.config -I/home/dsych/.local/source/neovim/src -I/home/dsych/.local/source/neovim/.deps/usr/include -I/usr/include -I/home/dsych/.local/source/neovim/build/src/nvim/auto -I/home/dsych/.local/source/neovim/build/include
Compiled by 

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/local/share/nvim"

Run :checkhealth for more info
```
* Operating system and version:
`Amazon Linux 2`

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
