### PR TITLE
Draft: Sort branches by authordate

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -200,8 +200,10 @@ git.branches = function(opts)
     .. "%(authorname)"
     .. "%(upstream:lstrip=2)"
     .. "%(committerdate:format-local:%Y/%m/%d %H:%M:%S)"
-  local output =
-    utils.get_os_command_output({ "git", "for-each-ref", "--perl", "--format", format, "--sort", "-authordate", opts.pattern }, opts.cwd)
+  local output = utils.get_os_command_output(
+    { "git", "for-each-ref", "--perl", "--format", format, "--sort", "-authordate", opts.pattern },
+    opts.cwd
+  )
 
   local results = {}
   local widths = {

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -201,7 +201,7 @@ git.branches = function(opts)
     .. "%(upstream:lstrip=2)"
     .. "%(committerdate:format-local:%Y/%m/%d %H:%M:%S)"
   local output =
-    utils.get_os_command_output({ "git", "for-each-ref", "--perl", "--format", format, opts.pattern }, opts.cwd)
+    utils.get_os_command_output({ "git", "for-each-ref", "--perl", "--format", format, "--sort", "-authordate", opts.pattern }, opts.cwd)
 
   local results = {}
   local widths = {


### PR DESCRIPTION
# Description

This pull request sorts the git branches picker by authordate. It is in a draft state however, since the sorting gets lost on input and I feel this is not the "telescope-way" of handling sorting. I feel i should probably annotate some sort of info to the data that gets picked and sort the picker itself based on this, rater than sorting via git's `--sort` flag.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've used it locally for some weeks.

**Configuration**:
nvim version:
NVIM v0.9.0-dev-1536+gfa7e1e260-dirty                                                                                                                                                       
Build type: Release                                                                                                                                                                         
LuaJIT 2.1.0-beta3                                                                                                                                                                          
                                                                                                                                                                                            
Features: +acl +iconv +tui              
* Operating system and version:
macOS 12.6

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
