### PR TITLE
Add treesitter as a required dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ latest neovim nightly commit is required for `telescope.nvim` to work.
 ### Required dependencies
 
 - [nvim-lua/plenary.nvim](https://github.com/nvim-lua/plenary.nvim) is required.
+- [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) is required.
 
 ### Suggested dependencies
 
@@ -65,7 +66,6 @@ wiki.
 ### Optional dependencies
 
 - [sharkdp/fd](https://github.com/sharkdp/fd) (finder)
-- [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) (finder/preview)
 - [neovim LSP]( https://neovim.io/doc/user/lsp.html) (picker)
 - [devicons](https://github.com/kyazdani42/nvim-web-devicons) (icons)
 
@@ -99,7 +99,7 @@ Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
 use {
   'nvim-telescope/telescope.nvim', tag = '0.1.0',
 -- or                            , branch = '0.1.x',
-  requires = { {'nvim-lua/plenary.nvim'} }
+  requires = { {'nvim-lua/plenary.nvim'} , {'nvim-treesitter/nvim-treesitter'} }
 }
 ```
 


### PR DESCRIPTION
# Description

Treesitter is a required dep as shown by checkhealth
![image](https://user-images.githubusercontent.com/79494436/203567316-78da96d2-b309-48d7-ac9c-7a070bbc1ba0.png)

## Type of change

Please delete options that are not relevant.

- This change requires is documentation update