### PR TITLE
fix(builtin.commands): no preview for multiline description commands

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1240,7 +1240,7 @@ function make_entry.gen_from_commands(opts)
       attrs,
       entry.nargs,
       entry.complete or "",
-      entry.definition,
+      entry.definition:gsub("\n", " "),
     }
   end
 


### PR DESCRIPTION
# Description

Currently if you have at least one command with multiline description the preview for `telescope.builtin.commands()` is broken, ie display an _empty looking_ floating picker.

![Screenshot 2022-11-25 at 01 19 22](https://user-images.githubusercontent.com/5817809/203881704-4f5bd2b7-821a-4083-a242-322683ceeb7a.png)

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
-- init.lua
vim.api.nvim_create_user_command('Kek', function() end, {
        desc=[[
        foo
        bar
        baz
        ]]
})
require('telescope.builtin').commands()
```

With this change the commands preview is displayed as expected

**Configuration**:
* Neovim version (nvim --version): 0.8.1
* Operating system and version: Macos

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
