### PR TITLE
feat(picker): keymaps display noremap/buffer indicators and add lhs filter

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1343,10 +1343,12 @@ builtin.keymaps({opts})                          *telescope.builtin.keymaps()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {modes}     (table)    a list of short-named keymap modes to search
-                               (default: { "n", "i", "c", "x" })
-        {show_plug} (boolean)  if true, the keymaps for which the lhs contains
-                               "<Plug>" are also shown (default: true)
+        {modes}      (table)    a list of short-named keymap modes to search
+                                (default: { "n", "i", "c", "x" })
+        {show_plug}  (boolean)  if true, the keymaps for which the lhs contains
+                                "<Plug>" are also shown (default: true)
+        {lhs_filter} (function) filter(lhs:string) -> boolean. true if the
+                                keymap should be shown (optional)
 
 
 builtin.filetypes({opts})                      *telescope.builtin.filetypes()*

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1347,6 +1347,8 @@ builtin.keymaps({opts})                          *telescope.builtin.keymaps()*
                                 (default: { "n", "i", "c", "x" })
         {show_plug}  (boolean)  if true, the keymaps for which the lhs contains
                                 "<Plug>" are also shown (default: true)
+        {only_buf}   (boolean)  if true, only show the buffer-local keymaps
+                                (default: false)
         {lhs_filter} (function) filter(lhs:string) -> boolean. true if the
                                 keymap should be shown (optional)
 

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1108,7 +1108,7 @@ end
 internal.keymaps = function(opts)
   opts.modes = vim.F.if_nil(opts.modes, { "n", "i", "c", "x" })
   opts.show_plug = vim.F.if_nil(opts.show_plug, true)
-  opts.only_buf_local = vim.F.if_nil(opts.only_buf_local, false)
+  opts.only_buf = vim.F.if_nil(opts.only_buf, false)
 
   local keymap_encountered = {} -- used to make sure no duplicates are inserted into keymaps_table
   local keymaps_table = {}
@@ -1134,7 +1134,7 @@ internal.keymaps = function(opts)
   for _, mode in pairs(opts.modes) do
     local global = vim.api.nvim_get_keymap(mode)
     local buf_local = vim.api.nvim_buf_get_keymap(0, mode)
-    if not opts.only_buf_local then
+    if not opts.only_buf then
       extract_keymaps(global)
     end
     extract_keymaps(buf_local)

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1108,6 +1108,7 @@ end
 internal.keymaps = function(opts)
   opts.modes = vim.F.if_nil(opts.modes, { "n", "i", "c", "x" })
   opts.show_plug = vim.F.if_nil(opts.show_plug, true)
+  opts.only_buf_local = vim.F.if_nil(opts.only_buf_local, false)
 
   local keymap_encountered = {} -- used to make sure no duplicates are inserted into keymaps_table
   local keymaps_table = {}
@@ -1133,7 +1134,9 @@ internal.keymaps = function(opts)
   for _, mode in pairs(opts.modes) do
     local global = vim.api.nvim_get_keymap(mode)
     local buf_local = vim.api.nvim_buf_get_keymap(0, mode)
-    extract_keymaps(global)
+    if not opts.only_buf_local then
+      extract_keymaps(global)
+    end
     extract_keymaps(buf_local)
   end
   opts.width_lhs = max_len_lhs + 1

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1119,7 +1119,10 @@ internal.keymaps = function(opts)
       local keymap_key = keymap.buffer .. keymap.mode .. keymap.lhs -- should be distinct for every keymap
       if not keymap_encountered[keymap_key] then
         keymap_encountered[keymap_key] = true
-        if opts.show_plug or not string.find(keymap.lhs, "<Plug>") then
+        if
+          (opts.show_plug or not string.find(keymap.lhs, "<Plug>"))
+          and (not opts.lhs_filter or opts.lhs_filter(keymap.lhs))
+        then
           table.insert(keymaps_table, keymap)
           max_len_lhs = math.max(max_len_lhs, #utils.display_termcodes(keymap.lhs))
         end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -331,6 +331,7 @@ builtin.registers = require_on_exported_call("telescope.builtin.__internal").reg
 ---@param opts table: options to pass to the picker
 ---@field modes table: a list of short-named keymap modes to search (default: { "n", "i", "c", "x" })
 ---@field show_plug boolean: if true, the keymaps for which the lhs contains "<Plug>" are also shown (default: true)
+---@field only_buf boolean: if true, only show the buffer-local keymaps (default: false)
 ---@field lhs_filter function: filter(lhs:string) -> boolean. true if the keymap should be shown (optional)
 builtin.keymaps = require_on_exported_call("telescope.builtin.__internal").keymaps
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -331,6 +331,7 @@ builtin.registers = require_on_exported_call("telescope.builtin.__internal").reg
 ---@param opts table: options to pass to the picker
 ---@field modes table: a list of short-named keymap modes to search (default: { "n", "i", "c", "x" })
 ---@field show_plug boolean: if true, the keymaps for which the lhs contains "<Plug>" are also shown (default: true)
+---@field lhs_filter function: filter(lhs:string) -> boolean. true if the keymap should be shown (optional)
 builtin.keymaps = require_on_exported_call("telescope.builtin.__internal").keymaps
 
 --- Lists all available filetypes, sets currently open buffer's filetype to selected filetype in Telescope on `<cr>`

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -827,11 +827,23 @@ function make_entry.gen_from_keymaps(opts)
     return utils.display_termcodes(entry.lhs)
   end
 
+  local function get_attr(entry)
+    local ret = ""
+    if entry.value.noremap ~= 0 then
+      ret = ret .. "*"
+    end
+    if entry.value.buffer ~= 0 then
+      ret = ret .. "@"
+    end
+    return ret
+  end
+
   local displayer = require("telescope.pickers.entry_display").create {
     separator = "▏",
     items = {
-      { width = 2 },
+      { width = 3 },
       { width = opts.width_lhs },
+      { width = 2 },
       { remaining = true },
     },
   }
@@ -839,6 +851,7 @@ function make_entry.gen_from_keymaps(opts)
     return displayer {
       entry.mode,
       get_lhs(entry),
+      get_attr(entry),
       get_desc(entry),
     }
   end


### PR DESCRIPTION
# Description

## Display indicators
`Telescope keymaps` notice in each keymap entry,  `*` means noremap and `@` meas buffer local. 
see `:h map-listing` about these indicators.
![图片](https://user-images.githubusercontent.com/45989017/204106026-50521cf8-754a-4208-8ab6-bc6afc5ed3fe.png)


## Add lhs filter

Sometimes I want to see only a subset of keymaps, 
1. The lhs of keymap that starts with some chars (this way I can use `require('telescope.builtin').keymaps` as building block for keymap-query helper, you know it, something like emacs' [embark-prefix-help-command](https://github.com/oantolin/embark))
2. The lhs of keymap that NOT contain some chars (this can filter out Dummy/Sentinel keymaps in [which-key.nvim](https://github.com/folke/which-key.nvim/issues/299))
3. Buffer local keymaps (look for them by typing `:map <buffer>`)

To achieve these, this PR introduce two parameters to `Telescope keymaps`, a function called `lhs_filter` and a boolean called `only_buf` (may not a bad name).

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
