### PR TITLE
Add new action to open quickfix window from quickfixhistory

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Built-in functions. Ready to be bound to any key you like.
 | `builtin.marks`                     | Lists vim marks and their value                                                                                                                             |
 | `builtin.colorscheme`               | Lists available colorschemes and applies them on `<cr>`                                                                                                     |
 | `builtin.quickfix`                  | Lists items in the quickfix list                                                                                                                            |
-| `builtin.quickfixhistory`           | Lists all quickfix lists in your history and open them with `builtin.quickfix`                                                                              |
+| `builtin.quickfixhistory`           | Lists all quickfix lists in your history and open them with `builtin.quickfix` or quickfix window                                                           |
 | `builtin.loclist`                   | Lists items from the current window's location list                                                                                                         |
 | `builtin.jumplist`                  | Lists Jump List entries                                                                                                                                     |
 | `builtin.vim_options`               | Lists vim options, allows you to edit the current value on `<cr>`                                                                                           |

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -449,11 +449,18 @@ internal.quickfixhistory = function(opts)
         end,
       },
       sorter = conf.generic_sorter(opts),
-      attach_mappings = function(_, _)
+      attach_mappings = function(_, map)
         action_set.select:replace(function(prompt_bufnr)
           local nr = action_state.get_selected_entry().nr
           actions.close(prompt_bufnr)
           internal.quickfix { nr = nr }
+        end)
+
+        map({ "i", "n" }, "<C-q>", function(prompt_bufnr)
+          local nr = action_state.get_selected_entry().nr
+          actions.close(prompt_bufnr)
+          vim.cmd(nr .. 'chistory')
+          vim.cmd('copen')
         end)
         return true
       end,

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -459,8 +459,8 @@ internal.quickfixhistory = function(opts)
         map({ "i", "n" }, "<C-q>", function(prompt_bufnr)
           local nr = action_state.get_selected_entry().nr
           actions.close(prompt_bufnr)
-          vim.cmd(nr .. 'chistory')
-          vim.cmd('copen')
+          vim.cmd(nr .. "chistory")
+          vim.cmd("copen")
         end)
         return true
       end,

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -460,7 +460,7 @@ internal.quickfixhistory = function(opts)
           local nr = action_state.get_selected_entry().nr
           actions.close(prompt_bufnr)
           vim.cmd(nr .. "chistory")
-          vim.cmd("copen")
+          vim.cmd "copen"
         end)
         return true
       end,


### PR DESCRIPTION
# Description

Add new action "open the qflist" for the quickfixhistory().
I want to open the quickfix within the quick fix window directly from quickfixhistory().

Fixes #2248

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] It can open the quick fix window from the selection by `<C-q>`.
- [x] It can open the builtin.quickfix() from the selection by `<CR>` (not changed).

**Configuration**:
* Neovim version (nvim --version): `NVIM v0.9.0-dev-9d7dc50`
* Operating system and version: `Linux 5.15.74.2-microsoft-standard-WSL2 #1 SMP Wed Nov 2 19:50:29 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
