### PR TITLE
support for multi-part file extensions like *.test.js

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -446,7 +446,8 @@ utils.transform_devicons = load_once(function()
         return display
       end
 
-      local icon, icon_highlight = devicons.get_icon(utils.path_tail(filename), nil, { default = true })
+      local basename = utils.path_tail(filename)
+      local icon, icon_highlight = devicons.get_icon(basename, vim.fn.fnamemodify(basename, ":e:e"), { default = true })
       local icon_display = (icon or " ") .. " " .. (display or "")
 
       if conf.color_devicons then
@@ -476,7 +477,8 @@ utils.get_devicons = load_once(function()
         return ""
       end
 
-      local icon, icon_highlight = devicons.get_icon(utils.path_tail(filename), nil, { default = true })
+      local basename = utils.path_tail(filename)
+      local icon, icon_highlight = devicons.get_icon(basename, vim.fn.fnamemodify(basename, ":e:e"), { default = true })
       if conf.color_devicons then
         return icon, icon_highlight
       else

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -432,6 +432,15 @@ local load_once = function(f)
   end
 end
 
+utils.file_extension = function(filename)
+  local parts = vim.split(filename, "%.")
+  if #parts > 2 then
+    return table.concat(vim.list_slice(parts, #parts - 1), ".")
+  else
+    return table.concat(vim.list_slice(parts, #parts), ".")
+  end
+end
+
 utils.transform_devicons = load_once(function()
   local has_devicons, devicons = pcall(require, "nvim-web-devicons")
 
@@ -448,7 +457,7 @@ utils.transform_devicons = load_once(function()
 
       local basename = utils.path_tail(filename)
       -- the double :e:e gets multipart extensions, if one exists, like *.test.js, for example
-      local icon, icon_highlight = devicons.get_icon(basename, vim.fn.fnamemodify(basename, ":e:e"), { default = true })
+      local icon, icon_highlight = devicons.get_icon(basename, utils.file_extension(basename), { default = true })
       local icon_display = (icon or " ") .. " " .. (display or "")
 
       if conf.color_devicons then
@@ -480,7 +489,7 @@ utils.get_devicons = load_once(function()
 
       local basename = utils.path_tail(filename)
       -- the double :e:e gets multipart extensions, if one exists, like *.test.js, for example
-      local icon, icon_highlight = devicons.get_icon(basename, vim.fn.fnamemodify(basename, ":e:e"), { default = true })
+      local icon, icon_highlight = devicons.get_icon(basename, utils.file_extension(basename), { default = true })
       if conf.color_devicons then
         return icon, icon_highlight
       else

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -447,6 +447,7 @@ utils.transform_devicons = load_once(function()
       end
 
       local basename = utils.path_tail(filename)
+      -- the double :e:e gets multipart extensions, if one exists, like *.test.js, for example
       local icon, icon_highlight = devicons.get_icon(basename, vim.fn.fnamemodify(basename, ":e:e"), { default = true })
       local icon_display = (icon or " ") .. " " .. (display or "")
 
@@ -478,6 +479,7 @@ utils.get_devicons = load_once(function()
       end
 
       local basename = utils.path_tail(filename)
+      -- the double :e:e gets multipart extensions, if one exists, like *.test.js, for example
       local icon, icon_highlight = devicons.get_icon(basename, vim.fn.fnamemodify(basename, ":e:e"), { default = true })
       if conf.color_devicons then
         return icon, icon_highlight

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -434,6 +434,7 @@ end
 
 utils.file_extension = function(filename)
   local parts = vim.split(filename, "%.")
+  -- this check enables us to get multi-part extensions, like *.test.js for example
   if #parts > 2 then
     return table.concat(vim.list_slice(parts, #parts - 1), ".")
   else
@@ -456,7 +457,6 @@ utils.transform_devicons = load_once(function()
       end
 
       local basename = utils.path_tail(filename)
-      -- the double :e:e gets multipart extensions, if one exists, like *.test.js, for example
       local icon, icon_highlight = devicons.get_icon(basename, utils.file_extension(basename), { default = true })
       local icon_display = (icon or " ") .. " " .. (display or "")
 
@@ -488,7 +488,6 @@ utils.get_devicons = load_once(function()
       end
 
       local basename = utils.path_tail(filename)
-      -- the double :e:e gets multipart extensions, if one exists, like *.test.js, for example
       local icon, icon_highlight = devicons.get_icon(basename, utils.file_extension(basename), { default = true })
       if conf.color_devicons then
         return icon, icon_highlight


### PR DESCRIPTION
# Description

Updates code used to get icons from `nvim-web-devicons` to pass the filename as well as extension.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

Set up `nvim-web-devicons` with configuration:

```lua
require('nvim-web-devicons').setup({
  override = {
    ['js'] = {
      icon = '',
      color = '#efd81d',
      cterm_color = '220',
      name = 'Js',
    },
    ['test.js'] = {
      icon = 'ﭧ',
      color = '#ffca28',
      cterm_color = '220',
      name = 'TestJavascript',
    },
  },
})
```

Then create a `*.js` and a `*.test.js` file, and open `:Telescope find_file`, and make sure the icons appear as configured.

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
