### PR TITLE
feat(builtin.buffers): add filter_fn option

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -884,23 +884,25 @@ internal.buffers = function(opts)
   local buffers = {}
   local default_selection_idx = 1
   for _, bufnr in ipairs(bufnrs) do
-    local flag = bufnr == vim.fn.bufnr "" and "%" or (bufnr == vim.fn.bufnr "#" and "#" or " ")
+    if not opts.filter_fn or opts.filter_fn(bufnr) then
+      local flag = bufnr == vim.fn.bufnr "" and "%" or (bufnr == vim.fn.bufnr "#" and "#" or " ")
 
-    if opts.sort_lastused and not opts.ignore_current_buffer and flag == "#" then
-      default_selection_idx = 2
-    end
+      if opts.sort_lastused and not opts.ignore_current_buffer and flag == "#" then
+        default_selection_idx = 2
+      end
 
-    local element = {
-      bufnr = bufnr,
-      flag = flag,
-      info = vim.fn.getbufinfo(bufnr)[1],
-    }
+      local element = {
+        bufnr = bufnr,
+        flag = flag,
+        info = vim.fn.getbufinfo(bufnr)[1],
+      }
 
-    if opts.sort_lastused and (flag == "#" or flag == "%") then
-      local idx = ((buffers[1] ~= nil and buffers[1].flag == "%") and 2 or 1)
-      table.insert(buffers, idx, element)
-    else
-      table.insert(buffers, element)
+      if opts.sort_lastused and (flag == "#" or flag == "%") then
+        local idx = ((buffers[1] ~= nil and buffers[1].flag == "%") and 2 or 1)
+        table.insert(buffers, idx, element)
+      else
+        table.insert(buffers, element)
+      end
     end
   end
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -311,6 +311,7 @@ builtin.reloader = require_on_exported_call("telescope.builtin.__internal").relo
 ---@field sort_lastused boolean: Sorts current and last buffer to the top and selects the lastused (default: false)
 ---@field sort_mru boolean: Sorts all buffers after most recent used. Not just the current and last one (default: false)
 ---@field bufnr_width number: Defines the width of the buffer numbers in front of the filenames  (default: dynamic)
+---@field filter_fn function: filter fn(bufnr:number). true if the buffer should be presented.
 builtin.buffers = require_on_exported_call("telescope.builtin.__internal").buffers
 
 --- Lists available colorschemes and applies them on `<cr>`


### PR DESCRIPTION
# Description

Adds an option `filter_fn` to `telescope.builtins.buffers` to filter out buffers from the picker. `filter_fn` is a function that takes a buffer number and returns `true` if the buffer should be kept.

Some example use-case:

- Search for buffers with the same filetype as current buffer.
- Search for terminal or other special buffers.
- Exclude special buffers from the search.
- Search for buffers with diagnostics.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

With a keymap to test different predicates. For example, do not show terminal buffers:

```lua
vim.api.nvim_set_keymap("<leader>fb", function()
    telescope.buffers({
        attach_mappings = function(_, map)
            map("i", "<C-q>", require("telescope.actions").delete_buffer)
            return true
        end,
        filter_fn = function(bufnr)
            return vim.api.nvim_buf_get_option(bufnr, "buftype") ~= "terminal"
        end,
    })
end)
```

**Configuration**:

- Neovim version (nvim --version): NVIM v0.8.1
- Operating system and version: macOS Ventura 13.0.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
