### PR TITLE
Fix #2157: do not use nvim_buf_line_count on unloaded buffers

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -641,7 +641,18 @@ function make_entry.gen_from_buffer(opts)
     local readonly = vim.api.nvim_buf_get_option(entry.bufnr, "readonly") and "=" or " "
     local changed = entry.info.changed == 1 and "+" or " "
     local indicator = entry.flag .. hidden .. readonly .. changed
-    local line_count = vim.api.nvim_buf_line_count(entry.bufnr)
+    local lnum = 1
+
+    -- account for potentially stale lnum as getbufinfo might not be updated or from resuming buffers picker
+    if entry.info.lnum ~= 0 then
+      -- but make sure the buffer is loaded, otherwise line_count is 0
+      if vim.api.nvim_buf_is_loaded(entry.bufnr) then
+        local line_count = vim.api.nvim_buf_line_count(entry.bufnr)
+        lnum = math.max(math.min(entry.info.lnum, line_count), 1)
+      else
+        lnum = entry.info.lnum
+      end
+    end
 
     return make_entry.set_default_entry_mt({
       value = bufname,
@@ -650,8 +661,7 @@ function make_entry.gen_from_buffer(opts)
 
       bufnr = entry.bufnr,
       filename = bufname,
-      -- account for potentially stale lnum as getbufinfo might not be updated or from resuming buffers picker
-      lnum = entry.info.lnum ~= 0 and math.max(math.min(entry.info.lnum, line_count), 1) or 1,
+      lnum = lnum,
       indicator = indicator,
     }, opts)
   end


### PR DESCRIPTION
# Description

Do not use nvim_buf_line_count on unloaded buffers, as the returned value is always 0

Fixes #2157

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

opening the buffer picker after restoring from a session now remembers last position

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)