### PR TITLE
fix: misidentification invert and files_with_matches (#2240)

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -73,7 +73,9 @@ local opts_contain_invert = function(args)
     if #v >= 2 and v:sub(1, 1) == "-" and v:sub(2, 2) ~= "-" then
       for i = 2, #v do
         local vi = v:sub(i, i)
-        if vi == "v" then
+        if vi == "=" then       -- ignore option -g=xxx
+          break
+        elseif vi == "v" then
           invert = true
         elseif vi == "l" then
           files_with_matches = true


### PR DESCRIPTION
# Description

if rg option '-g=xxxx' contain 'v' or 'l', will misidentification 

Fixes #2240

## Type of change
- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
