### PR TITLE
Added column size options for builtin.commands

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1233,15 +1233,17 @@ function make_entry.gen_from_autocommands(opts)
 end
 
 function make_entry.gen_from_commands(opts)
+  local command_columns = opts.command_columns or {} 
+
   local displayer = entry_display.create {
     separator = "▏",
     items = {
-      { width = 0.2 },
-      { width = 4 },
-      { width = 4 },
-      { width = 11 },
+      { width = command_columns.name or 0.2 },
+      { width = command_columns.attrs or 4 },
+      { width = command_columns.nargs or 4 },
+      { width = command_columns.complete or 11 },
       { remaining = true },
-    },
+    } 
   }
 
   local make_display = function(entry)
@@ -1255,12 +1257,14 @@ function make_entry.gen_from_commands(opts)
     if entry.register then
       attrs = attrs .. '"'
     end
+
     return displayer {
-      { entry.name, "TelescopeResultsIdentifier" },
-      attrs,
-      entry.nargs,
-      entry.complete or "",
-      entry.definition:gsub("\n", " "),
+      command_columns.name ~= 0 and
+      { entry.name, "TelescopeResultsIdentifier" } or nil,
+      command_columns.attrs ~= 0 and attrs or nil,
+      command_columns.nargs ~= 0 and entry.nargs or nil,
+      command_columns.complete ~= 0 and (entry.complete or "") or nil,
+      command_columns.definition ~= 0 and entry.definition:gsub("\n", " ") or nil,
     }
   end
 


### PR DESCRIPTION
# Description

Adds the option to change column sizes using builtin.commands.

For example:
```lua
require("telescope.builtin").commands({command_columns={attrs=2, complete=0, nargs=2, name=25}})
```
If a value of 0 is input the column will not be displayed by the picker. If no value is entered the size will not be changed.

Fixes #2263 

## Type of change

Please delete options that are not relevant.

- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Test A
- [ ] Test B

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.0-dev-414+gef5ab2bf7
* Operating system and version: Debian GNU/Linux 11 (bullseye)

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)