### PR TITLE
Missing binaries causing checkhealth failure

### DIFF
--- a/lua/telescope/health.lua
+++ b/lua/telescope/health.lua
@@ -9,6 +9,7 @@ local optional_dependencies = {
     package = {
       {
         name = "rg",
+        binaries = { "rg" },
         url = "[BurntSushi/ripgrep](https://github.com/BurntSushi/ripgrep)",
         optional = false,
       },


### PR DESCRIPTION
# Description

I am learning to use Neovim and telescope. I followed the README and got stuck with the `checkhealth telescope` command failing because the package dictionary was missing the binaries attribute. I fixed it.

Fixes # (issue)

Added binaries attribute to rg package.

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this locally on my install of neovim.

**Configuration**:
* Neovim version (nvim --version):

> NVIM v0.7.0
> Build type: RelWithDebInfo
> LuaJIT 2.1.0-beta3

* Operating system and version: 

> Fedora 35

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
