### PR TITLE
fix: jump to opened tab instead of opening a duplicate (fixes #2188)

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1292,7 +1292,7 @@ builtin.reloader({opts})                        *telescope.builtin.reloader()*
 
 builtin.buffers({opts})                          *telescope.builtin.buffers()*
     Lists open buffers in current neovim instance, opens selected buffer on
-    `<cr>`
+    `<cr>`. It also focuses already opened files in the tabs by default.
 
 
     Parameters: ~

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -69,7 +69,7 @@ do
   local map = {
     drop = "drop",
     ["tab drop"] = "tab drop",
-    edit = "buffer",
+    edit = "tabnext",
     new = "sbuffer",
     vnew = "vert sbuffer",
     tabedit = "tab sb",


### PR DESCRIPTION
# Description

Jump to already opened file/buffer/tab instead of opening a new one in current tab.

Fixes #2188

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change updates documentation

# How Has This Been Tested?
- [x] `make test`, no new failures besides those in master branch

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.0-dev-3576776
* Operating system and version: [K]ubuntu 22.04.1 LTS x86_64 

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
