### PR TITLE
fix: jumplist picker indexing the line after

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1353,7 +1353,7 @@ internal.jumplist = function(opts)
   local sorted_jumplist = {}
   for i = #jumplist, 1, -1 do
     if vim.api.nvim_buf_is_valid(jumplist[i].bufnr) then
-      jumplist[i].text = vim.api.nvim_buf_get_lines(jumplist[i].bufnr, jumplist[i].lnum, jumplist[i].lnum + 1, false)[1]
+      jumplist[i].text = vim.api.nvim_buf_get_lines(jumplist[i].bufnr, jumplist[i].lnum - 1, jumplist[i].lnum, false)[1]
         or ""
       table.insert(sorted_jumplist, jumplist[i])
     end


### PR DESCRIPTION
# Description

jumplist entry text is currently 1 line after

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```lua
local lnum = 3
print(vim.api.nvim_buf_get_lines(0, lnum, lnum + 1, false)[1])
-- this will give the text of line 4
print(vim.api.nvim_buf_get_lines(0, lnum - 1, lnum, false)[1])
-- this will give the text of line 3
```


**Configuration**:
* Neovim version (nvim --version): v0.8.1
* Operating system and version: Arch

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
