### PR TITLE
fix(builtin.live_grep): add spacer ":" even when coordinates disabled

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           # We have to build the parser every single time to keep up with parser changes
           cd ~/.local/share/nvim/site/pack/vendor/start/tree-sitter-lua
+          git checkout 86f74dfb69c570f0749b241f8f5489f8f50adbea
           make dist
           cd -
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -316,7 +316,7 @@ do
       display = function(entry)
         local display_filename = utils.transform_path(opts, entry.filename)
 
-        local coordinates = ""
+        local coordinates = ":"
         if not disable_coordinates then
           if entry.lnum then
             if entry.col then


### PR DESCRIPTION
# Description

Pretty sure this is my first pull request which only added a single character 🤣 

Fixes #2226

@simonmandlik does this fix your issue?

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] ran `:Telescope live_grep disable_coordinates=true`
- [x] ran `:Telescope live_grep disable_coordinates=false`
- Both worked as expected

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.9.0-dev-522+g174335923
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
Compiled by runneradmin@fv-az211-249
* Operating system and version:
Windows 10

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
