### PR TITLE
feat: add rockspec + luarocks upload workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: "release"
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: leafo/gh-actions-lua@v9
+        with:
+          luaVersion: "luajit-2.1.0-beta3"
+      - uses: leafo/gh-actions-luarocks@v4
+      - name: Install dkjson
+        run: luarocks install dkjson
+      - name: Luarocks Upload
+        env: 
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        run: make luarocks_upload
+      - name: Install release
+        run: make test_luarocks_install 

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,9 @@ lint:
 
 docgen:
 	nvim --headless --noplugin -u scripts/minimal_init.vim -c "luafile ./scripts/gendocs.lua" -c 'qa'
+
+luarocks_upload:
+	bash ./scripts/luarocks-upload.sh
+
+test_luarocks_install:
+	bash ./scripts/test-luarocks-install.sh

--- a/scripts/luarocks-upload.sh
+++ b/scripts/luarocks-upload.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Expects the LUAROCKS_API_KEY secret to be set
+
+TMP_DIR=$(mktemp -d)
+MODREV=$(git describe --tags --always --first-parent | tr -d "v")
+DEST_ROCKSPEC="$TMP_DIR/telescope.nvim-$MODREV-1.rockspec"
+cp "telescope.nvim-scm-1.rockspec" "$DEST_ROCKSPEC"
+sed -i "s/= 'scm'/= '$MODREV'/g" "$DEST_ROCKSPEC"
+luarocks upload "$DEST_ROCKSPEC" --api-key="$LUAROCKS_API_KEY"

--- a/scripts/test-luarocks-install.sh
+++ b/scripts/test-luarocks-install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+MODREV=$(git describe --tags --always --first-parent | tr -d "v")
+luarocks install "telescope.nvim" "$MODREV"

--- a/telescope.nvim-scm-1.rockspec
+++ b/telescope.nvim-scm-1.rockspec
@@ -1,0 +1,44 @@
+local MODREV, SPECREV = 'scm', '-1'
+rockspec_format = '3.0'
+package = 'telescope.nvim'
+version = MODREV .. SPECREV
+
+description = {
+  summary = 'Find, Filter, Preview, Pick. All lua, all the time.',
+  detailed = [[
+  A highly extendable fuzzy finder over lists. 
+  Built on the latest awesome features from neovim core. 
+  Telescope is centered around modularity, allowing for easy customization.
+  ]],
+  labels = { 'neovim', 'plugin', },
+  homepage = 'https://github.com/nvim-telescope/telescope.nvim',
+  license = 'MIT',
+}
+
+dependencies = {
+  'lua == 5.1',
+  'plenary.nvim',
+}
+
+source = {
+  url = 'https://github.com/nvim-telescope/telescope.nvim/archive/refs/tags/' .. MODREV .. '.zip',
+  dir = 'telescope.nvim-' .. MODREV
+}
+
+if MODREV == 'scm' then
+  source = {
+    url = 'git://github.com/nvim-telescope/telescope.nvim',
+  }
+end
+
+build = {
+  type = 'builtin',
+  copy_directories = {
+    'doc',
+    'ftplugin',
+    'plugin',
+    'scripts',
+    'autoload',
+    'data',
+  }
+}


### PR DESCRIPTION
# Description

`telescope.nvim` is a common dependency across Neovim plugins. Using luarocks may alleviate the need for users to specify their plugins' dependencies in their plugin manager.
(e.g., vim-plug or packer).

See also:
https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```console
luarocks install ./telescope.nvim-scm-1.rockspec --local
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
