### PR TITLE
docs: fix typos/wording

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2126,33 +2126,33 @@ MAKE_ENTRY                                                *telescope.make_entry*
 
 Each picker has a finder made up of two parts, the results which are the data
 to be displayed, and the entry_maker. These entry_makers are functions returned
-from make_entry functions. These will be referrd to as entry_makers in the
+from make_entry functions. These will be referred to as entry_makers in the
 following documentation.
 
-Every entry maker returns a function which accepts the data to be used for an
+Every entry maker returns a function that accepts the data to be used for an
 entry. This function will return an entry table (or nil, meaning skip this
-entry) which contains of the - following important keys:
+entry) which contains the following important keys:
 - value any: value key can be anything but still required
 - valid bool: is an optional key because it defaults to true but if the key is
-  set to false it will not be displayed by the picker. (optional)
+  set to false it will not be displayed by the picker (optional)
 - ordinal string: is the text that is used for filtering (required)
-- display string|function: is either a string of the text that is being 
-  displayed or a function receiving the entry at a later stage, when the entry 
-  is actually being displayed. A function can be useful here if complex 
-  calculation have to be done. `make_entry` can also return a second value a
+- display string|function: is either a string of the text that is being
+  displayed or a function receiving the entry at a later stage, when the entry
+  is actually being displayed. A function can be useful here if a complex
+  calculation has to be done. `make_entry` can also return a second value a
   highlight array which will then apply to the line. Highlight entry in this
-  array has the following signature `{ { start_col, end_col }, hl_group }` 
-  (required).
+  array has the following signature `{ { start_col, end_col }, hl_group }`
+  (required)
 - filename string: will be interpreted by the default `<cr>` action as open
   this file (optional)
 - bufnr number: will be interpreted by the default `<cr>` action as open this
   buffer (optional)
-- lnum number: lnum value which will be interpreted by the default `<cr>` 
+- lnum number: lnum value which will be interpreted by the default `<cr>`
   action as a jump to this line (optional)
 - col number: col value which will be interpreted by the default `<cr>` action
   as a jump to this column (optional)
 
-More information on easier displaying, see |telescope.pickers.entry_display|
+For more information on easier displaying, see |telescope.pickers.entry_display|
 
 TODO: Document something we call `entry_index`
 
@@ -2173,9 +2173,9 @@ the best performance.
 The create function will use the column widths passed to it in
 configaration.items. Each item in that table is the number of characters in the
 column. It's also possible for the final column to not have a fixed width, this
-will be shown in the configuartion as 'remaining = true'.
+will be shown in the configuration as 'remaining = true'.
 
-An example of this configuration is shown for the buffers picker
+An example of this configuration is shown for the buffers picker:
 >
 local displayer = entry_display.create {
   separator = " ",
@@ -2189,10 +2189,10 @@ local displayer = entry_display.create {
 <
 
 This shows 4 columns, the first is defined in the opts as the width we'll use
-when display_string the number of the buffer. The second has a fixed width of 4
-and the 3rd column's widht will be decided by the width of the icons we use.
-The fourth column will use the remaining space. Finally we have also defined
-the seperator between each column will be the space " ".
+when display_string is the number of the buffer. The second has a fixed width
+of 4 and the third column's width will be decided by the width of the icons we
+use. The fourth column will use the remaining space. Finally, we have also
+defined the separator between each column will be the space " ".
 
 An example of how the display reference will be used is shown, again for the
 buffers picker:
@@ -2208,11 +2208,12 @@ return displayer {
 There are two types of values each column can have. Either a simple String or a
 table containing the String as well as the hl_group.
 
-The displayer can return values, string and an optional highlights. String is
-all the text to be displayed for this entry as a single string. If parts of the
-string are to be highlighted they will be described in the highlights table.
+The displayer can return values, string and an optional highlights. The string
+is all the text to be displayed for this entry as a single string. If parts of
+the string are to be highlighted they will be described in the highlights
+table.
 
-For better understanding of how create() and displayer are used it's best to
+For a better understanding of how create() and displayer are used it's best to
 look at the code in make_entry.lua.
 
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2136,23 +2136,24 @@ entry) which contains the following important keys:
 - valid bool: is an optional key because it defaults to true but if the key is
   set to false it will not be displayed by the picker (optional)
 - ordinal string: is the text that is used for filtering (required)
-- display string|function: is either a string of the text that is being
-  displayed or a function receiving the entry at a later stage, when the entry
-  is actually being displayed. A function can be useful here if a complex
+- display string|function: is either a string of the text that is being 
+  displayed or a function receiving the entry at a later stage, when the entry 
+  is actually being displayed. A function can be useful here if a complex 
   calculation has to be done. `make_entry` can also return a second value a
   highlight array which will then apply to the line. Highlight entry in this
-  array has the following signature `{ { start_col, end_col }, hl_group }`
+  array has the following signature `{ { start_col, end_col }, hl_group }` 
   (required)
 - filename string: will be interpreted by the default `<cr>` action as open
   this file (optional)
 - bufnr number: will be interpreted by the default `<cr>` action as open this
   buffer (optional)
-- lnum number: lnum value which will be interpreted by the default `<cr>`
+- lnum number: lnum value which will be interpreted by the default `<cr>` 
   action as a jump to this line (optional)
 - col number: col value which will be interpreted by the default `<cr>` action
   as a jump to this column (optional)
 
-For more information on easier displaying, see |telescope.pickers.entry_display|
+For more information on easier displaying, see
+|telescope.pickers.entry_display|
 
 TODO: Document something we call `entry_index`
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -4,23 +4,23 @@
 ---
 --- Each picker has a finder made up of two parts, the results which are the
 --- data to be displayed, and the entry_maker. These entry_makers are functions
---- returned from make_entry functions. These will be referrd to as
+--- returned from make_entry functions. These will be referred to as
 --- entry_makers in the following documentation.
 ---
---- Every entry maker returns a function which accepts the data to be used for
+--- Every entry maker returns a function that accepts the data to be used for
 --- an entry. This function will return an entry table (or nil, meaning skip
---- this entry) which contains of the - following important keys:
+--- this entry) which contains the following important keys:
 --- - value any: value key can be anything but still required
 --- - valid bool: is an optional key because it defaults to true but if the key
----   is set to false it will not be displayed by the picker. (optional)
+---   is set to false it will not be displayed by the picker (optional)
 --- - ordinal string: is the text that is used for filtering (required)
 --- - display string|function: is either a string of the text that is being
 ---   displayed or a function receiving the entry at a later stage, when the entry
----   is actually being displayed. A function can be useful here if complex
----   calculation have to be done. `make_entry` can also return a second value
+---   is actually being displayed. A function can be useful here if a complex
+---   calculation has to be done. `make_entry` can also return a second value
 ---   a highlight array which will then apply to the line. Highlight entry in
 ---   this array has the following signature `{ { start_col, end_col }, hl_group }`
----   (required).
+---   (required)
 --- - filename string: will be interpreted by the default `<cr>` action as
 ---   open this file (optional)
 --- - bufnr number: will be interpreted by the default `<cr>` action as open
@@ -30,7 +30,7 @@
 --- - col number: col value which will be interpreted by the default `<cr>`
 ---   action as a jump to this column (optional)
 ---
---- More information on easier displaying, see |telescope.pickers.entry_display|
+--- For more information on easier displaying, see |telescope.pickers.entry_display|
 ---
 --- TODO: Document something we call `entry_index`
 ---@brief ]]

--- a/lua/telescope/pickers/entry_display.lua
+++ b/lua/telescope/pickers/entry_display.lua
@@ -14,9 +14,9 @@
 --- The create function will use the column widths passed to it in
 --- configaration.items. Each item in that table is the number of characters in
 --- the column. It's also possible for the final column to not have a fixed
---- width, this will be shown in the configuartion as 'remaining = true'.
+--- width, this will be shown in the configuration as 'remaining = true'.
 ---
---- An example of this configuration is shown for the buffers picker
+--- An example of this configuration is shown for the buffers picker:
 --- <code>
 --- local displayer = entry_display.create {
 ---   separator = " ",
@@ -30,10 +30,10 @@
 --- </code>
 ---
 --- This shows 4 columns, the first is defined in the opts as the width we'll
---- use when display_string the number of the buffer. The second has a fixed
---- width of 4 and the 3rd column's widht will be decided by the width of the
---- icons we use. The fourth column will use the remaining space. Finally we
---- have also defined the seperator between each column will be the space " ".
+--- use when display_string is the number of the buffer. The second has a fixed
+--- width of 4 and the third column's width will be decided by the width of the
+--- icons we use. The fourth column will use the remaining space. Finally, we
+--- have also defined the separator between each column will be the space " ".
 ---
 --- An example of how the display reference will be used is shown, again for
 --- the buffers picker:
@@ -49,12 +49,12 @@
 --- There are two types of values each column can have. Either a simple String
 --- or a table containing the String as well as the hl_group.
 ---
---- The displayer can return values, string and an optional highlights.
---- String is all the text to be displayed for this entry as a single string. If
---- parts of the string are to be highlighted they will be described in the
---- highlights table.
+--- The displayer can return values, string and an optional highlights. The string
+--- is all the text to be displayed for this entry as a single string. If parts of
+--- the string are to be highlighted they will be described in the highlights
+--- table.
 ---
---- For better understanding of how create() and displayer are used it's best to look
+--- For a better understanding of how create() and displayer are used it's best to look
 --- at the code in make_entry.lua.
 ---@brief ]]
 


### PR DESCRIPTION
# Description

Whilst browsing through the docs about `entry_makers` I noticed some grammar mistakes.

## Type of change

Docs update.

# How Has This Been Tested?

Opened and checked the docs.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
