### PR TITLE
docs: point to correct lua modules

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -192,8 +192,8 @@ telescope.setup({opts})                                    *telescope.setup()*
 
                                      *telescope.defaults.cycle_layout_list*
     cycle_layout_list: ~
-        Determines the layouts to cycle through when using `actions.cycle_layout_next`
-        and `actions.cycle_layout_prev`.
+        Determines the layouts to cycle through when using `actions.layout.cycle_layout_next`
+        and `actions.layout.cycle_layout_prev`.
         Should be a list of "layout setups".
         Each "layout setup" can take one of two forms:
         1. string <br>
@@ -514,7 +514,7 @@ telescope.setup({opts})                                    *telescope.setup()*
           - msg_bg_fillchar:  Character to fill background of unpreviewable buffers with
                               Default: "╱"
           - hide_on_startup:  Hide previewer when picker starts. Previewer can be toggled
-                              with actions.toggle_preview.
+                              with actions.layout.toggle_preview.
                               Default: false
 
 

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -194,8 +194,8 @@ append(
   "cycle_layout_list",
   { "horizontal", "vertical" },
   [[
-  Determines the layouts to cycle through when using `actions.cycle_layout_next`
-  and `actions.cycle_layout_prev`.
+  Determines the layouts to cycle through when using `actions.layout.cycle_layout_next`
+  and `actions.layout.cycle_layout_prev`.
   Should be a list of "layout setups".
   Each "layout setup" can take one of two forms:
   1. string <br>
@@ -611,7 +611,7 @@ append(
       - msg_bg_fillchar:  Character to fill background of unpreviewable buffers with
                           Default: "╱"
       - hide_on_startup:  Hide previewer when picker starts. Previewer can be toggled
-                          with actions.toggle_preview.
+                          with actions.layout.toggle_preview.
                           Default: false
     ]]
 )


### PR DESCRIPTION
# Description

A few places mention `action.foobar` which now are now in `action.layout.foobar`.

## Type of change

- This change requires a documentation update

# Checklist:

- [X] I have made corresponding changes to the documentation (lua annotations)
