### PR TITLE
feat(git): git_commits shows the current branch graph

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -56,7 +56,7 @@ end
 
 git.commits = function(opts)
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
-  local git_command = vim.F.if_nil(opts.git_command, { "git", "log", "--graph", "--oneline", "--no-decorate", "--", "." })
+  local git_command = vim.F.if_nil(opts.git_command, { "git", "log", "--graph", "--oneline", "--decorate", "--", "." })
 
   pickers
     .new(opts, {
@@ -115,8 +115,7 @@ git.bcommits = function(opts)
   opts.current_line = (opts.current_file == nil) and get_current_buf_line(opts.winnr) or nil
   opts.current_file = vim.F.if_nil(opts.current_file, vim.api.nvim_buf_get_name(opts.bufnr))
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
-  local git_command =
-    vim.F.if_nil(opts.git_command, { "git", "log", "--graph", "--oneline", "--no-decorate", "--follow" })
+  local git_command = vim.F.if_nil(opts.git_command, { "git", "log", "--graph", "--oneline", "--decorate", "--follow" })
 
   pickers
     .new(opts, {

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -56,7 +56,7 @@ end
 
 git.commits = function(opts)
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
-  local git_command = vim.F.if_nil(opts.git_command, { "git", "log", "--pretty=oneline", "--abbrev-commit", "--", "." })
+  local git_command = vim.F.if_nil(opts.git_command, { "git", "log", "--graph", "--oneline", "--no-decorate", "--", "." })
 
   pickers
     .new(opts, {
@@ -116,7 +116,7 @@ git.bcommits = function(opts)
   opts.current_file = vim.F.if_nil(opts.current_file, vim.api.nvim_buf_get_name(opts.bufnr))
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
   local git_command =
-    vim.F.if_nil(opts.git_command, { "git", "log", "--pretty=oneline", "--abbrev-commit", "--follow" })
+    vim.F.if_nil(opts.git_command, { "git", "log", "--graph", "--oneline", "--no-decorate", "--follow" })
 
   pickers
     .new(opts, {

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -431,17 +431,27 @@ function make_entry.gen_from_git_commits(opts)
       return nil
     end
 
-    local sha, msg = string.match(entry, "([^ ]+) (.+)")
+    local marker, sha, msg = string.match(entry, "([*\\/| ]+) +([0-9a-f]*) +(.*)")
+
+    if not sha then
+        marker = entry
+        sha = ""
+        msg = ""
+    end
 
     if not msg then
-      sha = entry
       msg = "<empty commit message>"
     end
 
+    marker, _ = string.gsub(marker, "\\", "+")
+    marker, _ = string.gsub(marker, "/", "-")
+    marker, _ = string.gsub(marker, "+", "/")
+    marker, _ = string.gsub(marker, "-", "\\")
+
     return make_entry.set_default_entry_mt({
       value = sha,
-      ordinal = sha .. " " .. msg,
-      msg = msg,
+      ordinal = marker .. " " .. sha .. " " .. msg,
+      msg = marker .. " " .. msg,
       display = make_display,
       current_file = opts.current_file,
     }, opts)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -434,9 +434,9 @@ function make_entry.gen_from_git_commits(opts)
     local marker, sha, msg = string.match(entry, "([*\\/| ]+) +([0-9a-f]*) +(.*)")
 
     if not sha then
-        marker = entry
-        sha = ""
-        msg = ""
+      marker = entry
+      sha = ""
+      msg = ""
     end
 
     if not msg then


### PR DESCRIPTION
# Description

I'd like to see a graph view in git_commits picker, and notice the closed issue (#1041) when I try to find some solutions.
I'm not familiar with the Lua language, so, a little modifications are written to achieve the basic demand.

Feat # (#1041)
show the current branch graph when viewing git_commits

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Invoking the git picker function **builtin.git_commits** by a vim key mapping, the the commits log with graph will displayed in the popup window.

_NB._ commit logs showing with graph will insert extra entries with no SHA value, so a error msg will shown in the vim msg bar if these extra entries selected.
