### PR TITLE
fix: correctly parse filenames with special chars in git_status

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -314,7 +314,7 @@ git.status = function(opts)
 
   local gen_new_finder = function()
     local expand_dir = vim.F.if_nil(opts.expand_dir, true)
-    local git_cmd = { "git", "status", "-s", "--", "." }
+    local git_cmd = { "git", "status", "-z", "--", "." }
 
     if expand_dir then
       table.insert(git_cmd, #git_cmd - 1, "-u")
@@ -332,7 +332,7 @@ git.status = function(opts)
     end
 
     return finders.new_table {
-      results = output,
+      results = vim.split(output[1], " ", { trimempty = true }),
       entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_status(opts)),
     }
   end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1342,7 +1342,13 @@ function make_entry.gen_from_git_status(opts)
     if entry == "" then
       return nil
     end
-    local mod, file = string.match(entry, "(..).*%s[->%s]?(.+)")
+
+    local mod, file = entry:match "^(..) (.+)$"
+    -- Ignore entries that are the PATH in XY ORIG_PATH PATH
+    -- (renamed or copied files)
+    if not mod then
+      return nil
+    end
 
     return setmetatable({
       value = file,


### PR DESCRIPTION
# Description

Fixes #2292. This uses `git status -z` instead of `git status --short` (see https://git-scm.com/docs/git-status/2.16.6#_porcelain_format_version_1) of which the output is easier to parse (e.g. filenames are not quoted). 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
In a Git repo with some files (`ls` shows `'$hey.txt'  '\esc2.txt'  '\esc.txt'   nenen.txt  'normal_"\renamed.txt'  '"qt.txt'  'two words.lua'`), then running `:Telescope git_status`.
The info from Git seems to be parsed correctly now and the file is opened as expected when pressing enter.

![telescope_pr](https://user-images.githubusercontent.com/40792180/210747999-ecfbbe7e-5204-4178-b1b7-7d82e84272f5.png)

The only things that's not working correctly yet is the previewer but that's a different issue (requiring updates to `from_entry.lua`).

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.0-dev-1729+g2d8bbe468     
* Operating system and version: Linux Mint 20.2 

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
