### PR TITLE
Note that live_grep uses ripgrep in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,12 +279,12 @@ Built-in functions. Ready to be bound to any key you like.
 
 ### File Pickers
 
-| Functions                           | Description                                                                                                                       |
-|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| `builtin.find_files`                | Lists files in your current working directory, respects .gitignore                                                                |
-| `builtin.git_files`                 | Fuzzy search through the output of `git ls-files` command, respects .gitignore                                                    |
-| `builtin.grep_string`               | Searches for the string under your cursor in your current working directory                                                       |
-| `builtin.live_grep`                 | Search for a string in your current working directory and get results live as you type, respects .gitignore                       |
+| Functions                           | Description                                                                                                                                                              |
+|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `builtin.find_files`                | Lists files in your current working directory, respects .gitignore                                                                                                       |
+| `builtin.git_files`                 | Fuzzy search through the output of `git ls-files` command, respects .gitignore                                                                                           |
+| `builtin.grep_string`               | Searches for the string under your cursor in your current working directory                                                                                              |
+| `builtin.live_grep`                 | Search for a string in your current working directory and get results live as you type, respects .gitignore. (Requires [ripgrep](https://github.com/BurntSushi/ripgrep)) |
 
 ### Vim Pickers
 


### PR DESCRIPTION
As mentioned in issue  #2304 I added a note that the live_grep picker requires ripgrep.