### PR TITLE
fix: cwd_only would not filter enough [0.1.x]

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -517,7 +517,7 @@ internal.oldfiles = function(opts)
   end
 
   if opts.cwd_only then
-    local cwd = vim.loop.cwd()
+    local cwd = vim.loop.cwd() .. "/"
     cwd = cwd:gsub([[\]], [[\\]])
     results = vim.tbl_filter(function(file)
       return vim.fn.matchstrpos(file, cwd)[2] ~= -1


### PR DESCRIPTION
This is a backport of PR #2308 that was merged by @kkharji to the 0.1.x branch.

# Description

cwd_only would also include unrelated folders, provided the current folder name was a prefix
Example: current folder is /home/user/fold. Telescope would also offer files from /home/user/folder.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create one folder named fold, another one named folder. Open and save fold/file1.txt and folder/file2.txt. Then run ":cd fold", and invoke `lua require'telescope.builtin'.oldfiles{cwd_only=true}`.

Without the fix, telescope will offer you both file1.txt and file2.txt. With the fix, telescope will offer you only file1.txt.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.8.0-1210-gd3
* Operating system and version: fedora linux 37

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)

PS: could it be possible to also backport this fix to the 0.1 stable branch?