### PR TITLE
feat(pickers): add opt.show_remote_tracking_branches to git_branches

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1028,10 +1028,17 @@ builtin.git_branches({opts})                *telescope.builtin.git_branches()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}          (string)   specify the path of the repo
-        {use_git_root} (boolean)  if we should use git root as cwd or the cwd
-                                  (important for submodule) (default: true)
-        {pattern}      (string)   specify the pattern to match all refs
+        {cwd}                           (string)   specify the path of the
+                                                   repo
+        {use_git_root}                  (boolean)  if we should use git root
+                                                   as cwd or the cwd
+                                                   (important for submodule)
+                                                   (default: true)
+        {show_remote_tracking_branches} (boolean)  show remote tracking
+                                                   branches like origin/main
+                                                   (default: true)
+        {pattern}                       (string)   specify the pattern to
+                                                   match all refs
 
 
 builtin.git_status({opts})                    *telescope.builtin.git_status()*

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -203,6 +203,7 @@ git.branches = function(opts)
     { "git", "for-each-ref", "--perl", "--format", format, "--sort", "-authordate", opts.pattern },
     opts.cwd
   )
+  local show_remote_tracking_branches = vim.F.if_nil(opts.show_remote_tracking_branches, true)
 
   local results = {}
   local widths = {
@@ -225,7 +226,11 @@ git.branches = function(opts)
     }
     local prefix
     if vim.startswith(entry.refname, "refs/remotes/") then
-      prefix = "refs/remotes/"
+      if show_remote_tracking_branches then
+        prefix = "refs/remotes/"
+      else
+        return
+      end
     elseif vim.startswith(entry.refname, "refs/heads/") then
       prefix = "refs/heads/"
     else

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -172,6 +172,7 @@ builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcomm
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
+---@field show_remote_tracking_branches boolean: show remote tracking branches like origin/main (default: true)
 ---@field pattern string: specify the pattern to match all refs
 builtin.git_branches = require_on_exported_call("telescope.builtin.__git").branches
 


### PR DESCRIPTION
# Description

Add a new option `show_remote_tracking_branches` to the `git_branches` picker so that the user can hide remote tracking branches like `origin/main` if they only care about local branches. Defaults to true which is the current behaviour.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- [x] Use `git_branch` picker with `opts.show_remote_tracking_branches = true` and verify tracking branches are shown
- [x] Use `git_branch` picker with `opts.show_remote_tracking_branches = false` and veryify tracking branches are not shown
- [x] Use `git_branch` picker with no options and verify that remote tracking branches are still shown

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
