### PR TITLE
feat: delete file with C-r keybind

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -267,6 +267,22 @@ actions.select_horizontal = {
   end,
 }
 
+--- Perform deletes the current file telescope has selcted
+actions.delete_file = {
+  action = function(prompt_bufnr)
+    local content = require("telescope.actions.state").get_selected_entry()
+
+    local path = content.cwd .. "/" .. content.value
+    local shortPath = vim.fn.pathshorten(vim.fn.fnamemodify(path, ":."))
+
+    vim.ui.input({ prompt = "Do you want to delete the file " .. shortPath .. " (y/n): " }, function(input)
+      if input == "y" then
+        vim.cmd("!rm -rf " .. path)
+      end
+    end)
+  end,
+}
+
 --- Perform 'vertical' action on selection, usually something like<br>
 ---`:vnew <selection>`
 ---

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -148,6 +148,8 @@ mappings.default_mappings = config.values.default_mappings
       ["<C-v>"] = actions.select_vertical,
       ["<C-t>"] = actions.select_tab,
 
+      ["<C-r>"] = actions.delete_file,
+
       ["<C-u>"] = actions.preview_scrolling_up,
       ["<C-d>"] = actions.preview_scrolling_down,
 


### PR DESCRIPTION
# Description
A lot of the time I find my self having a file in telescope and I wanted a quick way to delete instead of going into NETRW. This `<C-r>` keybind quickly allows you to fuzzy search for a file then delete it instead of having to find where it is in your filetree

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Opend fuzzy file searcher, searched for file, ran <C-r> to delete file pressed y to confirm and the file was gone

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.0-dev-642+g50f03773f
* Operating system and version: Arch Linux 6.0.12

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
