### PR TITLE
fix: wrap_results option breaking scrolling of results window

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1327,6 +1327,11 @@ function Picker:get_result_completor(results_bufnr, find_id, prompt, status_upda
     self:clear_extra_rows(results_bufnr)
     self.sorter:_finish(prompt)
 
+    if self.wrap_results and self.sorting_strategy == "descending" then
+      local visible_result_rows = vim.api.nvim_win_get_height(self.results_win)
+      vim.api.nvim_win_set_cursor(self.results_win, { self.max_results - visible_result_rows, 1 })
+      vim.api.nvim_win_set_cursor(self.results_win, { self.max_results, 1 })
+    end
     self:_on_complete()
   end)
 end


### PR DESCRIPTION
# Description

wrap_results option was breaking scroll position of results window when sorting strategy is descending. Because of that users are not able to see the most relevant result on the results window unless manually scrolled. This behavior is now fixed

Fixes  #1757 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested with files having long paths in multiple pickers like old_files, git_files
- [x] Tested with git commits picker

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.8.2
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by brew@HMBRW-A-001-M1-005.local

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/opt/homebrew/Cellar/neovim/0.8.2/share/nvim"
```
* Operating system and version: macos 12.6.2

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code

