### PR TITLE
feat: apply jump_type only if the definition file is different from the current file

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -24,3 +24,11 @@ globals = {
 read_globals = {
   "vim",
 }
+
+files = {
+  ["lua/telescope/builtin/init.lua"] = {
+    ignore = {
+      "631", -- allow line len > 120
+    }
+  },
+}

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1454,8 +1454,10 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
         {include_current_line} (boolean)  include current line (default:
                                           false)
         {jump_type}            (string)   how to goto reference if there is
-                                          only one, values: "tab", "split",
-                                          "vsplit", "never"
+                                          only one and the definition file is
+                                          different from the current file,
+                                          values: "tab", "split", "vsplit",
+                                          "never"
         {fname_width}          (number)   defines the width of the filename
                                           section (default: 30)
         {show_line}            (boolean)  show results text (default: true)
@@ -1501,8 +1503,10 @@ builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}   (string)   how to goto definition if there is only one,
-                                 values: "tab", "split", "vsplit", "never"
+        {jump_type}   (string)   how to goto definition if there is only one
+                                 and the definition file is different from the
+                                 current file, values: "tab", "split",
+                                 "vsplit", "never"
         {fname_width} (number)   defines the width of the filename section
                                  (default: 30)
         {show_line}   (boolean)  show results text (default: true)
@@ -1518,8 +1522,10 @@ builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}   (string)   how to goto definition if there is only one,
-                                 values: "tab", "split", "vsplit", "never"
+        {jump_type}   (string)   how to goto definition if there is only one
+                                 and the definition file is different from the
+                                 current file, values: "tab", "split",
+                                 "vsplit", "never"
         {fname_width} (number)   defines the width of the filename section
                                  (default: 30)
         {show_line}   (boolean)  show results text (default: true)
@@ -1536,8 +1542,9 @@ builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
 
     Options: ~
         {jump_type}   (string)   how to goto implementation if there is only
-                                 one, values: "tab", "split", "vsplit",
-                                 "never"
+                                 one and the definition file is different from
+                                 the current file, values: "tab", "split",
+                                 "vsplit", "never"
         {fname_width} (number)   defines the width of the filename section
                                  (default: 30)
         {show_line}   (boolean)  show results text (default: true)

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -40,12 +40,14 @@ lsp.references = function(opts)
     end
 
     if #locations == 1 and opts.jump_type ~= "never" then
-      if opts.jump_type == "tab" then
-        vim.cmd "tabedit"
-      elseif opts.jump_type == "split" then
-        vim.cmd "new"
-      elseif opts.jump_type == "vsplit" then
-        vim.cmd "vnew"
+      if filepath ~= locations[1].filename then
+        if opts.jump_type == "tab" then
+          vim.cmd "tabedit"
+        elseif opts.jump_type == "split" then
+          vim.cmd "new"
+        elseif opts.jump_type == "vsplit" then
+          vim.cmd "vnew"
+        end
       end
       -- jump to location
       local location = locations[1]
@@ -184,12 +186,14 @@ local function list_or_jump(action, title, opts)
     if #flattened_results == 0 then
       return
     elseif #flattened_results == 1 and opts.jump_type ~= "never" then
-      if opts.jump_type == "tab" then
-        vim.cmd "tabedit"
-      elseif opts.jump_type == "split" then
-        vim.cmd "new"
-      elseif opts.jump_type == "vsplit" then
-        vim.cmd "vnew"
+      if params.textDocument.uri ~= flattened_results[1].uri then
+        if opts.jump_type == "tab" then
+          vim.cmd "tabedit"
+        elseif opts.jump_type == "split" then
+          vim.cmd "new"
+        elseif opts.jump_type == "vsplit" then
+          vim.cmd "vnew"
+        end
       end
       vim.lsp.util.jump_to_location(flattened_results[1], offset_encoding)
     else

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -379,7 +379,7 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@param opts table: options to pass to the picker
 ---@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
 ---@field include_current_line boolean: include current line (default: false)
----@field jump_type string: how to goto reference if there is only one, values: "tab", "split", "vsplit", "never"
+---@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
@@ -401,7 +401,7 @@ builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp")
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
+---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
@@ -410,7 +410,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 --- Goto the definition of the type of the word under the cursor, if there's only one,
 --- otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one, values: "tab", "split", "vsplit", "never"
+---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
@@ -418,7 +418,7 @@ builtin.lsp_type_definitions = require("telescope.builtin.__lsp").type_definitio
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto implementation if there is only one, values: "tab", "split", "vsplit", "never"
+---@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)


### PR DESCRIPTION
# Description

Apply `jump_type` rule only if the definition file is different from the current file. I think most people expect open the definition on a new tab (or a split pane) only when we need to go to another file.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Set a key mapping `vim.keymap.set('n', 'gd', function() builtin.lsp_definitions{jump_type = 'tab'} end, bufopts)`:

- [x] Move the cursor on a symbol that has only one definition and type `gd`. If the definition is in the current file, it'll just jump to the corresponding position of the current file; otherwise it'll open the definition on a new tab.

Set a key mapping `vim.keymap.set('n', 'gr', function() builtin.lsp_references{jump_type = 'tab'} end, bufopts)`:

- [x] Move the cursor on a symbol that has only one reference and type `gr`. If the reference is in the current file, it'll just jump to the corresponding position of the current file; otherwise it'll open the reference on a new tab. 

**Configuration**:
* Neovim version (nvim --version): NVIM v0.8.2
* Operating system and version: Ubuntu 20.04 LTS (WSL2)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
