### PR TITLE
docs: telescope.txt spelling and grammar fixes

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -3287,7 +3287,7 @@ PREVIEWERS                                                *telescope.previewers*
 
 Provides a Previewer table that has to be implemented by each previewer. To
 achieve this, this module also provides two wrappers that abstract most of the
-work and make it really easy create new previewers.
+work and make it really easy to create new previewers.
   - `previewers.new_termopen_previewer`
   - `previewers.new_buffer_previewer`
 
@@ -3316,7 +3316,7 @@ previewers.Previewer()                      *telescope.previewers.Previewer()*
 
     What `:new` expects is listed below
 
-    The interface provides following set of functions. All of them, besides
+    The interface provides the following set of functions. All of them, besides
     `new`, will be handled by telescope pickers.
     - `:new(opts)`
     - `:preview(entry, status)`
@@ -3327,7 +3327,7 @@ previewers.Previewer()                      *telescope.previewers.Previewer()*
     `Previewer:new()` expects a table as input with following keys:
       - `setup` function(self): Will be called the first time preview will be 
         called.
-      - `teardown` function(self): Will be called on cleanup.
+      - `teardown` function(self): Will be called on clean up.
       - `preview_fn` function(self, entry, status): Will be called each time a
         new entry was selected.
       - `title` function(self): Will return the static title of the previewer.
@@ -3437,9 +3437,9 @@ previewers.new_buffer_previewer() *telescope.previewers.new_buffer_previewer()*
         table of vars that will be available in `self.state` in each
         `define_preview` call.
       - `teardown = function(self)` (optional) Will be called at the end, when
-        the picker is being closed and is meant to cleanup everything that was
+        the picker is being closed and is meant to clean up everything that was
         allocated by the previewer. The `buffer_previewer` will automatically
-        cleanup all created buffers. So you only need to handle things that
+        clean up all created buffers. So you only need to handle things that
         were introduced by you.
       - `keep_last_buf = true` (optional) Will not delete the last selected
         buffer. This would allow you to reuse that buffer in the select action.
@@ -3447,7 +3447,7 @@ previewers.new_buffer_previewer() *telescope.previewers.new_buffer_previewer()*
         recreating that buffer in an action. To access the last buffer number: 
         `require('telescope.state').get_global_key("last_preview_bufnr")`
       - `get_buffer_by_name = function(self, entry)` Allows you to set a unique
-        name for each buffer. This is used for caching purpose.
+        name for each buffer. This is used for caching purposes.
         `self.state.bufname` will be nil if the entry was never loaded or the
         unique name when it was loaded once. For example, useful if you have
         one file but multiple entries. This happens for grep and lsp builtins.
@@ -3543,7 +3543,7 @@ previewers.vim_buffer_vimgrep()    *telescope.previewers.vim_buffer_vimgrep()*
 
 
 previewers.vim_buffer_qflist()      *telescope.previewers.vim_buffer_qflist()*
-    Is the same as `vim_buffer_vimgrep` and only exist for consistency with
+    Is the same as `vim_buffer_vimgrep` and only exists for consistency with
     `term_previewers`.
 
     The preferred way of using this previewer is like this
@@ -3614,7 +3614,7 @@ HISTORY                                              *telescope.actions.history*
 A base implementation of a prompt history that provides a simple history and
 can be replaced with a custom implementation.
 
-For example: We provide a extension for a smart history that uses sql.nvim to
+For example: We provide an extension for a smart history that uses sql.nvim to
 map histories to metadata, like the calling picker or cwd.
 
 So you have a history for:

--- a/lua/telescope/actions/history.lua
+++ b/lua/telescope/actions/history.lua
@@ -11,7 +11,7 @@ local uv = vim.loop
 --- A base implementation of a prompt history that provides a simple history
 --- and can be replaced with a custom implementation.
 ---
---- For example: We provide a extension for a smart history that uses sql.nvim
+--- For example: We provide an extension for a smart history that uses sql.nvim
 --- to map histories to metadata, like the calling picker or cwd.
 ---
 --- So you have a history for:

--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -4,7 +4,7 @@
 ---@brief [[
 --- Provides a Previewer table that has to be implemented by each previewer.
 --- To achieve this, this module also provides two wrappers that abstract most
---- of the work and make it really easy create new previewers.
+--- of the work and make it really easy to create new previewers.
 ---   - `previewers.new_termopen_previewer`
 ---   - `previewers.new_buffer_previewer`
 ---
@@ -40,7 +40,7 @@ local previewers = {}
 ---
 --- What `:new` expects is listed below
 ---
---- The interface provides following set of functions. All of them, besides
+--- The interface provides the following set of functions. All of them, besides
 --- `new`, will be handled by telescope pickers.
 --- - `:new(opts)`
 --- - `:preview(entry, status)`
@@ -51,7 +51,7 @@ local previewers = {}
 --- `Previewer:new()` expects a table as input with following keys:
 ---   - `setup` function(self): Will be called the first time preview will be
 ---                           called.
----   - `teardown` function(self): Will be called on cleanup.
+---   - `teardown` function(self): Will be called on clean up.
 ---   - `preview_fn` function(self, entry, status): Will be called each time
 ---                                                 a new entry was selected.
 ---   - `title` function(self): Will return the static title of the previewer.
@@ -156,8 +156,8 @@ previewers.qflist = term_previewer.qflist
 ---     available in `self.state` in each `define_preview` call.
 ---   - `teardown = function(self)` (optional)
 ---     Will be called at the end, when the picker is being closed and is
----     meant to cleanup everything that was allocated by the previewer.
----     The `buffer_previewer` will automatically cleanup all created buffers.
+---     meant to clean up everything that was allocated by the previewer.
+---     The `buffer_previewer` will automatically clean up all created buffers.
 ---     So you only need to handle things that were introduced by you.
 ---   - `keep_last_buf = true` (optional)
 ---     Will not delete the last selected buffer. This would allow you to
@@ -167,7 +167,7 @@ previewers.qflist = term_previewer.qflist
 ---     `require('telescope.state').get_global_key("last_preview_bufnr")`
 ---   - `get_buffer_by_name = function(self, entry)`
 ---     Allows you to set a unique name for each buffer. This is used for
----     caching purpose. `self.state.bufname` will be nil if the entry was
+---     caching purposes. `self.state.bufname` will be nil if the entry was
 ---     never loaded or the unique name when it was loaded once. For example,
 ---     useful if you have one file but multiple entries. This happens for grep
 ---     and lsp builtins. So to make the cache work only load content if
@@ -258,7 +258,7 @@ previewers.vim_buffer_cat = buffer_previewer.cat
 --- case it's configured that way.
 previewers.vim_buffer_vimgrep = buffer_previewer.vimgrep
 
---- Is the same as `vim_buffer_vimgrep` and only exist for consistency with
+--- Is the same as `vim_buffer_vimgrep` and only exists for consistency with
 --- `term_previewers`.
 ---
 --- The preferred way of using this previewer is like this


### PR DESCRIPTION
# Description

Correct grammar and spelling errors in documentation to improve readability.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

Install telescope.nvim plugin using my fork and branch to verify my changes do not break formatting.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.8.2
* Operating system and version: Darwin 22.2.0 arm64

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
