### PR TITLE
feat: support selection for grep_string

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Built-in functions. Ready to be bound to any key you like.
 |-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `builtin.find_files`                | Lists files in your current working directory, respects .gitignore                                                                                                       |
 | `builtin.git_files`                 | Fuzzy search through the output of `git ls-files` command, respects .gitignore                                                                                           |
-| `builtin.grep_string`               | Searches for the string under your cursor in your current working directory                                                                                              |
+| `builtin.grep_string`               | Searches for the string under your cursor or selection in your current working directory                                                                                              |
 | `builtin.live_grep`                 | Search for a string in your current working directory and get results live as you type, respects .gitignore. (Requires [ripgrep](https://github.com/BurntSushi/ripgrep)) |
 
 ### Vim Pickers

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -804,7 +804,8 @@ builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
 
 
 builtin.grep_string({opts})                  *telescope.builtin.grep_string()*
-    Searches for the string under your cursor in your current working directory
+    Searches for the string under your cursor or the visual selection in your
+    current working directory
 
 
     Parameters: ~

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -168,10 +168,10 @@ files.grep_string = function(opts)
   local visual = vim.fn.mode() == "v"
 
   if visual == true then
-    local saved_reg = vim.fn.getreg('v')
+    local saved_reg = vim.fn.getreg("v")
     vim.cmd([[sil norm "vy]])
-    local sele = vim.fn.getreg('v')
-    vim.fn.setreg('v', saved_reg)
+    local sele = vim.fn.getreg("v")
+    vim.fn.setreg("v", saved_reg)
     word = vim.F.if_nil(opts.search, sele)
   else
     word = vim.F.if_nil(opts.search, vim.fn.expand "<cword>")

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -162,10 +162,16 @@ files.live_grep = function(opts)
 end
 
 files.grep_string = function(opts)
-  -- TODO: This should probably check your visual selection as well, if you've got one
   opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
   local vimgrep_arguments = vim.F.if_nil(opts.vimgrep_arguments, conf.vimgrep_arguments)
-  local word = vim.F.if_nil(opts.search, vim.fn.expand "<cword>")
+  local word
+  if vim.fn.mode() == 'v' then
+    vim.cmd([[sil norm "vy]])
+    local sele = vim.fn.getreg('v')
+    word = vim.F.if_nil(opts.search, sele)
+  else
+    word = vim.F.if_nil(opts.search, vim.fn.expand "<cword>")
+  end
   local search = opts.use_regex and word or escape_chars(word)
 
   local additional_args = {}

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -168,9 +168,9 @@ files.grep_string = function(opts)
   local visual = vim.fn.mode() == "v"
 
   if visual == true then
-    local saved_reg = vim.fn.getreg("v")
-    vim.cmd([[noautocmd sil norm "vy]])
-    local sele = vim.fn.getreg("v")
+    local saved_reg = vim.fn.getreg "v"
+    vim.cmd [[noautocmd sil norm "vy]]
+    local sele = vim.fn.getreg "v"
     vim.fn.setreg("v", saved_reg)
     word = vim.F.if_nil(opts.search, sele)
   else

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -166,8 +166,10 @@ files.grep_string = function(opts)
   local vimgrep_arguments = vim.F.if_nil(opts.vimgrep_arguments, conf.vimgrep_arguments)
   local word
   if vim.fn.mode() == 'v' then
+    local saved_reg = vim.fn.getreg('v')
     vim.cmd([[sil norm "vy]])
     local sele = vim.fn.getreg('v')
+    vim.fn.setreg('v', saved_reg)
     word = vim.F.if_nil(opts.search, sele)
   else
     word = vim.F.if_nil(opts.search, vim.fn.expand "<cword>")

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -169,7 +169,7 @@ files.grep_string = function(opts)
 
   if visual == true then
     local saved_reg = vim.fn.getreg("v")
-    vim.cmd([[sil norm "vy]])
+    vim.cmd([[noautocmd sil norm "vy]])
     local sele = vim.fn.getreg("v")
     vim.fn.setreg("v", saved_reg)
     word = vim.F.if_nil(opts.search, sele)

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -165,7 +165,9 @@ files.grep_string = function(opts)
   opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
   local vimgrep_arguments = vim.F.if_nil(opts.vimgrep_arguments, conf.vimgrep_arguments)
   local word
-  if vim.fn.mode() == 'v' then
+  local visual = vim.fn.mode() == "v"
+
+  if visual == true then
     local saved_reg = vim.fn.getreg('v')
     vim.cmd([[sil norm "vy]])
     local sele = vim.fn.getreg('v')
@@ -191,12 +193,22 @@ files.grep_string = function(opts)
     search = { "--", search }
   end
 
-  local args = flatten {
-    vimgrep_arguments,
-    additional_args,
-    opts.word_match,
-    search,
-  }
+  local args
+  if visual == true then
+    args = flatten {
+      vimgrep_arguments,
+      additional_args,
+      search,
+    }
+  else
+    args = flatten {
+      vimgrep_arguments,
+      additional_args,
+      opts.word_match,
+      search,
+    }
+  end
+
   opts.__inverted, opts.__matches = opts_contain_invert(args)
 
   if opts.grep_open_files then

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -57,7 +57,7 @@ end
 ---@field disable_coordinates boolean: don't show the line & row numbers (default: false)
 builtin.live_grep = require_on_exported_call("telescope.builtin.__files").live_grep
 
---- Searches for the string under your cursor in your current working directory
+--- Searches for the string under your cursor or the visual selection in your current working directory
 ---@param opts table: options to pass to the picker
 ---@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field search string: the query to search


### PR DESCRIPTION
# Description

Use the visual selection for live_grep when in visual mode

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

Bind in both normal and visual mode and manually test. Test normal mode. Then
in visual mode text that multiple words work and that word_match is disabled by
selecting only part of a word.

```lua
vim.keymap.set({'n', 'v'}, '<leader>tg', require('telescope.builtin').grep_string)
```

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.9.0-dev-742+g92a46727f-dirty
* Operating system and version:
Arch Linux 5.15.88-1-lts #1 SMP Sat, 14 Jan 2023 12:12:48 +0000 x86_64 GNU/Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
