### PR TITLE
fix: correctly restore cursor position in original window

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -374,13 +374,14 @@ actions.close = function(prompt_bufnr)
   local picker = action_state.get_current_picker(prompt_bufnr)
   local original_win_id = picker.original_win_id
   local cursor_valid, original_cursor = pcall(a.nvim_win_get_cursor, original_win_id)
-
   actions.close_pum(prompt_bufnr)
 
   require("telescope.pickers").on_close_prompt(prompt_bufnr)
   pcall(a.nvim_set_current_win, original_win_id)
   if cursor_valid and a.nvim_get_mode().mode == "i" and picker._original_mode ~= "i" then
-    pcall(a.nvim_win_set_cursor, original_win_id, { original_cursor[1], original_cursor[2] + 1 })
+    vim.defer_fn(function()
+      pcall(a.nvim_win_set_cursor, original_win_id, { original_cursor[1], original_cursor[2] })
+    end, 0)
   end
 end
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -371,18 +371,8 @@ end
 --- Close the Telescope window, usually used within an action
 ---@param prompt_bufnr number: The prompt bufnr
 actions.close = function(prompt_bufnr)
-  local picker = action_state.get_current_picker(prompt_bufnr)
-  local original_win_id = picker.original_win_id
-  local cursor_valid, original_cursor = pcall(a.nvim_win_get_cursor, original_win_id)
   actions.close_pum(prompt_bufnr)
-
   require("telescope.pickers").on_close_prompt(prompt_bufnr)
-  pcall(a.nvim_set_current_win, original_win_id)
-  if cursor_valid and a.nvim_get_mode().mode == "i" and picker._original_mode ~= "i" then
-    vim.defer_fn(function()
-      pcall(a.nvim_win_set_cursor, original_win_id, { original_cursor[1], original_cursor[2] })
-    end, 0)
-  end
 end
 
 --- Close the Telescope window, usually used within an action<br>

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1495,7 +1495,12 @@ function pickers.on_close_prompt(prompt_bufnr)
     event = "BufLeave",
     buffer = prompt_bufnr,
   }
-  picker.close_windows(status)
+
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<esc>", true, true, true), "n", true)
+  vim.defer_fn(function()
+    picker.close_windows(status)
+  end, 0)
+
   mappings.clear(prompt_bufnr)
 end
 


### PR DESCRIPTION
# Description

In some conditions such as when calling `man_pages` or `help_tags` the cursor
position in the original window is wrongly restored. This bug was introduced by
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 and seems to be caused by some weird
"race condition".

Fixes #2319

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- Before introducing this change `man_pages` and `help_tags` move the cursor to
the right when you hit Enter. With this change this doesn't happen. The commit
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 that introduced this bug tried to fix
the fact that when you leave Telesope with <C-c> from insert mode the cursor is
moved to the left by 1 position. But this made it so that under some circumstances
the opposite happens, that is for the cursor to be moved to the right. This
might have something to do with the Vim loop.
- `vim.api.nvim_put` on selection works correctly before and after the cursor

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
