### PR TITLE
feat: extend git_delete_branch to delete of all selected branches

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2719,7 +2719,7 @@ actions.git_track_branch({prompt_bufnr}) *telescope.actions.git_track_branch()*
 
 
 actions.git_delete_branch({prompt_bufnr}) *telescope.actions.git_delete_branch()*
-    Delete the currently selected branch
+    Delete all the selected branches
 
 
     Parameters: ~

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2719,7 +2719,7 @@ actions.git_track_branch({prompt_bufnr}) *telescope.actions.git_track_branch()*
 
 
 actions.git_delete_branch({prompt_bufnr}) *telescope.actions.git_delete_branch()*
-    Delete all the selected branches
+    Delete all currently selected branches
 
 
     Parameters: ~

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -688,7 +688,7 @@ actions.git_track_branch = make_git_branch_action {
 --- Delete the currently selected branches
 ---@param prompt_bufnr number: The prompt bufnr
 actions.git_delete_branch = function(prompt_bufnr)
-  local confirmation = vim.fn.input("Do you really want to delete the selected branches? [Y/n] ")
+  local confirmation = vim.fn.input "Do you really want to delete the selected branches? [Y/n] "
   if confirmation ~= "" and string.lower(confirmation) ~= "y" then
     return
   end

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -685,7 +685,7 @@ actions.git_track_branch = make_git_branch_action {
   end,
 }
 
---- Delete the currently selected branches
+--- Delete all currently selected branches
 ---@param prompt_bufnr number: The prompt bufnr
 actions.git_delete_branch = function(prompt_bufnr)
   local confirmation = vim.fn.input "Do you really want to delete the selected branches? [Y/n] "

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -685,18 +685,34 @@ actions.git_track_branch = make_git_branch_action {
   end,
 }
 
---- Delete the currently selected branch
+--- Delete the currently selected branches
 ---@param prompt_bufnr number: The prompt bufnr
-actions.git_delete_branch = make_git_branch_action {
-  should_confirm = true,
-  action_name = "actions.git_delete_branch",
-  confirmation_question = "Do you really wanna delete branch %s? [Y/n] ",
-  success_message = "Deleted branch: %s",
-  error_message = "Error when deleting branch: %s. Git returned: '%s'",
-  command = function(branch_name)
-    return { "git", "branch", "-D", branch_name }
-  end,
-}
+actions.git_delete_branch = function(prompt_bufnr)
+  local confirmation = vim.fn.input("Do you really want to delete the selected branches? [Y/n] ")
+  if confirmation ~= "" and string.lower(confirmation) ~= "y" then
+    return
+  end
+
+  local picker = action_state.get_current_picker(prompt_bufnr)
+  local action_name = "actions.git_delete_branch"
+  picker:delete_selection(function(selection)
+    local branch = selection.value
+    print("Deleting branch " .. branch)
+    local _, ret, stderr = utils.get_os_command_output({ "git", "branch", "-D", branch }, picker.cwd)
+    if ret == 0 then
+      utils.notify(action_name, {
+        msg = string.format("Deleted branch: %s", branch),
+        level = "INFO",
+      })
+    else
+      utils.notify(action_name, {
+        msg = string.format("Error when deleting branch: %s. Git returned: '%s'", branch, table.concat(stderr, " ")),
+        level = "ERROR",
+      })
+    end
+    return ret == 0
+  end)
+end
 
 --- Merge the currently selected branch
 ---@param prompt_bufnr number: The prompt bufnr


### PR DESCRIPTION
# Description

Extends the git_delete_branch action to delete all selected branches. It also keeps the picker open.
The default behavior of deleting the branch on which the cursor stands on still works.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- [x] tested in local vim

**Configuration**:
* Neovim version (nvim --version): 0.8.2
* Operating system and version: OSX 12.6

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)


Closes #2363 
