### PR TITLE
feat(treesitter): symbols & ignore symbols options

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -388,6 +388,12 @@ files.treesitter = function(opts)
     end
   end
 
+  results = utils.filter_symbols(results, opts)
+  if results == nil then
+    -- error message already printed in `utils.filter_symbols`
+    return
+  end
+
   if vim.tbl_isempty(results) then
     return
   end

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -223,6 +223,36 @@ lsp.implementations = function(opts)
   return list_or_jump("textDocument/implementation", "LSP Implementations", opts)
 end
 
+local post_filter_symbols = function(filtered_symbols)
+  if vim.tbl_isempty(filtered_symbols) then
+    return filtered_symbols
+  end
+
+  local current_buf = vim.api.nvim_get_current_buf()
+
+  -- filter adequately for workspace symbols
+  local filename_to_bufnr = {}
+  for _, symbol in ipairs(filtered_symbols) do
+    if filename_to_bufnr[symbol.filename] == nil then
+      filename_to_bufnr[symbol.filename] = vim.uri_to_bufnr(vim.uri_from_fname(symbol.filename))
+    end
+    symbol["bufnr"] = filename_to_bufnr[symbol.filename]
+  end
+  table.sort(filtered_symbols, function(a, b)
+    if a.bufnr == b.bufnr then
+      return a.lnum < b.lnum
+    end
+    if a.bufnr == current_buf then
+      return true
+    end
+    if b.bufnr == current_buf then
+      return false
+    end
+    return a.bufnr < b.bufnr
+  end)
+  return filtered_symbols
+end
+
 lsp.document_symbols = function(opts)
   local params = vim.lsp.util.make_position_params(opts.winnr)
   vim.lsp.buf_request(opts.bufnr, "textDocument/documentSymbol", params, function(err, result, _, _)
@@ -240,7 +270,7 @@ lsp.document_symbols = function(opts)
     end
 
     local locations = vim.lsp.util.symbols_to_items(result or {}, opts.bufnr) or {}
-    locations = utils.filter_symbols(locations, opts)
+    locations = utils.filter_symbols(locations, opts, post_filter_symbols)
     if locations == nil then
       -- error message already printed in `utils.filter_symbols`
       return
@@ -283,7 +313,7 @@ lsp.workspace_symbols = function(opts)
     end
 
     local locations = vim.lsp.util.symbols_to_items(server_result or {}, opts.bufnr) or {}
-    locations = utils.filter_symbols(locations, opts)
+    locations = utils.filter_symbols(locations, opts, post_filter_symbols)
     if locations == nil then
       -- error message already printed in `utils.filter_symbols`
       return
@@ -331,7 +361,7 @@ local function get_workspace_symbols_requester(bufnr, opts)
 
     local locations = vim.lsp.util.symbols_to_items(res or {}, bufnr) or {}
     if not vim.tbl_isempty(locations) then
-      locations = utils.filter_symbols(locations, opts) or {}
+      locations = utils.filter_symbols(locations, opts, post_filter_symbols) or {}
     end
     return locations
   end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -91,6 +91,8 @@ builtin.fd = builtin.find_files
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by kind of ts node you want to see (i.e. `:var:`)
 ---@field show_line boolean: if true, shows the row:column that the result is found at (default: true)
 ---@field bufnr number: specify the buffer number where treesitter should run. (default: current buffer)
+---@field symbols string|table: filter results by symbol kind(s)
+---@field ignore_symbols string|table: list of symbols to ignore
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
 builtin.treesitter = require_on_exported_call("telescope.builtin.__files").treesitter
 


### PR DESCRIPTION
# Description

Add new options `symbols` and `ignore_symbols` to the treesitter picker so that the user can filter the results similarly to lsp_* pickers that already support these options.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- [x] use `treesitter` picker with `opts.symbols = { "var" }` and verify only the variables are shown
- [x] use `treesitter` picker with `opts.ignore_symbols = { "var" }` and verify the variables are **not** show
- [x] use `lsp_document_symbols` picker with `opts.symbols = { "function" }` and verify only the functions are shown
- [x] use `lsp_document_symbols` picker with `opts.ignore_symbols = { "function" }` and verify the functions are **not** shown

**Configuration**:
* Neovim version (nvim --version): 0.8.2
* Operating system and version: MacOS Big Sur 11.15.2

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)

# P.S.

Dear Telescope maintainers and community! This is my first PR to this amazing project. I hope for your kind and honest feedback :)

# P.S. 2

I didn't quite understand the process of generating the documentation from the annotations. I pushed my commit to a non-master branch on my fork, but github action failed due to lack of permissions for github-actions bot.