### PR TITLE
fix: escape filename used in drop commands

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -83,7 +83,7 @@ do
     if command ~= "drop" and command ~= "tab drop" then
       vim.cmd(string.format("%s %d", command, bufnr))
     else
-      vim.cmd(string.format("%s %s", command, vim.api.nvim_buf_get_name(bufnr)))
+      vim.cmd(string.format("%s %s", command, vim.fn.fnameescape(vim.api.nvim_buf_get_name(bufnr))))
     end
   end
 end


### PR DESCRIPTION
# Description

Fixes an issue with the `drop` command in telescope where filenames with spaces or other special characters are not open properly.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Ran on local using filenames with spaces

**Configuration**:
* Neovim version (nvim --version): 0.8.2
* Operating system and version: Windows 11

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
