### PR TITLE
fix: use path separator from builtin utils in cwd_only

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -524,7 +524,7 @@ internal.oldfiles = function(opts)
   end
 
   if opts.cwd_only then
-    local cwd = vim.loop.cwd() .. "/"
+    local cwd = vim.loop.cwd() .. utils.get_separator()
     cwd = cwd:gsub([[\]], [[\\]])
     results = vim.tbl_filter(function(file)
       return vim.fn.matchstrpos(file, cwd)[2] ~= -1


### PR DESCRIPTION
# Description
Fixes  an issue of getting empty results with oldfiles with cwd_only option ON inside Windows OS.
Now it is using `utils.get_separator()` instead of a static string `"/"`.


## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] Ran on local and invode `lua require'telescope.builtin'.oldfiles{cwd_only=true}`

**Configuration**:
* Neovim version (nvim --version): v0.9.0-dev
* Operating system and version: Windows 10

# Checklist:

- [ x] My code follows the style guidelines of this project (stylua)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation (lua annotations)
