### PR TITLE
pick lsp_reference from multpile clients

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -53,7 +53,7 @@ lsp.references = function(opts)
     if vim.tbl_isempty(locations) then
       return
     end
-    -- make sure all client run before jump
+
     if #locations == 1 and opts.jump_type ~= "never" then
       if opts.jump_type == "tab" then
         vim.cmd "tabedit"

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -18,6 +18,7 @@ lsp.references = function(opts)
   local locations = {}
   local count = 0
   local picker
+  -- add t2 to t1 if lnum and col is unique
   local add_unique = function(t1, t2)
     for _, v in ipairs(t2) do
       local add = true
@@ -58,7 +59,7 @@ lsp.references = function(opts)
     if vim.tbl_isempty(locations) then
       return
     end
-
+    -- make sure all client run before jump
     count = count + 1
     if #locations == 1 and count == buf_clients_num and opts.jump_type ~= "never" then
       if opts.jump_type == "tab" then


### PR DESCRIPTION
# Description

When one buffer is attached to multiple lsp clients, current implementation will only allow one client's result be shown. 
This cause issues when two client return different set of references. 


## Type of change


- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Test A: Create an angular project using
```
ng new test
nvim test/src/app/app.component.ts
``` 
```Telescope lsp_references``` on ```title```(line 9)


**Configuration**:
* Neovim version (nvim --version): 0.8.2 and master
* Operating system and version: macOS 13.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
