### PR TITLE
fix: fix `reverse range in character class` error

### DIFF
--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -30,7 +30,7 @@ function from_entry.path(entry, validate, escape)
     -- TODO(conni2461): we are not going to return the expanded path because
     --                  this would lead to cache misses in the perviewer.
     --                  Requires overall refactoring in previewer interface
-    local expanded = vim.fn.expand(path)
+    local expanded = vim.fn.expand(vim.fn.escape(path, '?*[]'))
     if (vim.fn.filereadable(expanded) + vim.fn.isdirectory(expanded)) == 0 then
       return
     end

--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -30,7 +30,7 @@ function from_entry.path(entry, validate, escape)
     -- TODO(conni2461): we are not going to return the expanded path because
     --                  this would lead to cache misses in the perviewer.
     --                  Requires overall refactoring in previewer interface
-    local expanded = vim.fn.expand(vim.fn.escape(path, '?*[]'))
+    local expanded = vim.fn.expand(vim.fn.escape(path, "?*[]"))
     if (vim.fn.filereadable(expanded) + vim.fn.isdirectory(expanded)) == 0 then
       return
     end


### PR DESCRIPTION
# Description

`vim.fn.expand` seems to be interpreting brackets (`[]`) as something special. Escape the filename before trying to expand.

Fixes #2233
Fixes #2315

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create files with brackets in the filename, e.g. `[2023-01-23] Test.md`, and try previewing it.

**Configuration**:

* Neovim version (nvim --version):

```
NVIM v0.8.2
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by brew@Ventura

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/local/Cellar/neovim/0.8.2/share/nvim"

Run :checkhealth for more info
```

* Operating system and version: macOS Ventura 13.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
