### PR TITLE
fix: util regex highlighter producing error when scrolling too fast

### DIFF
--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -126,8 +126,7 @@ end
 --- Attach regex highlighter
 utils.regex_highlighter = function(bufnr, ft)
   if has_filetype(ft) then
-    vim.api.nvim_buf_set_option(bufnr, "syntax", ft)
-    return true
+    return pcall(vim.api.nvim_buf_set_option, bufnr, "syntax", ft)
   end
   return false
 end


### PR DESCRIPTION
# Description

When scrolling through files or typing continuously on a search window, the regex highlighter has a chance to produce this error:

![WindowsTerminal_nMPRqOVhfU](https://user-images.githubusercontent.com/9144208/214166212-b7d76418-fb64-4a22-b6f8-4d60b5358679.png)

The affected function is rewritten by wrapping `nvim_buf_set_option` in a protected call, and returning whether that call succeeded as a boolean value.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Open a new `[S]earch [F]iles` window, and type or scroll.

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.8.2
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
Compiled by runneradmin@fv-az28-353

Features: -acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM\sysinit.vim"
  fall-back for $VIM: "C:/Program Files (x86)/nvim/share/nvim"

Run :checkhealth for more info
```
* Operating system and version: Windows 10 Pro 21H2

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
