### PR TITLE
Avoid eval "= directly in builtin registers picker

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -831,7 +831,7 @@ function make_entry.gen_from_registers(opts)
   end
 
   return function(entry)
-    local contents = vim.fn.getreg(entry)
+    local contents = vim.fn.getreg(entry, 1)
     return make_entry.set_default_entry_mt({
       value = entry,
       ordinal = string.format("%s %s", entry, contents),


### PR DESCRIPTION
# Description

When open registers picker,  the expression in `"=` register is evaluated, which might lead to error.

Now specify second arg to `getreg` to get the expression (instead of "evaluated" result) for entry content, like what `:registers` command displays.

This has behavior change, if user still want to see/paste the evaluated result of `"=`, customization will be needed.
However the picker doesn't have detail doc/definition about the behavior, so I guess the break is minor.

Fixes #2228

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [ ] Manually run `:put =foo`, then `:Telescope registers`, should not raise `Vim:E121: Undefined variable: foo`

**Configuration**:
* Neovim version (nvim --version): v0.8.2
* Operating system and version: Windows 10

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
