### PR TITLE
feat: Added support for wrapping history on reaching history begin or end

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -388,20 +388,25 @@ telescope.setup({opts})                                    *telescope.setup()*
           },
 
         Fields:
-          - path:    The path to the telescope history as string.
-                     Default: stdpath("data")/telescope_history
-          - limit:   The amount of entries that will be written in the
-                     history.
-                     Warning: If limit is set to nil it will grow unbound.
-                     Default: 100
-          - handler: A lua function that implements the history.
-                     This is meant as a developer setting for extensions to
-                     override the history handling, e.g.,
-                     https://github.com/nvim-telescope/telescope-smart-history.nvim,
-                     which allows context sensitive (cwd + picker) history.
+          - path:       The path to the telescope history as string.
+                        Default: stdpath("data")/telescope_history
+          - limit:      The amount of entries that will be written in the
+                        history.
+                        Warning: If limit is set to nil it will grow unbound.
+                        Default: 100
+          - handler:    A lua function that implements the history.
+                        This is meant as a developer setting for extensions to
+                        override the history handling, e.g.,
+                        https://github.com/nvim-telescope/telescope-smart-history.nvim,
+                        which allows context sensitive (cwd + picker) history.
 
-                     Default:
-                     require('telescope.actions.history').get_simple_history
+                        Default:
+                        require('telescope.actions.history').get_simple_history
+          - cycle_wrap: Indicates whether the cycle_history_next and
+                        cycle_history_prev functions should wrap around to the
+                        beginning or end of the history entries on reaching
+                        their respective ends
+                        Default: false
 
                                           *telescope.defaults.cache_picker*
     cache_picker: ~
@@ -3633,14 +3638,17 @@ histories.History()                      *telescope.actions.history.History()*
 
 
     Fields: ~
-        {enabled} (boolean)  Will indicate if History is enabled or disabled
-        {path}    (string)   Will point to the location of the history file
-        {limit}   (string)   Will have the limit of the history. Can be nil,
-                             if limit is disabled.
-        {content} (table)    History table. Needs to be filled by your own
-                             History implementation
-        {index}   (number)   Used to keep track of the next or previous index.
-                             Default is #content + 1
+        {enabled}    (boolean)  Will indicate if History is enabled or
+                                disabled
+        {path}       (string)   Will point to the location of the history file
+        {limit}      (string)   Will have the limit of the history. Can be
+                                nil, if limit is disabled.
+        {content}    (table)    History table. Needs to be filled by your own
+                                History implementation
+        {index}      (number)   Used to keep track of the next or previous
+                                index. Default is #content + 1
+        {cycle_wrap} (boolean)  Controls if history will wrap on reaching
+                                beginning or end
 
 
 histories.History:new({opts})        *telescope.actions.history.History:new()*

--- a/lua/telescope/actions/history.lua
+++ b/lua/telescope/actions/history.lua
@@ -53,6 +53,7 @@ local histories = {}
 ---@field limit string: Will have the limit of the history. Can be nil, if limit is disabled.
 ---@field content table: History table. Needs to be filled by your own History implementation
 ---@field index number: Used to keep track of the next or previous index. Default is #content + 1
+---@field cycle_wrap boolean: Controls if history will wrap on reaching beginning or end
 histories.History = {}
 histories.History.__index = histories.History
 
@@ -75,6 +76,7 @@ function histories.History:new(opts)
   obj.path = vim.fn.expand(conf.history.path)
   obj.content = {}
   obj.index = 1
+  obj.cycle_wrap = conf.history.cycle_wrap
 
   opts.init(obj)
   obj._reset = opts.reset
@@ -125,6 +127,10 @@ function histories.History:get_next(line, picker)
   end
 
   local next_idx = self.index + 1
+  if next_idx > #self.content and self.cycle_wrap then
+    next_idx = 1
+  end
+
   if next_idx <= #self.content then
     self.index = next_idx
     return self.content[next_idx]
@@ -150,6 +156,10 @@ function histories.History:get_prev(line, picker)
   end
 
   local next_idx = self.index - 1
+  if next_idx < 1 and self.cycle_wrap then
+    next_idx = #self.content
+  end
+
   if self.index == #self.content + 1 then
     if line ~= "" then
       self:append(line, picker, true)

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -484,9 +484,10 @@ append(
 
                   Default:
                   require('telescope.actions.history').get_simple_history
-    - cycle_wrap: Indicates whether the cycle_history_next and cycle_history_prev
-                  functions should wrap around to the beginning or end of the
-                  history entries on reaching their respective ends
+    - cycle_wrap: Indicates whether the cycle_history_next and
+                  cycle_history_prev functions should wrap around to the
+                  beginning or end of the history entries on reaching
+                  their respective ends
                   Default: false]]
 )
 

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -454,6 +454,7 @@ append(
     handler = function(...)
       return require("telescope.actions.history").get_simple_history(...)
     end,
+    cycle_wrap = false,
   },
   [[
   This field handles the configuration for prompt history.
@@ -469,20 +470,24 @@ append(
     },
 
   Fields:
-    - path:    The path to the telescope history as string.
-               Default: stdpath("data")/telescope_history
-    - limit:   The amount of entries that will be written in the
-               history.
-               Warning: If limit is set to nil it will grow unbound.
-               Default: 100
-    - handler: A lua function that implements the history.
-               This is meant as a developer setting for extensions to
-               override the history handling, e.g.,
-               https://github.com/nvim-telescope/telescope-smart-history.nvim,
-               which allows context sensitive (cwd + picker) history.
+    - path:       The path to the telescope history as string.
+                  Default: stdpath("data")/telescope_history
+    - limit:      The amount of entries that will be written in the
+                  history.
+                  Warning: If limit is set to nil it will grow unbound.
+                  Default: 100
+    - handler:    A lua function that implements the history.
+                  This is meant as a developer setting for extensions to
+                  override the history handling, e.g.,
+                  https://github.com/nvim-telescope/telescope-smart-history.nvim,
+                  which allows context sensitive (cwd + picker) history.
 
-               Default:
-               require('telescope.actions.history').get_simple_history]]
+                  Default:
+                  require('telescope.actions.history').get_simple_history
+    - cycle_wrap: Indicates whether the cycle_history_next and cycle_history_prev
+                  functions should wrap around to the beginning or end of the
+                  history entries on reaching their respective ends
+                  Default: false]]
 )
 
 append(


### PR DESCRIPTION
# Description

As noted in the linked issue, cycling the prompt history doesn't wrap around — picking prev on reaching the start of history content, or next on reaching the end, prevents any history from showing up. A common alternative is to wrap back to the start of history, or back to the end of history (depending on direction). This pull request adds that functionality, controlled by a new config option to allow users to decide whether they want this wrapping or not.

Fixes https://github.com/nvim-telescope/telescope.nvim/issues/2301

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Installed my own branch in place of `nvim-telescope/telescope.nvim`, and then tested the following cases:

- Standard existing history file with many entries
  - `defaults.history.cycle_wrap = true`: wrapped both forwards and backwards
  - `defaults.history.cycle_wrap = false`: did not wrap in either direction (existing behaviour)
  - `defaults.history.cycle_wrap` unset in `init.lua`: Same as `false`
- Empty history file
 - Did not error on `defaults.history.cycle_wrap` set to `true`, `false`, or unset

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.8.2
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by brew@Ventura-arm64.local

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/opt/homebrew/Cellar/neovim/0.8.2/share/nvim"
```

* Operating system and version:
macOS Ventura 13.1

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
