### PR TITLE
fix: man_pages on macOS 13 and FreeBSD #2326

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -767,8 +767,16 @@ internal.man_pages = function(opts)
   opts.sections = vim.F.if_nil(opts.sections, { "1" })
   assert(vim.tbl_islist(opts.sections), "sections should be a list")
   opts.man_cmd = utils.get_lazy_default(opts.man_cmd, function()
-    local is_darwin = vim.loop.os_uname().sysname == "Darwin"
-    return is_darwin and { "apropos", " " } or { "apropos", "" }
+    local uname = vim.loop.os_uname()
+    local sysname = string.lower(uname.sysname)
+    if sysname == "darwin" then
+      local major_version = tonumber(vim.fn.matchlist(uname.release, [[^\(\d\+\)\..*]])[2]) or 0
+      return major_version >= 22 and { "apropos", "." } or { "apropos", " " }
+    elseif sysname == "freebsd" then
+      return { "apropos", "." }
+    else
+      return { "apropos", "" }
+    end
   end)
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_apropos(opts)
   opts.env = { PATH = vim.env.PATH, MANPATH = vim.env.MANPATH }


### PR DESCRIPTION
# Description

In macOS 13 (Ventura), `:Telescope man_pages` shows no results. This is caused by a difference in behavior between the [previous implementation of `apropos(1)`][man-30] up to [macOS 12.5][macos12.5] and the new [`man` package][man-44] used in [macOS 13][macos13], which [comes from FreeBSD][freebsd].

[macos12.5]:https://github.com/apple-oss-distributions/distribution-macOS/tree/macos-125
[macos13]: https://github.com/apple-oss-distributions/distribution-macOS/tree/macos-130
[man-30]:https://github.com/apple-oss-distributions/man/tree/man-30
[man-44]: https://github.com/apple-oss-distributions/man/tree/man-44
[freebsd]: https://github.com/apple-oss-distributions/man/blob/bc98aec579feecce753f2da60345f388f1130aff/.upstream_base_commits

This new `apropos(1)` is implemented as a shell script and loses the `" "` argument through variable expansions. Since `apropos(1)` expects a regular expression to filter the results of the `whatis` database, passing `"."` causes it to not lose the argument and match everything, thus returning all results so they can be filtered within Telescope.

In the process of investigating the root cause for the issue on macOS 13, I realized that `:Telescope man_pages` doesn't work in FreeBSD for the same reason. Therefore, I included it in the fix.

Fixes #2326

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test steps:
1. Start `nvim` (on either macOS 13 or FreeBSD).
2. Open `man_pages` picker with `:Telescope man_pages`.
   - Result: list is populated with available man pages.

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.8.2
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by brew@Ventura

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/local/Cellar/neovim/0.8.2/share/nvim"
```
* Operating system and version:
  - [x] macOS 13.0.1
  - [x] FreeBSD 13.1-RELEASE (virtual machine)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] ~I have commented my code, particularly in hard-to-understand areas~ - not applicable
- [x] ~I have made corresponding changes to the documentation (lua annotations)~ - not applicable
