### PR TITLE
feat: Allow filtering for oldfiles and buffers 

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1214,6 +1214,7 @@ builtin.oldfiles({opts})                        *telescope.builtin.oldfiles()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
+        {cwd}      (string)   specify a working directory to filter oldfiles by
         {only_cwd} (boolean)  show only files in the cwd (default: false)
         {cwd_only} (boolean)  alias for only_cwd
 
@@ -1301,6 +1302,8 @@ builtin.buffers({opts})                          *telescope.builtin.buffers()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
+        {cwd}                   (string)   specify a working directory 
+                                           to filter buffers list by
         {show_all_buffers}      (boolean)  if true, show all buffers,
                                            including unloaded buffers
                                            (default: true)

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -523,8 +523,9 @@ internal.oldfiles = function(opts)
     end
   end
 
-  if opts.cwd_only then
-    local cwd = vim.loop.cwd() .. utils.get_separator()
+  if opts.cwd_only or opts.cwd then
+    local cwd = opts.cwd_only and vim.loop.cwd() or opts.cwd
+    cwd = cwd .. utils.get_separator()
     cwd = cwd:gsub([[\]], [[\\]])
     results = vim.tbl_filter(function(file)
       return vim.fn.matchstrpos(file, cwd)[2] ~= -1
@@ -868,6 +869,9 @@ internal.buffers = function(opts)
       return false
     end
     if opts.cwd_only and not string.find(vim.api.nvim_buf_get_name(b), vim.loop.cwd(), 1, true) then
+      return false
+    end
+    if not opts.cwd_only and opts.cwd and not string.find(vim.api.nvim_buf_get_name(b), opts.cwd, 1, true) then
       return false
     end
     return true


### PR DESCRIPTION

# Description
Add cwd property for buffers and oldfiles to allow for filtering of specific directory when cwd only is not present

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Test A 
   * configure a buffers picker with a cwd property instead of cwd_only, and provide a directory such as /home/<user>/.projects
   * visit a file from your home directory /home/<user>/.vimrc
   * visit multiple files from any project located within the .projects directory
   * open buffers picker and observe that only the buffers from the .projects directory are visible
- [ ] Test B
   * using test A after we have visited the .projects files 
   * configure oldfiles pciker with a cwd property instead of cwd_only, and provide a directory such as /home/<user>/.projects
   * open oldfiles and observe that only the recent files from .projects are shown

**Configuration**:
* Neovim version (nvim --version): 0.8.1
* Operating system and version: Ubuntu 22

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
