### PR TITLE
revise the #2288

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -677,6 +677,21 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Default: require("telescope.previewers").buffer_previewer_maker
 
+                                         *telescope.defaults.git_log_graph*
+    git_log_graph: ~
+        Show git log with --graph option.
+          Args:
+          - show                      showing the graph or not
+              false (default)
+              true
+          - all_branches              showing all branches with graph
+              false (default)
+              true
+          - inverted                  if first git log showing on the top
+              false (default)
+              true
+          Default: {show = false, all_branches = false, inverted = false}
+
     Parameters: ~
         {opts} (table)  Configuration opts. Keys: defaults, pickers,
                         extensions

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -55,8 +55,18 @@ git.files = function(opts)
 end
 
 git.commits = function(opts)
+  local args = { "git", "log", "--oneline", "--", "." }
+  if conf.git_log_graph.show then
+    if conf.git_log_graph.all_branches then
+      args = { "git", "log", "--graph", "--all", "--oneline", "--decorate" }
+    else
+      args = { "git", "log", "--graph", "--oneline", "--decorate", "--", "." }
+    end
+  end
+  opts.git_log_graph = conf.git_log_graph
+
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
-  local git_command = vim.F.if_nil(opts.git_command, { "git", "log", "--graph", "--oneline", "--decorate", "--", "." })
+  local git_command = vim.F.if_nil(opts.git_command, args)
 
   pickers
     .new(opts, {
@@ -115,7 +125,7 @@ git.bcommits = function(opts)
   opts.current_line = (opts.current_file == nil) and get_current_buf_line(opts.winnr) or nil
   opts.current_file = vim.F.if_nil(opts.current_file, vim.api.nvim_buf_get_name(opts.bufnr))
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
-  local git_command = vim.F.if_nil(opts.git_command, { "git", "log", "--graph", "--oneline", "--decorate", "--follow" })
+  local git_command = vim.F.if_nil(opts.git_command, { "git", "log", "--oneline", "--follow" })
 
   pickers
     .new(opts, {

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -831,12 +831,12 @@ append(
     Default: require("telescope.previewers").buffer_previewer_maker]]
 )
 
- append(
-   "git_log_graph",
-   {
+append(
+  "git_log_graph",
+  {
     show = false,
     all_branches = false,
-    inverted = false
+    inverted = false,
   },
   [[
   Show git log with --graph option.
@@ -851,7 +851,7 @@ append(
         false (default)
         true
     Default: {show = false, all_branches = false, inverted = false}]]
- )
+)
 
 -- @param user_defaults table: a table where keys are the names of options,
 --    and values are the ones the user wants

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -831,6 +831,28 @@ append(
     Default: require("telescope.previewers").buffer_previewer_maker]]
 )
 
+ append(
+   "git_log_graph",
+   {
+    show = false,
+    all_branches = false,
+    inverted = false
+  },
+  [[
+  Show git log with --graph option.
+    Args:
+    - show                      showing the graph or not
+        false (default)
+        true
+    - all_branches              showing all branches with graph
+        false (default)
+        true
+    - inverted                  if first git log showing on the top
+        false (default)
+        true
+    Default: {show = false, all_branches = false, inverted = false}]]
+ )
+
 -- @param user_defaults table: a table where keys are the names of options,
 --    and values are the ones the user wants
 -- @param tele_defaults table: (optional) a table containing all of the defaults

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -409,6 +409,7 @@ end
 
 function make_entry.gen_from_git_commits(opts)
   opts = opts or {}
+  local git_log_graph = opts.git_log_graph or {}
 
   local displayer = entry_display.create {
     separator = " ",
@@ -442,10 +443,11 @@ function make_entry.gen_from_git_commits(opts)
       msg = "<empty commit message>"
     end
 
-    marker, _ = string.gsub(marker, "\\", "+")
-    marker, _ = string.gsub(marker, "/", "-")
-    marker, _ = string.gsub(marker, "+", "/")
-    marker, _ = string.gsub(marker, "-", "\\")
+    if not git_log_graph.inverted then
+      marker, _ = string.gsub(marker, "\\", "+")
+      marker, _ = string.gsub(marker, "/", "-")
+      marker, _ = string.gsub(marker, "+", "/")
+    end
 
     return make_entry.set_default_entry_mt({
       value = sha,


### PR DESCRIPTION
# Description

the revised version of #2288 

Fixes # (issue)
-   Fix: remove graph option in bcommits
-   Feat: add config to control the graph behaviour in commits

# How Has This Been Tested?

invoking the function  `builtin.git_bcommits` and `builtin.git_commits` with configuration 

**Configuration**:
```
require('telescope').setup{
  defaults = {
    -- Default configuration for telescope goes here:
    -- config_key = value,
    git_log_graph = {show = true, all_branches = true, inverted = false},
  },
}
```
