### PR TITLE
Add missing documentation for builtin lsp symbols

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1557,6 +1557,10 @@ builtin.lsp_document_symbols({opts}) *telescope.builtin.lsp_document_symbols()*
     Options: ~
         {fname_width}       (number)        defines the width of the filename
                                             section (default: 30)
+        {symbol_width}      (number)        defines the width of the symbol
+                                            section (default: 25)
+        {symbol_type_width} (number)        defines the width of the symbol
+                                            type section (default: 8)
         {show_line}         (boolean)       if true, shows the content of the
                                             line the tag is found on (default:
                                             false)
@@ -1581,6 +1585,10 @@ builtin.lsp_workspace_symbols({opts}) *telescope.builtin.lsp_workspace_symbols()
                                             (default: "")
         {fname_width}       (number)        defines the width of the filename
                                             section (default: 30)
+        {symbol_width}      (number)        defines the width of the symbol
+                                            section (default: 25)
+        {symbol_type_width} (number)        defines the width of the symbol
+                                            type section (default: 8)
         {show_line}         (boolean)       if true, shows the content of the
                                             line the tag is found on (default:
                                             false)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -429,6 +429,8 @@ builtin.lsp_implementations = require_on_exported_call("telescope.builtin.__lsp"
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
 ---@param opts table: options to pass to the picker
 ---@field fname_width number: defines the width of the filename section (default: 30)
+---@field symbol_width number: defines the width of the symbol section (default: 25)
+---@field symbol_type_width number: defines the width of the symbol type section (default: 8)
 ---@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
 ---@field ignore_symbols string|table: list of symbols to ignore
@@ -441,6 +443,8 @@ builtin.lsp_document_symbols = require_on_exported_call("telescope.builtin.__lsp
 ---@param opts table: options to pass to the picker
 ---@field query string: for what to query the workspace (default: "")
 ---@field fname_width number: defines the width of the filename section (default: 30)
+---@field symbol_width number: defines the width of the symbol section (default: 25)
+---@field symbol_type_width number: defines the width of the symbol type section (default: 8)
 ---@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
 ---@field symbols string|table: filter results by symbol kind(s)
 ---@field ignore_symbols string|table: list of symbols to ignore


### PR DESCRIPTION
Add missing documentation for symbol_width and symbol_type_width on lsp_document_symbols and lsp_workspace_symbols.

# Description

Documentation for symbol_width and symbol_type_width was missing for telescope.builtin.lsp_document_symbols and telescope.builtin.lsp_workspace_symbols.

## Type of change

Documentation update.

# How Has This Been Tested?

Opening a draft pull request to check the updated documentation.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.8.2
* Operating system and version: CentOS 7

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
