### PR TITLE
Let git_status keep selection row and prompt on git_staging_toggle action

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -357,7 +357,18 @@ git.status = function(opts)
       attach_mappings = function(prompt_bufnr, map)
         actions.git_staging_toggle:enhance {
           post = function()
-            action_state.get_current_picker(prompt_bufnr):refresh(gen_new_finder(), { reset_prompt = true })
+            local picker = action_state.get_current_picker(prompt_bufnr)
+
+            -- temporarily register a callback which keeps selection on refresh
+            local selection = picker:get_selection_row()
+            local callbacks = { unpack(picker._completion_callbacks) } -- shallow copy
+            picker:register_completion_callback(function(self)
+              self:set_selection(selection)
+              self._completion_callbacks = callbacks
+            end)
+
+            -- refresh
+            picker:refresh(gen_new_finder(), { reset_prompt = false })
           end,
         }
 


### PR DESCRIPTION
# Description

With this PR, `git_staging_toggle:post` will ...

- never `reset_prompt`
- keep selection row as much as possible
    - unless selection is removed from the filtered list and
        - the selection is formely on the top row when `sorting_strategy == "decending"`
        - the selection is formely on the bottom row when `sorting_strategy == "ascending"`

Sometimes, (un-)staging changes the order of filtered items.
In such cases, maybe it would be better to update selection row to track the new position of (un-)staged file.
However, I decided not to do it because

- implementation can be complex
- unexpected changes of selection row may distrub users from continuing to the next actions that users had in their mind

Although I think this is a great change, it is a breaking change at the same time.

If it is not likely, maybe we can add an option to `telescope.builtin.git_status` so that the default behavior remains same as before.
Unfortunately, I have not come up with a good name for that option.

Fixes #2371

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

## Prepare git repo and run open `Telescope git_status` with some default text.

``` bash
cd $(mktemp -d)
git init
touch aa ab ac ad ae
git add aa ab ac
git commit -m 'add files'
rm ac
echo 'x' | tee aa ab
nvim +"lua require('telescope.builtin').git_status({default_text = 'a'})"
```

## Test the behavior of `git_staging_toggle` with `<Tab>`

In the following steps, text in the prompt always remains `a`.

- [x] files are ordered alphabetically from bottom to the top
- [x] stage and unstage a modified file `ab`
    - keep selecting `ab` on the same row
- [x] stage and unstage a deleted file `ac`
    - keep selecting `ac` on the same row
- [x] stage untracked files `ae`
    - `ae` goes between `ac` and `ad`
    - selection row remains the same but the selected item becomes `ad`
- [x] unstage added file `ae`
    - `ae` goes to the top
    - selection row remains the same but the selected item becomes `ad`
- [x] stage deleted file `ac` and  stage untracked file `ae`
    - `ac` is considered to be moved to `ae`, resulting the removal of `ac` from the list and moving of `ae` between `ab` and `ad`
    - selection row resets to bottom where `aa` sits

The similar tests are performed on with `sorting_strategy = "ascending"`

**Configuration**:
* Neovim version (nvim --version): v0.9.0-dev-849+g7880eeb2e
* Operating system and version: Manjaro Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation (lua annotations)~~
