### PR TITLE
live_grep: Allow disabling of filename in result list

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -801,6 +801,8 @@ builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
         {max_results}         (number)          define a upper result value
         {disable_coordinates} (boolean)         don't show the line & row
                                                 numbers (default: false)
+        {disable_filenames}   (boolean)         don't show the file path
+                                                (default: false)
 
 
 builtin.grep_string({opts})                  *telescope.builtin.grep_string()*

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -272,6 +272,7 @@ do
 
     local disable_devicons = opts.disable_devicons
     local disable_coordinates = opts.disable_coordinates
+    local disable_filenames = opts.disable_filenames
     local only_sort_text = opts.only_sort_text
 
     local execute_keys = {
@@ -313,15 +314,18 @@ do
       cwd = vim.fn.expand(opts.cwd or vim.loop.cwd()),
 
       display = function(entry)
-        local display_filename = utils.transform_path(opts, entry.filename)
+        local display_filename = ""
+        if not disable_filenames then
+          display_filename = string.format("%s:", utils.transform_path(opts, entry.filename))
+        end
 
         local coordinates = ":"
         if not disable_coordinates then
           if entry.lnum then
             if entry.col then
-              coordinates = string.format(":%s:%s:", entry.lnum, entry.col)
+              coordinates = string.format("%s:%s:", entry.lnum, entry.col)
             else
-              coordinates = string.format(":%s:", entry.lnum)
+              coordinates = string.format("%s:", entry.lnum)
             end
           end
         end


### PR DESCRIPTION
= Description =

This patch adds a new option to the `live_grep` picker named `disable_filenames`. It will hide the filename in the result buffer.

This is useful when we are using `live_grep` for grepping inside a single file; it is not useful to see the path to the file since that is already known. This is especially true for files in deep paths.

In this case I am using `live_grep` to create an interactive log filtering mechanism. By using a custom sorter we can sort by line numbers. By removing the filename we can see a lot more of the logs.

Fixes #<issue not filed>

== Type of change ==

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

== How Has This Been Tested? ==

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

=== Test ===
Run the following in neovim with telescope available, inside a populated buffer. The results window will not show filenames: `:lua require('telescope.builtin').live_grep { search_dirs = { vim.api.nvim_buf_get_name(0) }, disable_filenames = true }`

Setting `disable_filenames = false` or removing the option makes the filenames reappear.

**Configuration**:
* Neovim version (nvim --version): 0.8.1
* Operating system and version: Linux 6.0.10 (NixOS 23.05.20221130.e76c78d (Stoat) x86_64)

= Checklist: =

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)