### PR TITLE
fix: execute autocmds correctly

### DIFF
--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -348,7 +348,7 @@ mappings.execute_keymap = function(prompt_bufnr, keymap_identifier)
   assert(key_func, string.format("Unsure of how we got this failure: %s %s", prompt_bufnr, keymap_identifier))
 
   key_func(prompt_bufnr)
-  vim.api.nvim_exec_autocmds("User TelescopeKeymap", {})
+  vim.api.nvim_exec_autocmds("User", { pattern = "TelescopeKeymap" })
 end
 
 mappings.clear = function(prompt_bufnr)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -344,7 +344,7 @@ function Picker:find()
   self.original_win_id = a.nvim_get_current_win()
 
   -- User autocmd run it before create Telescope window
-  vim.api.nvim_exec_autocmds("User TelescopeFindPre", {})
+  vim.api.nvim_exec_autocmds("User", { pattern = "TelescopeFindPre" })
 
   -- Create three windows:
   -- 1. Prompt window


### PR DESCRIPTION
# Description

I tried to use the `User TelescopeFindPre` event listed on the [README](https://github.com/nvim-telescope/telescope.nvim#autocmds), but the autocmd was never executed. This PR fixes that.

Autocmds are currently executed like this:

```lua
vim.api.nvim_exec_autocmds("User TelescopeKeymap", {})
```

And to my knowledge the pattern needs to be passed as an option:

```lua
vim.api.nvim_exec_autocmds("User", { pattern = "TelescopeKeymap" })
```

<br>

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

<br>

# How Has This Been Tested?

1. Add a autocmd:  
   `autocmd User TelescopeFindPre echo "-> TelescopeFindPre!"`
2. Open telescope

It should print "-> TelescopeFindPre!".

<br>

**Configuration**:
* Neovim version: `v0.9.0-dev-912+gfe1e6b82f`
* Operating system and version: macOS 13.1

<br>

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation (lua annotations)
