### PR TITLE
fix: rename ts_utils.get_node_range -> vim.treesitter.get_node_range

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -696,8 +696,7 @@ function make_entry.gen_from_treesitter(opts)
 
   local get_filename = get_filename_fn()
   return function(entry)
-    local ts_utils = require "nvim-treesitter.ts_utils"
-    local start_row, start_col, end_row, _ = ts_utils.get_node_range(entry.node)
+    local start_row, start_col, end_row, _ = vim.treesitter.get_node_range(entry.node)
     local node_text = vim.treesitter.get_node_text(entry.node, bufnr)
     return make_entry.set_default_entry_mt({
       value = entry.node,


### PR DESCRIPTION
# Description

fix: https://github.com/nvim-treesitter/nvim-treesitter/pull/4300

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I confirmed that the following command did not show any error message.

`lua require'telescope.builtin'.treesitter()`

**Configuration**:
* Neovim version (nvim --version): v0.9.0-dev-935+g3a5dddf24
* Operating system and version: Arch Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
