### PR TITLE
[POC] compact theme

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -77,6 +77,7 @@ function Picker:new(opts)
     entry_prefix = vim.F.if_nil(opts.entry_prefix, config.values.entry_prefix),
     multi_icon = vim.F.if_nil(opts.multi_icon, config.values.multi_icon),
 
+    theme = vim.F.if_nil(opts.theme, "dropdown"),
     initial_mode = vim.F.if_nil(opts.initial_mode, config.values.initial_mode),
     _original_mode = vim.api.nvim_get_mode().mode,
     debounce = vim.F.if_nil(tonumber(opts.debounce), nil),

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -344,7 +344,7 @@ layout_strategies.horizontal = make_documented_layout(
     height, h_space = calc_size_and_spacing(height, max_lines, bs, 2, 4, 1)
 
     prompt.height = 1
-    results.height = height - prompt.height - h_space
+    results.height = height - prompt.height - h_space + (self.theme == "minimal" and 1 or 0)
 
     if self.previewer then
       preview.height = height - 2 * bs
@@ -367,10 +367,12 @@ layout_strategies.horizontal = make_documented_layout(
     preview.line = math.floor((max_lines - height) / 2) + bs + 1
     if layout_config.prompt_position == "top" then
       prompt.line = preview.line
-      results.line = prompt.line + prompt.height + 1 + bs
+      results.line = prompt.line + prompt.height + bs + (self.theme == "minimal" and 0 or 1)
+      results.zindex = prompt.zindex + (self.theme == "minimal" and 1 or 0)
     elseif layout_config.prompt_position == "bottom" then
       results.line = preview.line
-      prompt.line = results.line + results.height + 1 + bs
+      prompt.line = results.line + results.height + bs + (self.theme == "minimal" and 0 or 1)
+      prompt.zindex = results.zindex + (self.theme == "minimal" and 1 or 0)
     else
       error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
     end
@@ -728,12 +730,15 @@ layout_strategies.vertical = make_documented_layout(
     else
       if layout_config.prompt_position == "top" then
         prompt.line = height_padding + (1 + bs)
-        results.line = prompt.line + prompt.height + (1 + bs)
-        preview.line = results.line + results.height + (1 + bs)
+        results.line = prompt.line + prompt.height + (1 + bs) - (self.theme == "minimal" and 1 or 0)
+        preview.line = results.line + results.height + (1 + bs) - (self.theme == "minimal" and 1 or 0)
+        preview.zindex = results.zindex + (self.theme == "minimal" and 1 or 0)
       elseif layout_config.prompt_position == "bottom" then
         results.line = height_padding + (1 + bs)
-        prompt.line = results.line + results.height + (1 + bs)
-        preview.line = prompt.line + prompt.height + (1 + bs)
+        prompt.line = results.line + results.height + (1 + bs) - (self.theme == "minimal" and 1 or 0)
+        preview.line = prompt.line + prompt.height + (1 + bs) - (self.theme == "minimal" and 1 or 0)
+        prompt.zindex = results.zindex + (self.theme == "minimal" and 1 or 0)
+        preview.zindex = prompt.zindex + (self.theme == "minimal" and 1 or 0)
       else
         error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
       end

--- a/lua/telescope/pickers/window.lua
+++ b/lua/telescope/pickers/window.lua
@@ -23,6 +23,7 @@ function p_window.get_initial_window_options(picker)
     borderchars = popup_borderchars.preview,
     enter = false,
     highlight = false,
+    zindex = 50
   }
 
   local results = {
@@ -30,6 +31,7 @@ function p_window.get_initial_window_options(picker)
     border = popup_border.results,
     borderchars = popup_borderchars.results,
     enter = false,
+    zindex = 50
   }
 
   local prompt = {
@@ -37,6 +39,7 @@ function p_window.get_initial_window_options(picker)
     border = popup_border.prompt,
     borderchars = popup_borderchars.prompt,
     enter = true,
+    zindex = 50
   }
 
   return {

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -64,6 +64,74 @@ function themes.get_dropdown(opts)
   return vim.tbl_deep_extend("force", theme_opts, opts)
 end
 
+--- Minimal style theme.
+---
+--- Usage:
+--- <code>
+---     local opts = {...} -- picker options
+---     local builtin = require('telescope.builtin')
+---     local themes = require('telescope.themes')
+---     builtin.find_files(themes.get_minimal(opts))
+--- </code>
+function themes.get_minimal(opts)
+  opts = opts or {}
+
+  local theme_opts = {
+    theme = "minimal",
+
+    results_title = false,
+
+    sorting_strategy = "ascending",
+    layout_strategy = "horizontal",
+    layout_config = {
+      preview_cutoff = 1, -- Preview should always show (unless previewer = false)
+
+      width = function(_, max_columns, _)
+        return math.min(max_columns, 80)
+      end,
+
+      height = function(_, _, max_lines)
+        return math.min(max_lines, 15)
+      end,
+    },
+
+    border = true,
+    borderchars = {
+      prompt = { "─", "│", "x", "│", "╭", "┬", "│", "│" },
+      results = { "─", "│", "─", "│", "├", "┤", "┴", "╰" },
+      preview = { "─", "│", "─", " ", "─", "╮", "╯", "─" },
+    },
+  }
+  if opts.layout_config and opts.layout_config.prompt_position == "bottom" then
+    theme_opts.borderchars = {
+      results = { "─", "│", "x", "│", "╭", "┬", "│", "│" },
+      prompt = { "─", "│", "─", "│", "├", "┤", "┴", "╰" },
+      preview = { "─", "│", "─", " ", "─", "╮", "╯", "─" },
+    }
+  end
+
+  if opts.layout_strategy and opts.layout_strategy == "vertical" then
+    local top = { "─", "│", "x", "│", "╭", "╮", "│", "│" }
+    local middle = { "─", "│", "─", "│", "├", "┤", "┴", "╰" }
+    local bottom = { "─", "│", "─", "│", "├", "┤", "╯", "╰" }
+
+    if opts.layout_config and opts.layout_config.prompt_position == "bottom" then
+      theme_opts.borderchars = {
+        results = top,
+        prompt = middle,
+        preview = bottom,
+      }
+    else
+      theme_opts.borderchars = {
+        prompt = top,
+        results = middle,
+        preview = bottom,
+      }
+    end
+  end
+  return vim.tbl_deep_extend("force", theme_opts, opts)
+end
+
 --- Cursor style theme.
 ---
 --- Usage:


### PR DESCRIPTION
# Description

I really love telescope.nvim, but I've never been a big fan of having three separate (looking) popups for the prompt, results, and preview. Looking at the plenary popup options, I noticed there were options for z-indexing that weren't being used within telescope. By adding those values, and doing some slight modifications to the vertical and horizontal layout strategies, I was able to produce the following compact theme.

To date it works with both the horizontal / vertical themes (not mirrored - yet) and either prompt_position.

If there is interest in me completing this work I would be happy to do so!

Here are a few example screenshots of the theme in action. (Note: I prefer to not have prompt/results/preview titles, but they do work as you'd expect due to the z-indexing):

<img width="1414" alt="image" src="https://user-images.githubusercontent.com/21346716/218633622-6a0ca15c-832b-4e52-bd24-78a7121678c2.png">

<img width="967" alt="image" src="https://user-images.githubusercontent.com/21346716/218633797-a8ddc69b-efd3-4c53-aa72-c4aa1f4f9d9a.png">


## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

TBD

**Configuration**:
* Neovim version (nvim --version): nightly
* Operating system and version: MacOS Ventura

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
