### PR TITLE
feat(git): Add bcommits_range picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Built-in functions. Ready to be bound to any key you like.
 |-------------------------------------|------------------------------------------------------------------------------------------------------------|
 | `builtin.git_commits`               | Lists git commits with diff preview, checkout action `<cr>`, reset mixed `<C-r>m`, reset soft `<C-r>s` and reset hard `<C-r>h` |
 | `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and checks them out on `<cr>`                                 |
-| `builtin.git_bcommits_range`        | Lists buffer's git commits in a range of lines. Use options `first` and `last` to specify the range. In visual mode, lists commits for the selected lines |
+| `builtin.git_bcommits_range`        | Lists buffer's git commits in a range of lines. Use options `from` and `to` to specify the range. In visual mode, lists commits for the selected lines |
 | `builtin.git_branches`              | Lists all branches with log preview, checkout action `<cr>`, track action `<C-t>`, rebase action`<C-r>`, create action `<C-a>`, switch action `<C-s>`, delete action `<C-d>` and merge action `<C-y>` |
 | `builtin.git_status`                | Lists current changes per file with diff preview and add action. (Multi-selection still WIP)               |
 | `builtin.git_stash`                 | Lists stash items in current repository with ability to apply them on `<cr>`                               |

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Built-in functions. Ready to be bound to any key you like.
 | Functions                           | Description                                                                                                |
 |-------------------------------------|------------------------------------------------------------------------------------------------------------|
 | `builtin.git_commits`               | Lists git commits with diff preview, checkout action `<cr>`, reset mixed `<C-r>m`, reset soft `<C-r>s` and reset hard `<C-r>h` |
-| `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and checks them out on `<cr>`                                 |
+| `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and checks them out on `<cr>`. In visual mode, lists commits for selected lines   |
 | `builtin.git_branches`              | Lists all branches with log preview, checkout action `<cr>`, track action `<C-t>`, rebase action`<C-r>`, create action `<C-a>`, switch action `<C-s>`, delete action `<C-d>` and merge action `<C-y>` |
 | `builtin.git_status`                | Lists current changes per file with diff preview and add action. (Multi-selection still WIP)               |
 | `builtin.git_stash`                 | Lists stash items in current repository with ability to apply them on `<cr>`                               |

--- a/README.md
+++ b/README.md
@@ -360,7 +360,8 @@ Built-in functions. Ready to be bound to any key you like.
 | Functions                           | Description                                                                                                |
 |-------------------------------------|------------------------------------------------------------------------------------------------------------|
 | `builtin.git_commits`               | Lists git commits with diff preview, checkout action `<cr>`, reset mixed `<C-r>m`, reset soft `<C-r>s` and reset hard `<C-r>h` |
-| `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and checks them out on `<cr>`. In visual mode, lists commits for selected lines   |
+| `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and checks them out on `<cr>`                                 |
+| `builtin.git_bcommits_range`        | Lists buffer's git commits in a range of lines. Use options `start` and `end` to specify the range. In visual mode, lists commits for the selected lines |
 | `builtin.git_branches`              | Lists all branches with log preview, checkout action `<cr>`, track action `<C-t>`, rebase action`<C-r>`, create action `<C-a>`, switch action `<C-s>`, delete action `<C-d>` and merge action `<C-y>` |
 | `builtin.git_status`                | Lists current changes per file with diff preview and add action. (Multi-selection still WIP)               |
 | `builtin.git_stash`                 | Lists stash items in current repository with ability to apply them on `<cr>`                               |

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Built-in functions. Ready to be bound to any key you like.
 |-------------------------------------|------------------------------------------------------------------------------------------------------------|
 | `builtin.git_commits`               | Lists git commits with diff preview, checkout action `<cr>`, reset mixed `<C-r>m`, reset soft `<C-r>s` and reset hard `<C-r>h` |
 | `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and checks them out on `<cr>`                                 |
-| `builtin.git_bcommits_range`        | Lists buffer's git commits in a range of lines. Use options `start` and `end` to specify the range. In visual mode, lists commits for the selected lines |
+| `builtin.git_bcommits_range`        | Lists buffer's git commits in a range of lines. Use options `first` and `last` to specify the range. In visual mode, lists commits for the selected lines |
 | `builtin.git_branches`              | Lists all branches with log preview, checkout action `<cr>`, track action `<C-t>`, rebase action`<C-r>`, create action `<C-a>`, switch action `<C-s>`, delete action `<C-d>` and merge action `<C-y>` |
 | `builtin.git_status`                | Lists current changes per file with diff preview and add action. (Multi-selection still WIP)               |
 | `builtin.git_stash`                 | Lists stash items in current repository with ability to apply them on `<cr>`                               |

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1030,6 +1030,7 @@ builtin.git_commits({opts})                  *telescope.builtin.git_commits()*
 
 builtin.git_bcommits({opts})                *telescope.builtin.git_bcommits()*
     Lists commits for current buffer with diff preview
+    In visual mode, lists commits for the selected lines
     - Default keymaps or your overridden `select_` keys:
       - `<cr>`: checks out the currently selected commit
       - `<c-v>`: opens a diff in a vertical split

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1075,10 +1075,10 @@ builtin.git_bcommits_range({opts})   *telescope.builtin.git_bcommits_range()*
         {git_command}  (table)    command that will be executed. the last
                                   element must be "-L".
                                   {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
-        {first}        (number)   the first line number in the range
+        {from}         (number)   the first line number in the range
                                   (default: current line)
-        {last}         (number)   the last line number in the range
-                                  (default: the value of first)
+        {to}           (number)   the last line number in the range
+                                  (default: the value of `from`)
         {operator}     (boolean)  select lines in operator-pending mode
                                   (default: false)
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1055,6 +1055,7 @@ builtin.git_bcommits({opts})                *telescope.builtin.git_bcommits()*
 builtin.git_bcommits_range({opts})   *telescope.builtin.git_bcommits_range()*
     Lists commits for a range of lines in the current buffer with diff preview
     In visual mode, lists commits for the selected lines
+    With operator mode enabled, lists commits inside the text object/motion
     - Default keymaps or your overridden `select_` keys:
       - `<cr>`: checks out the currently selected commit
       - `<c-v>`: opens a diff in a vertical split
@@ -1071,12 +1072,14 @@ builtin.git_bcommits_range({opts})   *telescope.builtin.git_bcommits_range()*
                                   (important for submodule) (default: true)
         {current_file} (string)   specify the current file that should be used
                                   for bcommits (default: current buffer)
-        {git_command}  (table)    command that will be executed.
+        {git_command}  (table)    command that will be executed. the last
+                                  element must be "-L".
                                   {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
-        {start}        (number)   the first line in the range
-                                  (optional in visual or operator mode)
-        {stop}         (number)   the last line in the range
-                                  (optional in visual or operator mode)
+        {first}        (number)   the first line number in the range
+                                  (optional in visual or operator mode;
+                                   runs git_bcommits if nil otherwise)
+        {last}         (number)   the last line number in the range
+                                  (default: the value of first)
         {operator}     (boolean)  select lines in operator-pending mode
                                   (default: false)
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1076,8 +1076,7 @@ builtin.git_bcommits_range({opts})   *telescope.builtin.git_bcommits_range()*
                                   element must be "-L".
                                   {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
         {first}        (number)   the first line number in the range
-                                  (optional in visual or operator mode;
-                                   runs git_bcommits if nil otherwise)
+                                  (default: current line)
         {last}         (number)   the last line number in the range
                                   (default: the value of first)
         {operator}     (boolean)  select lines in operator-pending mode

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1074,9 +1074,11 @@ builtin.git_bcommits_range({opts})   *telescope.builtin.git_bcommits_range()*
         {git_command}  (table)    command that will be executed.
                                   {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
         {start}        (number)   the first line in the range
-                                  (optional in visual mode)
+                                  (optional in visual or operator mode)
         {stop}         (number)   the last line in the range
-                                  (optional in visual mode)
+                                  (optional in visual or operator mode)
+        {operator}     (boolean)  select lines in operator-pending mode
+                                  (default: false)
 
 builtin.git_branches({opts})                *telescope.builtin.git_branches()*
     List branches for current directory, with output from `git log --oneline`

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1030,7 +1030,6 @@ builtin.git_commits({opts})                  *telescope.builtin.git_commits()*
 
 builtin.git_bcommits({opts})                *telescope.builtin.git_bcommits()*
     Lists commits for current buffer with diff preview
-    In visual mode, lists commits for the selected lines
     - Default keymaps or your overridden `select_` keys:
       - `<cr>`: checks out the currently selected commit
       - `<c-v>`: opens a diff in a vertical split
@@ -1052,6 +1051,32 @@ builtin.git_bcommits({opts})                *telescope.builtin.git_bcommits()*
         {git_command}   (table)    command that will be executed.
                                    {"git","log","--pretty=oneline","--abbrev-commit"}
 
+
+builtin.git_bcommits_range({opts})   *telescope.builtin.git_bcommits_range()*
+    Lists commits for a range of lines in the current buffer with diff preview
+    In visual mode, lists commits for the selected lines
+    - Default keymaps or your overridden `select_` keys:
+      - `<cr>`: checks out the currently selected commit
+      - `<c-v>`: opens a diff in a vertical split
+      - `<c-x>`: opens a diff in a horizontal split
+      - `<c-t>`: opens a diff in a new tab
+
+
+    Parameters: ~
+        {opts} (table)  options to pass to the picker
+
+    Options: ~
+        {cwd}          (string)   specify the path of the repo
+        {use_git_root} (boolean)  if we should use git root as cwd or the cwd
+                                  (important for submodule) (default: true)
+        {current_file} (string)   specify the current file that should be used
+                                  for bcommits (default: current buffer)
+        {git_command}  (table)    command that will be executed.
+                                  {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
+        {start}        (number)   the first line in the range
+                                  (optional in visual mode)
+        {stop}         (number)   the last line in the range
+                                  (optional in visual mode)
 
 builtin.git_branches({opts})                *telescope.builtin.git_branches()*
     List branches for current directory, with output from `git log --oneline`

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -198,8 +198,10 @@ git.bcommits_range = function(opts)
   opts.current_line = (opts.current_file == nil) and get_current_buf_line(opts.winnr) or nil
   opts.current_file = vim.F.if_nil(opts.current_file, vim.api.nvim_buf_get_name(opts.bufnr))
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
-  local git_command =
-    vim.F.if_nil(opts.git_command, { "git", "log", "--pretty=oneline", "--abbrev-commit", "--no-patch", "-L" })
+  opts.git_command = vim.F.if_nil(
+    opts.git_command,
+    git_command({ "log", "--pretty=oneline", "--abbrev-commit", "--no-patch", "-L" }, opts)
+  )
   local visual = string.find(vim.fn.mode(), "[vV]") ~= nil
 
   local line_number_first = opts.first
@@ -227,7 +229,7 @@ git.bcommits_range = function(opts)
       prompt_title = "Git BCommits in range",
       finder = finders.new_oneshot_job(
         vim.tbl_flatten {
-          git_command,
+          opts.git_command,
           line_range,
         },
         opts

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -215,6 +215,12 @@ git.bcommits_range = function(opts)
   elseif opts.operator_callback then
     line_number_first = vim.fn.line "'["
     line_number_last = vim.fn.line "']"
+  elseif line_number_first == nil then
+    table.remove(git_command)
+    table.insert(git_command, "--follow")
+    opts.git_command = git_command
+    git.bcommits(opts)
+    return
   end
   local line_range =
     string.format("%d,%d:%s", line_number_first, line_number_last, Path:new(opts.current_file):make_relative(opts.cwd))

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -216,11 +216,8 @@ git.bcommits_range = function(opts)
     line_number_first = vim.fn.line "'["
     line_number_last = vim.fn.line "']"
   elseif line_number_first == nil then
-    table.remove(git_command)
-    table.insert(git_command, "--follow")
-    opts.git_command = git_command
-    git.bcommits(opts)
-    return
+    line_number_first = vim.F.if_nil(line_number_first, vim.fn.line ".")
+    line_number_last = vim.F.if_nil(line_number_last, vim.fn.line ".")
   end
   local line_range =
     string.format("%d,%d:%s", line_number_first, line_number_last, Path:new(opts.current_file):make_relative(opts.cwd))

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -2,6 +2,7 @@ local actions = require "telescope.actions"
 local action_state = require "telescope.actions.state"
 local finders = require "telescope.finders"
 local make_entry = require "telescope.make_entry"
+local operators = require "telescope.operators"
 local pickers = require "telescope.pickers"
 local previewers = require "telescope.previewers"
 local utils = require "telescope.utils"
@@ -193,14 +194,6 @@ git.bcommits = function(opts)
     :find()
 end
 
-local last_bcommits_range_opts = {}
-
-local bcommits_range_callback = function()
-  last_bcommits_range_opts.operator = false
-  last_bcommits_range_opts.operator_callback = true
-  git.bcommits_range(last_bcommits_range_opts)
-end
-
 git.bcommits_range = function(opts)
   opts.current_line = (opts.current_file == nil) and get_current_buf_line(opts.winnr) or nil
   opts.current_file = vim.F.if_nil(opts.current_file, vim.api.nvim_buf_get_name(opts.bufnr))
@@ -215,9 +208,9 @@ git.bcommits_range = function(opts)
     line_number_first = vim.F.if_nil(line_number_first, vim.fn.line "v")
     line_number_last = vim.F.if_nil(line_number_last, vim.fn.line ".")
   elseif opts.operator then
-    last_bcommits_range_opts = opts
-    vim.o.operatorfunc = "v:lua.require'telescope.builtin.__git'.bcommits_range_callback"
-    vim.api.nvim_feedkeys("g@", "n", false)
+    opts.operator = false
+    opts.operator_callback = true
+    operators.run_operator(git.bcommits_range, opts)
     return
   elseif opts.operator_callback then
     line_number_first = vim.fn.line "'["
@@ -561,4 +554,4 @@ local function apply_checks(mod)
   return mod
 end
 
-return vim.tbl_extend("keep", apply_checks(git), { bcommits_range_callback = bcommits_range_callback })
+return apply_checks(git)

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -204,8 +204,8 @@ git.bcommits_range = function(opts)
   )
   local visual = string.find(vim.fn.mode(), "[vV]") ~= nil
 
-  local line_number_first = opts.first
-  local line_number_last = vim.F.if_nil(opts.last, line_number_first)
+  local line_number_first = opts.from
+  local line_number_last = vim.F.if_nil(opts.to, line_number_first)
   if visual then
     line_number_first = vim.F.if_nil(line_number_first, vim.fn.line "v")
     line_number_last = vim.F.if_nil(line_number_last, vim.fn.line ".")

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -209,22 +209,22 @@ git.bcommits_range = function(opts)
     vim.F.if_nil(opts.git_command, { "git", "log", "--pretty=oneline", "--abbrev-commit", "--no-patch", "-L" })
   local visual = string.find(vim.fn.mode(), "[vV]") ~= nil
 
-  local line_number_start = opts.start
-  local line_number_stop = vim.F.if_nil(opts.stop, line_number_start)
+  local line_number_first = opts.first
+  local line_number_last = vim.F.if_nil(opts.last, line_number_first)
   if visual then
-    line_number_start = vim.F.if_nil(line_number_start, vim.fn.line "v")
-    line_number_stop = vim.F.if_nil(line_number_stop, vim.fn.line ".")
+    line_number_first = vim.F.if_nil(line_number_first, vim.fn.line "v")
+    line_number_last = vim.F.if_nil(line_number_last, vim.fn.line ".")
   elseif opts.operator then
     last_bcommits_range_opts = opts
     vim.o.operatorfunc = "v:lua.require'telescope.builtin.__git'.bcommits_range_callback"
     vim.api.nvim_feedkeys("g@", "n", false)
     return
   elseif opts.operator_callback then
-    line_number_start = vim.fn.line "'["
-    line_number_stop = vim.fn.line "']"
+    line_number_first = vim.fn.line "'["
+    line_number_last = vim.fn.line "']"
   end
   local line_range =
-    string.format("%d,%d:%s", line_number_start, line_number_stop, Path:new(opts.current_file):make_relative(opts.cwd))
+    string.format("%d,%d:%s", line_number_first, line_number_last, Path:new(opts.current_file):make_relative(opts.cwd))
 
   pickers
     .new(opts, {

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -174,6 +174,7 @@ builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcomm
 
 --- Lists commits for a range of lines in the current buffer with diff preview
 --- In visual mode, lists commits for the selected lines
+--- With operator mode enabled, lists commits inside the text object/motion
 --- - Default keymaps or your overridden `select_` keys:
 ---   - `<cr>`: checks out the currently selected commit
 ---   - `<c-v>`: opens a diff in a vertical split
@@ -183,8 +184,8 @@ builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcomm
 ---@field cwd string: specify the path of the repo
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field current_file string: specify the current file that should be used for bcommits (default: current buffer)
----@field git_command table: command that will be executed. {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
----@field first number: the first line number in the range (optional in visual or operator mode)
+---@field git_command table: command that will be executed. the last element must be "-L". {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
+---@field first number: the first line number in the range (optional in visual or operator mode; runs git_bcommits if nil otherwise)
 ---@field last number: the last line number in the range (default: the value of `first`)
 ---@field operator boolean: select lines in operator-pending mode (default: false)
 builtin.git_bcommits_range = require_on_exported_call("telescope.builtin.__git").bcommits_range

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -185,7 +185,7 @@ builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcomm
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field current_file string: specify the current file that should be used for bcommits (default: current buffer)
 ---@field git_command table: command that will be executed. the last element must be "-L". {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
----@field first number: the first line number in the range (optional in visual or operator mode; runs git_bcommits if nil otherwise)
+---@field first number: the first line number in the range (default: current line)
 ---@field last number: the last line number in the range (default: the value of `first`)
 ---@field operator boolean: select lines in operator-pending mode (default: false)
 builtin.git_bcommits_range = require_on_exported_call("telescope.builtin.__git").bcommits_range

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -186,6 +186,7 @@ builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcomm
 ---@field git_command table: command that will be executed. {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
 ---@field start number: the first line in the range (optional in visual or operator mode)
 ---@field stop number: the last line in the range (optional in visual or operator mode)
+---@field operator boolean: select lines in operator-pending mode (default: false)
 builtin.git_bcommits_range = require_on_exported_call("telescope.builtin.__git").bcommits_range
 
 --- List branches for current directory, with output from `git log --oneline` shown in the preview window

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -159,7 +159,6 @@ builtin.git_files = require_on_exported_call("telescope.builtin.__git").files
 builtin.git_commits = require_on_exported_call("telescope.builtin.__git").commits
 
 --- Lists commits for current buffer with diff preview
---- In visual mode, lists commits for the selected lines
 --- - Default keymaps or your overridden `select_` keys:
 ---   - `<cr>`: checks out the currently selected commit
 ---   - `<c-v>`: opens a diff in a vertical split
@@ -172,6 +171,22 @@ builtin.git_commits = require_on_exported_call("telescope.builtin.__git").commit
 ---@field current_file string: specify the current file that should be used for bcommits (default: current buffer)
 ---@field git_command table: command that will be executed. {"git","log","--pretty=oneline","--abbrev-commit"}
 builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcommits
+
+--- Lists commits for a range of lines in the current buffer with diff preview
+--- In visual mode, lists commits for the selected lines
+--- - Default keymaps or your overridden `select_` keys:
+---   - `<cr>`: checks out the currently selected commit
+---   - `<c-v>`: opens a diff in a vertical split
+---   - `<c-x>`: opens a diff in a horizontal split
+---   - `<c-t>`: opens a diff in a new tab
+---@param opts table: options to pass to the picker
+---@field cwd string: specify the path of the repo
+---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
+---@field current_file string: specify the current file that should be used for bcommits (default: current buffer)
+---@field git_command table: command that will be executed. {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
+---@field start number: the first line in the range (optional in visual or operator mode)
+---@field stop number: the last line in the range (optional in visual or operator mode)
+builtin.git_bcommits_range = require_on_exported_call("telescope.builtin.__git").bcommits_range
 
 --- List branches for current directory, with output from `git log --oneline` shown in the preview window
 --- - Default keymaps:

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -185,8 +185,8 @@ builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcomm
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field current_file string: specify the current file that should be used for bcommits (default: current buffer)
 ---@field git_command table: command that will be executed. the last element must be "-L". {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
----@field first number: the first line number in the range (default: current line)
----@field last number: the last line number in the range (default: the value of `first`)
+---@field from number: the first line number in the range (default: current line)
+---@field to number: the last line number in the range (default: the value of `from`)
 ---@field operator boolean: select lines in operator-pending mode (default: false)
 builtin.git_bcommits_range = require_on_exported_call("telescope.builtin.__git").bcommits_range
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -184,8 +184,8 @@ builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcomm
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field current_file string: specify the current file that should be used for bcommits (default: current buffer)
 ---@field git_command table: command that will be executed. {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
----@field start number: the first line in the range (optional in visual or operator mode)
----@field stop number: the last line in the range (optional in visual or operator mode)
+---@field first number: the first line number in the range (optional in visual or operator mode)
+---@field last number: the last line number in the range (default: the value of `first`)
 ---@field operator boolean: select lines in operator-pending mode (default: false)
 builtin.git_bcommits_range = require_on_exported_call("telescope.builtin.__git").bcommits_range
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -159,6 +159,7 @@ builtin.git_files = require_on_exported_call("telescope.builtin.__git").files
 builtin.git_commits = require_on_exported_call("telescope.builtin.__git").commits
 
 --- Lists commits for current buffer with diff preview
+--- In visual mode, lists commits for the selected lines
 --- - Default keymaps or your overridden `select_` keys:
 ---   - `<cr>`: checks out the currently selected commit
 ---   - `<c-v>`: opens a diff in a vertical split

--- a/lua/telescope/operators.lua
+++ b/lua/telescope/operators.lua
@@ -1,0 +1,19 @@
+local operators = {}
+
+local last_operator = {}
+
+operators.operator_callback = function()
+  last_operator.callback(last_operator.opts)
+end
+
+-- enter operator-pending mode, see `:h map-operator`
+-- params:
+--   callback: the callback function to call after exiting operator-pending
+--   opts: options to pass to the callback
+operators.run_operator = function(callback, opts)
+  last_operator = { callback = callback, opts = opts }
+  vim.o.operatorfunc = "v:lua.require'telescope.operators'.operator_callback"
+  vim.api.nvim_feedkeys("g@", "mi", false)
+end
+
+return operators

--- a/lua/telescope/operators.lua
+++ b/lua/telescope/operators.lua
@@ -2,17 +2,21 @@ local operators = {}
 
 local last_operator = {}
 
+--- Execute the last saved operator callback and options
 operators.operator_callback = function()
   last_operator.callback(last_operator.opts)
 end
 
--- enter operator-pending mode, see `:h map-operator`
--- params:
---   callback: the callback function to call after exiting operator-pending
---   opts: options to pass to the callback
+--- Enters operator-pending mode, then executes callback.
+--- See `:h map-operator`
+---
+---@param callback function: the function to call after exiting operator-pending
+---@param opts table: options to pass to the callback
 operators.run_operator = function(callback, opts)
   last_operator = { callback = callback, opts = opts }
   vim.o.operatorfunc = "v:lua.require'telescope.operators'.operator_callback"
+  -- feed g@ to enter operator-pending mode
+  -- 'i' required for which-key compatibility, etc.
   vim.api.nvim_feedkeys("g@", "mi", false)
 end
 

--- a/lua/telescope/operators.lua
+++ b/lua/telescope/operators.lua
@@ -1,6 +1,6 @@
 local operators = {}
 
-local last_operator = {}
+local last_operator = { callback = function(_) end, opts = {} }
 
 --- Execute the last saved operator callback and options
 operators.operator_callback = function()


### PR DESCRIPTION
# Description

[fzf.vim](https://github.com/junegunn/fzf.vim#commands) has a feature where the `:BCommits` command shows only commits affecting the selected lines, if run from visual mode.

This functionality cannot be replicated in telescope with config options alone. Fzf.vim uses the [arguments](https://github.com/junegunn/fzf.vim/blob/dc71692255b62d1f67dc55c8e51ab1aa467b1d46/autoload/fzf/vim.vim#L1278) `git log --no-patch -L start,end:file`, which are not compatible with the filename that telescope appends to `git_commands`. (I tried some hacks like adding an argument to `git_commands` to make git ignore the filename argument, but they didn't work).

## Type of change

~~This PR only affects bcommits behavior when run in visual mode, so I think it's a minor change but could be considered breaking.~~

This PR adds `bcommits_range` to show commits affecting a range of lines. `bcommits_range` can get the range of selected lines in visual mode, and supports an operator-pending mode to get lines from the next text object or motion. To support operators, this PR also adds a new `telescope.operators` module.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- [x] Test A: Visually select lines of code, then activate the `bcommits_range` picker. Only commits affecting the selected lines should be shown. Check all previewer outputs to make sure they make sense.
- [x] Test B: Run test A from a subdirectory of the git directory. Behavior should be the same as before.
- [x] Test C: Run `bcommits_range` in normal mode, all commits for the file should be shown.
- [x] Test D: Run `<cmd>Telescope git_bcommits_range first=1 last=10<CR>` in normal mode. Commits affecting the first 10 lines should be shown.
- [x] Test E: Run `<cmd>Telescope git_bcommits_range operator=true<CR>` in normal mode followed by a motion or text object, e.g. `ip` for inner paragraph. All commits affecting the selected range should be shown.

**Configuration**:
* Neovim version (nvim --version): v0.8.3
* Operating system and version: macOS 13.2.1 Ventura

# Notes

- The line range in the file may not match the range used to filter commits, if there are uncommitted changes to the file (whether staged or not, it seems). This affects fzf.vim as well, and solving it could be tricky.
- I've supported visual block mode by including a ^V in `__git.lua`, not sure if that's ok, or if there's a better way to detect visual mode.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
