### PR TITLE
fix: prefix color highlighting on nvim 0.9

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -456,6 +456,10 @@ function Picker:find()
 
     await_schedule()
 
+    -- we need to set the prefix color after changing mode since
+    -- https://github.com/neovim/neovim/commit/cbf9199d65325c1167d7eeb02a34c85d243e781c
+    self:_reset_prefix_color()
+
     while true do
       -- Wait for the next input
       rx.last()


### PR DESCRIPTION
fix #2384
fix #2399