### PR TITLE
[DOCs] Remove extra `{` from Lazy.nvim package manager directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 -- plugins/telescope.lua:
 return {
-    {
     'nvim-telescope/telescope.nvim', tag = '0.1.1',
 -- or                              , branch = '0.1.1',
       dependencies = { 'nvim-lua/plenary.nvim' }


### PR DESCRIPTION
# Description

Remove extra `{` which was included in the snippet merged on https://github.com/nvim-telescope/telescope.nvim/pull/2377

Fixes # (issue)

## Type of change

- This change is a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Test A
- [x] Test B

**Configuration**:
* Neovim version (nvim --version): v0.8.3
* Operating system and version: macOS Ventura 13.2

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
