### PR TITLE
fix(from_entry): escape paths with `$` symbol

### DIFF
--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -30,7 +30,7 @@ function from_entry.path(entry, validate, escape)
     -- TODO(conni2461): we are not going to return the expanded path because
     --                  this would lead to cache misses in the perviewer.
     --                  Requires overall refactoring in previewer interface
-    local expanded = vim.fn.expand(vim.fn.escape(path, "?*[]"))
+    local expanded = vim.fn.expand(vim.fn.escape(path, "$?*[]"))
     if (vim.fn.filereadable(expanded) + vim.fn.isdirectory(expanded)) == 0 then
       return
     end


### PR DESCRIPTION
# Description

Adds support for viewing File Previews of paths with dollar symbols.
Eg. `./($lang)._index.tsx`
This is a new pattern supported by [Remix optional segments](https://remix.run/docs/en/v1/file-conventions/route-files-v2#optional-segments) file based routing.

Partially fixes downstream issue https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/244.
This fix also applies to many of the builtin pickers.

## Type of change
- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Test A
1. Create a file `touch "(\$lang)._index.ts"`
2. In that created file, enter some text `console.log('hello');`
3. With and without the PR checked out, use `:Telescope find_files` and search of the file and at look the File Preview
4. Without the PR is a blank preview; with shows the contents of the file
- [x] Test B
1. Verify other files can still be previewed find

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.9.0-dev-1070+g2630341db
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
```

* Operating system and version:
`Linux archlinux 6.1.12-arch1-1 #1 SMP PREEMPT_DYNAMIC Tue, 14 Feb 2023 22:08:08 +0000 x86_64 GNU/Linux`
# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
