### PR TITLE
feat: utilize last window cursor position

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -110,7 +110,7 @@ action_set.edit = function(prompt_bufnr, command)
 
     -- TODO: Check for off-by-one
     row = entry.row or entry.lnum
-    col = vim.F.if_nil(entry.col, 1)
+    col = entry.col
   elseif not entry.bufnr then
     -- TODO: Might want to remove this and force people
     -- to put stuff into `filename`
@@ -167,6 +167,11 @@ action_set.edit = function(prompt_bufnr, command)
       filename = Path:new(vim.fn.fnameescape(filename)):normalize(vim.loop.cwd())
       pcall(vim.cmd, string.format("%s %s", command, filename))
     end
+  end
+
+  if row == nil or col == nil then
+    local pos = vim.api.nvim_win_get_cursor(0)
+    row, col = pos[1], pos[2] + 1
   end
 
   if row and col then


### PR DESCRIPTION
closes #2386

# Description

When using pickers to open buffers, fallback on window's last cursor position for that buffer.
This preserves the cursor location (row and col) for previously opened buffers.

This only impacts the column location for the `buffers` picker. But currently also impact the line number as well for `find_files`. This last point might be too disruptive even though I believe the change is for the better. I can modify the PR to revert this however.

Fixes # (issue)
#2386

## Type of change

- New feature (non-breaking change which adds functionality) _MOSTLY_

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Feature Test
* open a buffer and move the cursor to somewhere not [1,1]
* open a new split `:vnew`
* `:Telescope buffers` and open the buffer from above -> cursor should be in the same location between the two windows (previously would always go to the 1st column)
* open a new split `:vnew`
* `:Telescope find_files` and open the buffer from above -> cursor should be in the same location between the windows (previously would always go to [1,1]) -> _this behavior MAY be consider too drastic_
- [x] Regression Test (ensure buffer pickers with provided row/col info is putting the cursor in an expected position)
* open a buffer and move the cursor to somewhere not [1,1]
* `:Telescope live_grep` and grep for some random word in that buffer not under the cursor of that buffer
* note the cursor position in the results list and select the entry
* cursor should move to the expected location

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.9.0-dev-1070+g2630341db
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
```
* Operating system and version: `Linux archlinux 6.1.12-arch1-1 #1 SMP PREEMPT_DYNAMIC Tue, 14 Feb 2023 22:08:08 +0000 x86_64 GNU/Linux`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
