### PR TITLE
feat(buffer_previewer): pass file details in TelescopePreviewLoaded autocmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,8 +400,25 @@ to configure more filetypes, take a look at
 
 If you want to configure the `vim_buffer_` previewer (e.g. you want the line to wrap), do this:
 
-```vim
-autocmd User TelescopePreviewerLoaded setlocal wrap
+```lua
+vim.api.nvim_create_autocmd("User", {
+  pattern = "TelescopePreviewerLoaded",
+  callback = function(args)
+  if args.data.filetype ~= "help" then
+    vim.bo.number = true
+  elseif args.data.bufname:match("*.csv")
+    vim.bo.wrap = false
+  end,
+})
+```
+
+A data field is passed to the callback, which contains the filetype and the buffer name.
+
+```lua
+{
+  filetype: string,
+  bufname: string
+}
 ```
 
 ## Sorters

--- a/README.md
+++ b/README.md
@@ -404,10 +404,11 @@ If you want to configure the `vim_buffer_` previewer (e.g. you want the line to 
 vim.api.nvim_create_autocmd("User", {
   pattern = "TelescopePreviewerLoaded",
   callback = function(args)
-  if args.data.filetype ~= "help" then
-    vim.bo.number = true
-  elseif args.data.bufname:match("*.csv")
-    vim.bo.wrap = false
+    if args.data.filetype ~= "help" then
+      vim.bo.number = true
+    elseif args.data.bufname:match("*.csv") then
+      vim.bo.wrap = false
+    end
   end,
 })
 ```
@@ -416,8 +417,9 @@ A data field is passed to the callback, which contains the filetype and the buff
 
 ```lua
 {
+  title: string, # preview window title
   filetype: string,
-  bufname: string
+  bufname: string,
 }
 ```
 

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -426,7 +426,14 @@ previewers.new_buffer_previewer = function(opts)
 
       if vim.api.nvim_buf_is_valid(self.state.bufnr) then
         vim.api.nvim_buf_call(self.state.bufnr, function()
-          vim.cmd "do User TelescopePreviewerLoaded"
+          vim.api.nvim_exec_autocmds("User", {
+            pattern = "TelescopePreviewerLoaded",
+            data = {
+              title = entry.preview_title,
+              bufname = self.state.bufname,
+              filetype = pfiletype.detect(self.state.bufname),
+            },
+          })
         end)
       end
     end)


### PR DESCRIPTION
This allows a user to use the buffer name and/or filetype to change settings in the previewer to change some aspect of the previewers behaviour. In this case deciding whether or not to show numbers in the previewer

# Description

This change converts the autocommand run when Telescope loads a preview in the `buffer_previewer` to also pass along extra information about the file e.g. the `bufname` or it's (plenary-detected) filetype.

The main motivation for this is that a user can do something like
```lua
    vim.api.nvim_create_autocmd({
      event = 'User',
      pattern = 'TelescopePreviewerLoaded',
      callback = function(args)
        if args.data.filetype ~= "help" then
        	vim.opt_local.number = true
		end
      end,
    })
```

Fixes # (issue)

## Type of change


- New feature (non-breaking change which adds functionality)
- This change requires a documentation update


**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation (lua annotations)
