### PR TITLE
fix: previewers & entry maker file encoding

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -802,6 +802,8 @@ builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
         {max_results}         (number)          define a upper result value
         {disable_coordinates} (boolean)         don't show the line & row
                                                 numbers (default: false)
+        {file_encoding}       (string)          file encoding for the entry &
+                                                previewer
 
 
 builtin.grep_string({opts})                  *telescope.builtin.grep_string()*
@@ -837,6 +839,8 @@ builtin.grep_string({opts})                  *telescope.builtin.grep_string()*
         {only_sort_text}      (boolean)         only sort the text, not the
                                                 file, line or row (default:
                                                 false)
+        {file_encoding}       (string)          file encoding for the entry &
+                                                previewer
 
 
 builtin.find_files({opts})                    *telescope.builtin.find_files()*
@@ -872,6 +876,8 @@ builtin.find_files({opts})                    *telescope.builtin.find_files()*
                                                 search
         {search_file}         (string)          specify a filename to search
                                                 for
+        {file_encoding}       (string)          file encoding for the
+                                                previewer
 
 
 builtin.fd()                                          *telescope.builtin.fd()*
@@ -897,6 +903,7 @@ builtin.treesitter()                          *telescope.builtin.treesitter()*
         {ignore_symbols}    (string|table)  list of symbols to ignore
         {symbol_highlights} (table)         string -> string. Matches symbol
                                             with hl_group
+        {file_encoding}     (string)        file encoding for the previewer
 
 
 builtin.current_buffer_fuzzy_find({opts}) *telescope.builtin.current_buffer_fuzzy_find()*
@@ -909,6 +916,7 @@ builtin.current_buffer_fuzzy_find({opts}) *telescope.builtin.current_buffer_fuzz
     Options: ~
         {skip_empty_lines} (boolean)  if true we don't display empty lines
                                       (default: false)
+        {file_encoding}    (string)   file encoding for the previewer
 
 
 builtin.tags({opts})                                *telescope.builtin.tags()*
@@ -980,6 +988,7 @@ builtin.git_files({opts})                      *telescope.builtin.git_files()*
                                         (default: false)
         {git_command}        (table)    command that will be executed.
                                         {"git","ls-files","--exclude-standard","--cached"}
+        {file_encoding}      (string)   file encoding for the previewer
 
 
 builtin.git_commits({opts})                  *telescope.builtin.git_commits()*
@@ -1237,10 +1246,11 @@ builtin.oldfiles({opts})                        *telescope.builtin.oldfiles()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}      (string)   specify a working directory to filter oldfiles
-                              by
-        {only_cwd} (boolean)  show only files in the cwd (default: false)
-        {cwd_only} (boolean)  alias for only_cwd
+        {cwd}           (string)   specify a working directory to filter
+                                   oldfiles by
+        {only_cwd}      (boolean)  show only files in the cwd (default: false)
+        {cwd_only}      (boolean)  alias for only_cwd
+        {file_encoding} (string)   file encoding for the previewer
 
 
 builtin.command_history({opts})          *telescope.builtin.command_history()*
@@ -1346,6 +1356,7 @@ builtin.buffers({opts})                          *telescope.builtin.buffers()*
         {bufnr_width}           (number)   Defines the width of the buffer
                                            numbers in front of the filenames 
                                            (default: dynamic)
+        {file_encoding}         (string)   file encoding for the previewer
 
 
 builtin.colorscheme({opts})                  *telescope.builtin.colorscheme()*
@@ -1365,6 +1376,9 @@ builtin.marks({opts})                              *telescope.builtin.marks()*
 
     Parameters: ~
         {opts} (table)  options to pass to the picker
+
+    Options: ~
+        {file_encoding} (string)  file encoding for the previewer
 
 
 builtin.registers({opts})                      *telescope.builtin.registers()*
@@ -1480,6 +1494,7 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
                                           section (default: 30)
         {show_line}            (boolean)  show results text (default: true)
         {trim_text}            (boolean)  trim results text (default: false)
+        {file_encoding}        (string)   file encoding for the previewer
 
 
 builtin.lsp_incoming_calls({opts})    *telescope.builtin.lsp_incoming_calls()*
@@ -1491,10 +1506,11 @@ builtin.lsp_incoming_calls({opts})    *telescope.builtin.lsp_incoming_calls()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
+        {fname_width}   (number)   defines the width of the filename section
+                                   (default: 30)
+        {show_line}     (boolean)  show results text (default: true)
+        {trim_text}     (boolean)  trim results text (default: false)
+        {file_encoding} (string)   file encoding for the previewer
 
 
 builtin.lsp_outgoing_calls({opts})    *telescope.builtin.lsp_outgoing_calls()*
@@ -1506,10 +1522,11 @@ builtin.lsp_outgoing_calls({opts})    *telescope.builtin.lsp_outgoing_calls()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
+        {fname_width}   (number)   defines the width of the filename section
+                                   (default: 30)
+        {show_line}     (boolean)  show results text (default: true)
+        {trim_text}     (boolean)  trim results text (default: false)
+        {file_encoding} (string)   file encoding for the previewer
 
 
 builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
@@ -1521,16 +1538,17 @@ builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}   (string)   how to goto definition if there is only one
-                                 and the definition file is different from the
-                                 current file, values: "tab", "split",
-                                 "vsplit", "never"
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
-        {reuse_win}   (boolean)  jump to existing window if buffer is already
-                                 opened (default: false)
+        {jump_type}     (string)   how to goto definition if there is only one
+                                   and the definition file is different from
+                                   the current file, values: "tab", "split",
+                                   "vsplit", "never"
+        {fname_width}   (number)   defines the width of the filename section
+                                   (default: 30)
+        {show_line}     (boolean)  show results text (default: true)
+        {trim_text}     (boolean)  trim results text (default: false)
+        {reuse_win}     (boolean)  jump to existing window if buffer is
+                                   already opened (default: false)
+        {file_encoding} (string)   file encoding for the previewer
 
 
 builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
@@ -1542,16 +1560,17 @@ builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}   (string)   how to goto definition if there is only one
-                                 and the definition file is different from the
-                                 current file, values: "tab", "split",
-                                 "vsplit", "never"
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
-        {reuse_win}   (boolean)  jump to existing window if buffer is already
-                                 opened (default: false)
+        {jump_type}     (string)   how to goto definition if there is only one
+                                   and the definition file is different from
+                                   the current file, values: "tab", "split",
+                                   "vsplit", "never"
+        {fname_width}   (number)   defines the width of the filename section
+                                   (default: 30)
+        {show_line}     (boolean)  show results text (default: true)
+        {trim_text}     (boolean)  trim results text (default: false)
+        {reuse_win}     (boolean)  jump to existing window if buffer is
+                                   already opened (default: false)
+        {file_encoding} (string)   file encoding for the previewer
 
 
 builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
@@ -1563,16 +1582,17 @@ builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}   (string)   how to goto implementation if there is only
-                                 one and the definition file is different from
-                                 the current file, values: "tab", "split",
-                                 "vsplit", "never"
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
-        {reuse_win}   (boolean)  jump to existing window if buffer is already
-                                 opened (default: false)
+        {jump_type}     (string)   how to goto implementation if there is only
+                                   one and the definition file is different
+                                   from the current file, values: "tab",
+                                   "split", "vsplit", "never"
+        {fname_width}   (number)   defines the width of the filename section
+                                   (default: 30)
+        {show_line}     (boolean)  show results text (default: true)
+        {trim_text}     (boolean)  trim results text (default: false)
+        {reuse_win}     (boolean)  jump to existing window if buffer is
+                                   already opened (default: false)
+        {file_encoding} (string)   file encoding for the previewer
 
 
 builtin.lsp_document_symbols({opts}) *telescope.builtin.lsp_document_symbols()*
@@ -1599,6 +1619,7 @@ builtin.lsp_document_symbols({opts}) *telescope.builtin.lsp_document_symbols()*
         {ignore_symbols}    (string|table)  list of symbols to ignore
         {symbol_highlights} (table)         string -> string. Matches symbol
                                             with hl_group
+        {file_encoding}     (string)        file encoding for the previewer
 
 
 builtin.lsp_workspace_symbols({opts}) *telescope.builtin.lsp_workspace_symbols()*
@@ -1627,6 +1648,7 @@ builtin.lsp_workspace_symbols({opts}) *telescope.builtin.lsp_workspace_symbols()
         {ignore_symbols}    (string|table)  list of symbols to ignore
         {symbol_highlights} (table)         string -> string. Matches symbol
                                             with hl_group
+        {file_encoding}     (string)        file encoding for the previewer
 
 
 builtin.lsp_dynamic_workspace_symbols({opts}) *telescope.builtin.lsp_dynamic_workspace_symbols()*
@@ -1649,6 +1671,7 @@ builtin.lsp_dynamic_workspace_symbols({opts}) *telescope.builtin.lsp_dynamic_wor
         {ignore_symbols}    (string|table)  list of symbols to ignore
         {symbol_highlights} (table)         string -> string. Matches symbol
                                             with hl_group
+        {file_encoding}     (string)        file encoding for the previewer
 
 
 builtin.diagnostics({opts})                  *telescope.builtin.diagnostics()*

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -55,6 +55,7 @@ end
 ---@field additional_args function|table: additional arguments to be passed on. Can be fn(opts) -> tbl
 ---@field max_results number: define a upper result value
 ---@field disable_coordinates boolean: don't show the line & row numbers (default: false)
+---@field file_encoding string: file encoding for the entry & previewer
 builtin.live_grep = require_on_exported_call("telescope.builtin.__files").live_grep
 
 --- Searches for the string under your cursor or the visual selection in your current working directory
@@ -68,6 +69,7 @@ builtin.live_grep = require_on_exported_call("telescope.builtin.__files").live_g
 ---@field additional_args function|table: additional arguments to be passed on. Can be fn(opts) -> tbl
 ---@field disable_coordinates boolean: don't show the line and row numbers (default: false)
 ---@field only_sort_text boolean: only sort the text, not the file, line or row (default: false)
+---@field file_encoding string: file encoding for the entry & previewer
 builtin.grep_string = require_on_exported_call("telescope.builtin.__files").grep_string
 
 --- Search for files (respecting .gitignore)
@@ -81,6 +83,7 @@ builtin.grep_string = require_on_exported_call("telescope.builtin.__files").grep
 ---@field no_ignore_parent boolean: show files ignored by .gitignore, .ignore, etc. in parent dirs. (default: false)
 ---@field search_dirs table: directory/directories/files to search
 ---@field search_file string: specify a filename to search for
+---@field file_encoding string: file encoding for the previewer
 builtin.find_files = require_on_exported_call("telescope.builtin.__files").find_files
 
 --- This is an alias for the `find_files` picker
@@ -94,11 +97,13 @@ builtin.fd = builtin.find_files
 ---@field symbols string|table: filter results by symbol kind(s)
 ---@field ignore_symbols string|table: list of symbols to ignore
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
+---@field file_encoding string: file encoding for the previewer
 builtin.treesitter = require_on_exported_call("telescope.builtin.__files").treesitter
 
 --- Live fuzzy search inside of the currently open buffer
 ---@param opts table: options to pass to the picker
 ---@field skip_empty_lines boolean: if true we don't display empty lines (default: false)
+---@field file_encoding string: file encoding for the previewer
 builtin.current_buffer_fuzzy_find = require_on_exported_call("telescope.builtin.__files").current_buffer_fuzzy_find
 
 --- Lists tags in current directory with tag location file preview (users are required to run ctags -R to generate tags
@@ -137,6 +142,7 @@ builtin.current_buffer_tags = require_on_exported_call("telescope.builtin.__file
 ---@field show_untracked boolean: if true, adds `--others` flag to command and shows untracked files (default: false)
 ---@field recurse_submodules boolean: if true, adds the `--recurse-submodules` flag to command (default: false)
 ---@field git_command table: command that will be executed. {"git","ls-files","--exclude-standard","--cached"}
+---@field file_encoding string: file encoding for the previewer
 builtin.git_files = require_on_exported_call("telescope.builtin.__git").files
 
 --- Lists commits for current directory with diff preview
@@ -276,6 +282,7 @@ builtin.loclist = require_on_exported_call("telescope.builtin.__internal").locli
 ---@field cwd string: specify a working directory to filter oldfiles by
 ---@field only_cwd boolean: show only files in the cwd (default: false)
 ---@field cwd_only boolean: alias for only_cwd
+---@field file_encoding string: file encoding for the previewer
 builtin.oldfiles = require_on_exported_call("telescope.builtin.__internal").oldfiles
 
 --- Lists commands that were executed recently, and reruns them on `<cr>`
@@ -322,6 +329,7 @@ builtin.reloader = require_on_exported_call("telescope.builtin.__internal").relo
 ---@field sort_lastused boolean: Sorts current and last buffer to the top and selects the lastused (default: false)
 ---@field sort_mru boolean: Sorts all buffers after most recent used. Not just the current and last one (default: false)
 ---@field bufnr_width number: Defines the width of the buffer numbers in front of the filenames  (default: dynamic)
+---@field file_encoding string: file encoding for the previewer
 builtin.buffers = require_on_exported_call("telescope.builtin.__internal").buffers
 
 --- Lists available colorschemes and applies them on `<cr>`
@@ -331,6 +339,7 @@ builtin.colorscheme = require_on_exported_call("telescope.builtin.__internal").c
 
 --- Lists vim marks and their value, jumps to the mark on `<cr>`
 ---@param opts table: options to pass to the picker
+---@field file_encoding string: file encoding for the previewer
 builtin.marks = require_on_exported_call("telescope.builtin.__internal").marks
 
 --- Lists vim registers, pastes the contents of the register on `<cr>`
@@ -391,6 +400,7 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field file_encoding string: file encoding for the previewer
 builtin.lsp_references = require_on_exported_call("telescope.builtin.__lsp").references
 
 --- Lists LSP incoming calls for word under the cursor, jumps to reference on `<cr>`
@@ -398,6 +408,7 @@ builtin.lsp_references = require_on_exported_call("telescope.builtin.__lsp").ref
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field file_encoding string: file encoding for the previewer
 builtin.lsp_incoming_calls = require_on_exported_call("telescope.builtin.__lsp").incoming_calls
 
 --- Lists LSP outgoing calls for word under the cursor, jumps to reference on `<cr>`
@@ -405,6 +416,7 @@ builtin.lsp_incoming_calls = require_on_exported_call("telescope.builtin.__lsp")
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field file_encoding string: file encoding for the previewer
 builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp").outgoing_calls
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
@@ -414,6 +426,7 @@ builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp")
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
+---@field file_encoding string: file encoding for the previewer
 builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").definitions
 
 --- Goto the definition of the type of the word under the cursor, if there's only one,
@@ -424,6 +437,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
+---@field file_encoding string: file encoding for the previewer
 builtin.lsp_type_definitions = require("telescope.builtin.__lsp").type_definitions
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
@@ -433,6 +447,7 @@ builtin.lsp_type_definitions = require("telescope.builtin.__lsp").type_definitio
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
+---@field file_encoding string: file encoding for the previewer
 builtin.lsp_implementations = require_on_exported_call("telescope.builtin.__lsp").implementations
 
 --- Lists LSP document symbols in the current buffer
@@ -446,6 +461,7 @@ builtin.lsp_implementations = require_on_exported_call("telescope.builtin.__lsp"
 ---@field symbols string|table: filter results by symbol kind(s)
 ---@field ignore_symbols string|table: list of symbols to ignore
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
+---@field file_encoding string: file encoding for the previewer
 builtin.lsp_document_symbols = require_on_exported_call("telescope.builtin.__lsp").document_symbols
 
 --- Lists LSP document symbols in the current workspace
@@ -460,6 +476,7 @@ builtin.lsp_document_symbols = require_on_exported_call("telescope.builtin.__lsp
 ---@field symbols string|table: filter results by symbol kind(s)
 ---@field ignore_symbols string|table: list of symbols to ignore
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
+---@field file_encoding string: file encoding for the previewer
 builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.__lsp").workspace_symbols
 
 --- Dynamically lists LSP for all workspace symbols
@@ -471,6 +488,7 @@ builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.__ls
 ---@field symbols string|table: filter results by symbol kind(s)
 ---@field ignore_symbols string|table: list of symbols to ignore
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
+---@field file_encoding string: file encoding for the previewer
 builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.builtin.__lsp").dynamic_workspace_symbols
 
 --

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -326,9 +326,10 @@ do
           end
         end
 
+        local text = opts.file_encoding and vim.iconv(entry.text, opts.file_encoding, "utf8") or entry.text
         local display, hl_group, icon = utils.transform_devicons(
           entry.filename,
-          string.format(display_string, display_filename, coordinates, entry.text),
+          string.format(display_string, display_filename, coordinates, text),
           disable_devicons
         )
 

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -60,7 +60,8 @@ local function split(s, sep, plain, opts)
   opts = opts or {}
   local t = {}
   for c in vim.gsplit(s, sep, plain) do
-    table.insert(t, c)
+    local line = opts.file_encoding and vim.iconv(c, opts.file_encoding, "utf8") or c
+    table.insert(t, line)
     if opts.preview.timeout then
       local diff_time = (vim.loop.hrtime() - opts.start_time) / 1e6
       if diff_time > opts.preview.timeout then
@@ -464,6 +465,7 @@ previewers.cat = defaulter(function(opts)
         bufname = self.state.bufname,
         winid = self.state.winid,
         preview = opts.preview,
+        file_encoding = opts.file_encoding,
       })
     end,
   }
@@ -518,6 +520,7 @@ previewers.vimgrep = defaulter(function(opts)
           callback = function(bufnr)
             jump_to_line(self, bufnr, entry.lnum)
           end,
+          file_encoding = opts.file_encoding,
         })
       end
     end,


### PR DESCRIPTION
# Description

Previewers and some entry_makers currently has poor support for non UTF8 encoded files.
This PR looks to add a new option `file_encoding` to pickers with for previewers `file_previewer` & `grep_previewer`, `qflist_previewer`.
This new option is consumed by `buffer_previewer.file_maker` to do some string processing with `vim.iconv`. A similar thing also happens in `make_entry.gen_from_vimgrep`.



Fixes #2415 
## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration


This change impacts the following pickers:
`live_grep`
`grep_string`
`find_files`
`git_files`
`treesitter`
`current_buffer_fuzzy_find`
`oldfiles`
`buffers`
`marks`
`lsp_dynamic_workspace_symbols`
`lsp_workspace_symbols`
`lsp_document_symbols`
`lsp_implementations`
`lsp_type_definitions`
`lsp_definitions`
`lsp_outgoing_calls`
`lsp_incoming_calls`
`lsp_references`


- [x] For each picker above, confirm previewer and entries look good for non-UTF8 encoded files

1.  create file with `acentuação`
2.  write file with latin1 encoding `:write ++enc=latin1`
3.  test pickers with `:Telescope <picker> file_encoding=latin1` and verify previewer/entry

- [x] Regression test with standard utf8 file and no `file_encoding` option

**Configuration**:
* Neovim version (nvim --version): `NVIM v0.9.0-dev-1070+g2630341db` 
* Operating system and version: `Linux archlinux 6.2.5-arch1-1`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
