### PR TITLE
feat: add user autocmd TelescopeResumePost

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Telescope user autocmds:
 |---------------------------------|---------------------------------------------------------|
 | `User TelescopeFindPre`         | Do it before Telescope creates all the floating windows |
 | `User TelescopePreviewerLoaded` | Do it after Telescope previewer window is created       |
+| `User TelescopeResumePost`      | Do it after Telescope resume action is fully completed  |
 
 ## Extensions
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1559,15 +1559,24 @@ function Picker:_resume_picker()
     index = index + 1
   end
   self.cache_picker.is_cached = false
+  local on_resume_complete = function()
+    if vim.api.nvim_buf_is_valid(self.prompt_bufnr) then
+      vim.api.nvim_buf_call(self.prompt_bufnr, function()
+        vim.cmd "do User TelescopeResumePost"
+      end)
+    end
+  end
   -- if text changed, required to set anew to restart finder; otherwise hl and selection
   if self.cache_picker.cached_prompt ~= self.default_text then
     self:set_prompt(self.default_text)
+    on_resume_complete()
   else
     -- scheduling required to apply highlighting and selection appropriately
     await_schedule(function()
       if self.cache_picker.selection_row ~= nil then
         self:set_selection(self.cache_picker.selection_row)
       end
+      on_resume_complete()
     end)
   end
 end


### PR DESCRIPTION
# Description

I'm working on an extension which performs some actions after the picker is fully resumed. By "fully resumed" I mean that finder has shown the results. I didn't find the way to do it in the current codebase. Therefore I'm proposing to add a new user automcd called `TelescopeResumePost` which is triggered when resume action is fully completed. I named the autocmd by analogy with `TelescopeFindPre` which already exists in the codebase.

Fixes #2439

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Launch any picker
2. Close the picker
3. Run
```lua
require('telescope.builtin').resume()
local prompt_bufnr = vim.api.nvim_get_current_buf()
vim.api.nvim_create_autocmd('User TelescopeResumePost', {
  buffer = prompt_bufnr,
  once = true,
  callback = function()
    print('User TelescopeResumePost works')
  end,
})
```

Then you should see line saying `User TelescopeResumePost works` when you open `:messages`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
