### PR TITLE
feat: Improve Git error output when calling Telescope git command in non-git directory

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -886,13 +886,16 @@ builtin.treesitter()                          *telescope.builtin.treesitter()*
 
 
     Options: ~
-        {show_line}         (boolean)  if true, shows the row:column that the
-                                       result is found at (default: true)
-        {bufnr}             (number)   specify the buffer number where
-                                       treesitter should run. (default:
-                                       current buffer)
-        {symbol_highlights} (table)    string -> string. Matches symbol with
-                                       hl_group
+        {show_line}         (boolean)       if true, shows the row:column that
+                                            the result is found at (default:
+                                            true)
+        {bufnr}             (number)        specify the buffer number where
+                                            treesitter should run. (default:
+                                            current buffer)
+        {symbols}           (string|table)  filter results by symbol kind(s)
+        {ignore_symbols}    (string|table)  list of symbols to ignore
+        {symbol_highlights} (table)         string -> string. Matches symbol
+                                            with hl_group
 
 
 builtin.current_buffer_fuzzy_find({opts}) *telescope.builtin.current_buffer_fuzzy_find()*

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -395,7 +395,11 @@ local set_opts_cwd = function(opts)
     local in_bare = utils.get_os_command_output({ "git", "rev-parse", "--is-bare-repository" }, opts.cwd)
 
     if in_worktree[1] ~= "true" and in_bare[1] ~= "true" then
-      error(opts.cwd .. " is not a git directory")
+      utils.notify("builtin.git", {
+        msg = opts.cwd .. " is not a git directory",
+        level = "ERROR",
+      })
+      return false
     elseif in_worktree[1] ~= "true" and in_bare[1] == "true" then
       opts.is_bare = true
     end
@@ -404,6 +408,7 @@ local set_opts_cwd = function(opts)
       opts.cwd = git_root[1]
     end
   end
+  return true
 end
 
 local function apply_checks(mod)
@@ -411,7 +416,10 @@ local function apply_checks(mod)
     mod[k] = function(opts)
       opts = vim.F.if_nil(opts, {})
 
-      set_opts_cwd(opts)
+      local success = set_opts_cwd(opts)
+      if success == false then
+        return
+      end
       v(opts)
     end
   end


### PR DESCRIPTION
# Description

Currently, when you're calling `:Telescope git_command` on a non-git directory, it's outputting an error exception detailing that current directory is not a directory. I don't think this error trace is necessary, just outputting message that current directory is not a git directory is enough .

Before: 
![image](https://user-images.githubusercontent.com/37890287/227141163-cc451cfd-51a9-4fa5-a661-0341bed49b26.png)

After:
![image](https://user-images.githubusercontent.com/37890287/227141197-8a27956c-b34e-44ba-8b8e-6e908550b6ac.png)



## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. On a non-git directory, run one of `Telescope git` command


**Configuration**:
* Neovim version (nvim --version): NVIM v0.8.3
* Operating system and version: Mac OS Ventura

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
