### PR TITLE
Find git root from current buffer

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -967,6 +967,8 @@ builtin.git_files({opts})                      *telescope.builtin.git_files()*
 
     Options: ~
         {cwd}                (string)   specify the path of the repo
+        {use_file_path}      (boolean)  if we should use the current buffer
+                                        git root (default: true)
         {use_git_root}       (boolean)  if we should use git root as cwd or
                                         the cwd (important for submodule)
                                         (default: true)
@@ -994,6 +996,8 @@ builtin.git_commits({opts})                  *telescope.builtin.git_commits()*
 
     Options: ~
         {cwd}          (string)   specify the path of the repo
+        {use_file_path}(boolean)  if we should use the current buffer
+                                  git root (default: false)
         {use_git_root} (boolean)  if we should use git root as cwd or the cwd
                                   (important for submodule) (default: true)
         {git_command}  (table)    command that will be executed.
@@ -1014,6 +1018,8 @@ builtin.git_bcommits({opts})                *telescope.builtin.git_bcommits()*
 
     Options: ~
         {cwd}          (string)   specify the path of the repo
+        {use_file_path}(boolean)  if we should use the current buffer
+                                  git root (default: false)
         {use_git_root} (boolean)  if we should use git root as cwd or the cwd
                                   (important for submodule) (default: true)
         {current_file} (string)   specify the current file that should be used
@@ -1042,6 +1048,8 @@ builtin.git_branches({opts})                *telescope.builtin.git_branches()*
     Options: ~
         {cwd}                           (string)   specify the path of the
                                                    repo
+        {use_file_path}                 (boolean)  if we should use the current buffer
+                                                   git root (default: false)
         {use_git_root}                  (boolean)  if we should use git root
                                                    as cwd or the cwd
                                                    (important for submodule)
@@ -1065,6 +1073,8 @@ builtin.git_status({opts})                    *telescope.builtin.git_status()*
 
     Options: ~
         {cwd}          (string)   specify the path of the repo
+        {use_file_path}(boolean)  if we should use the current buffer
+                                  git root (default: false)
         {use_git_root} (boolean)  if we should use git root as cwd or the cwd
                                   (important for submodule) (default: true)
         {git_icons}    (table)    string -> string. Matches name with icon
@@ -1083,6 +1093,8 @@ builtin.git_stash({opts})                      *telescope.builtin.git_stash()*
 
     Options: ~
         {cwd}          (string)   specify the path of the repo
+        {use_file_path}(boolean)  if we should use the current buffer
+                                  git root (default: false)
         {use_git_root} (boolean)  if we should use git root as cwd or the cwd
                                   (important for submodule) (default: true)
         {show_branch}  (boolean)  if we should display the branch name for git

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -968,7 +968,7 @@ builtin.git_files({opts})                      *telescope.builtin.git_files()*
     Options: ~
         {cwd}                (string)   specify the path of the repo
         {use_file_path}      (boolean)  if we should use the current buffer
-                                        git root (default: true)
+                                        git root (default: false)
         {use_git_root}       (boolean)  if we should use git root as cwd or
                                         the cwd (important for submodule)
                                         (default: true)
@@ -995,13 +995,13 @@ builtin.git_commits({opts})                  *telescope.builtin.git_commits()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}          (string)   specify the path of the repo
-        {use_file_path}(boolean)  if we should use the current buffer
-                                  git root (default: false)
-        {use_git_root} (boolean)  if we should use git root as cwd or the cwd
-                                  (important for submodule) (default: true)
-        {git_command}  (table)    command that will be executed.
-                                  {"git","log","--pretty=oneline","--abbrev-commit","--","."}
+        {cwd}           (string)   specify the path of the repo
+        {use_file_path} (boolean)  if we should use the current buffer git
+                                   root (default: false)
+        {use_git_root}  (boolean)  if we should use git root as cwd or the cwd
+                                   (important for submodule) (default: true)
+        {git_command}   (table)    command that will be executed.
+                                   {"git","log","--pretty=oneline","--abbrev-commit","--","."}
 
 
 builtin.git_bcommits({opts})                *telescope.builtin.git_bcommits()*
@@ -1017,15 +1017,15 @@ builtin.git_bcommits({opts})                *telescope.builtin.git_bcommits()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}          (string)   specify the path of the repo
-        {use_file_path}(boolean)  if we should use the current buffer
-                                  git root (default: false)
-        {use_git_root} (boolean)  if we should use git root as cwd or the cwd
-                                  (important for submodule) (default: true)
-        {current_file} (string)   specify the current file that should be used
-                                  for bcommits (default: current buffer)
-        {git_command}  (table)    command that will be executed.
-                                  {"git","log","--pretty=oneline","--abbrev-commit"}
+        {cwd}           (string)   specify the path of the repo
+        {use_file_path} (boolean)  if we should use the current buffer git
+                                   root (default: false)
+        {use_git_root}  (boolean)  if we should use git root as cwd or the cwd
+                                   (important for submodule) (default: true)
+        {current_file}  (string)   specify the current file that should be
+                                   used for bcommits (default: current buffer)
+        {git_command}   (table)    command that will be executed.
+                                   {"git","log","--pretty=oneline","--abbrev-commit"}
 
 
 builtin.git_branches({opts})                *telescope.builtin.git_branches()*
@@ -1048,8 +1048,9 @@ builtin.git_branches({opts})                *telescope.builtin.git_branches()*
     Options: ~
         {cwd}                           (string)   specify the path of the
                                                    repo
-        {use_file_path}                 (boolean)  if we should use the current buffer
-                                                   git root (default: false)
+        {use_file_path}                 (boolean)  if we should use the
+                                                   current buffer git root
+                                                   (default: false)
         {use_git_root}                  (boolean)  if we should use git root
                                                    as cwd or the cwd
                                                    (important for submodule)
@@ -1072,14 +1073,14 @@ builtin.git_status({opts})                    *telescope.builtin.git_status()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}          (string)   specify the path of the repo
-        {use_file_path}(boolean)  if we should use the current buffer
-                                  git root (default: false)
-        {use_git_root} (boolean)  if we should use git root as cwd or the cwd
-                                  (important for submodule) (default: true)
-        {git_icons}    (table)    string -> string. Matches name with icon
-                                  (see source code, make_entry.lua
-                                  git_icon_defaults)
+        {cwd}           (string)   specify the path of the repo
+        {use_file_path} (boolean)  if we should use the current buffer git
+                                   root (default: false)
+        {use_git_root}  (boolean)  if we should use git root as cwd or the cwd
+                                   (important for submodule) (default: true)
+        {git_icons}     (table)    string -> string. Matches name with icon
+                                   (see source code, make_entry.lua
+                                   git_icon_defaults)
 
 
 builtin.git_stash({opts})                      *telescope.builtin.git_stash()*
@@ -1092,13 +1093,13 @@ builtin.git_stash({opts})                      *telescope.builtin.git_stash()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}          (string)   specify the path of the repo
-        {use_file_path}(boolean)  if we should use the current buffer
-                                  git root (default: false)
-        {use_git_root} (boolean)  if we should use git root as cwd or the cwd
-                                  (important for submodule) (default: true)
-        {show_branch}  (boolean)  if we should display the branch name for git
-                                  stash entries (default: true)
+        {cwd}           (string)   specify the path of the repo
+        {use_file_path} (boolean)  if we should use the current buffer git
+                                   root (default: false)
+        {use_git_root}  (boolean)  if we should use git root as cwd or the cwd
+                                   (important for submodule) (default: true)
+        {show_branch}   (boolean)  if we should display the branch name for
+                                   git stash entries (default: true)
 
 
 builtin.builtin({opts})                          *telescope.builtin.builtin()*

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -383,7 +383,7 @@ local set_opts_cwd = function(opts)
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)
   elseif opts.use_file_path then
-    opts.cwd = vim.fn.finddir('.git', vim.fn.expand('%:p') .. ';')
+    opts.cwd = vim.fn.finddir(".git", vim.fn.expand "%:p" .. ";")
   else
     opts.cwd = vim.loop.cwd()
   end

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -382,6 +382,8 @@ end
 local set_opts_cwd = function(opts)
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)
+  elseif opts.use_file_path then
+    opts.cwd = vim.fn.finddir('.git', vim.fn.expand('%:p') .. ';')
   else
     opts.cwd = vim.loop.cwd()
   end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -132,6 +132,7 @@ builtin.current_buffer_tags = require_on_exported_call("telescope.builtin.__file
 ---   - `<cr>`: opens the currently selected file
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
+---@field use_file_path boolean: if we should use the current buffer git root (default: false)
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field show_untracked boolean: if true, adds `--others` flag to command and shows untracked files (default: false)
 ---@field recurse_submodules boolean: if true, adds the `--recurse-submodules` flag to command (default: false)
@@ -146,6 +147,7 @@ builtin.git_files = require_on_exported_call("telescope.builtin.__git").files
 ---   - `<C-r>h`: resets current branch to selected commit using hard mode
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
+---@field use_file_path boolean: if we should use the current buffer git root (default: false)
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field git_command table: command that will be executed. {"git","log","--pretty=oneline","--abbrev-commit","--","."}
 builtin.git_commits = require_on_exported_call("telescope.builtin.__git").commits
@@ -158,6 +160,7 @@ builtin.git_commits = require_on_exported_call("telescope.builtin.__git").commit
 ---   - `<c-t>`: opens a diff in a new tab
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
+---@field use_file_path boolean: if we should use the current buffer git root (default: false)
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field current_file string: specify the current file that should be used for bcommits (default: current buffer)
 ---@field git_command table: command that will be executed. {"git","log","--pretty=oneline","--abbrev-commit"}
@@ -173,6 +176,7 @@ builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcomm
 ---   - `<C-y>`: merges the currently selected branch, with confirmation prompt before deletion
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
+---@field use_file_path boolean: if we should use the current buffer git root (default: false)
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field show_remote_tracking_branches boolean: show remote tracking branches like origin/main (default: true)
 ---@field pattern string: specify the pattern to match all refs
@@ -184,6 +188,7 @@ builtin.git_branches = require_on_exported_call("telescope.builtin.__git").branc
 ---   - `<cr>`: opens the currently selected file
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
+---@field use_file_path boolean: if we should use the current buffer git root (default: false)
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field git_icons table: string -> string. Matches name with icon (see source code, make_entry.lua git_icon_defaults)
 builtin.git_status = require_on_exported_call("telescope.builtin.__git").status
@@ -193,6 +198,7 @@ builtin.git_status = require_on_exported_call("telescope.builtin.__git").status
 ---   - `<cr>`: runs `git apply` for currently selected stash
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify the path of the repo
+---@field use_file_path boolean: if we should use the current buffer git root (default: false)
 ---@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
 ---@field show_branch boolean: if we should display the branch name for git stash entries (default: true)
 builtin.git_stash = require_on_exported_call("telescope.builtin.__git").stash


### PR DESCRIPTION
# Description

This commit adds a new param for git_* builtin pickers to find the git root *from* the current file. The root is found as the first parent repo of the current buffer.
It is useful when working on a project containing multiple git repos like 
```
src/   <-- neovim cwd
   repo1/
      .git/
      file1
   repo2/
      .git/
      file2
```
Calling `Telescope git_commits` on file1 buffer will open all commits of the first repo. 

This feature is inspired by the way [fugitive](https://github.com/tpope/vim-fugitive) looks for the git root 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?
Set your cwd to a directory containing multiple git repos. Open any file. Call a git picker with the `use_file_path` flag set to `true` in Telescope, the repo of the current file is correctly found to display commits, status, or stash.

**Configuration**:
* Neovim version (nvim --version): any that can run Telescope (tested on 0.9.0)
* Operating system and version: any

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
