### PR TITLE
Implements horizontal scrolling in previewer & results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ Many familiar mapping patterns are set up as defaults.
 | `<C-t>`        | Go to a file in a new tab                            |
 | `<C-u>`        | Scroll up in preview window                          |
 | `<C-d>`        | Scroll down in preview window                        |
+| `<C-f>`        | Scroll left in preview window                        |
+| `<C-k>`        | Scroll right in preview window                       |
+| `<M-f>`        | Scroll left in results window                        |
+| `<M-k>`        | Scroll right in results window                       |
 | `<C-/>`        | Show mappings for picker actions (insert mode)       |
 | `?`            | Show mappings for picker actions (normal mode)       |
 | `<C-c>`        | Close telescope                                      |

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2473,6 +2473,22 @@ actions.preview_scrolling_down({prompt_bufnr}) *telescope.actions.preview_scroll
         {prompt_bufnr} (number)  The prompt bufnr
 
 
+actions.preview_scrolling_left({prompt_bufnr}) *telescope.actions.preview_scrolling_left()*
+    Scroll the preview window to the left
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.preview_scrolling_right({prompt_bufnr}) *telescope.actions.preview_scrolling_right()*
+    Scroll the preview window to the right
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
 actions.results_scrolling_up({prompt_bufnr}) *telescope.actions.results_scrolling_up()*
     Scroll the results window up
 
@@ -2483,6 +2499,22 @@ actions.results_scrolling_up({prompt_bufnr}) *telescope.actions.results_scrollin
 
 actions.results_scrolling_down({prompt_bufnr}) *telescope.actions.results_scrolling_down()*
     Scroll the results window down
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.results_scrolling_left({prompt_bufnr}) *telescope.actions.results_scrolling_left()*
+    Scroll the results window to the left
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.results_scrolling_right({prompt_bufnr}) *telescope.actions.results_scrolling_right()*
+    Scroll the results window to the right
 
 
     Parameters: ~
@@ -3348,6 +3380,7 @@ previewers.Previewer()                      *telescope.previewers.Previewer()*
     - `:teardown()`
     - `:send_input(input)`
     - `:scroll_fn(direction)`
+    - `:scroll_horizontal_fn(direction)`
 
     `Previewer:new()` expects a table as input with following keys:
       - `setup` function(self): Will be called the first time preview will be 
@@ -3363,6 +3396,8 @@ previewers.Previewer()                      *telescope.previewers.Previewer()*
         `termopen_previewer` and it can be used to send input to the terminal 
         application, like less.
       - `scroll_fn` function(self, direction): Used to make scrolling work.
+      - `scroll_horizontal_fn` function(self, direction): Used to make
+	horizontal scrolling work.
 
 
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -216,6 +216,18 @@ actions.preview_scrolling_down = function(prompt_bufnr)
   action_set.scroll_previewer(prompt_bufnr, 1)
 end
 
+--- Scroll the preview window to the left
+---@param prompt_bufnr number: The prompt bufnr
+actions.preview_scrolling_left = function(prompt_bufnr)
+  action_set.scroll_horizontal_previewer(prompt_bufnr, -1)
+end
+
+--- Scroll the preview window to the right
+---@param prompt_bufnr number: The prompt bufnr
+actions.preview_scrolling_right = function(prompt_bufnr)
+  action_set.scroll_horizontal_previewer(prompt_bufnr, 1)
+end
+
 --- Scroll the results window up
 ---@param prompt_bufnr number: The prompt bufnr
 actions.results_scrolling_up = function(prompt_bufnr)
@@ -226,6 +238,18 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 actions.results_scrolling_down = function(prompt_bufnr)
   action_set.scroll_results(prompt_bufnr, 1)
+end
+
+--- Scroll the results window to the left
+---@param prompt_bufnr number: The prompt bufnr
+actions.results_scrolling_left = function(prompt_bufnr)
+  action_set.scroll_horizontal_results(prompt_bufnr, -1)
+end
+
+--- Scroll the results window to the right
+---@param prompt_bufnr number: The prompt bufnr
+actions.results_scrolling_right = function(prompt_bufnr)
+  action_set.scroll_horizontal_results(prompt_bufnr, 1)
 end
 
 --- Center the cursor in the window, can be used after selecting a file to edit

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -203,6 +203,27 @@ action_set.scroll_previewer = function(prompt_bufnr, direction)
   previewer:scroll_fn(math.floor(speed * direction))
 end
 
+--- Scrolls the previewer to the left or right.
+--- Defaults to a half page scroll, but can be overridden using the `scroll_speed`
+--- option in `layout_config`. See |telescope.layout| for more details.
+---@param prompt_bufnr number: The prompt bufnr
+---@param direction number: The direction of the scrolling
+--      Valid directions include: "1", "-1"
+action_set.scroll_horizontal_previewer = function(prompt_bufnr, direction)
+  local previewer = action_state.get_current_picker(prompt_bufnr).previewer
+  local status = state.get_status(prompt_bufnr)
+
+  -- Check if we actually have a previewer and a preview window
+  if type(previewer) ~= "table" or previewer.scroll_horizontal_fn == nil or status.preview_win == nil then
+    return
+  end
+
+  local default_speed = vim.api.nvim_win_get_height(status.preview_win) / 2
+  local speed = status.picker.layout_config.scroll_speed or default_speed
+
+  previewer:scroll_horizontal_fn(math.floor(speed * direction))
+end
+
 --- Scrolls the results up or down.
 --- Defaults to a half page scroll, but can be overridden using the `scroll_speed`
 --- option in `layout_config`. See |telescope.layout| for more details.
@@ -221,6 +242,24 @@ action_set.scroll_results = function(prompt_bufnr, direction)
   end)
 
   action_set.shift_selection(prompt_bufnr, math.floor(speed) * direction)
+end
+
+--- Scrolls the results to the left or right.
+--- Defaults to a half page scroll, but can be overridden using the `scroll_speed`
+--- option in `layout_config`. See |telescope.layout| for more details.
+---@param prompt_bufnr number: The prompt bufnr
+---@param direction number: The direction of the scrolling
+--      Valid directions include: "1", "-1"
+action_set.scroll_horizontal_results = function(prompt_bufnr, direction)
+  local status = state.get_status(prompt_bufnr)
+  local default_speed = vim.api.nvim_win_get_height(status.results_win) / 2
+  local speed = status.picker.layout_config.scroll_speed or default_speed
+
+  local input = direction > 0 and [[zl]] or [[zh]]
+
+  vim.api.nvim_win_call(status.results_win, function()
+    vim.cmd([[normal! ]] .. math.floor(speed) .. input)
+  end)
 end
 
 -- ==================================================

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -148,9 +148,13 @@ mappings.default_mappings = config.values.default_mappings
 
       ["<C-u>"] = actions.preview_scrolling_up,
       ["<C-d>"] = actions.preview_scrolling_down,
+      ["<C-f>"] = actions.preview_scrolling_left,
+      ["<C-k>"] = actions.preview_scrolling_right,
 
       ["<PageUp>"] = actions.results_scrolling_up,
       ["<PageDown>"] = actions.results_scrolling_down,
+      ["<M-f>"] = actions.results_scrolling_left,
+      ["<M-k>"] = actions.results_scrolling_right,
 
       ["<Tab>"] = actions.toggle_selection + actions.move_selection_worse,
       ["<S-Tab>"] = actions.toggle_selection + actions.move_selection_better,

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -151,6 +151,19 @@ local scroll_fn = function(self, direction)
   end)
 end
 
+local scroll_horizontal_fn = function(self, direction)
+  if not self.state then
+    return
+  end
+
+  local input = direction > 0 and [[zl]] or [[zh]]
+  local count = math.abs(direction)
+
+  vim.api.nvim_win_call(self.state.winid, function()
+    vim.cmd([[normal! ]] .. count .. input)
+  end)
+end
+
 previewers.file_maker = function(filepath, bufnr, opts)
   opts = vim.F.if_nil(opts, {})
   -- TODO(conni2461): here shouldn't be any hardcoded magic numbers ...
@@ -406,6 +419,10 @@ previewers.new_buffer_previewer = function(opts)
 
   if not opts.scroll_fn then
     opts.scroll_fn = scroll_fn
+  end
+
+  if not opts.scroll_horizontal_fn then
+    opts.scroll_horizontal_fn = scroll_horizontal_fn
   end
 
   return Previewer:new(opts)

--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -47,6 +47,7 @@ local previewers = {}
 --- - `:teardown()`
 --- - `:send_input(input)`
 --- - `:scroll_fn(direction)`
+--- - `:scroll_horizontal_fn(direction)`
 ---
 --- `Previewer:new()` expects a table as input with following keys:
 ---   - `setup` function(self): Will be called the first time preview will be
@@ -64,6 +65,8 @@ local previewers = {}
 ---                                         used to send input to the terminal
 ---                                         application, like less.
 ---   - `scroll_fn` function(self, direction): Used to make scrolling work.
+---   - `scroll_horizontal_fn` function(self, direction): Used to make
+---                                                       horizontal scrolling work.
 previewers.Previewer = Previewer
 
 --- A shorthand for creating a new Previewer.

--- a/lua/telescope/previewers/previewer.lua
+++ b/lua/telescope/previewers/previewer.lua
@@ -26,6 +26,7 @@ function Previewer:new(opts)
     _teardown_func = opts.teardown,
     _send_input = opts.send_input,
     _scroll_fn = opts.scroll_fn,
+    _scroll_horizontal_fn = opts.scroll_horizontal_fn,
     preview_fn = opts.preview_fn,
     _empty_bufnr = nil,
   }, Previewer)
@@ -92,6 +93,14 @@ function Previewer:scroll_fn(direction)
     self:_scroll_fn(direction)
   else
     vim.api.nvim_err_writeln "scroll_fn is not defined for this previewer"
+  end
+end
+
+function Previewer:scroll_horizontal_fn(direction)
+  if self._scroll_horizontal_fn then
+    self:_scroll_horizontal_fn(direction)
+  else
+    vim.api.nvim_err_writeln "scroll_horizontal_fn is not defined for this previewer"
   end
 end
 


### PR DESCRIPTION
# Description

This implements horizontal scrolling, e.g. to the left and the right, in both the previewer window, mapped to \<C-f> and \<C-k> by default, resp., and the results window, mapped to \<M-f> and \<M-k> by default.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Open ``Telescope live_grep`` or ``Telescope find_files``, etc., input query, scroll to the left or to the right in the previewer or the results window with the above key mappings.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.7.2, Build type: Release, LuaJIT 2.1.0-beta3
* Operating system and version: Ubuntu 22.10 (kinetic)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
