### PR TITLE
Simplify vimgrep_arguments args

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -532,16 +532,13 @@ telescope.setup({opts})                                    *telescope.setup()*
         Hint: Make sure that color is currently set to `never` because we do
         not yet interpret color codes
         Hint 2: Make sure that these options are in your changes arguments:
-          "--no-heading", "--with-filename", "--line-number", "--column"
+          ("--no-heading", "--with-filename", "--line-number", "--column") or
+          "--vimgrep"
         because we need them so the ripgrep output is in the correct format.
 
         Default: {
           "rg",
-          "--color=never",
-          "--no-heading",
-          "--with-filename",
-          "--line-number",
-          "--column",
+          "--vimgrep",
           "--smart-case"
         }
 

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -633,7 +633,8 @@ append(
     Hint: Make sure that color is currently set to `never` because we do
     not yet interpret color codes
     Hint 2: Make sure that these options are in your changes arguments:
-      "--no-heading", "--with-filename", "--line-number", "--column"
+      ("--no-heading", "--with-filename", "--line-number", "--column") or
+      "--vimgrep"
     because we need them so the ripgrep output is in the correct format.
 
     Default: {

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -626,7 +626,7 @@ append(
 
 append(
   "vimgrep_arguments",
-  { "rg", "--color=never", "--no-heading", "--with-filename", "--line-number", "--column", "--smart-case" },
+  { "rg", "--vimgrep", "--smart-case" },
   [[
     Defines the command that will be used for `live_grep` and `grep_string`
     pickers.
@@ -638,11 +638,7 @@ append(
 
     Default: {
       "rg",
-      "--color=never",
-      "--no-heading",
-      "--with-filename",
-      "--line-number",
-      "--column",
+      "--vimgrep",
       "--smart-case"
     }]]
 )


### PR DESCRIPTION
# Description

ripgrep has an argument that returns results in vim format

```man
       --vimgrep
           Show results with every match on its own line, including line numbers and column numbers. With this option, a line with more than one match will be printed more than once.
```

which would replace `"--color=never", "--no-heading", "--with-filename", "--line-number", "--column"` and still produce the same result
## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Test A
- [ ] Test B

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
