### PR TITLE
fix: Use vim.treesitter.query.get() to avoid deprecation warning

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -886,13 +886,16 @@ builtin.treesitter()                          *telescope.builtin.treesitter()*
 
 
     Options: ~
-        {show_line}         (boolean)  if true, shows the row:column that the
-                                       result is found at (default: true)
-        {bufnr}             (number)   specify the buffer number where
-                                       treesitter should run. (default:
-                                       current buffer)
-        {symbol_highlights} (table)    string -> string. Matches symbol with
-                                       hl_group
+        {show_line}         (boolean)       if true, shows the row:column that
+                                            the result is found at (default:
+                                            true)
+        {bufnr}             (number)        specify the buffer number where
+                                            treesitter should run. (default:
+                                            current buffer)
+        {symbols}           (string|table)  filter results by symbol kind(s)
+        {ignore_symbols}    (string|table)  list of symbols to ignore
+        {symbol_highlights} (table)         string -> string. Matches symbol
+                                            with hl_group
 
 
 builtin.current_buffer_fuzzy_find({opts}) *telescope.builtin.current_buffer_fuzzy_find()*

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -458,7 +458,8 @@ files.current_buffer_fuzzy_find = function(opts)
   local _, ts_configs = pcall(require, "nvim-treesitter.configs")
 
   local parser_ok, parser = pcall(vim.treesitter.get_parser, opts.bufnr, filetype)
-  local query_ok, query = pcall(vim.treesitter.get_query, filetype, "highlights")
+  local query_get = vim.treesitter.query.get or vim.treesitter.get_query
+  local query_ok, query = pcall(query_get, filetype, "highlights")
   if parser_ok and query_ok and ts_ok and ts_configs.is_enabled("highlight", filetype, opts.bufnr) then
     local root = parser:parse()[1]:root()
 


### PR DESCRIPTION
# Description

fix: https://github.com/neovim/neovim/pull/22761

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I confirmed that the following command did not show any error message.

`Telescope current_buffer_fuzzy_find`

Configuration:

Neovim version (nvim --version): v0.9.0-dev-1288+g4863ca6b8
Operating system and version: Arch Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
