### PR TITLE
fix(action): grep_string select_default with nil column

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -169,9 +169,15 @@ action_set.edit = function(prompt_bufnr, command)
     end
   end
 
-  if row == nil or col == nil then
-    local pos = vim.api.nvim_win_get_cursor(0)
-    row, col = pos[1], pos[2] + 1
+  local pos = vim.api.nvim_win_get_cursor(0)
+  if col == nil then
+    if row == pos[1] then
+      col = pos[2] + 1
+    elseif row == nil then
+      row, col = pos[1], pos[2] + 1
+    else
+      col = 1
+    end
   end
 
   if row and col then


### PR DESCRIPTION
# Description

Regression bug from #2416 where `grep_string` results without column numbers where not respecting the row number on `select_default` when using `grep_string` with the command `:Telescope grep_string search=<CR>`

Closes #2444 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Verify bug fix
* use `:Telescope grep_string search=<CR>` to grep for anything that's not that on the first line of the file
* `select_default` on some entry - the file should open on the correct line
* also verify regular `:Telescop grep_string<CR>` works as expected taking you to the correct row/col of the file
- [x] Regression test for #2416
* open a buffer and move the cursor to somewhere not [1,1]
* open a new split `:vnew`
* `:Telescope buffers` and open the buffer from above -> cursor should be in the same location between the two windows 
* open a new split `:vnew`
* `:Telescope find_files` and open the file from above -> cursor should be in the same location between the windows (previously would always go to [1,1])

**Configuration**:
* Neovim version (nvim --version): `NVIM v0.9.0-dev-1290+g2257ade3d`
* Operating system and version: `Linux archlinux 6.1.12-arch1-1`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
