### PR TITLE
fix: icon hl width for various pickers

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -886,13 +886,16 @@ builtin.treesitter()                          *telescope.builtin.treesitter()*
 
 
     Options: ~
-        {show_line}         (boolean)  if true, shows the row:column that the
-                                       result is found at (default: true)
-        {bufnr}             (number)   specify the buffer number where
-                                       treesitter should run. (default:
-                                       current buffer)
-        {symbol_highlights} (table)    string -> string. Matches symbol with
-                                       hl_group
+        {show_line}         (boolean)       if true, shows the row:column that
+                                            the result is found at (default:
+                                            true)
+        {bufnr}             (number)        specify the buffer number where
+                                            treesitter should run. (default:
+                                            current buffer)
+        {symbols}           (string|table)  filter results by symbol kind(s)
+        {ignore_symbols}    (string|table)  list of symbols to ignore
+        {symbol_highlights} (table)         string -> string. Matches symbol
+                                            with hl_group
 
 
 builtin.current_buffer_fuzzy_find({opts}) *telescope.builtin.current_buffer_fuzzy_find()*

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -157,13 +157,13 @@ do
 
     mt_file_entry.cwd = cwd
     mt_file_entry.display = function(entry)
-      local hl_group
+      local hl_group, icon
       local display = utils.transform_path(opts, entry.value)
 
-      display, hl_group = utils.transform_devicons(entry.value, display, disable_devicons)
+      display, hl_group, icon = utils.transform_devicons(entry.value, display, disable_devicons)
 
       if hl_group then
-        return display, { { { 1, 3 }, hl_group } }
+        return display, { { { 1, #icon }, hl_group } }
       else
         return display
       end
@@ -326,14 +326,14 @@ do
           end
         end
 
-        local display, hl_group = utils.transform_devicons(
+        local display, hl_group, icon = utils.transform_devicons(
           entry.filename,
           string.format(display_string, display_filename, coordinates, entry.text),
           disable_devicons
         )
 
         if hl_group then
-          return display, { { { 1, 3 }, hl_group } }
+          return display, { { { 1, #icon }, hl_group } }
         else
           return display
         end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -440,13 +440,14 @@ utils.transform_devicons = load_once(function()
       local icon, icon_highlight = devicons.get_icon(basename, utils.file_extension(basename), { default = false })
       if not icon then
         icon, icon_highlight = devicons.get_icon(basename, nil, { default = true })
+        icon = icon or " "
       end
-      local icon_display = (icon or " ") .. " " .. (display or "")
+      local icon_display = icon .. " " .. (display or "")
 
       if conf.color_devicons then
-        return icon_display, icon_highlight
+        return icon_display, icon_highlight, icon
       else
-        return icon_display, nil
+        return icon_display, nil, icon
       end
     end
   else


### PR DESCRIPTION
# Description

Fix the highlight group width for devicons for various pickers' entry display.
Currently, certain entry makers fail to compensate for the icon widths not equal to 3.
Closes #2445 

Effects pickers using `gen_from_file` and `gen_from_vimgrep` make entries.
- `find_files`
- `git_files`
- `oldfiles`
- `live_grep`
- `grep_string`

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] verify overwriting devicon icons and colors (using config from issue #2445) work with the above mentioned pickers
- [x] verify that _not_ overwriting icons and colors still work with the above mentioned pickers

**Configuration**:
* Neovim version (nvim --version): `NVIM v0.9.0-dev-1305+g83bfd94d1`
* Operating system and version: `Linux archlinux 6.2.8-arch1-1`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
