### PR TITLE
fix: `vim.treesitter.get_query` deprecated

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -458,7 +458,8 @@ files.current_buffer_fuzzy_find = function(opts)
   local _, ts_configs = pcall(require, "nvim-treesitter.configs")
 
   local parser_ok, parser = pcall(vim.treesitter.get_parser, opts.bufnr, filetype)
-  local query_ok, query = pcall(vim.treesitter.query.get, filetype, "highlights")
+  local get_query = vim.treesitter.query.get or vim.treesitter.get_query
+  local query_ok, query = pcall(get_query, filetype, "highlights")
   if parser_ok and query_ok and ts_ok and ts_configs.is_enabled("highlight", filetype, opts.bufnr) then
     local root = parser:parse()[1]:root()
 

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -458,7 +458,7 @@ files.current_buffer_fuzzy_find = function(opts)
   local _, ts_configs = pcall(require, "nvim-treesitter.configs")
 
   local parser_ok, parser = pcall(vim.treesitter.get_parser, opts.bufnr, filetype)
-  local query_ok, query = pcall(vim.treesitter.get_query, filetype, "highlights")
+  local query_ok, query = pcall(vim.treesitter.query.get, filetype, "highlights")
   if parser_ok and query_ok and ts_ok and ts_configs.is_enabled("highlight", filetype, opts.bufnr) then
     local root = parser:parse()[1]:root()
 


### PR DESCRIPTION
# Description

vim.treesitter.get_query is deprecated use vim.treesitter.query.get

# Checklist:

- [x ] My code follows the style guidelines of this project (stylua)
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation (lua annotations)
