### PR TITLE
add 'full' for line_width in diagnostics options

### DIFF
--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -146,6 +146,14 @@ diagnostics.get = function(opts)
     return
   end
 
+  if type(opts.line_width) == "string" and opts.line_width ~= "full" then
+    utils.notify("builtin.diagnostics", {
+      msg = string.format("'%s' is not a valid value for line_width", opts.line_width),
+      level = "ERROR",
+    })
+    return
+  end
+
   opts.path_display = vim.F.if_nil(opts.path_display, "hidden")
   pickers
     .new(opts, {

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -483,7 +483,7 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 ---@field root_dir string|boolean: if set to string, get diagnostics only for buffers under this dir otherwise cwd
 ---@field no_unlisted boolean: if true, get diagnostics only for listed buffers
 ---@field no_sign boolean: hide DiagnosticSigns from Results (default: false)
----@field line_width string|number: Set length of diagnostic entry text in Results. Use 'full' for full untruncated text
+---@field line_width string|number: set length of diagnostic entry text in Results. Use 'full' for full untruncated text
 ---@field namespace number: limit your diagnostics to a specific namespace
 builtin.diagnostics = require_on_exported_call("telescope.builtin.__diagnostics").get
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -483,7 +483,7 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 ---@field root_dir string|boolean: if set to string, get diagnostics only for buffers under this dir otherwise cwd
 ---@field no_unlisted boolean: if true, get diagnostics only for listed buffers
 ---@field no_sign boolean: hide DiagnosticSigns from Results (default: false)
----@field line_width number: set length of diagnostic entry text in Results
+---@field line_width string|number: Set length of diagnostic entry text in Results. Use 'full' for full untruncated text
 ---@field namespace number: limit your diagnostics to a specific namespace
 builtin.diagnostics = require_on_exported_call("telescope.builtin.__diagnostics").get
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1165,15 +1165,8 @@ function make_entry.gen_from_diagnostics(opts)
   }
   local line_width = vim.F.if_nil(opts.line_width, 0.5)
   local line_width_opts = { width = line_width }
-  if type(line_width) == "string" then
-    if line_width == "full" then
-      line_width_opts = {}
-    else
-      utils.notify("make_entry.gen_from_diagnostics", {
-        msg = string.format("'%s' is not a valid value for line_width", line_width),
-        level = "ERROR",
-      })
-    end
+  if type(line_width) == "string" and line_width == "full" then
+    line_width_opts = {}
   end
   local hidden = utils.is_path_hidden(opts)
   if not hidden then

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1162,7 +1162,10 @@ function make_entry.gen_from_diagnostics(opts)
     if line_width == "full" then
       line_width_opts = {}
     else
-      error(string.format("'%s' is not a valid value for line_width", line_width))
+      utils.notify("make_entry.gen_from_diagnostics", {
+        msg = string.format("'%s' is not a valid value for line_width", line_width),
+        level = "ERROR",
+      })
     end
   end
   local hidden = utils.is_path_hidden(opts)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1157,9 +1157,17 @@ function make_entry.gen_from_diagnostics(opts)
     { remaining = true },
   }
   local line_width = vim.F.if_nil(opts.line_width, 0.5)
+  local line_width_opts = { width = line_width }
+  if type(line_width) == "string" then
+    if line_width == "full" then
+      line_width_opts = {}
+    else
+      error(string.format("'%s' is not a valid value for line_width", line_width))
+    end
+  end
   local hidden = utils.is_path_hidden(opts)
   if not hidden then
-    table.insert(display_items, 2, { width = line_width })
+    table.insert(display_items, 2, line_width_opts)
   end
   local displayer = entry_display.create {
     separator = "▏",


### PR DESCRIPTION
# Description

Added new value "full" for line_width option in builtin.diagnostics. When "full" is set there are no restrictions on diagnostics message line width and so whole message is shown.

![image](https://user-images.githubusercontent.com/23119893/230485368-1b9bed0f-cf70-46f8-8d60-339bef5c6182.png)

Until this change, line_width could only be number. Maximum line width was "one width" of picker window and longer messages were cut.

![image](https://user-images.githubusercontent.com/23119893/230485847-4e491eb0-bd71-4fdf-b2ee-acb7430d081e.png)

This was annoying since you generally want to read whole error message.

Fixes #2020

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list 
relevant details about your configuration

- [x] Verify change
- in config defaults set `wrap_line = true`
- open project where there is error with long message
- open diagnostics with `require('telescope.builtin').diagnostics({line_width='full'})`

**Configuration**:
* Neovim version (nvim --version): `NVIM v0.8.3`
* Operating system and version: `Linux 6.2.6-artix1-1`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
