### PR TITLE
add 'reuse_win' for reuse window in lsp definition options

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1516,6 +1516,8 @@ builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
                                  (default: 30)
         {show_line}   (boolean)  show results text (default: true)
         {trim_text}   (boolean)  trim results text (default: false)
+        {reuse_win}   (boolean)  jump to existing window if buffer is already
+                                 opened (default: false)
 
 
 builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
@@ -1535,6 +1537,8 @@ builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
                                  (default: 30)
         {show_line}   (boolean)  show results text (default: true)
         {trim_text}   (boolean)  trim results text (default: false)
+        {reuse_win}   (boolean)  jump to existing window if buffer is already
+                                 opened (default: false)
 
 
 builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
@@ -1554,6 +1558,8 @@ builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
                                  (default: 30)
         {show_line}   (boolean)  show results text (default: true)
         {trim_text}   (boolean)  trim results text (default: false)
+        {reuse_win}   (boolean)  jump to existing window if buffer is already
+                                 opened (default: false)
 
 
 builtin.lsp_document_symbols({opts}) *telescope.builtin.lsp_document_symbols()*

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -196,7 +196,8 @@ local function list_or_jump(action, title, opts)
           vim.cmd "vnew"
         end
       end
-      vim.lsp.util.jump_to_location(flattened_results[1], offset_encoding)
+
+      vim.lsp.util.jump_to_location(flattened_results[1], offset_encoding, opts.reuse_win)
     else
       local locations = vim.lsp.util.locations_to_items(flattened_results, offset_encoding)
       pickers

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -407,6 +407,7 @@ builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp")
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
 builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").definitions
 
 --- Goto the definition of the type of the word under the cursor, if there's only one,
@@ -416,6 +417,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
 builtin.lsp_type_definitions = require("telescope.builtin.__lsp").type_definitions
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
@@ -424,6 +426,7 @@ builtin.lsp_type_definitions = require("telescope.builtin.__lsp").type_definitio
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
 builtin.lsp_implementations = require_on_exported_call("telescope.builtin.__lsp").implementations
 
 --- Lists LSP document symbols in the current buffer


### PR DESCRIPTION
# Description

Added new option value "reuse_win".

so we can choose to reuse the existing window or not when the builtin.lsp_definitions, builtin.lsp_type_definitions and builtin.lsp_implementations only return one result.

## Type of change

Please delete options that are not relevant.


- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Test lsp definition，lsp_type_definition and lsp implementation is reusing an existing window

**Configuration**:
* Neovim version (nvim --version): NVIM v0.8.3
* Operating system and version: Darwin Kernel Version 22.3.0

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
