### PR TITLE
feat(lsp): support custom action when there is no result

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -886,13 +886,16 @@ builtin.treesitter()                          *telescope.builtin.treesitter()*
 
 
     Options: ~
-        {show_line}         (boolean)  if true, shows the row:column that the
-                                       result is found at (default: true)
-        {bufnr}             (number)   specify the buffer number where
-                                       treesitter should run. (default:
-                                       current buffer)
-        {symbol_highlights} (table)    string -> string. Matches symbol with
-                                       hl_group
+        {show_line}         (boolean)       if true, shows the row:column that
+                                            the result is found at (default:
+                                            true)
+        {bufnr}             (number)        specify the buffer number where
+                                            treesitter should run. (default:
+                                            current buffer)
+        {symbols}           (string|table)  filter results by symbol kind(s)
+        {ignore_symbols}    (string|table)  list of symbols to ignore
+        {symbol_highlights} (table)         string -> string. Matches symbol
+                                            with hl_group
 
 
 builtin.current_buffer_fuzzy_find({opts}) *telescope.builtin.current_buffer_fuzzy_find()*
@@ -1450,19 +1453,21 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {include_declaration}  (boolean)  include symbol declaration in the
-                                          lsp references (default: true)
-        {include_current_line} (boolean)  include current line (default:
-                                          false)
-        {jump_type}            (string)   how to goto reference if there is
-                                          only one and the definition file is
-                                          different from the current file,
-                                          values: "tab", "split", "vsplit",
-                                          "never"
-        {fname_width}          (number)   defines the width of the filename
-                                          section (default: 30)
-        {show_line}            (boolean)  show results text (default: true)
-        {trim_text}            (boolean)  trim results text (default: false)
+        {include_declaration}  (boolean)   include symbol declaration in the
+                                           lsp references (default: true)
+        {include_current_line} (boolean)   include current line (default:
+                                           false)
+        {jump_type}            (string)    how to goto reference if there is
+                                           only one and the definition file is
+                                           different from the current file,
+                                           values: "tab", "split", "vsplit",
+                                           "never"
+        {fname_width}          (number)    defines the width of the filename
+                                           section (default: 30)
+        {show_line}            (boolean)   show results text (default: true)
+        {trim_text}            (boolean)   trim results text (default: false)
+        {on_no_result}         (function)  what to do in case of no results
+                                           (default: nil)
 
 
 builtin.lsp_incoming_calls({opts})    *telescope.builtin.lsp_incoming_calls()*
@@ -1474,10 +1479,12 @@ builtin.lsp_incoming_calls({opts})    *telescope.builtin.lsp_incoming_calls()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
+        {fname_width}  (number)    defines the width of the filename section
+                                   (default: 30)
+        {show_line}    (boolean)   show results text (default: true)
+        {trim_text}    (boolean)   trim results text (default: false)
+        {on_no_result} (function)  what to do in case of no results (default:
+                                   nil)
 
 
 builtin.lsp_outgoing_calls({opts})    *telescope.builtin.lsp_outgoing_calls()*
@@ -1489,10 +1496,12 @@ builtin.lsp_outgoing_calls({opts})    *telescope.builtin.lsp_outgoing_calls()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
+        {fname_width}  (number)    defines the width of the filename section
+                                   (default: 30)
+        {show_line}    (boolean)   show results text (default: true)
+        {trim_text}    (boolean)   trim results text (default: false)
+        {on_no_result} (function)  what to do in case of no results (default:
+                                   nil)
 
 
 builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
@@ -1504,14 +1513,16 @@ builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}   (string)   how to goto definition if there is only one
-                                 and the definition file is different from the
-                                 current file, values: "tab", "split",
-                                 "vsplit", "never"
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
+        {jump_type}    (string)    how to goto definition if there is only one
+                                   and the definition file is different from
+                                   the current file, values: "tab", "split",
+                                   "vsplit", "never"
+        {fname_width}  (number)    defines the width of the filename section
+                                   (default: 30)
+        {show_line}    (boolean)   show results text (default: true)
+        {trim_text}    (boolean)   trim results text (default: false)
+        {on_no_result} (function)  what to do in case of no results (default:
+                                   nil)
 
 
 builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
@@ -1523,14 +1534,16 @@ builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}   (string)   how to goto definition if there is only one
-                                 and the definition file is different from the
-                                 current file, values: "tab", "split",
-                                 "vsplit", "never"
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
+        {jump_type}    (string)    how to goto definition if there is only one
+                                   and the definition file is different from
+                                   the current file, values: "tab", "split",
+                                   "vsplit", "never"
+        {fname_width}  (number)    defines the width of the filename section
+                                   (default: 30)
+        {show_line}    (boolean)   show results text (default: true)
+        {trim_text}    (boolean)   trim results text (default: false)
+        {on_no_result} (function)  what to do in case of no results (default:
+                                   nil)
 
 
 builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
@@ -1542,14 +1555,16 @@ builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}   (string)   how to goto implementation if there is only
-                                 one and the definition file is different from
-                                 the current file, values: "tab", "split",
-                                 "vsplit", "never"
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
+        {jump_type}    (string)    how to goto implementation if there is only
+                                   one and the definition file is different
+                                   from the current file, values: "tab",
+                                   "split", "vsplit", "never"
+        {fname_width}  (number)    defines the width of the filename section
+                                   (default: 30)
+        {show_line}    (boolean)   show results text (default: true)
+        {trim_text}    (boolean)   trim results text (default: false)
+        {on_no_result} (function)  what to do in case of no results (default:
+                                   nil)
 
 
 builtin.lsp_document_symbols({opts}) *telescope.builtin.lsp_document_symbols()*

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -36,6 +36,9 @@ lsp.references = function(opts)
     end
 
     if vim.tbl_isempty(locations) then
+      if opts.on_no_result then
+        opts.on_no_result()
+      end
       return
     end
 
@@ -84,6 +87,9 @@ local function call_hierarchy(opts, method, title, direction, item)
     end
 
     if not result or vim.tbl_isempty(result) then
+      if opts.on_no_result then
+        opts.on_no_result()
+      end
       return
     end
 
@@ -184,6 +190,9 @@ local function list_or_jump(action, title, opts)
     local offset_encoding = vim.lsp.get_client_by_id(ctx.client_id).offset_encoding
 
     if #flattened_results == 0 then
+      if opts.on_no_result then
+        opts.on_no_result()
+      end
       return
     elseif #flattened_results == 1 and opts.jump_type ~= "never" then
       if params.textDocument.uri ~= flattened_results[1].uri then

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -385,6 +385,7 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field on_no_result function: what to do in case of no results (default: nil)
 builtin.lsp_references = require_on_exported_call("telescope.builtin.__lsp").references
 
 --- Lists LSP incoming calls for word under the cursor, jumps to reference on `<cr>`
@@ -392,6 +393,7 @@ builtin.lsp_references = require_on_exported_call("telescope.builtin.__lsp").ref
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field on_no_result function: what to do in case of no results (default: nil)
 builtin.lsp_incoming_calls = require_on_exported_call("telescope.builtin.__lsp").incoming_calls
 
 --- Lists LSP outgoing calls for word under the cursor, jumps to reference on `<cr>`
@@ -399,6 +401,7 @@ builtin.lsp_incoming_calls = require_on_exported_call("telescope.builtin.__lsp")
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field on_no_result function: what to do in case of no results (default: nil)
 builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp").outgoing_calls
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
@@ -407,6 +410,7 @@ builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp")
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field on_no_result function: what to do in case of no results (default: nil)
 builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").definitions
 
 --- Goto the definition of the type of the word under the cursor, if there's only one,
@@ -416,6 +420,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field on_no_result function: what to do in case of no results (default: nil)
 builtin.lsp_type_definitions = require("telescope.builtin.__lsp").type_definitions
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
@@ -424,6 +429,7 @@ builtin.lsp_type_definitions = require("telescope.builtin.__lsp").type_definitio
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field on_no_result function: what to do in case of no results (default: nil)
 builtin.lsp_implementations = require_on_exported_call("telescope.builtin.__lsp").implementations
 
 --- Lists LSP document symbols in the current buffer


### PR DESCRIPTION
# Description

Following the thread [here](https://www.reddit.com/r/neovim/comments/12fburw/comment/jfh9aoe/?utm_source=share&utm_medium=web2x&context=3) I thought it would be nice to support a custom action in the case of no results from the LSP when eg finding definitions. For example a user can configure this to notify them which is helpful for slow LSPs since you might not know if it is still working or didn't find anything.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I called:

```lua
require('telescope.builtin').lsp_definitions({
  on_no_result = function()
    vim.notify("could not find a definition")
  end
})
```
on something which the LSP couldn't find a definition and saw the notification.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.0-dev-1312+g908494889
* Operating system and version: arch linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
