### PR TITLE
Change lsp_document_symbols display

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -291,6 +291,37 @@ lsp.document_symbols = function(opts)
     end
 
     opts.path_display = { "hidden" }
+
+    -- Add icon and find the max length of symbol so we can use that to size the kind column accordingly.
+    local symbol_type_max_width = 0
+    local symbol_type_length = function(location)
+      local config = require("telescope.config").values.lsp_symbol_icon
+      local mode = "text"
+      if config ~= false then
+        mode = config.mode
+      end
+
+      local lengths_for_modes = {
+        ["icon"] = location.icon:len(),
+        ["text"] = location.kind:len(),
+        ["icon_text"] = location.icon:len() + location.kind:len(),
+        ["text_icon"] = location.kind:len() + location.icon:len(),
+      }
+
+      return lengths_for_modes[mode];
+    end
+
+    for _, location in pairs(locations) do
+      location.icon = utils.get_lsp_symbol_icon(location.kind)
+
+      local len = symbol_type_length(location)
+      if len > symbol_type_max_width then
+        symbol_type_max_width = len
+      end
+    end
+
+    opts.symbol_type_width = symbol_type_max_width + 1
+
     pickers
       .new(opts, {
         prompt_title = "LSP Document Symbols",

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -294,6 +294,7 @@ lsp.document_symbols = function(opts)
 
     -- Add icon and find the max length of symbol so we can use that to size the kind column accordingly.
     local symbol_type_max_width = 0
+    local symbol_name_max_width = 0
     local symbol_type_length = function(location)
       local config = require("telescope.config").values.lsp_symbol_icon
       local mode = "text"
@@ -314,13 +315,20 @@ lsp.document_symbols = function(opts)
     for _, location in pairs(locations) do
       location.icon = utils.get_lsp_symbol_icon(location.kind)
 
-      local len = symbol_type_length(location)
-      if len > symbol_type_max_width then
-        symbol_type_max_width = len
+      local symbol_type_len = symbol_type_length(location)
+      if symbol_type_len > symbol_type_max_width then
+        symbol_type_max_width = symbol_type_len
+      end
+
+      local _, symbol_name = location.text:match "%[(.+)%]%s+(.*)"
+      local symbol_name_len = symbol_name:len()
+      if symbol_name_len > symbol_name_max_width then
+        symbol_name_max_width = symbol_name_len
       end
     end
 
-    opts.symbol_type_width = symbol_type_max_width + 1
+    opts.symbol_type_width = symbol_type_max_width
+    opts.symbol_name_width = symbol_name_max_width
 
     pickers
       .new(opts, {

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -828,6 +828,57 @@ append(
     Default: require("telescope.previewers").buffer_previewer_maker]]
 )
 
+append(
+  "lsp_symbol_icon",
+  {
+    mode = "icon_text",
+    icon_postfix = " ",
+    icon_prefix = "",
+    not_found_fallback = " ",
+    lspkind_preset = "default",
+    substitutions = {
+      Namespace = "Module"
+    }
+  },
+  [[
+    Symbol icons provides terse context at a glance and can be combined
+    with the lsp kind name (e.g. method, variable, etc) to inform about
+    the type of a given symbol.
+
+    This field handles configuration for symbol- icons and text shown
+    next to lsp symbols when using lsp_*_symbols pickers.
+    This functionality depends on `lspkind`
+    (https://github.com/onsails/lspkind.nvim). If `lspkind` is not available
+    all icons just appear as the empty string.
+
+    Fields:
+      - mode:                 Show only icon or icon and text.
+                              `icon`: Show only the icon.
+                              `text`: Show only the text.
+                              `icon_text`: Show icon and text.
+                              `text_icon`: Show text and icon.
+                              Default: icon_text
+      - icon_prefix:          A string to add before the icon.
+                              Default: ""
+      - icon_postfix:         A string to add after the icon.
+                              Default: " "
+      - not_found_fallback:   A string to use in case an icon for a symbol
+                              was not found.
+                              Default: " "
+      - lspkind_preset:       The preset to use with `lspkind`. The valid
+                              values are the same as with `lspkind`.
+                              `default`: Requires nerd-font.
+                              `codicons`: Requires codicons font.
+      - substitutions:        Sometimes the symbol kind reported by LSP does
+                              not match an icon in `lspkind`, but there may be
+                              another obvious candidate. Use this table to make
+                              that substitution.
+                              Default: {
+                                Namespace = "Module"
+                              }
+    ]]
+)
+
 -- @param user_defaults table: a table where keys are the names of options,
 --    and values are the ones the user wants
 -- @param tele_defaults table: (optional) a table containing all of the defaults
@@ -846,7 +897,7 @@ function config.set_defaults(user_defaults, tele_defaults)
         vim.tbl_deep_extend("keep", vim.F.if_nil(config.values[name], {}), vim.F.if_nil(default_val, {}))
       )
     end
-    if name == "history" or name == "cache_picker" or name == "preview" then
+    if name == "history" or name == "cache_picker" or name == "preview" or name == "lsp_symbol_icon" then
       if user_defaults[name] == false or config.values[name] == false then
         return false
       end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -514,7 +514,7 @@ function make_entry.gen_from_lsp_symbols(opts)
   -- If path is not hidden then its, filepath, symbol and type(still unbound)
   -- If show_line is also set, type is bound to len 8
   local display_items = {
-    { width = opts.symbol_type_width ~= nil and opts.symbol_type_width or 8 },
+    { width = opts.symbol_name_width ~= nil and opts.symbol_name_width or 8 },
     { remaining = true },
   }
 
@@ -535,7 +535,7 @@ function make_entry.gen_from_lsp_symbols(opts)
   }
   local type_highlight = vim.F.if_nil(opts.symbol_highlights or lsp_type_highlight)
 
-  local display_text = function(entry)
+  local display_text_for_symbol_kind = function(entry)
     local config = require("telescope.config").values.lsp_symbol_icon
     local mode = "text"
     if config ~= false then
@@ -561,14 +561,14 @@ function make_entry.gen_from_lsp_symbols(opts)
 
     if hidden then
       return displayer {
-        { display_text(entry), type_highlight[entry.symbol_type] },
         entry.symbol_name,
+        { display_text_for_symbol_kind(entry), type_highlight[entry.symbol_type] },
         msg,
       }
     else
       return displayer {
+        { display_text_for_symbol_kind(entry), type_highlight[entry.symbol_type] },
         utils.transform_path(opts, entry.filename),
-        { display_text(entry), type_highlight[entry.symbol_type] },
         entry.symbol_name,
         msg,
       }

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -514,7 +514,7 @@ function make_entry.gen_from_lsp_symbols(opts)
   -- If path is not hidden then its, filepath, symbol and type(still unbound)
   -- If show_line is also set, type is bound to len 8
   local display_items = {
-    { width = opts.symbol_width or 25 },
+    { width = opts.symbol_type_width ~= nil and opts.symbol_type_width or 8 },
     { remaining = true },
   }
 
@@ -535,6 +535,23 @@ function make_entry.gen_from_lsp_symbols(opts)
   }
   local type_highlight = vim.F.if_nil(opts.symbol_highlights or lsp_type_highlight)
 
+  local display_text = function(entry)
+    local config = require("telescope.config").values.lsp_symbol_icon
+    local mode = "text"
+    if config ~= false then
+        mode = config.mode
+    end
+
+    local texts_for_modes = {
+        ["icon"] = entry.icon,
+        ["text"] = entry.symbol_type:lower(),
+        ["icon_text"] = entry.icon .. entry.symbol_type:lower(),
+        ["text_icon"] = entry.symbol_type:lower() .. entry.icon,
+    }
+
+    return texts_for_modes[mode]
+  end
+
   local make_display = function(entry)
     local msg
 
@@ -544,15 +561,15 @@ function make_entry.gen_from_lsp_symbols(opts)
 
     if hidden then
       return displayer {
+        { display_text(entry), type_highlight[entry.symbol_type] },
         entry.symbol_name,
-        { entry.symbol_type:lower(), type_highlight[entry.symbol_type] },
         msg,
       }
     else
       return displayer {
         utils.transform_path(opts, entry.filename),
+        { display_text(entry), type_highlight[entry.symbol_type] },
         entry.symbol_name,
-        { entry.symbol_type:lower(), type_highlight[entry.symbol_type] },
         msg,
       }
     end
@@ -578,6 +595,7 @@ function make_entry.gen_from_lsp_symbols(opts)
       col = entry.col,
       symbol_name = symbol_name,
       symbol_type = symbol_type,
+      icon = entry.icon,
       start = entry.start,
       finish = entry.finish,
     }, opts)

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -489,6 +489,30 @@ utils.get_devicons = load_once(function()
   end
 end)
 
+utils.get_lsp_symbol_icon = load_once(function()
+  local has_lspkind, lspkind = pcall(require, "lspkind")
+  local config = require("telescope.config").values.lsp_symbol_icon
+
+  if has_lspkind == false or config == false then
+    return function(_, _)
+      return ""
+    end
+  end
+
+  return function(kind)
+    local icon = lspkind.symbolic(config.substitutions[kind] or kind, {
+      mode = "symbol",
+      preset = config.lspkind_preset
+    })
+
+    if icon == nil or icon == "" then
+      icon = config.not_found_fallback
+    end
+
+    return config.icon_prefix .. icon .. config.icon_postfix
+  end
+end)
+
 --- Telescope Wrapper around vim.notify
 ---@param funname string: name of the function that will be
 ---@param opts table: opts.level string, opts.msg string, opts.once bool


### PR DESCRIPTION
# Description

Before this patch, lsp document symbols would be displayed in two columns:

1. A column with the 25 first characters in the symbol name.
2. A column with the symbol kind that could take up remaining characters.

That seems a little wrong-way-around and unnecessary cutting of symbol names, which is why with this patch there are still two columns, but now they are:

1. A column with the symbol kind (column size fitted to the longest name)
2. A column with the symbol name that takes up the remaining space.

It could have just stopped there, but it sort of lacked some icons. So added is now configuration options for adding a symbol icon either in front of or after the symbol's kind. These options are documented in `config.lua`, but basically it is possible to:

* Have an icon or not (text will remain).
* Put the icon on either side of the text.
* Add space and or other characters around the icon.
* Choose which preset to use with `lspkind.nvim`
* Make substitutions on symbol kind, so if LSP reports kind `A` it can be translated to `B` in case `lspkind.nvim` has no icon for `A` but the one for `B` makes sense to use instead.
* Define what character(s) to fall back to in case an icon was not found.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Tested through different kinds of configuration and then invoking the lsp_document_symbols picker. For instance:

## Default
```
lsp_symbol_icon = {}
```
(or just leave it out completely)

## Text and icon
```
lsp_symbol_icon = {
  mode = "text_icon",
  lspkind_preset = "codicons",
  icon_prefix = " ",
  icon_postfix = ""
}
```

## Just the icon
```
lsp_symbol_icon = {
  mode = "icon",
  icon_prefix = "",
  icon_postfix = ""
}
```

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.8.3
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by runner@Mac-1675344370646.local

Features: +acl +iconv +tui

* Operating system and version: Darwin voyager.local 22.3.0 Darwin Kernel Version 22.3.0: Mon Jan 30 20:39:35 PST 2023; root:xnu-8792.81.3~2/RELEASE_ARM64_T8103 x86_64


# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
