### PR TITLE
fix: escape cwd symbols for `async_oneshot_finder`

### DIFF
--- a/lua/telescope/_.lua
+++ b/lua/telescope/_.lua
@@ -21,7 +21,7 @@ function AsyncJob.new(opts)
   self.stderr = opts.stderr or M.NullPipe()
 
   if opts.cwd and opts.cwd ~= "" then
-    self.uv_opts.cwd = vim.fn.expand(opts.cwd)
+    self.uv_opts.cwd = vim.fn.expand(vim.fn.escape(opts.cwd, "$"))
     -- this is a "illegal" hack for windows. E.g. If the git command returns `/` rather than `\` as delimiter,
     -- vim.fn.expand might just end up returning an empty string. Weird
     -- Because empty string is not allowed in libuv the job will not spawn. Solution is we just set it to opts.cwd


### PR DESCRIPTION
# Description

Using the `async_oneshot_finder` with cwd paths like `($lang)/` (used in [Remix](https://remix.run/docs/en/1.15.0/file-conventions/route-files-v2#optional-segments)) will error out due to the `$` being expanded by `vim.fn.expand`.

Fixes downstream issue https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/244

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created a directory `mkdir "(\$foo)"` and `cd` into it. From with that directory:

- [x] `:Telescope file_browser git_status=false grouped=false` (this forces using `async_oneshot_finder`) and verify it works
- [x] `:Telescope find_files cwd=%:p:h` and verify it works
- [x] verify both pickers above still work without the listed options


**Configuration**:
* Neovim version (nvim --version): `NVIM v0.10.0-dev-19+g339011f59`
* Operating system and version: `Linux archlinux 6.2.10-arch1-1`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
