### PR TITLE
implement filter for keymaps

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1406,8 +1406,11 @@ builtin.keymaps({opts})                          *telescope.builtin.keymaps()*
                                  true)
         {only_buf}   (boolean)   if true, only show the buffer-local keymaps
                                  (default: false)
-        {lhs_filter} (function)  filter(lhs:string) -> boolean. true if the
-                                 keymap should be shown (optional)
+        {lhs_filter} (function)  filter(lhs:string) -> boolean. true for
+                                 keymap.lhs if the keymap should be shown
+                                 (optional)
+        {filter}     (function)  filter(km:keymap) -> boolean. true for the
+                                 keymap if it should be shown (optional)
 
 
 builtin.filetypes({opts})                      *telescope.builtin.filetypes()*

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1129,7 +1129,6 @@ internal.registers = function(opts)
     :find()
 end
 
--- TODO: make filtering include the mapping and the action
 internal.keymaps = function(opts)
   opts.modes = vim.F.if_nil(opts.modes, { "n", "i", "c", "x" })
   opts.show_plug = vim.F.if_nil(opts.show_plug, true)
@@ -1148,6 +1147,7 @@ internal.keymaps = function(opts)
         if
           (opts.show_plug or not string.find(keymap.lhs, "<Plug>"))
           and (not opts.lhs_filter or opts.lhs_filter(keymap.lhs))
+          and (not opts.filter or opts.filter(keymap))
         then
           table.insert(keymaps_table, keymap)
           max_len_lhs = math.max(max_len_lhs, #utils.display_termcodes(keymap.lhs))

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -353,7 +353,8 @@ builtin.registers = require_on_exported_call("telescope.builtin.__internal").reg
 ---@field modes table: a list of short-named keymap modes to search (default: { "n", "i", "c", "x" })
 ---@field show_plug boolean: if true, the keymaps for which the lhs contains "<Plug>" are also shown (default: true)
 ---@field only_buf boolean: if true, only show the buffer-local keymaps (default: false)
----@field lhs_filter function: filter(lhs:string) -> boolean. true if the keymap should be shown (optional)
+---@field lhs_filter function: filter(lhs:string) -> boolean. true for keymap.lhs if the keymap should be shown (optional)
+---@field filter function: filter(km:keymap) -> boolean. true for the keymap if it should be shown (optional)
 builtin.keymaps = require_on_exported_call("telescope.builtin.__internal").keymaps
 
 --- Lists all available filetypes, sets currently open buffer's filetype to selected filetype in Telescope on `<cr>`


### PR DESCRIPTION
# Description

There was a todo for more flexible filtering in `builtin.keymaps` ( https://github.com/nvim-telescope/telescope.nvim/blob/7141515a7cabde46449675a403ed564416363887/lua/telescope/builtin/__internal.lua#L1127 ). I implemented this by adding another `filter` option accepting a keymap as its argument. 

I wanted to use this to only filter keymaps with a `desc`. While this could be a separate flag, I feel like this is cleaner. `lhs_filter` is now somewhat redundant.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?


Setup a keymap with a description, and select it:
```
vim.keymap.set("n", "abc", "<CR>", { desc = "do something" })
vim.keymap.set("n", "def", "<CR>", { desc = "do something else" })
vim.keymap.set("n", "xyz", function()
                               require("telescope.builtin").keymaps({ 
                                   filter = function(keymap)
                                       return keymap.desc and keymap.desc ~= "Nvim builtin"
                                   end,
                               })
                           end)
```


**Configuration**:
* Neovim version (nvim --version):
  ```
  NVIM v0.10.0-dev-41b7586
  Build type: Release
  LuaJIT 2.1.0-beta3
  
     system vimrc file: "$VIM/sysinit.vim"
    fall-back for $VIM: "/usr/local/share/nvim"
  ```


# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
