### PR TITLE
Open buffers in various directions

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -72,18 +72,36 @@ do
     edit = "buffer",
     new = "sbuffer",
     vnew = "vert sbuffer",
+    ["leftabove new"] = "leftabove sbuffer",
+    ["leftabove vnew"] = "leftabove vert sbuffer",
+    ["rightbelow new"] = "rightbelow sbuffer",
+    ["rightbelow vnew"] = "rightbelow vert sbuffer",
+    ["topleft new"] = "topleft sbuffer",
+    ["topleft vnew"] = "topleft vert sbuffer",
+    ["botright new"] = "botright sbuffer",
+    ["botright vnew"] = "botright vert sbuffer",
     tabedit = "tab sb",
   }
 
   edit_buffer = function(command, bufnr)
-    command = map[command]
-    if command == nil then
-      error "There was no associated buffer command"
+    local buf_command = map[command]
+    if buf_command == nil then
+      local valid_commands = vim.tbl_map(function(cmd)
+        return string.format("%q", cmd)
+      end, vim.tbl_keys(map))
+      table.sort(valid_commands)
+      error(
+        string.format(
+          "There was no associated buffer command for %q.\nValid commands are: %s.",
+          command,
+          table.concat(valid_commands, ", ")
+        )
+      )
     end
-    if command ~= "drop" and command ~= "tab drop" then
-      vim.cmd(string.format("%s %d", command, bufnr))
+    if buf_command ~= "drop" and buf_command ~= "tab drop" then
+      vim.cmd(string.format("%s %d", buf_command, bufnr))
     else
-      vim.cmd(string.format("%s %s", command, vim.fn.fnameescape(vim.api.nvim_buf_get_name(bufnr))))
+      vim.cmd(string.format("%s %s", buf_command, vim.fn.fnameescape(vim.api.nvim_buf_get_name(bufnr))))
     end
   end
 end
@@ -91,7 +109,21 @@ end
 --- Edit a file based on the current selection.
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param command string: The command to use to open the file.
---      Valid commands include: "edit", "new", "vedit", "tabedit"
+--      Valid commands are:
+--      - "edit"
+--      - "new"
+--      - "vedit"
+--      - "tabedit"
+--      - "drop"
+--      - "tab drop"
+--      - "leftabove new"
+--      - "leftabove vnew"
+--      - "rightbelow new"
+--      - "rightbelow vnew"
+--      - "topleft new"
+--      - "topleft vnew"
+--      - "botright new"
+--      - "botright vnew"
 action_set.edit = function(prompt_bufnr, command)
   local entry = action_state.get_selected_entry()
 


### PR DESCRIPTION
Fix the problem I reported in <https://github.com/nvim-telescope/telescope.nvim/issues/1725#issuecomment-1502548033>. Supporting the abbreviations of the commands to specify the direction makes too many combinations, so I added only their unabbreviated names.

In addition, make the error message more detailed for users that passes unsupported command.

# Description

Fix the problem I reported in <https://github.com/nvim-telescope/telescope.nvim/issues/1725#issuecomment-1502548033>.

## Type of change

- Bug fix
- This change requires a documentation update

# How Has This Been Tested?

- [x] Test A: The selected buffer is opened at the left of the current window:
    1. Run nvim with several files (e.g. `nvim .gitignore .luacheckrc .stylua.toml` at the root of this project).
    2. Run `:Telescope buffers`
    3. Hit `<C-p>` to  select a buffer different from the current one.
    4. Hit `<C-h>`.
- [x] Test B: The new detailed error message is shown when executing a unsupported command:
    1. Run nvim with several files (e.g. `nvim .gitignore .luacheckrc .stylua.toml` at the root of this project).
    2. Run `:Telescope buffers`
    3. Hit `<C-p>` to  select a buffer different from the current one. 
    4. Hit `<C-k>`.

**Configuration for the tests above**:

Configuration related to telescope:

```lua
local hjkl_mappings = {
  ["<C-h>"] = function(prompt_bufnr)
    return require'telescope.actions.set'.edit(prompt_bufnr, "leftabove vnew")
  end,
  ["<C-j>"] = function(prompt_bufnr)
    return require'telescope.actions.set'.edit(prompt_bufnr, "rightbelow new")
  end,
  ["<C-k>"] = function(prompt_bufnr)
    return require'telescope.actions.set'.edit(prompt_bufnr, "bo new")
  end,
  ["<C-l>"] = function(prompt_bufnr)
    return require'telescope.actions.set'.edit(prompt_bufnr, "rightbelow vnew")
  end,
}
require('telescope').setup{
  defaults = {
    -- Default configuration for telescope goes here:
    -- config_key = value,
    mappings = {
      n = hjkl_mappings,
      i = hjkl_mappings,
    }
  },
  pickers = {
    -- Default configuration for builtin pickers goes here:
    -- picker_name = {
    --   picker_config_key = value,
    --   ...
    -- }
    -- Now the picker_config_key will be applied every time you call this
    -- builtin picker
  },
  extensions = {
    -- Your extension configuration goes here:
    -- extension_name = {
    --   extension_config_key = value,
    -- }
    -- please take a look at the readme of the extension you want to configure
  }
}
```

* Neovim version (nvim --version): NVIM v0.9.0
* Operating system and version: Windows 10 21H2

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
