### PR TITLE
fix: some builtin functions missing in completion list

### DIFF
--- a/plugin/telescope.lua
+++ b/plugin/telescope.lua
@@ -118,7 +118,7 @@ end, {
     if n == 0 then
       return vim.tbl_filter(function(val)
         return vim.startswith(val, l[2])
-      end, vim.tbl_extend("force", builtin_list, extensions_list))
+      end, vim.tbl_flatten({builtin_list, extensions_list}))
     end
 
     if n == 1 then


### PR DESCRIPTION
# Description

if there is extension_list, then the builtin_list would be replaced/overriden. e.g. if there are 3 items in extension_list, then first 3 items in builtin_list would be replaced when you type `:Telescope fi` and press tab to get completion list.

Fixes # (issue)
root cause: builtin_list/extension_list is list-like table, not map-like table, so vim.tbl_extend will not work in this case. we want to merge two list together actually in the case.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] How to reproduce/test
1. make sure there is at least one telescope extension.
2. when you type `:Telescope xx` and press enter, you'll find one builtin command is missing, if there are 5 extensions, the 5 builtin commands are missing.
3. after applying the fix, the problem is fixed.


**Configuration**:
* Neovim version (nvim --version):
```NVIM v0.8.0
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
Compilation: /usr/bin/cc -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=1 -DNVIM_TS_HAS_SET_MATCH_LIMIT -DNVIM_TS_HAS_SET_ALLOCATOR -O2 -g -Og -g -Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion -Wdouble-promotion -Wmissing-noreturn -Wmissing-format-attribute -Wmissing-prototypes -Wimplicit-fallthrough -Wvla -fstack-protector-strong -fno-common -fdiagnostics-color=auto -DINCLUDE_GENERATED_DECLARATIONS -D_GNU_SOURCE -DNVIM_MSGPACK_HAS_FLOAT32 -DNVIM_UNIBI_HAS_VAR_FROM -DMIN_LOG_LEVEL=3 -I/builddir/build/BUILD/neovim-0.8.0/x86_64-redhat-linux-gnu/cmake.config -I/builddir/build/BUILD/neovim-0.8.0/src -I/usr/include -I/usr/include/luajit-2.1 -I/builddir/build/BUILD/neovim-0.8.0/x86_64-redhat-linux-gnu/src/nvim/auto -I/builddir/build/BUILD/neovim-0.8.0/x86_64-redhat-linux-gnu/include
Compiled by mockbuild@koji

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/share/nvim"

Run :checkhealth for more info```
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
