### PR TITLE
feat(diagnotics): add `disable_coordinates` option

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1642,28 +1642,31 @@ builtin.diagnostics({opts})                  *telescope.builtin.diagnostics()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {bufnr}          (number|nil)      Buffer number to get diagnostics
-                                           from. Use 0 for current buffer or
-                                           nil for all buffers
-        {severity}       (string|number)   filter diagnostics by severity name
-                                           (string) or id (number)
-        {severity_limit} (string|number)   keep diagnostics equal or more
-                                           severe wrt severity name (string)
-                                           or id (number)
-        {severity_bound} (string|number)   keep diagnostics equal or less
-                                           severe wrt severity name (string)
-                                           or id (number)
-        {root_dir}       (string|boolean)  if set to string, get diagnostics
-                                           only for buffers under this dir
-                                           otherwise cwd
-        {no_unlisted}    (boolean)         if true, get diagnostics only for
-                                           listed buffers
-        {no_sign}        (boolean)         hide DiagnosticSigns from Results
-                                           (default: false)
-        {line_width}     (number)          set length of diagnostic entry text
-                                           in Results
-        {namespace}      (number)          limit your diagnostics to a
-                                           specific namespace
+        {bufnr}               (number|nil)      Buffer number to get
+                                                diagnostics from. Use 0 for
+                                                current buffer or nil for all
+                                                buffers
+        {severity}            (string|number)   filter diagnostics by severity
+                                                name (string) or id (number)
+        {severity_limit}      (string|number)   keep diagnostics equal or more
+                                                severe wrt severity name
+                                                (string) or id (number)
+        {severity_bound}      (string|number)   keep diagnostics equal or less
+                                                severe wrt severity name
+                                                (string) or id (number)
+        {root_dir}            (string|boolean)  if set to string, get
+                                                diagnostics only for buffers
+                                                under this dir otherwise cwd
+        {no_unlisted}         (boolean)         if true, get diagnostics only
+                                                for listed buffers
+        {no_sign}             (boolean)         hide DiagnosticSigns from
+                                                Results (default: false)
+        {line_width}          (number)          set length of diagnostic entry
+                                                text in Results
+        {namespace}           (number)          limit your diagnostics to a
+                                                specific namespace
+        {disable_coordinates} (boolean)         don't show the line & row
+                                                numbers (default: false)
 
 
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -485,6 +485,7 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 ---@field no_sign boolean: hide DiagnosticSigns from Results (default: false)
 ---@field line_width number: set length of diagnostic entry text in Results
 ---@field namespace number: limit your diagnostics to a specific namespace
+---@field disable_coordinates boolean: don't show the line & row numbers (default: false)
 builtin.diagnostics = require_on_exported_call("telescope.builtin.__diagnostics").get
 
 local apply_config = function(mod)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1152,8 +1152,15 @@ function make_entry.gen_from_diagnostics(opts)
     return signs
   end)()
 
+  local sign_width
+  if opts.disable_coordinates then
+    sign_width = signs ~= nil and 2 or 0
+  else
+    sign_width = signs ~= nil and 10 or 8
+  end
+
   local display_items = {
-    { width = signs ~= nil and 10 or 8 },
+    { width = sign_width },
     { remaining = true },
   }
   local line_width = vim.F.if_nil(opts.line_width, 0.5)
@@ -1171,8 +1178,9 @@ function make_entry.gen_from_diagnostics(opts)
 
     -- add styling of entries
     local pos = string.format("%4d:%2d", entry.lnum, entry.col)
+    local line_info_text = signs and signs[entry.type] .. " " or ""
     local line_info = {
-      (signs and signs[entry.type] .. " " or "") .. pos,
+      opts.disable_coordinates and line_info_text or line_info_text .. pos,
       "DiagnosticSign" .. entry.type,
     }
 


### PR DESCRIPTION
# Description

Adds new options `disable_coordinates` to the `diagnostics` picker.

Closes #2475 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Verify the picker is working using a combination of options
* `:Telescope diagnostics` - base case
* `:Telescope diagnostics disable_coordinates=true` - new option
* `:Telescope diagnostics no_sign=true` - test existing option
* `:Telescope diagnostics disable_coordinates=true no_sign=true` - test together with existing option

**Configuration**:
* Neovim version (nvim --version): `NVIM v0.10.0-dev-19+g339011f59`
* Operating system and version: `Linux archlinux 6.2.11-arch1-1`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
