### PR TITLE
fix(health): remove deprecated api warnings in health check

### DIFF
--- a/lua/telescope/health.lua
+++ b/lua/telescope/health.lua
@@ -1,4 +1,9 @@
 local health = vim.health or require "health"
+local start = health.start or health.report_start
+local ok = health.ok or health.report_ok
+local warn = health.warn or health.report_warn
+local error = health.error or health.report_error
+
 local extension_module = require "telescope._extensions"
 local extension_info = require("telescope").extensions
 local is_win = vim.api.nvim_call_function("has", { "win32" }) == 1
@@ -60,23 +65,23 @@ local M = {}
 
 M.check = function()
   -- Required lua libs
-  health.report_start "Checking for required plugins"
+  start "Checking for required plugins"
   for _, plugin in ipairs(required_plugins) do
     if lualib_installed(plugin.lib) then
-      health.report_ok(plugin.lib .. " installed.")
+      ok(plugin.lib .. " installed.")
     else
       local lib_not_installed = plugin.lib .. " not found."
       if plugin.optional then
-        health.report_warn(("%s %s"):format(lib_not_installed, plugin.info))
+        warn(("%s %s"):format(lib_not_installed, plugin.info))
       else
-        health.report_error(lib_not_installed)
+        error(lib_not_installed)
       end
     end
   end
 
   -- external dependencies
   -- TODO: only perform checks if user has enabled dependency in their config
-  health.report_start "Checking external dependencies"
+  start "Checking external dependencies"
 
   for _, opt_dep in pairs(optional_dependencies) do
     for _, package in ipairs(opt_dep.package) do
@@ -84,9 +89,9 @@ M.check = function()
       if not installed then
         local err_msg = ("%s: not found."):format(package.name)
         if package.optional then
-          health.report_warn(("%s %s"):format(err_msg, ("Install %s for extended capabilities"):format(package.url)))
+          warn(("%s %s"):format(err_msg, ("Install %s for extended capabilities"):format(package.url)))
         else
-          health.report_error(
+          error(
             ("%s %s"):format(
               err_msg,
               ("`%s` finder will not function without %s installed."):format(opt_dep.finder_name, package.url)
@@ -95,13 +100,13 @@ M.check = function()
         end
       else
         local eol = version:find "\n"
-        health.report_ok(("%s: found %s"):format(package.name, version:sub(0, eol - 1) or "(unknown version)"))
+        ok(("%s: found %s"):format(package.name, version:sub(0, eol - 1) or "(unknown version)"))
       end
     end
   end
 
   -- Extensions
-  health.report_start "===== Installed extensions ====="
+  start "===== Installed extensions ====="
 
   local installed = {}
   for extension_name, _ in pairs(extension_info) do
@@ -112,11 +117,11 @@ M.check = function()
   for _, installed_ext in ipairs(installed) do
     local extension_healthcheck = extension_module._health[installed_ext]
 
-    health.report_start(string.format("Telescope Extension: `%s`", installed_ext))
+    start(string.format("Telescope Extension: `%s`", installed_ext))
     if extension_healthcheck then
       extension_healthcheck()
     else
-      health.report_info "No healthcheck provided"
+      info "No healthcheck provided"
     end
   end
 end

--- a/lua/telescope/health.lua
+++ b/lua/telescope/health.lua
@@ -3,6 +3,7 @@ local start = health.start or health.report_start
 local ok = health.ok or health.report_ok
 local warn = health.warn or health.report_warn
 local error = health.error or health.report_error
+local info = health.info or health.report_info
 
 local extension_module = require "telescope._extensions"
 local extension_info = require("telescope").extensions


### PR DESCRIPTION
# Description

This PR allows to remove the warnings regarding deprecated API `vim.health.report_*`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

By running the `checkhealth` command should give no more warning about this API deprecation.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.0-dev-102+g85bc9e897
* Operating system and version: macOS 13.3.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
