### PR TITLE
fix(preview): update mime-type check for json files (#2221)

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -192,8 +192,8 @@ previewers.file_maker = function(filepath, bufnr, opts)
         if opts.preview.check_mime_type == true and has_file and opts.ft == "" then
           -- avoid SIGABRT in buffer previewer happening with utils.get_os_command_output
           local output = capture(string.format([[file --mime-type -b "%s"]], filepath))
-          local mime_type = vim.split(output, "/")[1]
-          if mime_type ~= "text" and mime_type ~= "inode" then
+          local mime_type = vim.split(output, "/")
+          if mime_type[1] ~= "text" and mime_type[1] ~= "inode" and mime_type[2] ~= "json" then
             if type(opts.preview.mime_hook) == "function" then
               vim.schedule_wrap(opts.preview.mime_hook)(filepath, bufnr, opts)
             else
@@ -205,6 +205,9 @@ previewers.file_maker = function(filepath, bufnr, opts)
               )
             end
             return
+          end
+          if mime_type[2] == "json" then
+            opts.ft = "json"
           end
         end
 


### PR DESCRIPTION
# Description

Fix JSON files without file extensions being treated as non-text files as its MIME type is `application\json`.
The [current implementation](https://github.com/nvim-telescope/telescope.nvim/blob/f2645c13205abb9ee3dbcee68416645c69b863c8/lua/telescope/previewers/buffer_previewer.lua#L195) splits the output of the `file` command and only uses the first item of the split output to check if file reviewable.

Also manually setting `opt.ft` to `json` for syntax highlighting as [`plenary.filetype.detect`](https://github.com/nvim-telescope/telescope.nvim/blob/f2645c13205abb9ee3dbcee68416645c69b863c8/lua/telescope/previewers/buffer_previewer.lua#L165) is unable to recognize JSON files without file extension

Issue #2221

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create a JSON file with no file extension and some dummy data
```json
{
   "dummy": "data"
}
```

- [x] `Telescope find_files` and verify the file is previewable and syntax highlight is working

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.0
* Operating system and version: Windows 11 version 22H2 (Build No: 22621, Arch: x86_64)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
