### PR TITLE
Exclude directories (netrw) from the `oldfiles` picker

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -519,7 +519,8 @@ internal.oldfiles = function(opts)
   end
 
   for _, file in ipairs(vim.v.oldfiles) do
-    if vim.loop.fs_stat(file) and not vim.tbl_contains(results, file) and file ~= current_file then
+    local file_stat = vim.loop.fs_stat(file)
+    if file_stat and file_stat.type == "file" and not vim.tbl_contains(results, file) and file ~= current_file then
       table.insert(results, file)
     end
   end


### PR DESCRIPTION
# Description

This PR removes directories from the `oldfiles` picker results

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run `:Telescope oldfiles` - after this commit directories (opened via netrw) should be removed from the results.  

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
