### PR TITLE
feat(file_previewer): add option for `ls --short`

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -523,6 +523,10 @@ telescope.setup({opts})                                    *telescope.setup()*
           - hide_on_startup:  Hide previewer when picker starts. Previewer can be toggled
                               with actions.layout.toggle_preview.
                               Default: false
+          - ls_short:         Determines whether to use the `--short` flag for the `ls`
+                              command when previewing directories. Otherwise will result
+                              to using `--long`.
+                              Default: false
 
 
                                      *telescope.defaults.vimgrep_arguments*

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -621,6 +621,10 @@ append(
       - hide_on_startup:  Hide previewer when picker starts. Previewer can be toggled
                           with actions.layout.toggle_preview.
                           Default: false
+      - ls_short:         Determines whether to use the `--short` flag for the `ls`
+                          command when previewing directories. Otherwise will result
+                          to using `--long`.
+                          Default: false
     ]]
 )
 

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -95,7 +95,7 @@ color_hash[6] = function(line)
   return color_hash[line:sub(1, 1)]
 end
 
-local colorize_ls = function(bufnr, data, sections)
+local colorize_ls_long = function(bufnr, data, sections)
   local windows_add = Path.path.sep == "\\" and 2 or 0
   for lnum, line in ipairs(data) do
     local section = sections[lnum]
@@ -115,6 +115,44 @@ local colorize_ls = function(bufnr, data, sections)
       )
     end
   end
+end
+
+local handle_directory_preview = function(filepath, bufnr, opts)
+  opts.preview.ls_short = vim.F.if_nil(opts.preview.ls_short, false)
+
+  local set_colorize_lines
+  if opts.preview.ls_short then
+    local PATH_SECTION = 6
+    set_colorize_lines = function(data, sections)
+      local paths = {}
+      for i, line in ipairs(data) do
+        local section = sections[i][PATH_SECTION]
+        local path = line:sub(section.start_index, section.end_index)
+        table.insert(paths, path)
+      end
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, paths)
+      for i, path in ipairs(paths) do
+        local hl = color_hash[PATH_SECTION](data[i])
+        vim.api.nvim_buf_add_highlight(bufnr, ns_previewer, hl, i - 1, 0, #path)
+      end
+    end
+  else
+    set_colorize_lines = function(data, sections)
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, data)
+      colorize_ls_long(bufnr, data, sections)
+    end
+  end
+
+  pscan.ls_async(filepath, {
+    hidden = true,
+    group_directories_first = true,
+    on_exit = vim.schedule_wrap(function(data, sections)
+      set_colorize_lines(data, sections)
+      if opts.callback then
+        opts.callback(bufnr)
+      end
+    end),
+  })
 end
 
 local search_cb_jump = function(self, bufnr, query)
@@ -177,17 +215,7 @@ previewers.file_maker = function(filepath, bufnr, opts)
         return
       end
       if stat.type == "directory" then
-        pscan.ls_async(filepath, {
-          hidden = true,
-          group_directories_first = true,
-          on_exit = vim.schedule_wrap(function(data, sections)
-            vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, data)
-            colorize_ls(bufnr, data, sections)
-            if opts.callback then
-              opts.callback(bufnr)
-            end
-          end),
-        })
+        handle_directory_preview(filepath, bufnr, opts)
       else
         if opts.preview.check_mime_type == true and has_file and opts.ft == "" then
           -- avoid SIGABRT in buffer previewer happening with utils.get_os_command_output

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -122,8 +122,8 @@ local handle_directory_preview = function(filepath, bufnr, opts)
 
   local set_colorize_lines
   if opts.preview.ls_short then
-    local PATH_SECTION = 6
     set_colorize_lines = function(data, sections)
+      local PATH_SECTION = Path.path.sep == "\\" and 4 or 6
       local paths = {}
       for i, line in ipairs(data) do
         local section = sections[i][PATH_SECTION]
@@ -132,7 +132,7 @@ local handle_directory_preview = function(filepath, bufnr, opts)
       end
       vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, paths)
       for i, path in ipairs(paths) do
-        local hl = color_hash[PATH_SECTION](data[i])
+        local hl = color_hash[6](data[i])
         vim.api.nvim_buf_add_highlight(bufnr, ns_previewer, hl, i - 1, 0, #path)
       end
     end


### PR DESCRIPTION
# Description

Adds a new previewer option (`ls_short`) to allow for the file previewer for directories to not use `--long` flag for `ls`.

With default previewer options:
![image](https://user-images.githubusercontent.com/66286082/235549102-1f9bf429-77b4-470c-ac60-37d6d12f0df2.png)

With `{ preview = { ls_short = true } }` option:
![image](https://user-images.githubusercontent.com/66286082/235549013-ac29dcaf-d739-4257-91d8-a8ee843b397b.png)


This is a repeated request for downstream [`telescope-file-browser`](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/267)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Test file previewer using both default and new option

**Configuration**:
* Neovim version (nvim --version): `NVIM v0.10.0-dev-19+g339011f59`
* Operating system and version: `Linux archlinux 6.2.12-arch1-1`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
