### PR TITLE
Revert "chore: simplify vimgrep_arguments args (#2440)"

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -532,13 +532,16 @@ telescope.setup({opts})                                    *telescope.setup()*
         Hint: Make sure that color is currently set to `never` because we do
         not yet interpret color codes
         Hint 2: Make sure that these options are in your changes arguments:
-          ("--no-heading", "--with-filename", "--line-number", "--column") or
-          "--vimgrep"
+          "--no-heading", "--with-filename", "--line-number", "--column"
         because we need them so the ripgrep output is in the correct format.
 
         Default: {
           "rg",
-          "--vimgrep",
+          "--color=never",
+          "--no-heading",
+          "--with-filename",
+          "--line-number",
+          "--column",
           "--smart-case"
         }
 

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -626,20 +626,23 @@ append(
 
 append(
   "vimgrep_arguments",
-  { "rg", "--vimgrep", "--smart-case" },
+  { "rg", "--color=never", "--no-heading", "--with-filename", "--line-number", "--column", "--smart-case" },
   [[
     Defines the command that will be used for `live_grep` and `grep_string`
     pickers.
     Hint: Make sure that color is currently set to `never` because we do
     not yet interpret color codes
     Hint 2: Make sure that these options are in your changes arguments:
-      ("--no-heading", "--with-filename", "--line-number", "--column") or
-      "--vimgrep"
+      "--no-heading", "--with-filename", "--line-number", "--column"
     because we need them so the ripgrep output is in the correct format.
 
     Default: {
       "rg",
-      "--vimgrep",
+      "--color=never",
+      "--no-heading",
+      "--with-filename",
+      "--line-number",
+      "--column",
       "--smart-case"
     }]]
 )


### PR DESCRIPTION
This reverts commit cfe6df6257aa7ee691fb56305923e9fec6c83c97.

# Description

It appears that the commit above is causing issues in certain instances when using grepping pickers.
The `--vimgrep` option seems to be the culprit.

[BurntSushi](https://github.com/BurntSushi/ripgrep/issues/2505#issuecomment-1536422272) doesn't really recommend using `--vimgrep`:
> --vimgrep is itself a strange thing, and is IMO legacy. It would probably be better if text editor plugins used ripgrep's --json flag to get structured matches. This is what VS Code does, for example.

Issue is reproducible live grepping in this repo/directory: https://github.com/swagger-api/swagger-ui/tree/master/dist

Fixes #2482

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Tested live grepping in the [swagger repo](https://github.com/swagger-api/swagger-ui) with/without `--vimgrep` option

**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.0-dev-19+g339011f59
* Operating system and version: Linux archlinux 6.2.12-arch1-1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
