### PR TITLE
Prefix color highlighting reset only on nvim 9.0

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -458,7 +458,9 @@ function Picker:find()
 
     -- we need to set the prefix color after changing mode since
     -- https://github.com/neovim/neovim/commit/cbf9199d65325c1167d7eeb02a34c85d243e781c
-    self:_reset_prefix_color()
+    if vim.fn.has "nvim-9.0" == 1 then
+      self:_reset_prefix_color()
+    end
 
     while true do
       -- Wait for the next input


### PR DESCRIPTION
# Description

Just adds an if around what I believe to be the appropriate version to start doing that refresh.

Feel free to rewrite / ignore.

Fixes #2461

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Just manually tested on my neovim version

**Configuration**:
* Neovim version (nvim --version): 7.2
* Operating system and version: Debian bookworm

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)