### PR TITLE
feat(pickers): display preview title at the same position as results title for bottom_pane layout

### DIFF
--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -898,6 +898,9 @@ layout_strategies.bottom_pane = make_documented_layout(
       if type(results.title) == "string" then
         results.title = { { pos = "S", text = results.title } }
       end
+      if type(preview.title) == "string" then
+        preview.title = { { pos = "S", text = preview.title } }
+      end
     elseif layout_config.prompt_position == "bottom" then
       results.line = max_lines - results.height - (1 + bs) + 1
       preview.line = results.line


### PR DESCRIPTION
# Description

Here is the current behavior of `bottom_pane` layout:

* When `prompt_position = 'bottom'`. Results and preview title are both at the top:

![2023-05-07-14:46:20+07](https://user-images.githubusercontent.com/67634026/236664779-0381d564-7a00-4868-a252-f3d57a2988ff.png)

* When `prompt_position = 'top'` (default). Preview title is displayed at the top, while results title is at the bottom (pretty out of place):

![2023-05-07-14:49:31+07](https://user-images.githubusercontent.com/67634026/236664934-f42dfe3c-ae32-447c-9dcd-e2b33bdad3b3.png)

And here is how it looks with this change:

![2023-05-07-14:58:49+07](https://user-images.githubusercontent.com/67634026/236665306-b800bd64-843f-4cfe-9eb8-4b0e2bd30f76.png)


This is a really small change for the position of the preview title of `bottom_pane` layout. I know the bottom_pane layout function can be overridden within my personal config, but I think this should be the default for consistency, considering that all the other layouts display the titles at the same position (normally at the top of the popup).

## Type of change

A *subjective* aesthetics change.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)