### PR TITLE
feat(ts)!: use upstream treesitter implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,7 @@ jobs:
             manager: sudo apt-get
             packages: -y ripgrep
           - os: ubuntu-22.04
-            rev: v0.7.2/nvim-linux64.tar.gz
-            manager: sudo apt-get
-            packages: -y ripgrep
-          - os: ubuntu-22.04
-            rev: v0.8.1/nvim-linux64.tar.gz
+            rev: v0.9.0/nvim-linux64.tar.gz
             manager: sudo apt-get
             packages: -y ripgrep
           - os: macos-12
@@ -27,11 +23,7 @@ jobs:
             manager: brew
             packages: ripgrep
           - os: macos-12
-            rev: v0.7.2/nvim-macos.tar.gz
-            manager: brew
-            packages: ripgrep
-          - os: macos-12
-            rev: v0.8.1/nvim-macos.tar.gz
+            rev: v0.9.0/nvim-macos.tar.gz
             manager: brew
             packages: ripgrep
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   luacheck:
     name: Luacheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -20,7 +20,7 @@ jobs:
 
   stylua:
     name: stylua
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: JohnnyMorganz/stylua-action@v2

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Telescope Wiki</sub>
 
 This section should guide you to run your first builtin pickers.
 
-[Neovim (v0.7.0)](https://github.com/neovim/neovim/releases/tag/v0.7.0) or the
+[Neovim (v0.9.0)](https://github.com/neovim/neovim/releases/tag/v0.9.0) or the
 latest neovim nightly commit is required for `telescope.nvim` to work.
 
 ### Required dependencies

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -506,17 +506,14 @@ telescope.setup({opts})                                    *telescope.setup()*
                               highlighting, which falls back to regex-based highlighting.
                               `true`: treesitter highlighting for all available filetypes
                               `false`: regex-based highlighting for all filetypes
-                              `table`: following nvim-treesitters highlighting options:
-                                It contains two keys:
-                                  - enable boolean|table: if boolean, enable all ts
-                                                          highlighing with that flag,
-                                                          disable still considered.
-                                                          Containing a list of filetypes,
-                                                          that are enabled, disabled
-                                                          ignored because it doesnt make
-                                                          any sense in this case.
-                                  - disable table: containing a list of filetypes
-                                                   that are disabled
+                              `table`: may contain the following keys:
+                                  - enable boolean|table: if boolean, enable ts
+                                                          highlighting for all supported
+                                                          filetypes.
+                                                          if table, ts highlighting is only
+                                                            enabled for given filetypes.
+                                  - disable table: list of filetypes for which ts highlighting
+                                                   is not used if `enable = true`.
                               Default: true
           - msg_bg_fillchar:  Character to fill background of unpreviewable buffers with
                               Default: "╱"
@@ -2289,6 +2286,14 @@ utils.transform_path({opts}, {path})        *telescope.utils.transform_path()*
 
     Return: ~
         string: The transformed path ready to be displayed
+
+
+utils.has_ts_parser({lang})                  *telescope.utils.has_ts_parser()*
+    Checks if treesitter parser for language is installed
+
+
+    Parameters: ~
+        {lang} (string)
 
 
 utils.notify({funname}, {opts})                     *telescope.utils.notify()*

--- a/doc/telescope_changelog.txt
+++ b/doc/telescope_changelog.txt
@@ -255,4 +255,17 @@ following breaking changes are included in this PR:
 <
 
 
+                                                    *telescope.changelog-2499*
+
+Date: May 24, 2023
+PR: https://github.com/nvim-telescope/telescope.nvim/pull/2499
+
+We decided to bump the minimum Neovim version to 0.9.0, in order to remove a
+couple of no longer required workarounds. That includes using upstream
+treesitter implementation in favor of nvim-treesitter.
+If you still have a requirement for Neovim 0.7 or 0.8, we also have a stable
+branch 0.1.x (or version, currently 0.1.1) which will not receive this version
+bump and will continue to offer support for older Neovim versions.
+
+
  vim:tw=78:ts=8:ft=help:norl:

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -604,17 +604,14 @@ append(
                           highlighting, which falls back to regex-based highlighting.
                           `true`: treesitter highlighting for all available filetypes
                           `false`: regex-based highlighting for all filetypes
-                          `table`: following nvim-treesitters highlighting options:
-                            It contains two keys:
-                              - enable boolean|table: if boolean, enable all ts
-                                                      highlighing with that flag,
-                                                      disable still considered.
-                                                      Containing a list of filetypes,
-                                                      that are enabled, disabled
-                                                      ignored because it doesnt make
-                                                      any sense in this case.
-                              - disable table: containing a list of filetypes
-                                               that are disabled
+                          `table`: may contain the following keys:
+                              - enable boolean|table: if boolean, enable ts
+                                                      highlighting for all supported
+                                                      filetypes.
+                                                      if table, ts highlighting is only
+                                                        enabled for given filetypes.
+                              - disable table: list of filetypes for which ts highlighting
+                                               is not used if `enable = true`.
                           Default: true
       - msg_bg_fillchar:  Character to fill background of unpreviewable buffers with
                           Default: "╱"

--- a/lua/telescope/health.lua
+++ b/lua/telescope/health.lua
@@ -38,7 +38,7 @@ local required_plugins = {
   {
     lib = "nvim-treesitter",
     optional = true,
-    info = "",
+    info = "(Required for `:Telescope treesitter`.)",
   },
 }
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -489,6 +489,12 @@ utils.get_devicons = load_once(function()
   end
 end)
 
+--- Checks if treesitter parser for language is installed
+---@param lang string
+utils.has_ts_parser = function(lang)
+  return pcall(vim.treesitter.language.add, lang)
+end
+
 --- Telescope Wrapper around vim.notify
 ---@param funname string: name of the function that will be
 ---@param opts table: opts.level string, opts.msg string, opts.once bool

--- a/plugin/telescope.lua
+++ b/plugin/telescope.lua
@@ -118,7 +118,7 @@ end, {
     if n == 0 then
       return vim.tbl_filter(function(val)
         return vim.startswith(val, l[2])
-      end, vim.tbl_flatten({builtin_list, extensions_list}))
+      end, vim.tbl_flatten { builtin_list, extensions_list })
     end
 
     if n == 1 then

--- a/plugin/telescope.lua
+++ b/plugin/telescope.lua
@@ -1,5 +1,5 @@
-if 1 ~= vim.fn.has "nvim-0.7.0" then
-  vim.api.nvim_err_writeln "Telescope.nvim requires at least nvim-0.7.0. See `:h telescope.changelog-1851`"
+if 1 ~= vim.fn.has "nvim-0.9.0" then
+  vim.api.nvim_err_writeln "Telescope.nvim requires at least nvim-0.9.0. See `:h telescope.changelog-2499`"
   return
 end
 


### PR DESCRIPTION
Use upstream vim.treesitter features for treesitter highlighting instead of requiring nvim-treesitter.

Note: This bumps the minimum Neovim version to 0.9.0; if you still want to support 0.8.0, this needs one or two minor compatibility shims to account for renamed functions.

Fixes #2498

