### PR TITLE
Revert "Prefix color highlighting reset only on nvim 9.0"

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -458,9 +458,7 @@ function Picker:find()
 
     -- we need to set the prefix color after changing mode since
     -- https://github.com/neovim/neovim/commit/cbf9199d65325c1167d7eeb02a34c85d243e781c
-    if vim.fn.has "nvim-9.0" == 1 then
-      self:_reset_prefix_color()
-    end
+    self:_reset_prefix_color()
 
     while true do
       -- Wait for the next input


### PR DESCRIPTION
Reverts nvim-telescope/telescope.nvim#2492