### PR TITLE
fix(lsp_definitions): compare file uri with `targetUri`

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -186,7 +186,8 @@ local function list_or_jump(action, title, opts)
     if #flattened_results == 0 then
       return
     elseif #flattened_results == 1 and opts.jump_type ~= "never" then
-      if params.textDocument.uri ~= flattened_results[1].uri then
+      local uri = params.textDocument.uri
+      if uri ~= flattened_results[1].uri and uri ~= flattened_results[1].targetUri then
         if opts.jump_type == "tab" then
           vim.cmd "tabedit"
         elseif opts.jump_type == "split" then


### PR DESCRIPTION
# Description

This is a really minor change that fixes a little issue introduced in #2324: many LSPs use the field `targetUri` instead of `uri`, so now it's compatible with (almost?) every LSP.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

(I'm omitting everything else because I  literally changed 2 lines of code)