### PR TITLE
feat: Patch sorting popup autocomplete items and initial builtin items

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -62,6 +62,10 @@ internal.builtin = function(opts)
     end
   end
 
+  table.sort(objs, function(a, b)
+    return a.text < b.text
+  end)
+
   opts.bufnr = vim.api.nvim_get_current_buf()
   opts.winnr = vim.api.nvim_get_current_win()
   pickers

--- a/plugin/telescope.lua
+++ b/plugin/telescope.lua
@@ -116,9 +116,12 @@ end, {
     local n = #l - 2
 
     if n == 0 then
+      local commands = vim.tbl_flatten({builtin_list, extensions_list})
+      table.sort(commands)
+
       return vim.tbl_filter(function(val)
         return vim.startswith(val, l[2])
-      end, vim.tbl_flatten({builtin_list, extensions_list}))
+      end, commands)
     end
 
     if n == 1 then
@@ -128,13 +131,18 @@ end, {
 
       if #is_extension > 0 then
         local extensions_subcommand_dict = require("telescope.command").get_extensions_subcommand()
+        local commands = extensions_subcommand_dict[l[2]]
+        table.sort(commands)
+
         return vim.tbl_filter(function(val)
           return vim.startswith(val, l[3])
-        end, extensions_subcommand_dict[l[2]])
+        end, commands)
       end
     end
 
     local options_list = vim.tbl_keys(require("telescope.config").values)
+    table.sort(options_list)
+
     return vim.tbl_filter(function(val)
       return vim.startswith(val, l[#l])
     end, options_list)

--- a/plugin/telescope.lua
+++ b/plugin/telescope.lua
@@ -116,7 +116,7 @@ end, {
     local n = #l - 2
 
     if n == 0 then
-      local commands = vim.tbl_flatten({builtin_list, extensions_list})
+      local commands = vim.tbl_flatten { builtin_list, extensions_list }
       table.sort(commands)
 
       return vim.tbl_filter(function(val)


### PR DESCRIPTION
# Description

I noticed that neovim wasn't sorting the list of autocomplete items when pressing tab in the command line.

In my very limited lua + nvim knowledge, there doesn't seem to be a way to create an autocommand that intercepts the completion list in the command popup.

So I decided to try my hand at brute-forcing the solution from telescope's side.

Here I sort the list of available commands for each of the 4 possible code paths.

The initial builtin list is also unsorted.

Let me know if this is useful or if you have any other recommendations for sorting the options. It's also ok if this feature is not wanted. 👍

(I messed up and renamed the branch on the closed PR #2515 not knowing GH would close it. Sorry for the double submission)

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Various `print` commands to ensure I hit all 4 paths.
![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/46309283-89cf-4605-8412-466d9fc569af)
- [x] Testing the autocompletions manually and ensuring no errors or unexpected suggestions.
- [x] `n == 0`
![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/5a2f7cdf-42e3-4d54-bab5-a13c9d036b15)
- `:Telescope <Tab>`
  - Before:
  ![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/8d2e2852-6ae9-4dcf-bbef-101f62648604)
  - After:
  ![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/2f6e5307-5367-4692-a39e-997e5f549444)
- `:Telescope l<Tab>`
  - Before:
  ![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/aeaae11e-a39a-4b17-884f-edef70e8d863)
  - After:
  ![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/7da70509-6017-4ada-8947-ab6c2fc26467)


- [x] `n == 1 and #is_extension > 0`
![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/5520ddd9-6afd-4c1f-8676-30d371308dba)
- `:Telescope gh <Tab>`
  - Before:
  ![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/41236bbc-9ca0-4fd8-9a93-f7c89609e0e1)
  - After:
  ![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/3f795777-8bfa-4163-bcc3-a67f3bcdcddb)

- [x] `n == 1 and #is_extension == 0`
![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/5fadeb2b-dd05-4c85-aadb-46cbd0e19eba)
- `:Telescope autocommands <Tab>`
  - Before:
![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/fcc0795d-2f15-47f1-8f34-2b981ef5ac3f)
  - After:
![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/a8182b4b-df59-4ade-bba1-2be77151c9ae)

- [x] `n > 1`
![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/8ee94ce8-ac87-4941-b633-e36ddfe80656)
- `:Telescope autocommands wrap_results <Tab>`
  - Before:
![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/e0f47763-9e2d-4e54-96dc-71cb92eecf47)
  - After:
  ![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/acebc74d-2f87-41af-bd76-ce8314fcbd9a)

- `:Telescope gh issues <Tab>`
  - Before:
![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/a252f59a-f8aa-4488-b8ca-59284019e2be)
  - After:
![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/2e8bd0c3-a83f-4e47-9006-01199707bebe)


- [x] Builtin list
Left: Before
Right: After
![image](https://github.com/nvim-telescope/telescope.nvim/assets/4416345/e940396a-ff11-4103-b72d-d6198878c5cd)

All tests pass on the fork ✅

**Configuration**:
* Neovim version (nvim --version): 0.9.0
* Operating system and version: Ubuntu 22.04 in WSL2 on Windows 11

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
