### PR TITLE
fix: highlights start at index 0 (was broken on nightly)

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -163,7 +163,7 @@ do
       display, hl_group, icon = utils.transform_devicons(entry.value, display, disable_devicons)
 
       if hl_group then
-        return display, { { { 1, #icon }, hl_group } }
+        return display, { { { 0, #icon }, hl_group } }
       else
         return display
       end
@@ -333,7 +333,7 @@ do
         )
 
         if hl_group then
-          return display, { { { 1, #icon }, hl_group } }
+          return display, { { { 0, #icon }, hl_group } }
         else
           return display
         end


### PR DESCRIPTION
# Description

There were two locations where icons were highlighted at index `1`.
Highlight indices start at `0`, so that was wrong.

What happened instead is that the highlight started inside a multi-byte character.

That used to work accidentally, but with the virtual text PR, this now breaks.

https://github.com/neovim/neovim/pull/20130

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
