### PR TITLE
feat!(previewer): replace plenary.filetype with vim.filetype.match

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,13 +390,15 @@ Built-in functions. Ready to be bound to any key you like.
 The default previewers are from now on `vim_buffer_` previewers. They use vim
 buffers for displaying files and use tree-sitter or regex for file highlighting.
 
-These previewers are guessing the filetype of the selected file, so there might
-be cases where they miss, leading to wrong highlights. This is because we can't
-determine the filetype in the traditional way: We don't do `bufload` and instead
-read the file asynchronously with `vim.loop.fs_` and attach only a highlighter;
-otherwise the speed of the previewer would slow down considerably. If you want
-to configure more filetypes, take a look at
-[plenary wiki](https://github.com/nvim-lua/plenary.nvim#plenaryfiletype).
+These previewers are using `vim.filetype` to guess the filetype for the
+selected file. The guessing is done by inspecting the filename, the head of the
+file(shebang) and the tail of the file (modeline). If you have trouble with
+filetype detection you should read `:help vim.filetype`.
+
+We need to do it manually because we can't determine the filetype in the
+traditional way: We don't do `bufload` and instead read the file asynchronously
+with `vim.loop.fs_` and attach only a highlighter; otherwise the speed of the
+previewer would slow down considerably.
 
 If you want to configure the `vim_buffer_` previewer (e.g. you want the line to wrap), do this:
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -442,8 +442,8 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Fields:
           - check_mime_type:  Use `file` if available to try to infer whether the
-                              file to preview is a binary if plenary's
-                              filetype detection fails.
+                              file to preview is a binary if filetype
+                              detection fails.
                               Windows users get `file` from:
                               https://github.com/julian-r/file-windows
                               Set to false to attempt to preview any mime type.
@@ -496,11 +496,10 @@ telescope.setup({opts})                                    *telescope.setup()*
                                   end,
                                 }
                               The configuration recipes for relevant examples.
-                              Note: if plenary does not recognize your filetype yet --
-                              1) Please consider contributing to:
-                                 $PLENARY_REPO/data/plenary/filetypes/builtin.lua
-                              2) Register your filetype locally as per link
-                                 https://github.com/nvim-lua/plenary.nvim#plenaryfiletype
+                              Note: we use vim.filetype filetype detection,
+                                    so if you have troubles with files not
+                                    highlighting correctly, please read
+                                    |vim.filetype|
                               Default: nil
           - treesitter:       Determines whether the previewer performs treesitter
                               highlighting, which falls back to regex-based highlighting.

--- a/doc/telescope_changelog.txt
+++ b/doc/telescope_changelog.txt
@@ -268,4 +268,15 @@ branch 0.1.x (or version, currently 0.1.1) which will not receive this version
 bump and will continue to offer support for older Neovim versions.
 
 
+                                                    *telescope.changelog-2529*
+
+Date: June 09, 2023
+PR: https://github.com/nvim-telescope/telescope.nvim/pull/2529
+
+We finally removed usage of `plenary.filetype` to determine filetypes for
+previewing and replaced it with `vim.filetype`. So if you have highlighting
+issues you no longer have to configure `plenary`, but rather read
+|vim.filetype|.
+
+
  vim:tw=78:ts=8:ft=help:norl:

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -540,8 +540,8 @@ append(
 
     Fields:
       - check_mime_type:  Use `file` if available to try to infer whether the
-                          file to preview is a binary if plenary's
-                          filetype detection fails.
+                          file to preview is a binary if filetype
+                          detection fails.
                           Windows users get `file` from:
                           https://github.com/julian-r/file-windows
                           Set to false to attempt to preview any mime type.
@@ -594,11 +594,10 @@ append(
                               end,
                             }
                           The configuration recipes for relevant examples.
-                          Note: if plenary does not recognize your filetype yet --
-                          1) Please consider contributing to:
-                             $PLENARY_REPO/data/plenary/filetypes/builtin.lua
-                          2) Register your filetype locally as per link
-                             https://github.com/nvim-lua/plenary.nvim#plenaryfiletype
+                          Note: we use vim.filetype filetype detection,
+                                so if you have troubles with files not
+                                highlighting correctly, please read
+                                |vim.filetype|
                           Default: nil
       - treesitter:       Determines whether the previewer performs treesitter
                           highlighting, which falls back to regex-based highlighting.


### PR DESCRIPTION
CC @clason 

this would drop usage of `plenary.filetype`

still left todo
- [ ] remove old documentation

seems like vim.filetype match doesnt have support for modeline so we still do that manually
`:lua print(vim.filetype.match({ contents = { " vim:tw=78:ts=8:ft=help:norl:" } }))`