### PR TITLE
Prevent pfiletype from failing when bufname is nil

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -431,7 +431,7 @@ previewers.new_buffer_previewer = function(opts)
             data = {
               title = entry.preview_title,
               bufname = self.state.bufname,
-              filetype = pfiletype.detect(self.state.bufname),
+              filetype = pfiletype.detect(self.state.bufname or ''),
             },
           })
         end)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -431,7 +431,7 @@ previewers.new_buffer_previewer = function(opts)
             data = {
               title = entry.preview_title,
               bufname = self.state.bufname,
-              filetype = pfiletype.detect(self.state.bufname or ''),
+              filetype = pfiletype.detect(self.state.bufname or ""),
             },
           })
         end)


### PR DESCRIPTION
# Description

This is fixing an issue introduced in [this commit](https://github.com/nvim-telescope/telescope.nvim/commit/80eefd8ff00145ef6ca4b7c64ef355b224f6e630).

A fresh install of `NvChad` fails with following error:

```
Error executing vim.schedule lua callback: ...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:428: Error executing lua: ...al/share/nvim/lazy/plenary.nvim/lua/plenary/filetype.lua:55: attempt to index l
ocal 'filename' (a nil value)
stack traceback:
        ...al/share/nvim/lazy/plenary.nvim/lua/plenary/filetype.lua:55: in function '_get_extension_parts'
        ...al/share/nvim/lazy/plenary.nvim/lua/plenary/filetype.lua:103: in function 'detect_from_extension'
        ...al/share/nvim/lazy/plenary.nvim/lua/plenary/filetype.lua:168: in function 'detect'
        ...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:434: in function <...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:428>
        [C]: in function 'nvim_buf_call'
        ...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:428: in function <...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:422>
stack traceback:
        [C]: in function 'nvim_buf_call'
        ...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:428: in function <...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:422>
```

Maybe there is a cleaner way to do this but this is a quick and defensive solution to the problem. If you want to fix it differently, it's OK.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To reproduce it:

1. Setup a fresh NvChad install.
2. Run `nvim`.
3. Wait for Lazy to install the plugins (it takes latest of `telescope.nvim`).
4. Quit the editor, as instructed.
5. Run `nvim`.
6. Type `<leader>th` to open theme editor (it runs buffer_previewer logic).
7. 💥

**Configuration**:

```
NVIM v0.9.0
Build type: Release
LuaJIT 2.1.0-beta3
```
```
MacOS 13.2.1
```
