### PR TITLE
fix(bcommits): wrong entry field is used

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -780,7 +780,7 @@ actions.git_checkout_current_buffer = function(prompt_bufnr)
     return
   end
   actions.close(prompt_bufnr)
-  utils.get_os_command_output({ "git", "checkout", selection.value, "--", selection.file }, cwd)
+  utils.get_os_command_output({ "git", "checkout", selection.value, "--", selection.current_file }, cwd)
   vim.cmd "checktime"
 end
 


### PR DESCRIPTION
# Description

Upon making entry for git_bcommits picker, current file path is saved to `current_file` field of entry:

https://github.com/nvim-telescope/telescope.nvim/blob/6d3fbffe426794296a77bb0b37b6ae0f4f14f807/lua/telescope/make_entry.lua#L446

... but `git_checkout_current_buffer` action does attempt to read current file from wrong field of selected entry -- `file`:

https://github.com/nvim-telescope/telescope.nvim/blob/6d3fbffe426794296a77bb0b37b6ae0f4f14f807/lua/telescope/actions/init.lua#L783

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No specific configuration needed to reproduce this issue. Just:

1. Open git tracked file in Neovim
2. Execute `:Telescope git_bcommits`
3. Pick any previous commit for current buffer
4. Notice that there is now changed HEAD in the repo instead of checking out single file

**Configuration**:
* Neovim version (nvim --version):

```
NVIM v0.9.1
Build type: Release
LuaJIT 2.1.0-beta3

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/share/nvim"

Run :checkhealth for more info
```

* Operating system and version:

```
Operating System: Arch Linux 
Kernel Version: 6.3.5-zen2-1-zen (64-bit)
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
