### PR TITLE
fix registers: add small delete remove black hole

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1099,7 +1099,7 @@ internal.marks = function(opts)
 end
 
 internal.registers = function(opts)
-  local registers_table = { '"', "_", "#", "=", "_", "/", "*", "+", ":", ".", "%" }
+  local registers_table = { '"', "-", "#", "=", "/", "*", "+", ":", ".", "%" }
 
   -- named
   for i = 0, 9 do


### PR DESCRIPTION
# Description

The builtin.registers picker had two copies of the black hole register ( "_ ) and didn't show the small delete register ( "- ) at all. I added the small delete register and since the black hole register never holds any information I removed that one. 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I used it to paste words from my small delete register.

**Configuration**:
* Neovim version (nvim --version): 0.9.1
* Operating system and version: EndeavourOS