### PR TITLE
fix: use `:botright` modifier for quickfix window open

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1061,7 +1061,7 @@ end
 --- `actions.smart_send_to_qflist + actions.open_qflist`
 ---@param prompt_bufnr number: The prompt bufnr
 actions.open_qflist = function(prompt_bufnr)
-  vim.cmd [[copen]]
+  vim.cmd [[botright copen]]
 end
 
 --- Open the location list. It makes sense to use this in combination with one of the send_to_loclist actions

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -465,7 +465,7 @@ internal.quickfixhistory = function(opts)
           local nr = action_state.get_selected_entry().nr
           actions.close(prompt_bufnr)
           vim.cmd(nr .. "chistory")
-          vim.cmd "copen"
+          vim.cmd "botright copen"
         end)
         return true
       end,


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

Fixes https://github.com/nvim-telescope/telescope.nvim/issues/2142

Aligns the behavior with `vim.diagnostic.setqflist`. Vim's default behavior with `:copen` is kinda buggy. It opens the window below the last window in the layout (i.e. at the bottom right corner). Created an issue about that https://github.com/vim/vim/issues/12501.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Open two split (left and right)
- [ ] Open the quickfix window from telescope using `<C-q>`
- [ ] It should open at the bottom (instead of bottom right corner)

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
