### PR TITLE
refactor(previewer): remove with_preview_window

### DIFF
--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -1,4 +1,3 @@
-local context_manager = require "plenary.context_manager"
 local ts_utils = require "telescope.utils"
 local strings = require "plenary.strings"
 local conf = require("telescope.config").values
@@ -50,18 +49,6 @@ utils.filetype_detect = function(filepath)
     if match and match ~= "" then
       return match
     end
-  end
-end
-
-utils.with_preview_window = function(status, bufnr, callable)
-  if bufnr and vim.api.nvim_buf_call and false then
-    vim.api.nvim_buf_call(bufnr, callable)
-  else
-    return context_manager.with(function()
-      vim.cmd(string.format("noautocmd call nvim_set_current_win(%s)", status.preview_win))
-      coroutine.yield()
-      vim.cmd(string.format("noautocmd call nvim_set_current_win(%s)", status.prompt_win))
-    end, callable)
   end
 end
 


### PR DESCRIPTION
ref: https://github.com/nvim-telescope/telescope.nvim/issues/2552 

removes usage of context_manager