### PR TITLE
fix(previewer): Cast filepath to string before matching for filetype

### DIFF
--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -33,6 +33,10 @@ local detect_from_modeline = function(p)
 end
 
 utils.filetype_detect = function(filepath)
+  if type(filepath) ~= string then
+    filepath = tostring(filepath)
+  end
+
   local match = vim.filetype.match { filename = filepath }
   if match and match ~= "" then
     return match


### PR DESCRIPTION
# Description

In a previous commit the way telescope's previewer detected the filetype relied on plenary's filetype detection. Recently it appears this has been changed to a util function within telescope. Plenary's filetype detection always casted its input to a string before matching with `vim.filetype.match` but this new util function does not.

This caused a problem with octo's previewer where the `get_buffer_by_name` function returns an integer representing the Issue/PR number. Seeing as how the previous filetype detection function always casted to a string before matching, I believe its a telescope issue rather than a octo.nvim issue 🤔 

Closes #2564 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `require("telescope.previewers.utils").filetype_detect(1)` expects not to raise an error but return an empty string

**Configuration**:
```
NVIM v0.9.1
Build type: Release
LuaJIT 2.1.0-beta3
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
