### PR TITLE
fix(live_grep/grep_string): support non-utf8 patterns

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -126,6 +126,10 @@ files.live_grep = function(opts)
     end
   end
 
+  if opts.file_encoding then
+    additional_args[#additional_args + 1] = "--encoding=" .. opts.file_encoding
+  end
+
   local args = flatten { vimgrep_arguments, additional_args }
   opts.__inverted, opts.__matches = opts_contain_invert(args)
 
@@ -185,6 +189,10 @@ files.grep_string = function(opts)
     elseif type(opts.additional_args) == "table" then
       additional_args = opts.additional_args
     end
+  end
+
+  if opts.file_encoding then
+    additional_args[#additional_args + 1] = "--encoding=" .. opts.file_encoding
   end
 
   if search == "" then

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -326,10 +326,9 @@ do
           end
         end
 
-        local text = opts.file_encoding and vim.iconv(entry.text, opts.file_encoding, "utf8") or entry.text
         local display, hl_group, icon = utils.transform_devicons(
           entry.filename,
-          string.format(display_string, display_filename, coordinates, text),
+          string.format(display_string, display_filename, coordinates, entry.text),
           disable_devicons
         )
 


### PR DESCRIPTION
# Description
Fixes not being able to query/use patterns that were non-UTF8 by passing the existing `opts.file_encoding` option to ripgrep as `--encoding`.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Use `live_grep` and `grep_string` with `file_encoding=latin1` and search for `ç` inside files with that character present

