### PR TITLE
feat(pickers): fully customizable layout

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -146,6 +146,13 @@ telescope.setup({opts})                                    *telescope.setup()*
 
         Default: 'horizontal'
 
+                                         *telescope.defaults.create_layout*
+    create_layout: ~
+        Configure the layout of Telescope pickers.
+        See |telescope.pickers.layout| for details.
+
+        Default: 'nil'
+
                                          *telescope.defaults.layout_config*
     layout_config: ~
         Determines the default configuration values for layout strategies.
@@ -1945,6 +1952,155 @@ ordered from the lowest priority to the highest priority.
     end,
   }
 <
+
+
+================================================================================
+LAYOUT                                                *telescope.pickers.layout*
+
+The telescope pickers layout can be configured using the
+|telescope.defaults.create_layout| option.
+
+Parameters: ~
+  - picker : A Picker object.
+
+Return: ~
+  - layout : instance of `TelescopeLayout` class.
+
+Example: ~
+>
+local Layout = require "telescope.pickers.layout"
+
+require("telescope").setup {
+  create_layout = function(picker)
+    local function create_window(enter, width, height, row, col, title)
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local winid = vim.api.nvim_open_win(bufnr, enter, {
+        style = "minimal",
+        relative = "editor",
+        width = width,
+        height = height,
+        row = row,
+        col = col,
+        border = "single",
+        title = title,
+      })
+
+      vim.wo[winid].winhighlight = "Normal:Normal"
+
+      return Layout.Window {
+        bufnr = bufnr,
+        winid = winid,
+      }
+    end
+
+    local function destory_window(window)
+      if window then
+        if vim.api.nvim_win_is_valid(window.winid) then
+          vim.api.nvim_win_close(window.winid, true)
+        end
+        if vim.api.nvim_buf_is_valid(window.bufnr) then
+          vim.api.nvim_buf_delete(window.bufnr, { force = true })
+        end
+      end
+    end
+
+    local layout = Layout {
+      picker = picker,
+      mount = function(self)
+        self.results = create_window(false, 40, 20, 0, 0, "Results")
+        self.preview = create_window(false, 40, 23, 0, 42, "Preview")
+        self.prompt = create_window(true, 40, 1, 22, 0, "Prompt")
+      end,
+      unmount = function(self)
+        destory_window(self.results)
+        destory_window(self.preview)
+        destory_window(self.prompt)
+      end,
+      update = function(self) end,
+    }
+
+    return layout
+  end,
+}
+<
+
+TelescopeWindowBorder.config                    *TelescopeWindowBorder.config*
+
+
+    Fields: ~
+        {bufnr}        (integer)
+        {winid}        (integer|nil)
+        {change_title} (nil|function)  (self: TelescopeWindowBorder, title:
+                                       string, pos?:
+                                       "NW"|"N"|"NE"|"SW"|"S"|"SE"):nil
+
+
+TelescopeWindowBorder                                  *TelescopeWindowBorder*
+
+
+    Fields: ~
+        {bufnr} (integer|nil)
+        {winid} (integer|nil)
+
+
+TelescopeWindow.config                                *TelescopeWindow.config*
+
+
+    Fields: ~
+        {bufnr}  (integer)
+        {winid}  (integer|nil)
+        {border} (TelescopeWindowBorder.config|nil)
+
+
+TelescopeWindow                                              *TelescopeWindow*
+
+
+    Fields: ~
+        {border} (TelescopeWindowBorder)
+        {bufnr}  (integer)
+        {winid}  (integer)
+
+
+TelescopeLayout.config                                *TelescopeLayout.config*
+
+
+    Fields: ~
+        {mount}   (function)             (self: TelescopeLayout):nil
+        {unmount} (function)             (self: TelescopeLayout):nil
+        {update}  (function)             (self: TelescopeLayout):nil
+        {prompt}  (TelescopeWindow|nil)
+        {results} (TelescopeWindow|nil)
+        {preview} (TelescopeWindow|nil)
+
+
+TelescopeLayout                                              *TelescopeLayout*
+
+
+    Fields: ~
+        {prompt}  (TelescopeWindow)
+        {results} (TelescopeWindow)
+        {preview} (TelescopeWindow|nil)
+
+
+Layout:mount()                              *telescope.pickers.layout:mount()*
+    Create the layout. This needs to ensure the required properties are
+    populated.
+
+
+
+Layout:unmount()                          *telescope.pickers.layout:unmount()*
+    Destroy the layout. This is responsible for performing clean-up, for
+    example:
+     - deleting buffers
+     - closing windows
+     - clearing autocmds
+
+
+
+Layout:update()                            *telescope.pickers.layout:update()*
+    Refresh the layout. This is called when, for example, vim is resized.
+
+
 
 
 ================================================================================

--- a/lua/telescope/actions/generate.lua
+++ b/lua/telescope/actions/generate.lua
@@ -75,12 +75,12 @@ action_generate.refine = function(prompt_bufnr, opts)
   end
 
   -- title
-  if opts.prompt_title and current_picker.prompt_border then
-    current_picker.prompt_border:change_title(opts.prompt_title)
+  if opts.prompt_title and current_picker.layout.prompt.border then
+    current_picker.layout.prompt.border:change_title(opts.prompt_title)
   end
 
-  if opts.results_title and current_picker.results_border then
-    current_picker.results_border:change_title(opts.results_title)
+  if opts.results_title and current_picker.layout.results.border then
+    current_picker.layout.results.border:change_title(opts.results_title)
   end
 
   local results = {}

--- a/lua/telescope/actions/layout.lua
+++ b/lua/telescope/actions/layout.lua
@@ -26,10 +26,11 @@ action_layout.toggle_preview = function(prompt_bufnr)
   local picker = action_state.get_current_picker(prompt_bufnr)
   local status = state.get_status(picker.prompt_bufnr)
 
-  if picker.previewer and status.preview_win then
+  local preview_winid = status.layout.preview and status.layout.preview.winid
+  if picker.previewer and preview_winid then
     picker.hidden_previewer = picker.previewer
     picker.previewer = nil
-  elseif picker.hidden_previewer and not status.preview_win then
+  elseif picker.hidden_previewer and not preview_winid then
     picker.previewer = picker.hidden_previewer
     picker.hidden_previewer = nil
   else

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -230,12 +230,13 @@ action_set.scroll_previewer = function(prompt_bufnr, direction)
   local previewer = action_state.get_current_picker(prompt_bufnr).previewer
   local status = state.get_status(prompt_bufnr)
 
+  local preview_winid = status.layout.preview and status.layout.preview.winid
   -- Check if we actually have a previewer and a preview window
-  if type(previewer) ~= "table" or previewer.scroll_fn == nil or status.preview_win == nil then
+  if type(previewer) ~= "table" or previewer.scroll_fn == nil or preview_winid == nil then
     return
   end
 
-  local default_speed = vim.api.nvim_win_get_height(status.preview_win) / 2
+  local default_speed = vim.api.nvim_win_get_height(status.layout.preview.winid) / 2
   local speed = status.picker.layout_config.scroll_speed or default_speed
 
   previewer:scroll_fn(math.floor(speed * direction))
@@ -270,12 +271,12 @@ end
 --      Valid directions include: "1", "-1"
 action_set.scroll_results = function(prompt_bufnr, direction)
   local status = state.get_status(prompt_bufnr)
-  local default_speed = vim.api.nvim_win_get_height(status.results_win) / 2
+  local default_speed = vim.api.nvim_win_get_height(status.layout.results.winid) / 2
   local speed = status.picker.layout_config.scroll_speed or default_speed
 
   local input = direction > 0 and [[]] or [[]]
 
-  vim.api.nvim_win_call(status.results_win, function()
+  vim.api.nvim_win_call(status.layout.results.winid, function()
     vim.cmd([[normal! ]] .. math.floor(speed) .. input)
   end)
 

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -991,8 +991,10 @@ internal.colorscheme = function(opts)
         preview_fn = function(_, entry, status)
           if not deleted then
             deleted = true
-            del_win(status.preview_win)
-            del_win(status.preview_border_win)
+            if status.layout.preview then
+              del_win(status.layout.preview.winid)
+              del_win(status.layout.preview.border.winid)
+            end
           end
           vim.cmd("colorscheme " .. entry.value)
         end,

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -188,6 +188,16 @@ append(
   Default: 'horizontal']]
 )
 
+append(
+  "create_layout",
+  nil,
+  [[
+  Configure the layout of Telescope pickers.
+  See |telescope.pickers.layout| for details.
+
+  Default: 'nil']]
+)
+
 append("layout_config", layout_config_defaults, layout_config_description)
 
 append(

--- a/lua/telescope/pickers/entry_display.lua
+++ b/lua/telescope/pickers/entry_display.lua
@@ -75,8 +75,8 @@ entry_display.create = function(configuration)
         if width == nil then
           local status = state.get_status(vim.F.if_nil(configuration.prompt_bufnr, vim.api.nvim_get_current_buf()))
           local s = {}
-          s[1] = vim.api.nvim_win_get_width(status.results_win) - #status.picker.selection_caret
-          s[2] = vim.api.nvim_win_get_height(status.results_win)
+          s[1] = vim.api.nvim_win_get_width(status.layout.results.winid) - #status.picker.selection_caret
+          s[2] = vim.api.nvim_win_get_height(status.layout.results.winid)
           width = resolve.resolve_width(v.width)(nil, s[1], s[2])
         end
         if type(item) == "table" then

--- a/lua/telescope/pickers/layout.lua
+++ b/lua/telescope/pickers/layout.lua
@@ -1,0 +1,193 @@
+---@tag telescope.pickers.layout
+---@config { ["module"] = "telescope.pickers.layout" }
+
+---@brief [[
+--- The telescope pickers layout can be configured using the
+--- |telescope.defaults.create_layout| option.
+---
+--- Parameters: ~
+---   - picker : A Picker object.
+---
+--- Return: ~
+---   - layout : instance of `TelescopeLayout` class.
+---
+--- Example: ~
+--- <code>
+--- local Layout = require "telescope.pickers.layout"
+---
+--- require("telescope").setup {
+---   create_layout = function(picker)
+---     local function create_window(enter, width, height, row, col, title)
+---       local bufnr = vim.api.nvim_create_buf(false, true)
+---       local winid = vim.api.nvim_open_win(bufnr, enter, {
+---         style = "minimal",
+---         relative = "editor",
+---         width = width,
+---         height = height,
+---         row = row,
+---         col = col,
+---         border = "single",
+---         title = title,
+---       })
+---
+---       vim.wo[winid].winhighlight = "Normal:Normal"
+---
+---       return Layout.Window {
+---         bufnr = bufnr,
+---         winid = winid,
+---       }
+---     end
+---
+---     local function destory_window(window)
+---       if window then
+---         if vim.api.nvim_win_is_valid(window.winid) then
+---           vim.api.nvim_win_close(window.winid, true)
+---         end
+---         if vim.api.nvim_buf_is_valid(window.bufnr) then
+---           vim.api.nvim_buf_delete(window.bufnr, { force = true })
+---         end
+---       end
+---     end
+---
+---     local layout = Layout {
+---       picker = picker,
+---       mount = function(self)
+---         self.results = create_window(false, 40, 20, 0, 0, "Results")
+---         self.preview = create_window(false, 40, 23, 0, 42, "Preview")
+---         self.prompt = create_window(true, 40, 1, 22, 0, "Prompt")
+---       end,
+---       unmount = function(self)
+---         destory_window(self.results)
+---         destory_window(self.preview)
+---         destory_window(self.prompt)
+---       end,
+---       update = function(self) end,
+---     }
+---
+---     return layout
+---   end,
+--- }
+--- </code>
+---@brief ]]
+
+local function wrap_instance(class, instance)
+  local self = instance
+  if not getmetatable(instance) then
+    self = setmetatable(instance, { __index = class })
+  end
+  return self
+end
+
+---@class TelescopeWindowBorder.config
+---@field bufnr integer
+---@field winid integer|nil
+---@field change_title nil|function: (self: TelescopeWindowBorder, title: string, pos?: "NW"|"N"|"NE"|"SW"|"S"|"SE"):nil
+
+---@param class TelescopeWindowBorder
+---@param config TelescopeWindowBorder.config
+---@return TelescopeWindowBorder
+local function init_border(class, config)
+  config = config or {}
+
+  ---@type TelescopeWindowBorder
+  local self = wrap_instance(class, config)
+  if not self.change_title then
+    self.change_title = class.change_title
+  end
+
+  return self
+end
+
+---@class TelescopeWindowBorder
+---@field bufnr integer|nil
+---@field winid integer|nil
+local Border = setmetatable({}, {
+  __call = init_border,
+  __name = "TelescopeWindowBorder",
+})
+
+---@param title string
+---@param pos "NW"|"N"|"NE"|"SW"|"S"|"SE"|nil
+function Border:change_title(title, pos) end
+
+---@class TelescopeWindow.config
+---@field bufnr integer
+---@field winid integer|nil
+---@field border TelescopeWindowBorder.config|nil
+
+---@param class TelescopeWindow
+---@param config TelescopeWindow.config
+---@return TelescopeWindow
+local function init_window(class, config)
+  config = config or {}
+
+  ---@type TelescopeWindow
+  local self = wrap_instance(class, config)
+  self.border = Border(config.border)
+
+  return self
+end
+
+---@class TelescopeWindow
+---@field border TelescopeWindowBorder
+---@field bufnr integer
+---@field winid integer
+local Window = setmetatable({}, {
+  __call = init_window,
+  __name = "TelescopeWindow",
+})
+
+---@class TelescopeLayout.config
+---@field mount function: (self: TelescopeLayout):nil
+---@field unmount function: (self: TelescopeLayout):nil
+---@field update function: (self: TelescopeLayout):nil
+---@field prompt TelescopeWindow|nil
+---@field results TelescopeWindow|nil
+---@field preview TelescopeWindow|nil
+
+---@param class TelescopeLayout
+---@param config TelescopeLayout.config
+---@return TelescopeLayout
+local function init_layout(class, config)
+  config = config or {}
+
+  ---@type TelescopeLayout
+  local self = wrap_instance(class, config)
+
+  assert(config.mount, "missing layout:mount")
+  assert(config.unmount, "missing layout:unmount")
+  assert(config.update, "missing layout:update")
+
+  return self
+end
+
+---@class TelescopeLayout
+---@field prompt TelescopeWindow
+---@field results TelescopeWindow
+---@field preview TelescopeWindow|nil
+local Layout = setmetatable({
+  Window = Window,
+}, {
+  __call = init_layout,
+  __name = "TelescopeLayout",
+})
+
+--- Create the layout.
+--- This needs to ensure the required properties are populated.
+function Layout:mount() end
+
+--- Destroy the layout.
+--- This is responsible for performing clean-up, for example:
+---  - deleting buffers
+---  - closing windows
+---  - clearing autocmds
+function Layout:unmount() end
+
+--- Refresh the layout.
+--- This is called when, for example, vim is resized.
+function Layout:update() end
+
+---@alias TelescopeWindow.constructor fun(config: TelescopeWindow.config): TelescopeWindow
+---@alias TelescopeLayout.constructor fun(config: TelescopeLayout.config): TelescopeLayout
+
+return Layout --[[@as TelescopeLayout.constructor|{ Window: TelescopeWindow.constructor }]]

--- a/lua/telescope/previewers/previewer.lua
+++ b/lua/telescope/previewers/previewer.lua
@@ -39,7 +39,7 @@ function Previewer:preview(entry, status)
     end
 
     if vim.api.nvim_buf_is_valid(self._empty_bufnr) then
-      vim.api.nvim_win_set_buf(status.preview_win, self._empty_bufnr)
+      vim.api.nvim_win_set_buf(status.layout.preview.winid, self._empty_bufnr)
     end
     return
   end

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -185,19 +185,20 @@ previewers.new_termopen_previewer = function(opts)
   end
 
   function opts.preview_fn(self, entry, status)
+    local preview_winid = status.layout.preview and status.layout.preview.winid
     if get_bufnr(self) == nil then
-      set_bufnr(self, vim.api.nvim_win_get_buf(status.preview_win))
+      set_bufnr(self, vim.api.nvim_win_get_buf(preview_winid))
     end
 
     local prev_bufnr = get_bufnr_by_bufentry(self, entry)
     if prev_bufnr then
       self.state.termopen_bufnr = prev_bufnr
-      utils.win_set_buf_noautocmd(status.preview_win, self.state.termopen_bufnr)
+      utils.win_set_buf_noautocmd(preview_winid, self.state.termopen_bufnr)
       self.state.termopen_id = term_ids[self.state.termopen_bufnr]
     else
       local bufnr = vim.api.nvim_create_buf(false, true)
       set_bufnr(self, bufnr)
-      utils.win_set_buf_noautocmd(status.preview_win, bufnr)
+      utils.win_set_buf_noautocmd(preview_winid, bufnr)
 
       local term_opts = {
         cwd = opts.cwd or vim.loop.cwd(),
@@ -277,7 +278,7 @@ previewers.vimgrep = defaulter(function(opts)
     end,
 
     get_command = function(entry, status)
-      local win_id = status.preview_win
+      local win_id = status.layout.preview and status.layout.preview.winid
       local height = vim.api.nvim_win_get_height(win_id)
 
       local p = from_entry.path(entry, true, false)
@@ -312,7 +313,7 @@ previewers.qflist = defaulter(function(opts)
     end,
 
     get_command = function(entry, status)
-      local win_id = status.preview_win
+      local win_id = status.layout.preview and status.layout.preview.winid
       local height = vim.api.nvim_win_get_height(win_id)
 
       local p = from_entry.path(entry, true, false)

--- a/lua/telescope/testharness/helpers.lua
+++ b/lua/telescope/testharness/helpers.lua
@@ -7,7 +7,7 @@ end
 
 test_helpers.get_results_bufnr = function()
   local state = require "telescope.state"
-  return state.get_status(vim.api.nvim_get_current_buf()).results_bufnr
+  return state.get_status(vim.api.nvim_get_current_buf()).layout.results.bufnr
 end
 
 test_helpers.get_file = function()

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -203,7 +203,7 @@ end
 
 local calc_result_length = function(truncate_len)
   local status = get_status(vim.api.nvim_get_current_buf())
-  local len = vim.api.nvim_win_get_width(status.results_win) - status.picker.selection_caret:len() - 2
+  local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
   return type(truncate_len) == "number" and len - truncate_len or len
 end
 

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -16,6 +16,7 @@ docs.test = function()
     "./lua/telescope/builtin/init.lua",
     "./lua/telescope/themes.lua",
     "./lua/telescope/mappings.lua",
+    "./lua/telescope/pickers/layout.lua",
     "./lua/telescope/pickers/layout_strategies.lua",
     "./lua/telescope/config/resolve.lua",
     "./lua/telescope/make_entry.lua",


### PR DESCRIPTION
# Description

Introduces a `create_layout` config. It enables plugging in completely separate UI components.

This also enables features like this to stay outside Telescope core: https://github.com/nvim-telescope/telescope.nvim/pull/2381

Telescope core can essentially stop caring about layout customization. It'll only require `create_layout` to return a specific structure. And the rest can be managed externally.

Related Issues/PRs:
- https://github.com/nvim-telescope/telescope.nvim/issues/2548
- https://github.com/nvim-telescope/telescope.nvim/issues/2508
- https://github.com/nvim-telescope/telescope.nvim/issues/1054
- https://github.com/nvim-telescope/telescope.nvim/pull/2381

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

![Kapture 2023-06-13 at 16 13 27](https://github.com/nvim-telescope/telescope.nvim/assets/8050659/f9b76172-f65a-4a07-81d2-bb8812a5546a)

```lua
local Layout = require("nui.layout")
local Popup = require("nui.popup")

local telescope = require("telescope")
local TSLayout = require("telescope.pickers.layout")

telescope.setup({
  defaults = {
    create_layout = function(picker)
      local border = {
        results = {
          top_left = "┌",
          top = "─",
          top_right = "┬",
          right = "│",
          bottom_right = "",
          bottom = "",
          bottom_left = "",
          left = "│",
        },
        results_patch = {
          minimal = {
            top_left = "┌",
            top_right = "┐",
          },
          horizontal = {
            top_left = "┌",
            top_right = "┬",
          },
          vertical = {
            top_left = "├",
            top_right = "┤",
          },
        },
        prompt = {
          top_left = "├",
          top = "─",
          top_right = "┤",
          right = "│",
          bottom_right = "┘",
          bottom = "─",
          bottom_left = "└",
          left = "│",
        },
        prompt_patch = {
          minimal = {
            bottom_right = "┘",
          },
          horizontal = {
            bottom_right = "┴",
          },
          vertical = {
            bottom_right = "┘",
          },
        },
        preview = {
          top_left = "┌",
          top = "─",
          top_right = "┐",
          right = "│",
          bottom_right = "┘",
          bottom = "─",
          bottom_left = "└",
          left = "│",
        },
        preview_patch = {
          minimal = {},
          horizontal = {
            bottom = "─",
            bottom_left = "",
            bottom_right = "┘",
            left = "",
            top_left = "",
          },
          vertical = {
            bottom = "",
            bottom_left = "",
            bottom_right = "",
            left = "│",
            top_left = "┌",
          },
        },
      }

      local results = Popup({
        focusable = false,
        border = {
          style = border.results,
          text = {
            top = picker.results_title,
            top_align = "center",
          },
        },
        win_options = {
          winhighlight = "Normal:Normal",
        },
      })

      local prompt = Popup({
        enter = true,
        border = {
          style = border.prompt,
          text = {
            top = picker.prompt_title,
            top_align = "center",
          },
        },
        win_options = {
          winhighlight = "Normal:Normal",
        },
      })

      local preview = Popup({
        focusable = false,
        border = {
          style = border.preview,
          text = {
            top = picker.preview_title,
            top_align = "center",
          },
        },
      })

      local box_by_kind = {
        vertical = Layout.Box({
          Layout.Box(preview, { grow = 1 }),
          Layout.Box(results, { grow = 1 }),
          Layout.Box(prompt, { size = 3 }),
        }, { dir = "col" }),
        horizontal = Layout.Box({
          Layout.Box({
            Layout.Box(results, { grow = 1 }),
            Layout.Box(prompt, { size = 3 }),
          }, { dir = "col", size = "50%" }),
          Layout.Box(preview, { size = "50%" }),
        }, { dir = "row" }),
        minimal = Layout.Box({
          Layout.Box(results, { grow = 1 }),
          Layout.Box(prompt, { size = 3 }),
        }, { dir = "col" }),
      }

      local function get_box()
        local height, width = vim.o.lines, vim.o.columns
        local box_kind = "horizontal"
        if width < 100 then
          box_kind = "vertical"
          if height < 40 then
            box_kind = "minimal"
          end
        elseif width < 120 then
          box_kind = "minimal"
        end
        return box_by_kind[box_kind], box_kind
      end

      local function prepare_layout_parts(layout, box_type)
        layout.results = TSLayout.Window(results)
        results.border:set_style(border.results_patch[box_type])

        layout.prompt = TSLayout.Window(prompt)
        prompt.border:set_style(border.prompt_patch[box_type])

        if box_type == "minimal" then
          layout.preview = nil
        else
          layout.preview = TSLayout.Window(preview)
          preview.border:set_style(border.preview_patch[box_type])
        end
      end

      local box, box_kind = get_box()
      local layout = Layout({
        relative = "editor",
        position = "50%",
        size = {
          height = "60%",
          width = "90%",
        },
      }, box)

      layout.picker = picker
      prepare_layout_parts(layout, box_kind)

      local layout_update = layout.update
      function layout:update()
        local box, box_kind = get_box()
        prepare_layout_parts(layout, box_kind)
        layout_update(self, box)
      end

      return TSLayout(layout)
    end,
  }
})
```

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
