### PR TITLE
Fix tagrelative option not considered in builtin.tags

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -538,7 +538,7 @@ files.tags = function(opts)
   end)()
 
   if not tags_command then
-    utils.notify("builtin.find_files", {
+    utils.notify("builtin.tags", {
       msg = "You need to install either grep or rg",
       level = "ERROR",
     })

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -534,7 +534,7 @@ files.tags = function(opts)
     if 1 == vim.fn.executable "rg" then
       return { "rg", "-H", "-N", "--no-heading", "--color", "never", "-v", "^!|^$" }
     elseif 1 == vim.fn.executable "grep" then
-      return { "grep", "-H", "--color=never", "-v", "^!\\|^$"}
+      return { "grep", "-H", "--color=never", "-v", "^!\\|^$" }
     end
   end)()
 

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -529,6 +529,22 @@ files.current_buffer_fuzzy_find = function(opts)
 end
 
 files.tags = function(opts)
+  local tags_command = (function()
+    if 1 == vim.fn.executable "rg" then
+      return { "rg", "-H", "-N", "--no-heading", "--color", "never", "^" }
+    elseif 1 == vim.fn.executable "grep" then
+      return { "grep", "-H", "--color=never", "^"}
+    end
+  end)()
+
+  if not tags_command then
+    utils.notify("builtin.find_files", {
+      msg = "You need to install either grep or rg",
+      level = "ERROR",
+    })
+    return
+  end
+
   local tagfiles = opts.ctags_file and { opts.ctags_file } or vim.fn.tagfiles()
   for i, ctags_file in ipairs(tagfiles) do
     tagfiles[i] = vim.fn.expand(ctags_file, true)
@@ -545,7 +561,7 @@ files.tags = function(opts)
   pickers
     .new(opts, {
       prompt_title = "Tags",
-      finder = finders.new_oneshot_job(flatten { "cat", tagfiles }, opts),
+      finder = finders.new_oneshot_job(flatten { tags_command, tagfiles }, opts),
       previewer = previewers.ctags.new(opts),
       sorter = conf.generic_sorter(opts),
       attach_mappings = function()

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -529,11 +529,12 @@ files.current_buffer_fuzzy_find = function(opts)
 end
 
 files.tags = function(opts)
+  -- find lines not matching tags file format (begins with !) or empty lines.
   local tags_command = (function()
     if 1 == vim.fn.executable "rg" then
-      return { "rg", "-H", "-N", "--no-heading", "--color", "never", "^" }
+      return { "rg", "-H", "-N", "--no-heading", "--color", "never", "-v", "^!|^$" }
     elseif 1 == vim.fn.executable "grep" then
-      return { "grep", "-H", "--color=never", "^"}
+      return { "grep", "-H", "--color=never", "-v", "^!\\|^$"}
     end
   end)()
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1088,7 +1088,7 @@ function make_entry.gen_from_ctags(opts)
   return function(line)
     local tag_file
     -- split line by ':'
-    tag_file, line = string.match(line, '([^:]+):(.+)')
+    tag_file, line = string.match(line, "([^:]+):(.+)")
 
     local tag, file, scode, lnum
     -- ctags gives us: 'tags\tfile\tsource'

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1086,7 +1086,14 @@ function make_entry.gen_from_ctags(opts)
 
   local current_file_cache = {}
   return function(line)
-    if line == "" or line:sub(1, 1) == "!" then
+    if line == "" then
+      return nil
+    end
+    local tag_file
+    tag_file, line = string.match(line, '([^:]+):(.+)')
+
+    -- do not include tag file format
+    if line:sub(1, 1) == "!" then
       return nil
     end
 
@@ -1096,6 +1103,12 @@ function make_entry.gen_from_ctags(opts)
     if not tag then
       -- hasktags gives us: 'tags\tfile\tlnum'
       tag, file, lnum = string.match(line, "([^\t]+)\t([^\t]+)\t(%d+).*")
+    end
+
+    -- append tag file path
+    if vim.opt.tagrelative:get() then
+      local tag_path = Path:new(tag_file):parent():make_relative(cwd)
+      file = tag_path .. "/" .. file
     end
 
     if Path.path.sep == "\\" then

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1086,16 +1086,9 @@ function make_entry.gen_from_ctags(opts)
 
   local current_file_cache = {}
   return function(line)
-    if line == "" then
-      return nil
-    end
     local tag_file
+    -- split line by ':'
     tag_file, line = string.match(line, '([^:]+):(.+)')
-
-    -- do not include tag file format
-    if line:sub(1, 1) == "!" then
-      return nil
-    end
 
     local tag, file, scode, lnum
     -- ctags gives us: 'tags\tfile\tsource'
@@ -1107,8 +1100,8 @@ function make_entry.gen_from_ctags(opts)
 
     -- append tag file path
     if vim.opt.tagrelative:get() then
-      local tag_path = Path:new(tag_file):parent():make_relative(cwd)
-      file = tag_path .. "/" .. file
+      local tag_path = Path:new(tag_file):parent()
+      file = Path:new(tag_path .. "/" .. file):normalize(cwd)
     end
 
     if Path.path.sep == "\\" then


### PR DESCRIPTION
# Description

This makes buitin.tags respect tagrelative option. Instead of using `cat` command to show content of tags file `rg` or `grep` is used as they are able to print which file the line is from.

Fixes #1309

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create a tag which is **not** located in the directory you open nvim but in a subfolder. The tags in the tag file are then relative to the subfolder and not nvim's cwd. Run `:Telescope tags` when you have a file open in the subfolder, this should result in showing the tagpaths relative to nvim's cwd.

**Configuration**:
* Neovim version (nvim --version): 0.9.0
* Operating system and version: Ubuntu 22.04.2 LTS

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
