### PR TITLE
fix(lsp_dynamic_workspace_symbols): add prefilter as per documentation (after to_fuzzy_refine)

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1657,8 +1657,8 @@ builtin.lsp_dynamic_workspace_symbols({opts}) *telescope.builtin.lsp_dynamic_wor
     Dynamically lists LSP for all workspace symbols
     - Default keymaps:
       - `<C-l>`: show autocompletion menu to prefilter your query by type of
-        symbol you want to see (i.e. `:variable:`), only work after refining to
-        fuzzy search using <C-space>
+        symbol you want to see (i.e. `:variable:`), only works after refining
+        to fuzzy search using <C-space>
 
 
     Parameters: ~

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1657,7 +1657,8 @@ builtin.lsp_dynamic_workspace_symbols({opts}) *telescope.builtin.lsp_dynamic_wor
     Dynamically lists LSP for all workspace symbols
     - Default keymaps:
       - `<C-l>`: show autocompletion menu to prefilter your query by type of
-        symbol you want to see (i.e. `:variable:`)
+        symbol you want to see (i.e. `:variable:`), only work after refining to
+        fuzzy search using <C-space>
 
 
     Parameters: ~
@@ -3168,10 +3169,32 @@ action_set.scroll_previewer({prompt_bufnr}, {direction}) *telescope.actions.set.
         {direction}    (number)  The direction of the scrolling
 
 
+action_set.scroll_horizontal_previewer({prompt_bufnr}, {direction}) *telescope.actions.set.scroll_horizontal_previewer()*
+    Scrolls the previewer to the left or right. Defaults to a half page scroll,
+    but can be overridden using the `scroll_speed` option in `layout_config`.
+    See |telescope.layout| for more details.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+        {direction}    (number)  The direction of the scrolling
+
+
 action_set.scroll_results({prompt_bufnr}, {direction}) *telescope.actions.set.scroll_results()*
     Scrolls the results up or down. Defaults to a half page scroll, but can be
     overridden using the `scroll_speed` option in `layout_config`. See
     |telescope.layout| for more details.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+        {direction}    (number)  The direction of the scrolling
+
+
+action_set.scroll_horizontal_results({prompt_bufnr}, {direction}) *telescope.actions.set.scroll_horizontal_results()*
+    Scrolls the results to the left or right. Defaults to a half page scroll,
+    but can be overridden using the `scroll_speed` option in `layout_config`.
+    See |telescope.layout| for more details.
 
 
     Parameters: ~
@@ -3455,8 +3478,8 @@ previewers.Previewer()                      *telescope.previewers.Previewer()*
         `termopen_previewer` and it can be used to send input to the terminal 
         application, like less.
       - `scroll_fn` function(self, direction): Used to make scrolling work.
-      - `scroll_horizontal_fn` function(self, direction): Used to make
-	horizontal scrolling work.
+      - `scroll_horizontal_fn` function(self, direction): Used to make 
+        horizontal scrolling work.
 
 
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1338,20 +1338,30 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 actions.to_fuzzy_refine = function(prompt_bufnr)
   local line = action_state.get_current_line()
-  local prefix = (function()
+  local opts = (function()
+    local opts = {
+      sorter = conf.generic_sorter {},
+    }
+
     local title = action_state.get_current_picker(prompt_bufnr).prompt_title
     if title == "Live Grep" then
-      return "Find Word"
+      opts.prefix = "Find Word"
     elseif title == "LSP Dynamic Workspace Symbols" then
-      return "LSP Workspace Symbols"
+      opts.prefix = "LSP Workspace Symbols"
+      opts.sorter = conf.prefilter_sorter {
+        tag = "symbol_type",
+        sorter = opts.sorter,
+      }
     else
-      return "Fuzzy over"
+      opts.prefix = "Fuzzy over"
     end
+
+    return opts
   end)()
 
   require("telescope.actions.generate").refine(prompt_bufnr, {
-    prompt_title = string.format("%s (%s)", prefix, line),
-    sorter = conf.generic_sorter {},
+    prompt_title = string.format("%s (%s)", opts.prefix, line),
+    sorter = opts.sorter,
   })
 end
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -482,7 +482,7 @@ builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.__ls
 
 --- Dynamically lists LSP for all workspace symbols
 --- - Default keymaps:
----   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`), only work after refining to fuzzy search using <C-space>
+---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`), only works after refining to fuzzy search using <C-space>
 ---@param opts table: options to pass to the picker
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: if true, shows the content of the line the symbol is found on (default: false)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -482,7 +482,7 @@ builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.__ls
 
 --- Dynamically lists LSP for all workspace symbols
 --- - Default keymaps:
----   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
+---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`), only work after refining to fuzzy search using <C-space>
 ---@param opts table: options to pass to the picker
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: if true, shows the content of the line the symbol is found on (default: false)


### PR DESCRIPTION
# Description

The doc states that `lsp_dynamic_workspace_symbols` supports prefiltering using `<C-l>` mapping, but it doesn't.
This PR adds support for prefiltering after refining to fuzzy search.

Fixes #2089.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Execute command `:Telescope lsp_dynamic_workspace_symbols`.
2. Type something to start fetching symbols.
3. Press `<C-space>` to refine to fuzzy search.
4. Press `<C-l>` to do prefiltering:

![image](https://github.com/nvim-telescope/telescope.nvim/assets/13317164/2d3007aa-8ad6-4151-8ccd-c8f558010896)


**Configuration**:
* Neovim version (nvim --version): `NVIM v0.10.0-dev-551+ge27377e33`
* Operating system and version: arch

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
