### PR TITLE
fix: fix builtins lazy loading

### DIFF
--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -439,7 +439,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
 ---@field file_encoding string: file encoding for the previewer
-builtin.lsp_type_definitions = require("telescope.builtin.__lsp").type_definitions
+builtin.lsp_type_definitions = require_on_exported_call("telescope.builtin.__lsp").type_definitions
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker


### PR DESCRIPTION
# Description

One of the builtins unconditionally requires `__lsp` module causing too many modules to load on startup by simple `require("telescope.builtins")`.

Before:

```
020.600  000.025  000.025: require('telescope._extensions')
020.604  000.072  000.047: require('telescope')
020.804  000.015  000.015: require('plenary.tbl')
020.809  000.037  000.022: require('plenary.vararg.rotate')
020.810  000.055  000.018: require('plenary.vararg')
020.826  000.015  000.015: require('plenary.errors')
020.847  000.019  000.019: require('plenary.functional')
020.850  000.118  000.030: require('plenary.async.async')
020.870  000.019  000.019: require('plenary.async.structs')
020.875  000.170  000.033: require('plenary.async.control')
021.154  000.022  000.022: require('plenary.bit')
021.175  000.013  000.013: require('ffi')
021.184  000.099  000.064: require('plenary.path')
021.190  000.127  000.028: require('plenary.strings')
021.215  000.024  000.024: require('telescope.deprecated')
021.378  000.103  000.103: require('plenary.log')
021.424  000.171  000.069: require('telescope.log')
021.538  000.058  000.058: require('plenary.job')
021.580  000.040  000.040: require('telescope.state')
021.586  000.160  000.062: require('telescope.utils')
021.590  000.373  000.042: require('telescope.sorters')
023.019  002.024  001.501: require('telescope.config')
023.126  000.047  000.047: require('plenary.window.border')
023.154  000.025  000.025: require('plenary.window')
023.173  000.018  000.018: require('plenary.popup.utils')
023.177  000.155  000.065: require('plenary.popup')
023.206  000.027  000.027: require('telescope.pickers.scroller')
023.231  000.023  000.023: require('telescope.actions.state')
023.257  000.025  000.025: require('telescope.actions.utils')
023.328  000.038  000.038: require('telescope.actions.mt')
023.348  000.089  000.051: require('telescope.actions.set')
023.424  000.040  000.040: require('telescope.config.resolve')
023.427  000.066  000.026: require('telescope.pickers.entry_display')
023.455  000.027  000.027: require('telescope.from_entry')
023.766  002.889  000.452: require('telescope.actions')
023.940  000.130  000.130: require('telescope.make_entry')
024.050  000.027  000.027: require('plenary.async.util')
024.053  000.049  000.022: require('plenary.async.tests')
024.055  000.080  000.031: require('plenary.async')
024.057  000.114  000.034: require('telescope.finders.async_static_finder')
024.140  000.027  000.027: require('plenary.class')
024.155  000.078  000.051: require('telescope._')
024.156  000.099  000.021: require('telescope.finders.async_oneshot_finder')
024.192  000.035  000.035: require('telescope.finders.async_job_finder')
024.199  000.431  000.054: require('telescope.finders')
024.354  000.069  000.069: require('telescope.debounce')
024.471  000.113  000.113: require('telescope.mappings')
024.503  000.030  000.030: require('telescope.pickers.highlights')
024.526  000.021  000.021: require('telescope.pickers.window')
024.584  000.027  000.027: require('telescope.algos.linked_list')
024.589  000.062  000.035: require('telescope.entry_manager')
024.612  000.023  000.023: require('telescope.pickers.multi')
024.629  000.428  000.111: require('telescope.pickers')
024.638  003.984  000.066: require('telescope.builtin.__lsp')
024.658  004.053  000.069: require('telescope.builtin')
```

After:

```
022.798  000.028  000.028: require('telescope._extensions')
022.801  000.074  000.047: require('telescope')
022.868  000.065  000.065: require('telescope.builtin')
023.063  000.022  000.022: require('plenary.bit')
023.085  000.020  000.020: require('plenary.functional')
023.108  000.015  000.015: require('ffi')
023.116  000.134  000.076: require('plenary.path')
023.122  000.172  000.038: require('plenary.strings')
023.144  000.021  000.021: require('telescope.deprecated')
023.271  000.075  000.075: require('plenary.log')
023.291  000.111  000.036: require('telescope.log')
023.389  000.045  000.045: require('plenary.job')
023.410  000.020  000.020: require('telescope.state')
023.415  000.122  000.057: require('telescope.utils')
023.420  000.275  000.042: require('telescope.sorters')
024.876  002.005  001.538: require('telescope.config')
```

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)