### PR TITLE
expand paths more smartly

### DIFF
--- a/lua/telescope/_.lua
+++ b/lua/telescope/_.lua
@@ -5,6 +5,7 @@ local log = require "plenary.log"
 
 local async = require "plenary.async"
 local channel = require("plenary.async").control.channel
+local utils = require "telescope.utils"
 
 local M = {}
 
@@ -21,7 +22,7 @@ function AsyncJob.new(opts)
   self.stderr = opts.stderr or M.NullPipe()
 
   if opts.cwd and opts.cwd ~= "" then
-    self.uv_opts.cwd = vim.fn.expand(vim.fn.escape(opts.cwd, "$"))
+    self.uv_opts.cwd = utils.smart_path_expand(opts.cwd)
     -- this is a "illegal" hack for windows. E.g. If the git command returns `/` rather than `\` as delimiter,
     -- vim.fn.expand might just end up returning an empty string. Weird
     -- Because empty string is not allowed in libuv the job will not spawn. Solution is we just set it to opts.cwd

--- a/lua/telescope/actions/history.lua
+++ b/lua/telescope/actions/history.lua
@@ -73,7 +73,7 @@ function histories.History:new(opts)
   if conf.history.limit then
     obj.limit = conf.history.limit
   end
-  obj.path = vim.fn.expand(conf.history.path)
+  obj.path = utils.smart_path_expand(conf.history.path)
   obj.content = {}
   obj.index = 1
   obj.cycle_wrap = conf.history.cycle_wrap

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -96,12 +96,12 @@ files.live_grep = function(opts)
   local vimgrep_arguments = opts.vimgrep_arguments or conf.vimgrep_arguments
   local search_dirs = opts.search_dirs
   local grep_open_files = opts.grep_open_files
-  opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
+  opts.cwd = utils.smart_path_expand(opts.cwd or vim.loop.cwd())
 
   local filelist = get_open_filelist(grep_open_files, opts.cwd)
   if search_dirs then
     for i, path in ipairs(search_dirs) do
-      search_dirs[i] = vim.fn.expand(path)
+      search_dirs[i] = utils.smart_path_expand(path)
     end
   end
 
@@ -166,7 +166,7 @@ files.live_grep = function(opts)
 end
 
 files.grep_string = function(opts)
-  opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
+  opts.cwd = utils.smart_path_expand(opts.cwd or vim.loop.cwd())
   local vimgrep_arguments = vim.F.if_nil(opts.vimgrep_arguments, conf.vimgrep_arguments)
   local word
   local visual = vim.fn.mode() == "v"
@@ -225,7 +225,7 @@ files.grep_string = function(opts)
     end
   elseif opts.search_dirs then
     for _, path in ipairs(opts.search_dirs) do
-      table.insert(args, vim.fn.expand(path))
+      table.insert(args, utils.smart_path_expand(path))
     end
   end
 
@@ -278,7 +278,7 @@ files.find_files = function(opts)
 
   if search_dirs then
     for k, v in pairs(search_dirs) do
-      search_dirs[k] = vim.fn.expand(v)
+      search_dirs[k] = utils.smart_path_expand(v)
     end
   end
 
@@ -355,7 +355,7 @@ files.find_files = function(opts)
   end
 
   if opts.cwd then
-    opts.cwd = vim.fn.expand(opts.cwd)
+    opts.cwd = utils.smart_path_expand(opts.cwd)
   end
 
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)
@@ -444,7 +444,7 @@ end
 
 files.current_buffer_fuzzy_find = function(opts)
   -- All actions are on the current buffer
-  local filename = vim.fn.expand(vim.api.nvim_buf_get_name(opts.bufnr))
+  local filename = utils.smart_path_expand(vim.api.nvim_buf_get_name(opts.bufnr))
   local filetype = vim.api.nvim_buf_get_option(opts.bufnr, "filetype")
 
   local lines = vim.api.nvim_buf_get_lines(opts.bufnr, 0, -1, false)
@@ -548,7 +548,7 @@ files.tags = function(opts)
 
   local tagfiles = opts.ctags_file and { opts.ctags_file } or vim.fn.tagfiles()
   for i, ctags_file in ipairs(tagfiles) do
-    tagfiles[i] = vim.fn.expand(ctags_file, true)
+    tagfiles[i] = utils.smart_path_expand(ctags_file, true)
   end
   if vim.tbl_isempty(tagfiles) then
     utils.notify("builtin.tags", {

--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -7,6 +7,7 @@ This file is still WIP, so expect some changes if you're trying to consume these
 This will provide standard mechanism for accessing information from an entry.
 
 --============================================================================= ]]
+local utils = require "telescope.utils"
 
 local from_entry = {}
 
@@ -30,7 +31,7 @@ function from_entry.path(entry, validate, escape)
     -- TODO(conni2461): we are not going to return the expanded path because
     --                  this would lead to cache misses in the perviewer.
     --                  Requires overall refactoring in previewer interface
-    local expanded = vim.fn.expand(vim.fn.escape(path, "$?*[]"))
+    local expanded = utils.smart_path_expand(path)
     if (vim.fn.filereadable(expanded) + vim.fn.isdirectory(expanded)) == 0 then
       return
     end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -149,7 +149,7 @@ do
   function make_entry.gen_from_file(opts)
     opts = opts or {}
 
-    local cwd = vim.fn.expand(opts.cwd or vim.loop.cwd())
+    local cwd = utils.smart_path_expand(opts.cwd or vim.loop.cwd())
 
     local disable_devicons = opts.disable_devicons
 
@@ -310,7 +310,7 @@ do
     local display_string = "%s%s%s"
 
     mt_vimgrep_entry = {
-      cwd = vim.fn.expand(opts.cwd or vim.loop.cwd()),
+      cwd = utils.smart_path_expand(opts.cwd or vim.loop.cwd()),
 
       display = function(entry)
         local display_filename = utils.transform_path(opts, entry.filename)
@@ -605,7 +605,7 @@ function make_entry.gen_from_buffer(opts)
     },
   }
 
-  local cwd = vim.fn.expand(opts.cwd or vim.loop.cwd())
+  local cwd = utils.smart_path_expand(opts.cwd or vim.loop.cwd())
 
   local make_display = function(entry)
     -- bufnr_width + modes + icon + 3 spaces + : + lnum
@@ -1023,7 +1023,7 @@ end
 function make_entry.gen_from_ctags(opts)
   opts = opts or {}
 
-  local cwd = vim.fn.expand(opts.cwd or vim.loop.cwd())
+  local cwd = utils.smart_path_expand(opts.cwd or vim.loop.cwd())
   local current_file = Path:new(vim.api.nvim_buf_get_name(opts.bufnr)):normalize(cwd)
 
   local display_items = {

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -255,7 +255,7 @@ previewers.file_maker = function(filepath, bufnr, opts)
   end
   if opts.bufname ~= filepath then
     if not vim.in_fast_event() then
-      filepath = vim.fn.expand(filepath)
+      filepath = utils.smart_path_expand(filepath)
     end
     vim.loop.fs_stat(filepath, function(_, stat)
       if not stat then

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -13,17 +13,17 @@ local bat_options = { "--style=plain", "--color=always", "--paging=always" }
 local has_less = (vim.fn.executable "less" == 1) and conf.use_less
 
 local get_file_stat = function(filename)
-  return vim.loop.fs_stat(vim.fn.expand(filename)) or {}
+  return vim.loop.fs_stat(utils.smart_path_expand(filename)) or {}
 end
 
 local list_dir = (function()
   if vim.fn.has "win32" == 1 then
     return function(dirname)
-      return { "cmd.exe", "/c", "dir", vim.fn.expand(dirname) }
+      return { "cmd.exe", "/c", "dir", utils.smart_path_expand(dirname) }
     end
   else
     return function(dirname)
-      return { "ls", "-la", vim.fn.expand(dirname) }
+      return { "ls", "-la", utils.smart_path_expand(dirname) }
     end
   end
 end)()
@@ -55,7 +55,7 @@ local bat_maker = function(filename, lnum, start, finish)
     command,
     bat_options,
     "--",
-    vim.fn.expand(filename),
+    utils.smart_path_expand(filename),
   }
 end
 
@@ -74,15 +74,15 @@ local cat_maker = function(filename, _, start, _)
 
   if has_less then
     if start then
-      return { "less", "-RS", string.format("+%s", start), vim.fn.expand(filename) }
+      return { "less", "-RS", string.format("+%s", start), utils.smart_path_expand(filename) }
     else
-      return { "less", "-RS", vim.fn.expand(filename) }
+      return { "less", "-RS", utils.smart_path_expand(filename) }
     end
   else
     return {
       "cat",
       "--",
-      vim.fn.expand(filename),
+      utils.smart_path_expand(filename),
     }
   end
 end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -15,6 +15,10 @@ local get_status = require("telescope.state").get_status
 
 local utils = {}
 
+utils.smart_path_expand = function(path)
+  return path:match "^[%#<]" and vim.fn.expand(path) or vim.fn.fnameescape(path)
+end
+
 utils.get_separator = function()
   return Path.path.sep
 end
@@ -220,7 +224,7 @@ utils.transform_path = function(opts, path)
         if opts.cwd then
           cwd = opts.cwd
           if not vim.in_fast_event() then
-            cwd = vim.fn.expand(opts.cwd)
+            cwd = utils.smart_path_expand(opts.cwd)
           end
         else
           cwd = vim.loop.cwd()


### PR DESCRIPTION
getting tired of unusual paths being over expanded by `vim.fn.expand` causing an assortment of issues (commonly in telescope-file-browser).

this might be overkill and have some edge cases where things being under expanded. 
i'll ride this branch for a few days to see how it goes.

partially closes https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/289