### PR TITLE
fix: do not ignore mappings from `setup()` when attach_mappings provided

### DIFF
--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -551,6 +551,14 @@ local apply_config = function(mod)
         end
       end
 
+      if defaults.attach_mappings and opts.attach_mappings then
+        local opts_attach = opts.attach_mappings
+        opts.attach_mappings = function(prompt_bufnr, map)
+          defaults.attach_mappings(prompt_bufnr, map)
+          return opts_attach(prompt_bufnr, map)
+        end
+      end
+
       v(vim.tbl_extend("force", defaults, opts))
     end
   end


### PR DESCRIPTION
# Description

Fixes #2612

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with the steps from #2612

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
