### PR TITLE
Add custom ignore pattern

### DIFF
--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -81,6 +81,7 @@ builtin.grep_string = require_on_exported_call("telescope.builtin.__files").grep
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
 ---@field no_ignore boolean: show files ignored by .gitignore, .ignore, etc. (default: false)
 ---@field no_ignore_parent boolean: show files ignored by .gitignore, .ignore, etc. in parent dirs. (default: false)
+---@field ignore_patterns table: list of patterns to ignore
 ---@field search_dirs table: directory/directories/files to search
 ---@field search_file string: specify a filename to search for
 ---@field file_encoding string: file encoding for the previewer


### PR DESCRIPTION
# Description

I have introduced an option to `find_files` picker as `ignore_patterns` which takes a table that should contain an array of patterns to be ignored while searching for files.
Motivation: I use find_files with the option `hidden` set to `true` for fuzzy finding in my projects because:
- I want to open some files which I have ignored.
- fuzzy find any new files which are still not tracked. (so `git_files` picker does not work for this case)
- find files in my dotfiles

I came across an issue where in my current setup:
```
vim.keymap.set('v', '<C-p>', function()
  builtin.find_files {
    cwd = vim.g.bmax_cwd,
    hidden = true,
    follow = true,
  }
end, { desc = '[S]earch [F]iles' })
```
 It loads all the files from my `.git` folder because `hidden` = true` would include all dotfiles. Then I checked if I can just ignore some patterns, which got me playing with the source code and which led me to search through the git hub issues and I saw a similar feature request. 

Now users can use `ignore_patters` options to add patterns to ignore like this:
```
  builtin.find_files { 
    hidden = true,
    ignore_patterns = {
       ".git/",
       ".yarn/"
    },
  }
```
Fixes # ([2383](https://github.com/nvim-telescope/telescope.nvim/issues/2383))

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

I have only tested it manually, by adding the patterns.

- [x] Test A: Add `ignore_patters` option to `find_files` and check for results in telescope

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.9.0
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3

* Operating system and version:
Ubuntu 22.04.2 LTS x86_64

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
