### PR TITLE
expand paths more selectively

### DIFF
--- a/lua/telescope/_.lua
+++ b/lua/telescope/_.lua
@@ -5,6 +5,7 @@ local log = require "plenary.log"
 
 local async = require "plenary.async"
 local channel = require("plenary.async").control.channel
+local utils = require "telescope.utils"
 
 local M = {}
 
@@ -21,7 +22,7 @@ function AsyncJob.new(opts)
   self.stderr = opts.stderr or M.NullPipe()
 
   if opts.cwd and opts.cwd ~= "" then
-    self.uv_opts.cwd = vim.fn.expand(vim.fn.escape(opts.cwd, "$"))
+    self.uv_opts.cwd = utils.path_expand(opts.cwd)
     -- this is a "illegal" hack for windows. E.g. If the git command returns `/` rather than `\` as delimiter,
     -- vim.fn.expand might just end up returning an empty string. Weird
     -- Because empty string is not allowed in libuv the job will not spawn. Solution is we just set it to opts.cwd

--- a/lua/telescope/actions/history.lua
+++ b/lua/telescope/actions/history.lua
@@ -73,7 +73,7 @@ function histories.History:new(opts)
   if conf.history.limit then
     obj.limit = conf.history.limit
   end
-  obj.path = vim.fn.expand(conf.history.path)
+  obj.path = utils.path_expand(conf.history.path)
   obj.content = {}
   obj.index = 1
   obj.cycle_wrap = conf.history.cycle_wrap

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -115,12 +115,12 @@ files.live_grep = function(opts)
   end
   local search_dirs = opts.search_dirs
   local grep_open_files = opts.grep_open_files
-  opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
+  opts.cwd = opts.cwd and utils.path_expand(opts.cwd) or vim.loop.cwd()
 
   local filelist = get_open_filelist(grep_open_files, opts.cwd)
   if search_dirs then
     for i, path in ipairs(search_dirs) do
-      search_dirs[i] = vim.fn.expand(path)
+      search_dirs[i] = utils.path_expand(path)
     end
   end
 
@@ -246,7 +246,7 @@ files.grep_string = function(opts)
     end
   elseif opts.search_dirs then
     for _, path in ipairs(opts.search_dirs) do
-      table.insert(args, vim.fn.expand(path))
+      table.insert(args, utils.path_expand(path))
     end
   end
 
@@ -299,7 +299,7 @@ files.find_files = function(opts)
 
   if search_dirs then
     for k, v in pairs(search_dirs) do
-      search_dirs[k] = vim.fn.expand(v)
+      search_dirs[k] = utils.path_expand(v)
     end
   end
 
@@ -376,7 +376,7 @@ files.find_files = function(opts)
   end
 
   if opts.cwd then
-    opts.cwd = vim.fn.expand(opts.cwd)
+    opts.cwd = utils.path_expand(opts.cwd)
   end
 
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)
@@ -466,7 +466,7 @@ end
 
 files.current_buffer_fuzzy_find = function(opts)
   -- All actions are on the current buffer
-  local filename = vim.fn.expand(vim.api.nvim_buf_get_name(opts.bufnr))
+  local filename = vim.api.nvim_buf_get_name(opts.bufnr)
   local filetype = vim.api.nvim_buf_get_option(opts.bufnr, "filetype")
 
   local lines = vim.api.nvim_buf_get_lines(opts.bufnr, 0, -1, false)

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -459,7 +459,7 @@ end
 local set_opts_cwd = function(opts)
   opts.use_git_root = vim.F.if_nil(opts.use_git_root, true)
   if opts.cwd then
-    opts.cwd = vim.fn.expand(opts.cwd)
+    opts.cwd = utils.path_expand(opts.cwd)
   elseif opts.use_file_path then
     opts.cwd = current_path_toplevel()
     if not opts.cwd then

--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -7,6 +7,7 @@ This file is still WIP, so expect some changes if you're trying to consume these
 This will provide standard mechanism for accessing information from an entry.
 
 --============================================================================= ]]
+local utils = require "telescope.utils"
 
 local from_entry = {}
 
@@ -30,7 +31,7 @@ function from_entry.path(entry, validate, escape)
     -- TODO(conni2461): we are not going to return the expanded path because
     --                  this would lead to cache misses in the perviewer.
     --                  Requires overall refactoring in previewer interface
-    local expanded = vim.fn.expand(vim.fn.escape(path, "$?*[]"))
+    local expanded = utils.path_expand(path)
     if (vim.fn.filereadable(expanded) + vim.fn.isdirectory(expanded)) == 0 then
       return
     end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -149,7 +149,7 @@ do
   function make_entry.gen_from_file(opts)
     opts = opts or {}
 
-    local cwd = vim.fn.expand(opts.cwd or vim.loop.cwd())
+    local cwd = utils.path_expand(opts.cwd or vim.loop.cwd())
 
     local disable_devicons = opts.disable_devicons
 
@@ -310,7 +310,7 @@ do
     local display_string = "%s%s%s"
 
     mt_vimgrep_entry = {
-      cwd = vim.fn.expand(opts.cwd or vim.loop.cwd()),
+      cwd = utils.path_expand(opts.cwd or vim.loop.cwd()),
 
       display = function(entry)
         local display_filename = utils.transform_path(opts, entry.filename)
@@ -592,7 +592,7 @@ function make_entry.gen_from_buffer(opts)
     },
   }
 
-  local cwd = vim.fn.expand(opts.cwd or vim.loop.cwd())
+  local cwd = utils.path_expand(opts.cwd or vim.loop.cwd())
 
   local make_display = function(entry)
     -- bufnr_width + modes + icon + 3 spaces + : + lnum
@@ -1011,7 +1011,7 @@ end
 function make_entry.gen_from_ctags(opts)
   opts = opts or {}
 
-  local cwd = vim.fn.expand(opts.cwd or vim.loop.cwd())
+  local cwd = utils.path_expand(opts.cwd or vim.loop.cwd())
   local current_file = Path:new(vim.api.nvim_buf_get_name(opts.bufnr)):normalize(cwd)
 
   local display_items = {

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -262,7 +262,7 @@ previewers.file_maker = function(filepath, bufnr, opts)
   end
   if opts.bufname ~= filepath then
     if not vim.in_fast_event() then
-      filepath = vim.fn.expand(filepath)
+      filepath = utils.path_expand(filepath)
     end
     vim.loop.fs_stat(filepath, function(_, stat)
       if not stat then

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -13,17 +13,17 @@ local bat_options = { "--style=plain", "--color=always", "--paging=always" }
 local has_less = (vim.fn.executable "less" == 1) and conf.use_less
 
 local get_file_stat = function(filename)
-  return vim.loop.fs_stat(vim.fn.expand(filename)) or {}
+  return vim.loop.fs_stat(utils.path_expand(filename)) or {}
 end
 
 local list_dir = (function()
   if vim.fn.has "win32" == 1 then
     return function(dirname)
-      return { "cmd.exe", "/c", "dir", vim.fn.expand(dirname) }
+      return { "cmd.exe", "/c", "dir", utils.path_expand(dirname) }
     end
   else
     return function(dirname)
-      return { "ls", "-la", vim.fn.expand(dirname) }
+      return { "ls", "-la", utils.path_expand(dirname) }
     end
   end
 end)()
@@ -55,7 +55,7 @@ local bat_maker = function(filename, lnum, start, finish)
     command,
     bat_options,
     "--",
-    vim.fn.expand(filename),
+    utils.path_expand(filename),
   }
 end
 
@@ -74,15 +74,15 @@ local cat_maker = function(filename, _, start, _)
 
   if has_less then
     if start then
-      return { "less", "-RS", string.format("+%s", start), vim.fn.expand(filename) }
+      return { "less", "-RS", string.format("+%s", start), utils.path_expand(filename) }
     else
-      return { "less", "-RS", vim.fn.expand(filename) }
+      return { "less", "-RS", utils.path_expand(filename) }
     end
   else
     return {
       "cat",
       "--",
-      vim.fn.expand(filename),
+      utils.path_expand(filename),
     }
   end
 end

--- a/lua/tests/helpers.lua
+++ b/lua/tests/helpers.lua
@@ -3,6 +3,7 @@ local make_entry = require "telescope.make_entry"
 local previewers = require "telescope.previewers"
 local pickers = require "telescope.pickers"
 local sorters = require "telescope.sorters"
+local utils = require "telescope.utils"
 
 local helpers = {}
 
@@ -24,7 +25,7 @@ helpers.auto_find_files = function(opts)
   end
 
   if opts.cwd then
-    opts.cwd = vim.fn.expand(opts.cwd)
+    opts.cwd = utils.path_expand(opts.cwd)
   end
 
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)


### PR DESCRIPTION
There's a few areas where I believe we're over expanding paths.

We've done some quick fixes with `vim.fn.escape` here and there but I want to explore rather than escaping certain characters then expanding, only expanding when the provided "path" is worth expanding (starts with either '%', '#' or '<'). 

~The places where I'm made changes, it should be safe to assume that at that point, a $ in a path mean the literal $ rather than some shell variable and I'm not even sure _if_ they even ever need expanding.~

Edit: ^ this should largely not be a concern anymore. Unlike with `vim.fn.escape`, `vim.fs.normalize` only expands `$` if it's actually a shell variable. 

closes https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/289

also relevant: 
https://github.com/nvim-telescope/telescope.nvim/pull/2457