### PR TITLE
Revert "Fix tagrelative option not considered in builtin.tags (#2583)"

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -529,23 +529,6 @@ files.current_buffer_fuzzy_find = function(opts)
 end
 
 files.tags = function(opts)
-  -- find lines not matching tags file format (begins with !) or empty lines.
-  local tags_command = (function()
-    if 1 == vim.fn.executable "rg" then
-      return { "rg", "-H", "-N", "--no-heading", "--color", "never", "-v", "^!|^$" }
-    elseif 1 == vim.fn.executable "grep" then
-      return { "grep", "-H", "--color=never", "-v", "^!\\|^$" }
-    end
-  end)()
-
-  if not tags_command then
-    utils.notify("builtin.tags", {
-      msg = "You need to install either grep or rg",
-      level = "ERROR",
-    })
-    return
-  end
-
   local tagfiles = opts.ctags_file and { opts.ctags_file } or vim.fn.tagfiles()
   for i, ctags_file in ipairs(tagfiles) do
     tagfiles[i] = vim.fn.expand(ctags_file, true)
@@ -562,7 +545,7 @@ files.tags = function(opts)
   pickers
     .new(opts, {
       prompt_title = "Tags",
-      finder = finders.new_oneshot_job(flatten { tags_command, tagfiles }, opts),
+      finder = finders.new_oneshot_job(flatten { "cat", tagfiles }, opts),
       previewer = previewers.ctags.new(opts),
       sorter = conf.generic_sorter(opts),
       attach_mappings = function()

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1086,9 +1086,9 @@ function make_entry.gen_from_ctags(opts)
 
   local current_file_cache = {}
   return function(line)
-    local tag_file
-    -- split line by ':'
-    tag_file, line = string.match(line, "([^:]+):(.+)")
+    if line == "" or line:sub(1, 1) == "!" then
+      return nil
+    end
 
     local tag, file, scode, lnum
     -- ctags gives us: 'tags\tfile\tsource'
@@ -1096,12 +1096,6 @@ function make_entry.gen_from_ctags(opts)
     if not tag then
       -- hasktags gives us: 'tags\tfile\tlnum'
       tag, file, lnum = string.match(line, "([^\t]+)\t([^\t]+)\t(%d+).*")
-    end
-
-    -- append tag file path
-    if vim.opt.tagrelative:get() then
-      local tag_path = Path:new(tag_file):parent()
-      file = Path:new(tag_path .. "/" .. file):normalize(cwd)
     end
 
     if Path.path.sep == "\\" then


### PR DESCRIPTION
This reverts commit 6074847b6ee4b725747c8fc540d9b6b128ac8a12 due to performance regression.
Related PR https://github.com/nvim-telescope/telescope.nvim/pull/2583


closes #2627 