### PR TITLE
Added option to prioritize severity when sorting diagnostics items

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1744,6 +1744,9 @@ builtin.diagnostics({opts})                  *telescope.builtin.diagnostics()*
                                                 buffers
         {severity}            (string|number)   filter diagnostics by severity
                                                 name (string) or id (number)
+        {severity_sort}       (boolean)         Prioritize severity when
+                                                sorting diagnostics items
+						(default: false)
         {severity_limit}      (string|number)   keep diagnostics equal or more
                                                 severe wrt severity name
                                                 (string) or id (number)

--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -68,6 +68,7 @@ local diagnostics_to_tbl = function(opts)
       col = diagnostic.col + 1,
       text = vim.trim(diagnostic.message:gsub("[\n]", "")),
       type = severities[diagnostic.severity] or severities[1],
+      severity = diagnostic.severity or 1,
     }
   end
 
@@ -79,6 +80,9 @@ local diagnostics_to_tbl = function(opts)
 
   -- sort results by bufnr (prioritize cur buf), severity, lnum
   table.sort(items, function(a, b)
+    if opts.severity_sort and a.severity ~= b.severity then
+      return a.severity < b.severity
+    end
     if a.bufnr == b.bufnr then
       if a.type == b.type then
         return a.lnum < b.lnum

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -523,6 +523,7 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 ---   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
 ---@param opts table: options to pass to the picker
 ---@field bufnr number|nil: Buffer number to get diagnostics from. Use 0 for current buffer or nil for all buffers
+---@field severity_sort|boolean: Prioritize severity when sorting diagnostics items
 ---@field severity string|number: filter diagnostics by severity name (string) or id (number)
 ---@field severity_limit string|number: keep diagnostics equal or more severe wrt severity name (string) or id (number)
 ---@field severity_bound string|number: keep diagnostics equal or less severe wrt severity name (string) or id (number)


### PR DESCRIPTION
# Description

Added option to prioritize severity when sorting diagnostics items
Fixes #2631

Example:
```lua
require('telescope.builtin').diagnostics({ severity_sort = true })
```
Result:
<img width="766" alt="Screenshot 2023-08-04 at 2 55 17 PM" src="https://github.com/nvim-telescope/telescope.nvim/assets/8187501/ff376dfc-b86d-48aa-8e86-16f8e583cff1">

## Type of change
New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested by turning this flag on and off and observing the desired results.

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.10.0-dev-737+gdf2f5e391-Homebrew
Build type: Release
LuaJIT 2.1.0-beta3
```
* Operating system and version:
macOS 13.4.1 (22F82)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
