### PR TITLE
fix: autocmd example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,9 +412,9 @@ vim.api.nvim_create_autocmd("User", {
   pattern = "TelescopePreviewerLoaded",
   callback = function(args)
     if args.data.filetype ~= "help" then
-      vim.bo.number = true
+      vim.wo.number = true
     elseif args.data.bufname:match("*.csv") then
-      vim.bo.wrap = false
+      vim.wo.wrap = false
     end
   end,
 })


### PR DESCRIPTION
# Description

The following `autocmd` example in README is wrong, since both `number` and `wrap` are window-scoped options.

https://github.com/nvim-telescope/telescope.nvim/blob/d2e17ba18a6840b7e7079764b282616c3188e0de/README.md?plain=1#L410-L421

## Type of change

- This change requires a documentation update

# How Has This Been Tested?

Tests are not needed.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
