### PR TITLE
feat: add searching indicator (#1713)

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -353,24 +353,24 @@ append(
 
 append(
   "get_status_text",
-  function(self)
+  function(self, opts)
     local ww = #(self:get_multi_selection())
     local xx = (self.stats.processed or 0) - (self.stats.filtered or 0)
     local yy = self.stats.processed or 0
-    if xx == 0 and yy == 0 then
-      return ""
+
+    local status_icon = ""
+    if opts and not opts.completed then
+      status_icon = "*"
     end
 
-    -- local status_icon
-    -- if opts.completed then
-    --   status_icon = "✔️"
-    -- else
-    --   status_icon = "*"
-    -- end
+    if xx == 0 and yy == 0 then
+      return status_icon
+    end
+
     if ww == 0 then
-      return string.format("%s / %s", xx, yy)
+      return string.format("%s %s / %s", status_icon, xx, yy)
     else
-      return string.format("%s / %s / %s", ww, xx, yy)
+      return string.format("%s %s / %s / %s", status_icon, ww, xx, yy)
     end
   end,
   [[

--- a/lua/telescope/finders.lua
+++ b/lua/telescope/finders.lua
@@ -87,6 +87,7 @@ function JobFinder:_find(prompt, process_result, process_complete)
 
   local opts = self:fn_command(prompt)
   if not opts then
+    process_complete()
     return
   end
 

--- a/lua/telescope/finders/async_job_finder.lua
+++ b/lua/telescope/finders/async_job_finder.lua
@@ -33,6 +33,7 @@ return function(opts)
 
     local job_opts = fn_command(prompt)
     if not job_opts then
+      process_complete()
       return
     end
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -789,7 +789,7 @@ function Picker:get_selection_row()
     end
     return self._selection_row
   end
-  return self.max_results
+  return self:get_reset_row()
 end
 
 --- Move the current selection by `change` steps


### PR DESCRIPTION
# Description
add a searching indicator `*` to prompt
<img width="1141" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/13499986/c0c2f4bd-3c5f-4ee7-98a1-9a39b140375b">
when searching is done. it will dispear.
<img width="496" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/13499986/fed52381-7f5e-44e6-942d-8e7ab5594168">

also fix the bug in `function Picker:get_selection_row()`
  when `self.sorting_strategy == "ascending"` it should return 0 not `max_results`

Fixes # (issue)
#1713

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Configuration**:
* Neovim version (nvim --version):0.9.1
* Operating system and version:macOS 13.4

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
