### PR TITLE
add missing dependency warning for ripgrep

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -36,6 +36,22 @@ local escape_chars = function(string)
   })
 end
 
+local has_rg_program = function(picker_name, program)
+  if vim.fn.executable(program) == 1 then
+    return true
+  end
+
+  utils.notify(picker_name, {
+    msg = string.format(
+      "'ripgrep', or similar alternative, is a required dependency for the %s picker. "
+        .. "Visit https://github.com/BurntSushi/ripgrep#installation for installation instructions.",
+      picker_name
+    ),
+    level = "ERROR",
+  })
+  return false
+end
+
 local get_open_filelist = function(grep_open_files, cwd)
   if not grep_open_files then
     return nil
@@ -94,6 +110,9 @@ end
 --  opts.grep_open_files -- boolean to restrict search to open files
 files.live_grep = function(opts)
   local vimgrep_arguments = opts.vimgrep_arguments or conf.vimgrep_arguments
+  if not has_rg_program("live_grep", vimgrep_arguments[1]) then
+    return
+  end
   local search_dirs = opts.search_dirs
   local grep_open_files = opts.grep_open_files
   opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
@@ -166,8 +185,10 @@ files.live_grep = function(opts)
 end
 
 files.grep_string = function(opts)
-  opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
   local vimgrep_arguments = vim.F.if_nil(opts.vimgrep_arguments, conf.vimgrep_arguments)
+  if not has_rg_program("grep_string", vimgrep_arguments[1]) then
+    return
+  end
   local word
   local visual = vim.fn.mode() == "v"
 


### PR DESCRIPTION
For live_grep and grep_string pickers.

Still semi-regularly see comments on old issues about missing rg as a dependency for live_grep https://github.com/nvim-telescope/telescope.nvim/issues/506.

I think adding a warning for these pickers when ripgrep (or some alternative referenced in a non-default `vimgrep_arguments`) is not found will probably save quite a few people some headache.

@Conni2461 maybe we can back port?

PS: redo of #2623