### PR TITLE
fix: handle windows file paths as uris

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -174,8 +174,11 @@ utils.is_path_hidden = function(opts, path_display)
 end
 
 local URI_SCHEME_PATTERN = "^([a-zA-Z]+[a-zA-Z0-9.+-]*):.*"
+local FILE_PATH_PATTERN = "^[a-zA-Z]:\\"
 utils.is_uri = function(filename)
-  return filename:match(URI_SCHEME_PATTERN) ~= nil
+  local is_uri_match = filename:match(URI_SCHEME_PATTERN) ~= nil
+  local is_file_path_match = filename:match(FILE_PATH_PATTERN)
+  return is_uri_match and not is_file_path_match
 end
 
 local calc_result_length = function(truncate_len)


### PR DESCRIPTION
# Description

Accurate detection of both URIs and Windows file paths.

Fixes #2604

## Type of change

- Bug fix (non-breaking change which fixes an issue)
 
# How Has This Been Tested?

```
local URI_SCHEME_PATTERN = "^([a-zA-Z]+[a-zA-Z0-9.+-]*):.*"
local FILE_PATH_PATTERN = "^[a-zA-Z]:\\"
is_uri = function(filename)
  local is_uri_match = filename:match(URI_SCHEME_PATTERN) ~= nil
  local is_file_path_match = filename:match(FILE_PATH_PATTERN)
  return is_uri_match and not is_file_path_match
  --return filename:match("^%w+://") ~= nil -- before #2604
end

uris = {
  [[https://www.example.com/index.html]],
  [[ftp://ftp.example.com/files/document.pdf]],
  [[mailto:user@example.com]],
  [[tel:+1234567890]],
  [[file:///home/user/documents/report.docx]],
  [[news:comp.lang.python]],
  [[ldap://ldap.example.com:389/dc=example]],dc=com,
  [[git://github.com/user/repo.git]],
  [[steam://run/123456]],
  [[magnet:?xt=urn:btih:6B4C3343E1C63A1BC36AEB8A3D1F52C4EDEEB096]]
}

paths = {
  -- windows
  [[C:\Users\Usuario\Documents\archivo.txt]],
  [[D:\Projects\project_folder\source_code.py]],
  [[E:\Music\song.mp3]],
  -- macos
  [[/Users/Usuario/Documents/archivo.txt]],
  [[/Applications/App.app/Contents/MacOS/app_executable]],
  [[/Volumes/ExternalDrive/Data/file.xlsx]],
  -- linux
  [[/home/usuario/documents/archivo.txt]],
  [[/var/www/html/index.html]],
  [[/mnt/backup/backup_file.tar.gz]]
}

print('--- uris ---')
for _, uri in pairs(uris) do print(is_uri(uri)) end
print('--- paths ---')
for _, path in pairs(paths) do print(is_uri(path)) end
```

**Configuration**:
* Neovim version (nvim --version): 0.9.1
* Operating system and version: Windows 10

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
