### PR TITLE
perf(utils): linear scan `is_uri`

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -173,12 +173,32 @@ utils.is_path_hidden = function(opts, path_display)
     or type(path_display) == "table" and (vim.tbl_contains(path_display, "hidden") or path_display.hidden)
 end
 
-local URI_SCHEME_PATTERN = "^([a-zA-Z]+[a-zA-Z0-9.+-]*):.*"
-local WINDOWS_ROOT_PATTERN = "^[a-zA-Z]:\\"
 utils.is_uri = function(filename)
-  local is_uri_match = filename:match(URI_SCHEME_PATTERN) ~= nil
-  local is_windows_root_match = filename:match(WINDOWS_ROOT_PATTERN)
-  return is_uri_match and not is_windows_root_match
+  local char = string.byte(filename, 1)
+
+  -- is alpha?
+  if char < 65 or (char > 90 and char < 97) or char > 122 then
+    return false
+  end
+
+  for i = 2, #filename do
+    char = string.byte(filename, i)
+    if char == 58 then -- `:`
+      return i < #filename and string.byte(filename, i + 1) ~= 92 -- `\`
+    elseif
+      not (
+        (char >= 48 and char <= 57) -- 0-9
+        or (char >= 65 and char <= 90) -- A-Z
+        or (char >= 97 and char <= 122) -- a-z
+        or char == 43 -- `+`
+        or char == 46 -- `.`
+        or char == 45 -- `-`
+      )
+    then
+      return false
+    end
+  end
+  return false
 end
 
 local calc_result_length = function(truncate_len)

--- a/lua/tests/automated/utils_spec.lua
+++ b/lua/tests/automated/utils_spec.lua
@@ -1,7 +1,7 @@
 local utils = require "telescope.utils"
 
 describe("is_uri", function()
-  it("detects valid uris", function()
+  describe("detects valid uris", function()
     local uris = {
       [[https://www.example.com/index.html]],
       [[ftp://ftp.example.com/files/document.pdf]],
@@ -16,40 +16,64 @@ describe("is_uri", function()
     }
 
     for _, uri in ipairs(uris) do
-      assert.True(utils.is_uri(uri))
+      it(uri, function()
+        assert.True(utils.is_uri(uri))
+      end)
     end
   end)
 
-  it("handles windows paths", function()
+  describe("detects invalid uris/paths", function()
+    local inputs = {
+      "hello",
+      "hello:",
+      "123",
+    }
+    for _, input in ipairs(inputs) do
+      it(input, function()
+        assert.False(utils.is_uri(input))
+      end)
+    end
+  end)
+
+  describe("handles windows paths", function()
     local paths = {
       [[C:\Users\Usuario\Documents\archivo.txt]],
       [[D:\Projects\project_folder\source_code.py]],
       [[E:\Music\song.mp3]],
     }
-    for _, path in ipairs(paths) do
-      assert.False(utils.is_uri(path))
+
+    for _, uri in ipairs(paths) do
+      it(uri, function()
+        assert.False(utils.is_uri(uri))
+      end)
     end
   end)
 
-  it("handles linux paths", function()
+  describe("handles linux paths", function()
     local paths = {
       [[/home/usuario/documents/archivo.txt]],
       [[/var/www/html/index.html]],
       [[/mnt/backup/backup_file.tar.gz]],
     }
+
     for _, path in ipairs(paths) do
-      assert.False(utils.is_uri(path))
+      it(path, function()
+        assert.False(utils.is_uri(path))
+      end)
     end
   end)
 
-  it("handles macos paths", function()
+  describe("handles macos paths", function()
     local paths = {
       [[/Users/Usuario/Documents/archivo.txt]],
       [[/Applications/App.app/Contents/MacOS/app_executable]],
       [[/Volumes/ExternalDrive/Data/file.xlsx]],
     }
+
     for _, path in ipairs(paths) do
-      assert.False(utils.is_uri(path))
+      it(path, function()
+        assert.False(utils.is_uri(path))
+      end)
     end
   end)
 end)


### PR DESCRIPTION
Benchmarked against 80k+ unique paths, both Windows and Linux (macos should be close enough to llinux).

Approximately 13% faster for linux paths and 55% faster for windows paths.

```
hyperfine 'luajit current_linux.lua' 'luajit fast_linux.lua' --warmup 10
Benchmark 1: luajit current_linux.lua
  Time (mean ± σ):      25.7 ms ±   0.8 ms    [User: 22.7 ms, System: 3.4 ms]
  Range (min … max):    24.0 ms …  28.8 ms    87 runs

Benchmark 2: luajit fast_linux.lua
  Time (mean ± σ):      22.7 ms ±   0.8 ms    [User: 19.4 ms, System: 3.6 ms]
  Range (min … max):    21.4 ms …  26.0 ms    99 runs

Summary
  luajit fast_linux.lua ran
    1.13 ± 0.05 times faster than luajit current_linux.lua

hyperfine 'luajit current_win.lua' 'luajit fast_win.lua' --warmup 10
Benchmark 1: luajit current_win.lua
  Time (mean ± σ):      36.3 ms ±   0.9 ms    [User: 34.1 ms, System: 2.7 ms]
  Range (min … max):    34.7 ms …  38.9 ms    69 runs

Benchmark 2: luajit fast_win.lua
  Time (mean ± σ):      23.5 ms ±   0.7 ms    [User: 21.1 ms, System: 2.9 ms]
  Range (min … max):    22.4 ms …  25.7 ms    95 runs

Summary
  luajit fast_win.lua ran
    1.55 ± 0.06 times faster than luajit current_win.lua
```