### PR TITLE
WIP fix escapeing windows special chars

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -197,6 +197,9 @@ action_set.edit = function(prompt_bufnr, command)
     -- prevents restarting lsp server
     if vim.api.nvim_buf_get_name(0) ~= filename or command ~= "edit" then
       filename = Path:new(filename):normalize(vim.loop.cwd())
+      if utils.is_windows then
+        filename = utils.escape_windows_special_chars(filename)
+      end
       pcall(vim.cmd, string.format("%s %s", command, vim.fn.fnameescape(filename)))
     end
   end

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -489,6 +489,9 @@ previewers.cat = defaulter(function(opts)
     end,
 
     get_buffer_by_name = function(_, entry)
+      if utils.is_windows then
+        entry.path = utils.escape_windows_special_chars(entry.path)
+      end
       return from_entry.path(entry, false)
     end,
 
@@ -552,6 +555,9 @@ previewers.vimgrep = defaulter(function(opts)
     end,
 
     get_buffer_by_name = function(_, entry)
+      if utils.is_windows then
+        entry.path = utils.escape_windows_special_chars(entry.path)
+      end
       return from_entry.path(entry, false)
     end,
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -13,6 +13,8 @@ local log = require "telescope.log"
 local truncate = require("plenary.strings").truncate
 local get_status = require("telescope.state").get_status
 
+local is_windows = vim.fn.has "win32" == 1 or vim.fn.has "win32unix" == 1
+
 local utils = {}
 
 utils.get_separator = function()
@@ -29,6 +31,14 @@ utils.get_lazy_default = function(x, defaulter, ...)
   else
     return x
   end
+end
+
+utils.is_windows = function()
+  return is_windows
+end
+
+utils.escape_windows_special_chars = function(string)
+  return string:gsub("%(", "\\("):gsub("%)", "\\)")
 end
 
 utils.repeated_table = function(n, val)
@@ -186,6 +196,7 @@ local calc_result_length = function(truncate_len)
   local len = vim.api.nvim_win_get_width(status.results_win) - status.picker.selection_caret:len() - 2
   return type(truncate_len) == "number" and len - truncate_len or len
 end
+
 
 --- Transform path is a util function that formats a path based on path_display
 --- found in `opts` or the default value from config.


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

Fixes #2446 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Tested on windows by navigating Telescope pickers and opening files to ensure special characters were escaped.

**Configuration**:
* Neovim version (nvim --version): 0.9.1
* Operating system and version: Windows 11

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
