### PR TITLE
feat: check if cmd extension can be loaded

### DIFF
--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -194,6 +194,12 @@ local function run_command(args)
     return
   end
 
+  local ok = pcall(require("telescope").load_extension, cmd)
+  if ok then
+    extensions[cmd][cmd](opts)
+    return
+  end
+
   utils.notify("run_command", {
     msg = "Unknown command",
     level = "ERROR",


### PR DESCRIPTION
# Description

As a last resort if no other cmd is found in `run_cmd`, check if the command can be loaded as an extension.

I know pcall is a bit hacky, but not needing to load every extension on startup is nice.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

Install extension `telescope-frecency`, but don't load it with `load_extension`. Then, run `:Telescope frecency`. Before this change, this would error. Now, the command runs as expected.