### PR TITLE
feat(jobs): emit job errors

### DIFF
--- a/lua/telescope/finders/async_job_finder.lua
+++ b/lua/telescope/finders/async_job_finder.lua
@@ -1,5 +1,6 @@
 local async_job = require "telescope._"
 local LinesPipe = require("telescope._").LinesPipe
+local ErrorPipe = require("telescope._").ErrorPipe
 
 local make_entry = require "telescope.make_entry"
 local log = require "telescope.log"
@@ -46,6 +47,7 @@ return function(opts)
     end
 
     local stdout = LinesPipe()
+    local stderr = ErrorPipe()
 
     job = async_job.spawn {
       command = job_opts.command,
@@ -55,7 +57,10 @@ return function(opts)
       writer = writer,
 
       stdout = stdout,
+      stderr = stderr,
     }
+
+    stderr:start()
 
     local line_num = 0
     for line in stdout:iter(true) do


### PR DESCRIPTION
@Conni2461 thoughts on doing something like this (and possible for oneshot_job as well)?

I feel like 50% of to notification I get for telescope these days is people having issues with live_grep not working. Sometimes it's just a matter of checking they have it installed but other times it's almost possibly to tell what the issue is.