### PR TITLE
fix: use nil for the default diagnostics severity

### DIFF
--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -87,7 +87,7 @@ local diagnostics_to_tbl = function(opts)
       diagnosis_opts.severity["max"] = opts.severity_bound
     end
   end
-  if vim.version() > vim.version.parse "0.9.1" and vim.tbl_isempty(diagnosis_opts.severity) then
+  if vim.version().minor > 9 and vim.tbl_isempty(diagnosis_opts.severity) then
     diagnosis_opts.severity = nil
   end
 

--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -69,7 +69,7 @@ local diagnostics_to_tbl = function(opts)
   opts.severity_limit = convert_diagnostic_type(severities, opts.severity_limit)
   opts.severity_bound = convert_diagnostic_type(severities, opts.severity_bound)
 
-  local diagnosis_opts = { severity = {}, namespace = opts.namespace }
+  local diagnosis_opts = { severity = nil, namespace = opts.namespace }
   if opts.severity ~= nil then
     if opts.severity_limit ~= nil or opts.severity_bound ~= nil then
       utils.notify("builtin.diagnostics", {

--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -69,7 +69,7 @@ local diagnostics_to_tbl = function(opts)
   opts.severity_limit = convert_diagnostic_type(severities, opts.severity_limit)
   opts.severity_bound = convert_diagnostic_type(severities, opts.severity_bound)
 
-  local diagnosis_opts = { severity = nil, namespace = opts.namespace }
+  local diagnosis_opts = { severity = {}, namespace = opts.namespace }
   if opts.severity ~= nil then
     if opts.severity_limit ~= nil or opts.severity_bound ~= nil then
       utils.notify("builtin.diagnostics", {
@@ -86,6 +86,9 @@ local diagnostics_to_tbl = function(opts)
     if opts.severity_bound ~= nil then
       diagnosis_opts.severity["max"] = opts.severity_bound
     end
+  end
+  if vim.version() > vim.version.parse "0.9.1" and vim.tbl_isempty(diagnosis_opts.severity) then
+    diagnosis_opts.severity = nil
   end
 
   opts.root_dir = opts.root_dir == true and vim.loop.cwd() or opts.root_dir


### PR DESCRIPTION


# Description

https://github.com/neovim/neovim/pull/24736 has introduced a new syntax for severity format in `vim.diagnostic.get()`.

Fix #2661

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] `:Telescope diagnostics` at a file with diagnostic warnings.

**Configuration**:
* Neovim version (nvim --version):
   - Neovim HEAD
      ```
      NVIM v0.10.0-dev-3455+g18062f70d-Homebrew
      Build type: Release
      LuaJIT 2.1.0-beta3
      ```
* Operating system and version: macOS Ventura 13.4.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
