### PR TITLE
fix: escape characters in make_entry

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -149,7 +149,7 @@ do
   function make_entry.gen_from_file(opts)
     opts = opts or {}
 
-    local cwd = vim.fn.expand(opts.cwd or vim.loop.cwd())
+    local cwd = vim.fn.expand(vim.fn.escape(opts.cwd or vim.loop.cwd(), "$?*[]"))
 
     local disable_devicons = opts.disable_devicons
 


### PR DESCRIPTION
# Description

- this applies the same fix in #2345 to make_entry

Fixes #2675

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
This was tested on the reproduction case provided in #2675 

1. `mkdir '[will-fail]'`
2. `cd '[will-fail]'`
3.  `nvim` inside of the directory
4. `lua require('telescope.builtin').find_files()`
5. `make_entry.gen_from_file` no longer fails

**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.0-dev-856+ge928161bd
* Operating system and version: WSL Fedora 38

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
