### PR TITLE
fix(files.current_buffer_fuzzy_find): fix nil indexing on enter if no…

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -538,6 +538,10 @@ files.current_buffer_fuzzy_find = function(opts)
         action_set.select:enhance {
           post = function()
             local selection = action_state.get_selected_entry()
+            if not selection then
+              return
+            end
+
             vim.api.nvim_win_set_cursor(0, { selection.lnum, 0 })
           end,
         }


### PR DESCRIPTION
…thing is selected

# Description

If you hit enter when there is nothing selected it does a nil indexing. This fixes that.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing. With local plugins in Packer.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
