### PR TITLE
Redraw results win after process_complete

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -493,12 +493,6 @@ function Picker:find()
           log.warn("Finder failed with msg: ", msg)
         end
 
-        await_schedule()
-        if not vim.api.nvim_win_is_valid(self.results_win) then
-          return
-        end
-        vim.api.nvim_win_call(self.results_win, vim.cmd.redraw)
-
         local diff_time = (vim.loop.hrtime() - start_time) / 1e6
         if self.debounce and diff_time < self.debounce then
           async.util.sleep(self.debounce - diff_time)
@@ -518,14 +512,6 @@ function Picker:find()
 
         status_updater { completed = false }
         self._on_lines(...)
-
-        vim.schedule(function()
-          if not vim.api.nvim_win_is_valid(self.results_win) then
-            return
-          end
-          vim.api.nvim_win_call(self.results_win, vim.cmd.redraw)
-        end)
-        self:move_selection(self.sorting_strategy == "ascending" and 1 or -1)
       end
     end,
 
@@ -1351,6 +1337,8 @@ function Picker:get_result_completor(results_bufnr, find_id, prompt, status_upda
       local visible_result_rows = vim.api.nvim_win_get_height(self.results_win)
       vim.api.nvim_win_set_cursor(self.results_win, { self.max_results - visible_result_rows, 1 })
       vim.api.nvim_win_set_cursor(self.results_win, { self.max_results, 1 })
+    else
+      vim.api.nvim_win_set_cursor(self.results_win, { self:get_selection_row(), 0 })
     end
     self:_on_complete()
   end)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -521,12 +521,10 @@ function Picker:find()
         status_updater { completed = false }
         self._on_lines(...)
 
-        if self.sorting_strategy then
-          if self.sorting_strategy == "ascending" then
-            self:move_selection(1)
-          else
-            self:move_selection(-1)
-          end
+        if self.sorting_strategy == "ascending" then
+          self:move_selection(1)
+        else
+          self:move_selection(-1)
         end
       end
     end,

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -525,6 +525,7 @@ function Picker:find()
           end
           vim.api.nvim_win_call(self.results_win, vim.cmd.redraw)
         end)
+        self:move_selection(self.sorting_strategy == "ascending" and 1 or -1)
       end
     end,
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -499,7 +499,7 @@ function Picker:find()
             return
           end
           vim.api.nvim_win_call(self.results_win, function()
-            vim.cmd "redraw!"
+            vim.cmd "redraw"
           end)
         end)
 
@@ -523,11 +523,9 @@ function Picker:find()
         status_updater { completed = false }
         self._on_lines(...)
 
-        if self.sorting_strategy == "ascending" then
-          self:move_selection(1)
-        else
-          self:move_selection(-1)
-        end
+        vim.api.nvim_win_call(self.results_win, function()
+          vim.cmd "redraw"
+        end)
       end
     end,
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -523,9 +523,7 @@ function Picker:find()
         status_updater { completed = false }
         self._on_lines(...)
 
-        vim.api.nvim_win_call(self.results_win, function()
-          vim.cmd "redraw"
-        end)
+        self:move_selection(self.sorting_strategy == "ascending" and 1 or -1)
       end
     end,
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -498,7 +498,9 @@ function Picker:find()
           if not vim.api.nvim_win_is_valid(self.results_win) then
             return
           end
-          vim.api.nvim_win_set_cursor(self.results_win, vim.api.nvim_win_get_cursor(self.results_win))
+          vim.api.nvim_win_call(self.results_win, function()
+            vim.cmd "redraw!"
+          end)
         end)
 
         local diff_time = (vim.loop.hrtime() - start_time) / 1e6

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1333,12 +1333,10 @@ function Picker:get_result_completor(results_bufnr, find_id, prompt, status_upda
     self:clear_extra_rows(results_bufnr)
     self.sorter:_finish(prompt)
 
-    if self.wrap_results and self.sorting_strategy == "descending" then
+    if self.sorting_strategy == "descending" then
       local visible_result_rows = vim.api.nvim_win_get_height(self.results_win)
       vim.api.nvim_win_set_cursor(self.results_win, { self.max_results - visible_result_rows, 1 })
       vim.api.nvim_win_set_cursor(self.results_win, { self.max_results, 1 })
-    else
-      vim.api.nvim_win_set_cursor(self.results_win, { self:get_selection_row(), 0 })
     end
     self:_on_complete()
   end)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -493,6 +493,14 @@ function Picker:find()
           log.warn("Finder failed with msg: ", msg)
         end
 
+        -- add an nvim_win_set_cursor to force the results win be redrawn
+        vim.schedule(function()
+          if not vim.api.nvim_win_is_valid(self.results_win) then
+            return
+          end
+          vim.api.nvim_win_set_cursor(self.results_win, vim.api.nvim_win_get_cursor(self.results_win))
+        end)
+
         local diff_time = (vim.loop.hrtime() - start_time) / 1e6
         if self.debounce and diff_time < self.debounce then
           async.util.sleep(self.debounce - diff_time)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -493,15 +493,11 @@ function Picker:find()
           log.warn("Finder failed with msg: ", msg)
         end
 
-        -- add an nvim_win_set_cursor to force the results win be redrawn
-        vim.schedule(function()
-          if not vim.api.nvim_win_is_valid(self.results_win) then
-            return
-          end
-          vim.api.nvim_win_call(self.results_win, function()
-            vim.cmd "redraw"
-          end)
-        end)
+        await_schedule()
+        if not vim.api.nvim_win_is_valid(self.results_win) then
+          return
+        end
+        vim.api.nvim_win_call(self.results_win, vim.cmd.redraw)
 
         local diff_time = (vim.loop.hrtime() - start_time) / 1e6
         if self.debounce and diff_time < self.debounce then
@@ -523,7 +519,12 @@ function Picker:find()
         status_updater { completed = false }
         self._on_lines(...)
 
-        self:move_selection(self.sorting_strategy == "ascending" and 1 or -1)
+        vim.schedule(function()
+          if not vim.api.nvim_win_is_valid(self.results_win) then
+            return
+          end
+          vim.api.nvim_win_call(self.results_win, vim.cmd.redraw)
+        end)
       end
     end,
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -520,6 +520,14 @@ function Picker:find()
 
         status_updater { completed = false }
         self._on_lines(...)
+
+        if self.sorting_strategy then
+          if self.sorting_strategy == "ascending" then
+            self:move_selection(1)
+          else
+            self:move_selection(-1)
+          end
+        end
       end
     end,
 


### PR DESCRIPTION
# Description

Fix #2667.
After process_complete, call `nvim_win_set_cursor` to redraw results win.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

