### PR TITLE
fix(builtin.pickers): fix wrong picker resuming when using filtering

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1158,12 +1158,25 @@ end
 --- This action is not mapped by default and only intended for |builtin.pickers|.
 ---@param prompt_bufnr number: The prompt bufnr
 actions.remove_selected_picker = function(prompt_bufnr)
-  local current_picker = action_state.get_current_picker(prompt_bufnr)
-  local selection_index = current_picker:get_index(current_picker:get_selection_row())
+  local curr_picker = action_state.get_current_picker(prompt_bufnr)
+  local curr_entry = action_state.get_selected_entry()
   local cached_pickers = state.get_global_key "cached_pickers"
-  current_picker:delete_selection(function()
+
+  if not curr_entry then
+    return
+  end
+
+  local selection_index, _ = utils.list_find(function(v)
+    if curr_entry.value == v.value then
+      return true
+    end
+    return false
+  end, curr_picker.finder.results)
+
+  curr_picker:delete_selection(function()
     table.remove(cached_pickers, selection_index)
   end)
+
   if #cached_pickers == 0 then
     actions.close(prompt_bufnr)
   end

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -194,9 +194,21 @@ internal.pickers = function(opts)
       cache_picker = false,
       attach_mappings = function(_, map)
         actions.select_default:replace(function(prompt_bufnr)
-          local current_picker = action_state.get_current_picker(prompt_bufnr)
-          local selection_index = current_picker:get_index(current_picker:get_selection_row())
+          local curr_picker = action_state.get_current_picker(prompt_bufnr)
+          local curr_entry = action_state.get_selected_entry()
+          if not curr_entry then
+            return
+          end
+
           actions.close(prompt_bufnr)
+
+          local selection_index, _ = utils.list_find(function(v)
+            if curr_entry.value == v.value then
+              return true
+            end
+            return false
+          end, curr_picker.finder.results)
+
           opts.cache_picker = opts._cache_picker
           opts["cache_index"] = selection_index
           opts["initial_mode"] = cached_pickers[selection_index].initial_mode

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -559,4 +559,12 @@ utils.__git_command = function(args, opts)
   return vim.list_extend(_args, args)
 end
 
+utils.list_find = function(func, list)
+  for i, v in ipairs(list) do
+    if func(v, i, list) then
+      return i, v
+    end
+  end
+end
+
 return utils


### PR DESCRIPTION
# Description

When filtering builtin.pickers doesn't resume the correct picker or delete it.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran require('telescope.builtin').live_grep 10 times with different queries. Then search for specific entries and hit enter and verified that there resumed picker has the distinct text that I had selected. I also removed some of them from the beginning, middle and end. 

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code