### PR TITLE
fix(telescope.state.get_existing_prompts): it should only return keys that are numbers

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1227,7 +1227,7 @@ end
 
 --- Close all open Telescope pickers
 function Picker:close_existing_pickers()
-  for _, prompt_bufnr in ipairs(state.get_existing_prompts()) do
+  for _, prompt_bufnr in ipairs(state.get_existing_prompt_bufnrs()) do
     pcall(actions.close, prompt_bufnr)
   end
 end

--- a/lua/telescope/state.lua
+++ b/lua/telescope/state.lua
@@ -25,7 +25,9 @@ function state.clear_status(prompt_bufnr)
 end
 
 function state.get_existing_prompts()
-  return vim.tbl_keys(TelescopeGlobalState)
+  return vim.tbl_filter(function(key)
+    return type(key) == "number"
+  end, TelescopeGlobalState)
 end
 
 return state

--- a/lua/telescope/state.lua
+++ b/lua/telescope/state.lua
@@ -24,10 +24,16 @@ function state.clear_status(prompt_bufnr)
   state.set_status(prompt_bufnr, nil)
 end
 
-function state.get_existing_prompts()
-  return vim.tbl_filter(function(key)
-    return type(key) == "number"
-  end, vim.tbl_keys(TelescopeGlobalState))
+function state.get_existing_prompt_bufnrs()
+  local prompt_bufnrs = {}
+
+  for key, _ in pairs(TelescopeGlobalState) do
+    if type(key) == "number" then
+      table.insert(prompt_bufnrs, key)
+    end
+  end
+
+  return prompt_bufnrs
 end
 
 return state

--- a/lua/telescope/state.lua
+++ b/lua/telescope/state.lua
@@ -27,7 +27,7 @@ end
 function state.get_existing_prompts()
   return vim.tbl_filter(function(key)
     return type(key) == "number"
-  end, TelescopeGlobalState)
+  end, vim.tbl_keys(TelescopeGlobalState))
 end
 
 return state


### PR DESCRIPTION
# Description

telescope.state.get_existing_prompts currently returns all the keys from TelescopeGlobalState, this includes the 'global' key. This function is only used in Picker:close_existing_pickers where we iterate through the  prompt_bufnr and call actions.close on each prompt_bufnr so it should only return keys that are numbers

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run
:lua =require('telescope.state').get_existing_prompts()
When there are no pickers opened. It should return and empty table. With a picker present it should return the bufnr for that picker's prompt.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code