### PR TITLE
feat(scrolling and mouse support): support scrolling and selecting with the mouse

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1460,9 +1460,9 @@ actions.mouse_scroll_up = function(prompt_bufnr)
 
   local mouse_win = vim.fn.getmousepos().winid
   if picker.results_win == mouse_win then
-    vim.defer_fn(function()
+    vim.schedule(function()
       actions.move_selection_next(prompt_bufnr)
-    end, 0)
+    end)
     return ""
   else
     return "<ScrollWheelDown>"
@@ -1474,9 +1474,9 @@ actions.mouse_scroll_down = function(prompt_bufnr)
 
   local mouse_win = vim.fn.getmousepos().winid
   if mouse_win == picker.results_win then
-    vim.defer_fn(function()
+    vim.schedule(function()
       actions.move_selection_previous(prompt_bufnr)
-    end, 0)
+    end)
     return ""
   else
     return "<ScrollWheelUp>"
@@ -1510,13 +1510,13 @@ actions.mouse_click = function(prompt_bufnr)
 
   local pos = vim.fn.getmousepos()
   if pos.winid == picker.results_win then
-    vim.defer_fn(function()
-      picker:set_selection(picker:get_row(picker.max_results - pos.line + 1))
-    end, 0)
+    vim.schedule(function()
+      picker:set_selection(pos.line - 1)
+    end)
   elseif pos.winid == picker.preview_win then
-    vim.defer_fn(function()
+    vim.schedule(function()
       actions.select_default(prompt_bufnr)
-    end, 0)
+    end)
   end
   return ""
 end
@@ -1526,10 +1526,10 @@ actions.double_mouse_click = function(prompt_bufnr)
 
   local pos = vim.fn.getmousepos()
   if pos.winid == picker.results_win then
-    vim.defer_fn(function()
-      picker:set_selection(picker:get_row(picker.max_results - pos.line + 1))
+    vim.schedule(function()
+      picker:set_selection(pos.line - 1)
       actions.select_default(prompt_bufnr)
-    end, 0)
+    end)
   end
   return ""
 end

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1455,6 +1455,85 @@ end
 
 actions.nop = function(_) end
 
+actions.mouse_scroll_up = function(prompt_bufnr)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+
+  local mouse_win = vim.fn.getmousepos().winid
+  if picker.results_win == mouse_win then
+    vim.defer_fn(function()
+      actions.move_selection_next(prompt_bufnr)
+    end, 0)
+    return ""
+  else
+    return "<ScrollWheelDown>"
+  end
+end
+
+actions.mouse_scroll_down = function(prompt_bufnr)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+
+  local mouse_win = vim.fn.getmousepos().winid
+  if mouse_win == picker.results_win then
+    vim.defer_fn(function()
+      actions.move_selection_previous(prompt_bufnr)
+    end, 0)
+    return ""
+  else
+    return "<ScrollWheelUp>"
+  end
+end
+
+actions.mouse_scroll_right = function(prompt_bufnr)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+
+  local mouse_win = vim.fn.getmousepos().winid
+  if mouse_win == picker.results_win then
+    return ""
+  else
+    return "<ScrollWheelLeft>"
+  end
+end
+
+actions.mouse_scroll_left = function(prompt_bufnr)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+
+  local mouse_win = vim.fn.getmousepos().winid
+  if mouse_win == picker.results_win then
+    return ""
+  else
+    return "<ScrollWheelRight>"
+  end
+end
+
+actions.mouse_click = function(prompt_bufnr)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+
+  local pos = vim.fn.getmousepos()
+  if pos.winid == picker.results_win then
+    vim.defer_fn(function()
+      picker:set_selection(picker:get_row(picker.max_results - pos.line + 1))
+    end, 0)
+  elseif pos.winid == picker.preview_win then
+    vim.defer_fn(function()
+      actions.select_default(prompt_bufnr)
+    end, 0)
+  end
+  return ""
+end
+
+actions.double_mouse_click = function(prompt_bufnr)
+  local picker = action_state.get_current_picker(prompt_bufnr)
+
+  local pos = vim.fn.getmousepos()
+  if pos.winid == picker.results_win then
+    vim.defer_fn(function()
+      picker:set_selection(picker:get_row(picker.max_results - pos.line + 1))
+      actions.select_default(prompt_bufnr)
+    end, 0)
+  end
+  return ""
+end
+
 -- ==================================================
 -- Transforms modules and sets the correct metatables.
 -- ==================================================

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -133,6 +133,37 @@ local mappings = {}
 mappings.default_mappings = config.values.default_mappings
   or {
     i = {
+      ["<ScrollWheelDown>"] = {
+        actions.mouse_scroll_up,
+        type = "action",
+        opts = { expr = true },
+      },
+      ["<ScrollWheelUp>"] = {
+        actions.mouse_scroll_down,
+        type = "action",
+        opts = { expr = true },
+      },
+      ["<ScrollWheelLeft>"] = {
+        actions.mouse_scroll_right,
+        type = "action",
+        opts = { expr = true },
+      },
+      ["<ScrollWheelRight>"] = {
+        actions.mouse_scroll_left,
+        type = "action",
+        opts = { expr = true },
+      },
+      ["<LeftMouse>"] = {
+        actions.mouse_click,
+        type = "action",
+        opts = { expr = true },
+      },
+      ["<2-LeftMouse>"] = {
+        actions.double_mouse_click,
+        type = "action",
+        opts = { expr = true },
+      },
+
       ["<C-n>"] = actions.move_selection_next,
       ["<C-p>"] = actions.move_selection_previous,
 
@@ -168,8 +199,38 @@ mappings.default_mappings = config.values.default_mappings
       -- disable c-j because we dont want to allow new lines #2123
       ["<C-j>"] = actions.nop,
     },
-
     n = {
+      ["<ScrollWheelDown>"] = {
+        actions.mouse_scroll_up,
+        type = "action",
+        opts = { expr = true },
+      },
+      ["<ScrollWheelUp>"] = {
+        actions.mouse_scroll_down,
+        type = "action",
+        opts = { expr = true },
+      },
+      ["<ScrollWheelLeft>"] = {
+        actions.mouse_scroll_right,
+        type = "action",
+        opts = { expr = true },
+      },
+      ["<ScrollWheelRight>"] = {
+        actions.mouse_scroll_left,
+        type = "action",
+        opts = { expr = true },
+      },
+      ["<LeftMouse>"] = {
+        actions.mouse_click,
+        type = "action",
+        opts = { expr = true },
+      },
+      ["<2-LeftMouse>"] = {
+        actions.double_mouse_click,
+        type = "action",
+        opts = { expr = true },
+      },
+
       ["<esc>"] = actions.close,
       ["<CR>"] = actions.select_default,
       ["<C-x>"] = actions.select_horizontal,

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -73,6 +73,7 @@ local function default_create_layout(picker)
       local popup_opts = picker:get_window_options(vim.o.columns, line_count)
 
       -- `popup.nvim` massaging so people don't have to remember minheight shenanigans
+      popup_opts.results.focusable = true
       popup_opts.results.minheight = popup_opts.results.height
       popup_opts.results.highlight = "TelescopeResultsNormal"
       popup_opts.results.borderhighlight = "TelescopeResultsBorder"
@@ -81,7 +82,9 @@ local function default_create_layout(picker)
       popup_opts.prompt.highlight = "TelescopePromptNormal"
       popup_opts.prompt.borderhighlight = "TelescopePromptBorder"
       popup_opts.prompt.titlehighlight = "TelescopePromptTitle"
+
       if popup_opts.preview then
+        popup_opts.preview.focusable = true
         popup_opts.preview.minheight = popup_opts.preview.height
         popup_opts.preview.highlight = "TelescopePreviewNormal"
         popup_opts.preview.borderhighlight = "TelescopePreviewBorder"
@@ -163,6 +166,7 @@ local function default_create_layout(picker)
           popup.move(results_win, popup_opts.results)
           popup.move(preview_win, popup_opts.preview)
         else
+          popup_opts.preview.focusable = true
           popup_opts.preview.highlight = "TelescopePreviewNormal"
           popup_opts.preview.borderhighlight = "TelescopePreviewBorder"
           popup_opts.preview.titlehighlight = "TelescopePreviewTitle"
@@ -521,6 +525,9 @@ end
 function Picker:find()
   self:close_existing_pickers()
   self:reset_selection()
+
+  self.__original_mousemoveevent = vim.o.mousemoveevent
+  vim.o.mousemoveevent = true
 
   self.original_win_id = a.nvim_get_current_win()
 
@@ -1581,6 +1588,8 @@ function pickers.on_close_prompt(prompt_bufnr)
     buffer = prompt_bufnr,
   }
   picker.close_windows(status)
+
+  vim.o.mousemoveevent = picker.__original_mousemoveevent
 end
 
 function pickers.on_resize_window(prompt_bufnr)


### PR DESCRIPTION
# Description

Make it possible to scroll the results and preview window and add general mouse support.
It adds the following:
- scroll the results and preview window
- select items on click in the results window
- clicking on the preview window opens the specific buffer
- double clicking on a result opens the specific result

It resolves issue https://github.com/nvim-telescope/telescope.nvim/issues/2680

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

This is a preliminary version. It needs to be refactored and improved

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
