### PR TITLE
fix(internal.resume): dynamic_preview_title was not respected and title became static

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -161,6 +161,7 @@ internal.resume = function(opts)
     picker.hidden_previewer = nil
     opts.previewer = vim.F.if_nil(opts.previewer, false)
   end
+  opts.resumed_picker = true
   pickers.new(opts, picker):find()
 end
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -148,7 +148,7 @@ function Picker:new(opts)
       obj.all_previewers = { obj.all_previewers }
     end
     obj.previewer = obj.all_previewers[obj.current_previewer_index]
-    if obj.preview_title == nil or #obj.all_previewers > 1 then
+    if obj.preview_title == nil or #obj.all_previewers > 1 or opts.resumed_picker and opts.fix_preview_title ~= true then
       obj.preview_title = obj.previewer:title(nil, config.values.dynamic_preview_title)
     else
       obj.fix_preview_title = true

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -148,7 +148,11 @@ function Picker:new(opts)
       obj.all_previewers = { obj.all_previewers }
     end
     obj.previewer = obj.all_previewers[obj.current_previewer_index]
-    if obj.preview_title == nil or #obj.all_previewers > 1 or opts.resumed_picker and opts.fix_preview_title ~= true then
+    if
+      obj.preview_title == nil
+      or #obj.all_previewers > 1
+      or opts.resumed_picker and opts.fix_preview_title ~= true
+    then
       obj.preview_title = obj.previewer:title(nil, config.values.dynamic_preview_title)
     else
       obj.fix_preview_title = true


### PR DESCRIPTION
In Picker:new there was
```lua
    if obj.preview_title == nil or #obj.all_previewers > 1 then
      obj.preview_title = obj.previewer:title(nil, config.values.dynamic_preview_title)
    else
      obj.fix_preview_title = true
    end
```
so if a preview_title was not provided at creation it became static forever. This is a problem when you resume a picker as internal.resume calls Picker:new again and the same preview_title is populated during runtime by the dynamic_preview_title. So now that field is not nil and will become static forever.

To fix it add an additional check. If the picker is resumed and fix_preview_title is not already set by the first creation do not set it now.

This fixes https://github.com/nvim-telescope/telescope.nvim/issues/2689

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing. Set   dynamic_preview_title = true in defaults when you setup Telescope and then open the find_files picker close it and resume.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code