### PR TITLE
fix: `prompt_prefix` leading whitespace normal mode cc

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1760,8 +1760,9 @@ builtin.diagnostics({opts})                  *telescope.builtin.diagnostics()*
                                                 for listed buffers
         {no_sign}             (boolean)         hide DiagnosticSigns from
                                                 Results (default: false)
-        {line_width}          (number)          set length of diagnostic entry
-                                                text in Results
+        {line_width}          (string|number)   set length of diagnostic entry
+                                                text in Results. Use 'full'
+                                                for full untruncated text
         {namespace}           (number)          limit your diagnostics to a
                                                 specific namespace
         {disable_coordinates} (boolean)         don't show the line & row

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1513,7 +1513,10 @@ end
 
 --- Get the prompt text without the prompt prefix.
 function Picker:_get_prompt()
-  return vim.api.nvim_buf_get_lines(self.prompt_bufnr, 0, 1, false)[1]:sub(#self.prompt_prefix + 1)
+  local cursor_line = vim.api.nvim_win_get_cursor(self.prompt_win)[1] - 1
+  return vim.api
+    .nvim_buf_get_lines(self.prompt_bufnr, cursor_line, cursor_line + 1, false)[1]
+    :sub(#self.prompt_prefix + 1)
 end
 
 function Picker:_reset_highlights()


### PR DESCRIPTION
# Description

`prompt_prefix` with leading whitespace combined with the normal mode `cc` command was resulting in telescope getting the prompt text from the wrong line

More details: https://github.com/nvim-telescope/telescope.nvim/issues/2698#issuecomment-1718469405

Fixes #2698 
