### PR TITLE
fix: only validate severity table when using a range

### DIFF
--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -86,9 +86,9 @@ local diagnostics_to_tbl = function(opts)
     if opts.severity_bound ~= nil then
       diagnosis_opts.severity["max"] = opts.severity_bound
     end
-  end
-  if vim.version().minor > 9 and vim.tbl_isempty(diagnosis_opts.severity) then
-    diagnosis_opts.severity = nil
+    if vim.version().minor > 9 and vim.tbl_isempty(diagnosis_opts.severity) then
+      diagnosis_opts.severity = nil
+    end
   end
 
   opts.root_dir = opts.root_dir == true and vim.loop.cwd() or opts.root_dir


### PR DESCRIPTION
# Description
There was a small issue on the diagnostics builtin where if a single severity was set as a single string value, the execution would break due to a invalid check if that value was a table. Which should only be applicable when setting a range (limit and bound).

Just moved that validation where only a range is used and not a single severity.

Fixes #2708 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Test for setting a single severity level (ERROR), on a project with and without valid diagnostics.
- [x] Test by setting a range of severities (limit: WARN, bound: ERROR), on a project with and without valid diagnostics.

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
