### PR TITLE
fix(git): `tbl_isarray` compat with nvim 0.9

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -428,7 +428,7 @@ end
 local try_worktrees = function(opts)
   local worktrees = conf.git_worktrees
 
-  if vim.tbl_isarray(worktrees) then
+  if vim.tbl_islist(worktrees) then
     for _, wt in ipairs(worktrees) do
       if vim.startswith(opts.cwd, wt.toplevel) then
         opts.toplevel = wt.toplevel


### PR DESCRIPTION
closes #2707 

`tbl_islist` vs `tbl_isarray` shouldn't matter here