### PR TITLE
feat(preview)!: add `opts.preview.highlight_limit` with default 1MB

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -525,6 +525,7 @@ append(
   {
     check_mime_type = not has_win,
     filesize_limit = 25,
+    highlight_limit = 1,
     timeout = 250,
     treesitter = true,
     msg_bg_fillchar = "╱",
@@ -549,6 +550,9 @@ append(
       - filesize_limit:   The maximum file size in MB attempted to be previewed.
                           Set to false to attempt to preview any file size.
                           Default: 25
+      - highlight_limit:  The maximum file size in MB attempted to be highlighted.
+                          Set to false to attempt to highlight any file size.
+                          Default: 1
       - timeout:          Timeout the previewer if the preview did not
                           complete within `timeout` milliseconds.
                           Set to false to not timeout preview.

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -182,8 +182,8 @@ local handle_file_preview = function(filepath, bufnr, stat, opts)
       end
     end
 
+    local mb_filesize = stat.size / bytes_to_megabytes
     if opts.preview.filesize_limit then
-      local mb_filesize = math.floor(stat.size / bytes_to_megabytes)
       if mb_filesize > opts.preview.filesize_limit then
         if type(opts.preview.filesize_hook) == "function" then
           opts.preview.filesize_hook(filepath, bufnr, opts)
@@ -228,7 +228,10 @@ local handle_file_preview = function(filepath, bufnr, stat, opts)
         if opts.callback then
           opts.callback(bufnr)
         end
-        putils.highlighter(bufnr, opts.ft, opts)
+
+        if not (opts.preview.highlight_limit and mb_filesize > opts.preview.highlight_limit) then
+          putils.highlighter(bufnr, opts.ft, opts)
+        end
       else
         if type(opts.preview.timeout_hook) == "function" then
           opts.preview.timeout_hook(filepath, bufnr, opts)
@@ -243,12 +246,14 @@ end
 
 local PREVIEW_TIMEOUT_MS = 250
 local PREVIEW_FILESIZE_MB = 25
+local PREVIEW_HIGHLIGHT_MB = 1
 
 previewers.file_maker = function(filepath, bufnr, opts)
   opts = vim.F.if_nil(opts, {})
   opts.preview = vim.F.if_nil(opts.preview, {})
   opts.preview.timeout = vim.F.if_nil(opts.preview.timeout, PREVIEW_TIMEOUT_MS)
   opts.preview.filesize_limit = vim.F.if_nil(opts.preview.filesize_limit, PREVIEW_FILESIZE_MB)
+  opts.preview.highlight_limit = vim.F.if_nil(opts.preview.highlight_limit, PREVIEW_HIGHLIGHT_MB)
   opts.preview.msg_bg_fillchar = vim.F.if_nil(opts.preview.msg_bg_fillchar, "╱")
   opts.preview.treesitter = vim.F.if_nil(opts.preview.treesitter, true)
   if opts.use_ft_detect == nil then


### PR DESCRIPTION
Fixes #2247 - highlighting is not async (yet) so blocks input

BREAKING CHANGE: Default value will cause files > 1MB to not be highlighted. Removing this default would make this a non-breaking change.

The following Wiki section should also be updated to point out this new option: https://github.com/nvim-telescope/telescope.nvim/wiki/Configuration-Recipes#disable-highlighting-for-certain-files

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Used Telescope in my repo with huge files, no longer hangs
- [x] Tried `highlight_limit = false` and `highlight_limit = 25`, hangs again

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)