### PR TITLE
Fix resize/preview toggles of the cursor layout

### DIFF
--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -565,6 +565,7 @@ layout_strategies.cursor = make_documented_layout(
     local preview = initial_options.preview
     local results = initial_options.results
     local prompt = initial_options.prompt
+    local winid = self.original_win_id
 
     local height_opt = layout_config.height
     local height = resolve.resolve_height(height_opt)(self, max_columns, max_lines)
@@ -599,16 +600,16 @@ layout_strategies.cursor = make_documented_layout(
       results.width = prompt.width
     end
 
-    local position = vim.api.nvim_win_get_position(0)
+    local position = vim.api.nvim_win_get_position(winid)
     local winbar = (function()
       if vim.fn.exists "&winbar" == 1 then
-        return vim.o.winbar == "" and 0 or 1
+        return vim.wo[winid].winbar == "" and 0 or 1
       end
       return 0
     end)()
     local top_left = {
-      line = vim.fn.winline() + position[1] + bs + winbar,
-      col = vim.fn.wincol() + position[2],
+      line = vim.api.nvim_win_call(winid, vim.fn.winline) + position[1] + bs + winbar,
+      col = vim.api.nvim_win_call(winid, vim.fn.wincol) + position[2],
     }
     local bot_right = {
       line = top_left.line + height - 1,


### PR DESCRIPTION
# Description

The cursor layout uses winline() and wincol() to calculate the cursor position. Both these functions operate on the currently active window. The first time the calculations are performed, that happens to be the window active before showing the Telescope window. However, if the editor is then resized or the preview window is toggled, the active window changes. The result is that recalculating the position is then done using the wrong window, resulting in the Telescope window moving around in an erratic manner.

To fix this, we have to scope the winline() and wincol() calls to the original window ID.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To test, you'll need to use the `cursor` layout. If you then show Telescope, followed by either resizing the editor window or toggling the preview panel on/off, you'll notice the Telescope window moving around in an erratic manner. This is no longer the case with these changes.

**Configuration**:
* Neovim version (nvim --version): 0.9.2
* Operating system and version: Fedora Silverblue 38

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
