### PR TITLE
feat(current_buffer_fuzzy_find): `results_ts_highlight` option

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -929,9 +929,11 @@ builtin.current_buffer_fuzzy_find({opts}) *telescope.builtin.current_buffer_fuzz
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {skip_empty_lines} (boolean)  if true we don't display empty lines
-                                      (default: false)
-        {file_encoding}    (string)   file encoding for the previewer
+        {skip_empty_lines}     (boolean)  if true we don't display empty lines
+                                          (default: false)
+        {results_ts_highlight} (boolean)  highlight result entries with
+                                          treesitter (default: true)
+        {file_encoding}        (string)   file encoding for the previewer
 
 
 builtin.tags({opts})                                *telescope.builtin.tags()*
@@ -2862,6 +2864,11 @@ actions.git_switch_branch({prompt_bufnr}) *telescope.actions.git_switch_branch()
 
     Parameters: ~
         {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.git_rename_branch()            *telescope.actions.git_rename_branch()*
+    Action to rename selected git branch
+
 
 
 actions.git_track_branch({prompt_bufnr}) *telescope.actions.git_track_branch()*

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -480,8 +480,9 @@ files.current_buffer_fuzzy_find = function(opts)
     })
   end
 
+  opts.results_ts_highlight = vim.F.if_nil(opts.results_ts_highlight, true)
   local lang = vim.treesitter.language.get_lang(filetype)
-  if lang and utils.has_ts_parser(lang) then
+  if opts.results_ts_highlight and lang and utils.has_ts_parser(lang) then
     local parser = vim.treesitter.get_parser(opts.bufnr, lang)
     local query = vim.treesitter.query.get(lang, "highlights")
     local root = parser:parse()[1]:root()

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -103,6 +103,7 @@ builtin.treesitter = require_on_exported_call("telescope.builtin.__files").trees
 --- Live fuzzy search inside of the currently open buffer
 ---@param opts table: options to pass to the picker
 ---@field skip_empty_lines boolean: if true we don't display empty lines (default: false)
+---@field results_ts_highlight boolean: highlight result entries with treesitter (default: true)
 ---@field file_encoding string: file encoding for the previewer
 builtin.current_buffer_fuzzy_find = require_on_exported_call("telescope.builtin.__files").current_buffer_fuzzy_find
 


### PR DESCRIPTION
adds new option to the `current_buffer_fuzzy_find` picker `results_ts_highlight` to enable/disable treesitter highlight for result entries (default: true)

closes https://github.com/nvim-telescope/telescope.nvim/issues/2720