### PR TITLE
fix: buffer not in list when go to references

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -40,25 +40,27 @@ lsp.references = function(opts)
     end
 
     if #locations == 1 and opts.jump_type ~= "never" then
-      if filepath ~= locations[1].filename then
+      local location = locations[1]
+      local filename = location.filename
+      if filepath ~= filename then
         if opts.jump_type == "tab" then
           vim.cmd "tabedit"
         elseif opts.jump_type == "split" then
           vim.cmd "new"
         elseif opts.jump_type == "vsplit" then
           vim.cmd "vnew"
+        else
+          vim.cmd ("badd " .. (filename or "[No Name]"))
         end
       end
       -- jump to location
-      local location = locations[1]
       local bufnr = opts.bufnr
-      if location.filename then
-        local uri = location.filename
-        if not utils.is_uri(uri) then
-          uri = vim.uri_from_fname(uri)
+      if filename then
+        if not utils.is_uri(filename) then
+          filename = vim.uri_from_fname(filename)
         end
 
-        bufnr = vim.uri_to_bufnr(uri)
+        bufnr = vim.uri_to_bufnr(filename)
       end
       vim.api.nvim_win_set_buf(0, bufnr)
       vim.api.nvim_win_set_cursor(0, { location.lnum, location.col - 1 })


### PR DESCRIPTION
# Description

there is file opened but is nobuflisted when go to references with no jump_type, so create a buffer before set win buf is good

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Test go to references with jump_type nil, open file in buffer, then call command `:buffers` should see it

**Configuration**:
* Neovim version (nvim --version): 0.9.2
* Operating system and version: darwin arm64, 13.6 (22G120)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code

