### PR TITLE
fix(actions): fixes folding. Fixes #699

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -201,6 +201,13 @@ action_set.edit = function(prompt_bufnr, command)
     end
   end
 
+  -- HACK: fixes folding: https://github.com/nvim-telescope/telescope.nvim/issues/699
+  if vim.wo.foldmethod == "expr" then
+    vim.schedule(function()
+      vim.opt.foldmethod = "expr"
+    end)
+  end
+
   local pos = vim.api.nvim_win_get_cursor(0)
   if col == nil then
     if row == pos[1] then


### PR DESCRIPTION
# Description

Folding (with `foldexpr`) for files opened with Telescope is broken.

Fixes #699

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] set a foldxpr and open a file with telescope. foldexpr should work

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
