### PR TITLE
Bugfix in LSP Outgoing Calls

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -95,14 +95,12 @@ local function call_hierarchy(opts, method, title, direction, item)
     local locations = {}
     for _, ch_call in pairs(result) do
       local ch_item = ch_call[direction]
-      for _, range in pairs(ch_call.fromRanges) do
-        table.insert(locations, {
-          filename = vim.uri_to_fname(ch_item.uri),
-          text = ch_item.name,
-          lnum = range.start.line + 1,
-          col = range.start.character + 1,
-        })
-      end
+      table.insert(locations, {
+        filename = vim.uri_to_fname(ch_item.uri),
+        text = ch_item.name,
+        lnum = ch_item.range.start.line + 1,
+        col = ch_item.range.start.character + 1,
+      })
     end
 
     pickers


### PR DESCRIPTION
# Description

I have noticed an issue with the `LSP Outgoing Calls`.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

Below are the the `LSP Outgoing Calls` shown for the [InputContext](https://github.com/dagster-io/dagster/blob/25b72467251f6c51f73f71039c09de1f6fb1521d/python_modules/dagster/dagster/_core/execution/context/input.py#L39) Python class from the `dagster` package.

As it can be seen in the below screenshot, the highlighted line is different between `LSP Outgoing Calls`  and `Grep Preview`, which clearly highlights a different line:
![000703](https://github.com/nvim-telescope/telescope.nvim/assets/33010612/f6bc6113-1a31-4050-8229-972df902e3ae)

Here is the same thing, but with the results in the `quickfix` window and the highlighted line in the upper window, to easily see that the problem is the returned line number:
![000704](https://github.com/nvim-telescope/telescope.nvim/assets/33010612/d6a28c92-e51b-47a1-9be7-d2e707e94b65)

Upon investigation, it turned out the problem was in the `call_hierarchy` function, in the way `locations` is populated from `results`. This PR provides a fix.

Now the outgoing window looks correct:
![000705](https://github.com/nvim-telescope/telescope.nvim/assets/33010612/ff4301a7-6b19-4cdb-a951-d01ce0caf86c)

As it can be seen from the `quickfix` window, the line numbers are now different:
![000706](https://github.com/nvim-telescope/telescope.nvim/assets/33010612/c8145ccf-5881-44ba-807b-993013343825)

# How Has This Been Tested?
- logging out and inspecting the `results` and `locations` local vars in [call_hierarchy](https://github.com/nvim-telescope/telescope.nvim/blob/8c69f58427f98b2ca39a90a36db830c06e30351c/lua/telescope/builtin/__lsp.lua#L84-L122)
- visually within neovim
  - the inspection which resulted in the above screenshots
  - inspecting that `LSP Incoming Calls` still work correctly after the change, because the same `call_hierarchy` func gets called there

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.1 (from `nix`)
* Operating system and version: Ubuntu 22.04.3 LTS aarch64
