### PR TITLE
fix: correctly create User autocmd in action.which_key

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1409,7 +1409,8 @@ actions.which_key = function(prompt_bufnr, opts)
   -- only set up autocommand after showing preview completed
   if opts.close_with_action then
     vim.schedule(function()
-      vim.api.nvim_create_autocmd("User TelescopeKeymap", {
+      vim.api.nvim_create_autocmd("User", {
+        pattern = "TelescopeKeymap",
         once = true,
         callback = function()
           pcall(vim.api.nvim_win_close, km_win_id, true)


### PR DESCRIPTION
# Description

fixes actions.which_key for 0.9.4 

Related #2734 #2735 but ~~there is more work to be done to fix it for 0.1.x~~

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
