### PR TITLE
fix(actions): set location list title

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -950,11 +950,12 @@ local send_all_to_qf = function(prompt_bufnr, mode, target)
   actions.close(prompt_bufnr)
 
   vim.api.nvim_exec_autocmds("QuickFixCmdPre", {})
+  local qf_title = string.format([[%s (%s)]], picker.prompt_title, prompt)
   if target == "loclist" then
     vim.fn.setloclist(picker.original_win_id, qf_entries, mode)
+    vim.fn.setloclist(picker.original_win_id, {}, 'a', { title = qf_title })
   else
     vim.fn.setqflist(qf_entries, mode)
-    local qf_title = string.format([[%s (%s)]], picker.prompt_title, prompt)
     vim.fn.setqflist({}, "a", { title = qf_title })
   end
   vim.api.nvim_exec_autocmds("QuickFixCmdPost", {})


### PR DESCRIPTION
# Description

Small fix that sets the title also when sending results to the location list.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested by printing `w:quickfix_title` in my statusline.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.0-dev-1220+g4db77017fb
* Operating system and version: Arch Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
