### PR TITLE
fix: do not send data to closed stream

### DIFF
--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -221,6 +221,10 @@ previewers.new_termopen_previewer = function(opts)
 
       local term_id = get_term_id(self)
       if term_id then
+        if not utils.job_is_running(term_id) then
+          return
+        end
+
         vim.fn.chansend(term_id, termcode)
       end
     end


### PR DESCRIPTION
# Description

This pull request fixes the following error:

```
E5108: Error executing lua: Vim:Can't send data to closed stream
stack traceback:
[C]: in function 'chansend'
/lua/telescope/previewers/term_previewer.lua:224: in function '_send_input'
/lua/telescope/previewers/previewer.lua:85: in function 'send_input'
/lua/telescope/previewers/term_previewer.lua:238: in function '_scroll_fn'
/lua/telescope/previewers/previewer.lua:93: in function 'scroll_fn'
/lua/telescope/actions/set.lua:249: in function 'run_replace_or_original'
/lua/telescope/actions/mt.lua:65: in function 'scroll_previewer'
/lua/telescope/actions/init.lua:222: in function 'run_replace_or_original'
```

This error can be triggered using `new_termopen_previewer()`, in case its `get_command()` ends without pagination [(full code)](https://github.com/frantisekstanko/telescope-git-diff/blob/main/lua/git_diff/init.lua) and then attempting to scroll down in the previewer.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- manual test: run telescope with `new_termopen_previewer` and `get_command` which returns a non-paginated output and attempt to scroll down

**Configuration**:
* Neovim version (nvim --version): 0.9.4
* Operating system and version: OpenSUSE Tumbleweed 20231017

[My full telescope config](https://github.com/frantisekstanko/dotfiles/blob/main/.config/nvim/lua/main/plugins/enabled/telescope.lua)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
