### PR TITLE
feat(lsp-jump-type): `tab drop` as new `jump_type` option for `go-to` LSP pickers

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1549,8 +1549,8 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
         {jump_type}            (string)   how to goto reference if there is
                                           only one and the definition file is
                                           different from the current file,
-                                          values: "tab", "split", "vsplit",
-                                          "never"
+                                          values: "tab", "tab drop", "split",
+                                          "vsplit", "never"
         {fname_width}          (number)   defines the width of the filename
                                           section (default: 30)
         {show_line}            (boolean)  show results text (default: true)
@@ -1601,8 +1601,8 @@ builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
     Options: ~
         {jump_type}     (string)   how to goto definition if there is only one
                                    and the definition file is different from
-                                   the current file, values: "tab", "split",
-                                   "vsplit", "never"
+                                   the current file, values: "tab", "tab
+                                   drop", "split", "vsplit", "never"
         {fname_width}   (number)   defines the width of the filename section
                                    (default: 30)
         {show_line}     (boolean)  show results text (default: true)
@@ -1623,8 +1623,8 @@ builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
     Options: ~
         {jump_type}     (string)   how to goto definition if there is only one
                                    and the definition file is different from
-                                   the current file, values: "tab", "split",
-                                   "vsplit", "never"
+                                   the current file, values: "tab", "tab
+                                   drop", "split", "vsplit", "never"
         {fname_width}   (number)   defines the width of the filename section
                                    (default: 30)
         {show_line}     (boolean)  show results text (default: true)
@@ -1645,8 +1645,8 @@ builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
     Options: ~
         {jump_type}     (string)   how to goto implementation if there is only
                                    one and the definition file is different
-                                   from the current file, values: "tab",
-                                   "split", "vsplit", "never"
+                                   from the current file, values: "tab", "tab
+                                   drop", "split", "vsplit", "never"
         {fname_width}   (number)   defines the width of the filename section
                                    (default: 30)
         {show_line}     (boolean)  show results text (default: true)

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -47,6 +47,8 @@ lsp.references = function(opts)
           vim.cmd "new"
         elseif opts.jump_type == "vsplit" then
           vim.cmd "vnew"
+        elseif opts.jump_type == "tab drop" then
+          vim.cmd("tab drop " .. locations[1].filename)
         end
       end
       -- jump to location

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -197,6 +197,9 @@ local function list_or_jump(action, title, opts)
           vim.cmd "new"
         elseif opts.jump_type == "vsplit" then
           vim.cmd "vnew"
+        elseif opts.jump_type == "tab drop" then
+          local file_path = vim.uri_to_fname(flattened_results[1].uri)
+          vim.cmd("tab drop " .. file_path)
         end
       end
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -416,7 +416,7 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@param opts table: options to pass to the picker
 ---@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
 ---@field include_current_line boolean: include current line (default: false)
----@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "tab drop", "never"
+---@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
@@ -441,7 +441,7 @@ builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp")
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "tab drop", "never"
+---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
@@ -452,7 +452,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 --- Goto the definition of the type of the word under the cursor, if there's only one,
 --- otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "tab drop", "never"
+---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
@@ -462,7 +462,7 @@ builtin.lsp_type_definitions = require_on_exported_call("telescope.builtin.__lsp
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "tab drop", "never"
+---@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -416,7 +416,7 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@param opts table: options to pass to the picker
 ---@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
 ---@field include_current_line boolean: include current line (default: false)
----@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "never"
+---@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "tab drop", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
@@ -441,7 +441,7 @@ builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp")
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "never"
+---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "tab drop", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
@@ -452,7 +452,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 --- Goto the definition of the type of the word under the cursor, if there's only one,
 --- otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "never"
+---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "tab drop", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
@@ -462,7 +462,7 @@ builtin.lsp_type_definitions = require_on_exported_call("telescope.builtin.__lsp
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "never"
+---@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "split", "vsplit", "tab drop", "never"
 ---@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)


### PR DESCRIPTION
# Description

Sometimes when I'm coding I want to jump to a definition using the command `builtin.lsp_definitions`, for example, and it adds a new buffer on top of the buffer I'm working on. This behavior is something I don't like, so I started reading the documentation for changing that behavior and I found a parameter called [`jump_type`](https://github.com/nvim-telescope/telescope.nvim/blob/74ce793a60759e3db0d265174f137fb627430355/lua/telescope/builtin/init.lua#L444) and I set it to `tab`. However, there is another problem: when I jump to a definition, it adds a new tab buffer, but, if that tab buffer is already opened, it does not jump to it, it adds a new one. So, the behavior that I was looking for only exists with the command `tab drop`, so I added it to the list of options for the `jump_type` parameter of the following commands: `builtin.lsp_type_definitions`, `builtin.lsp_implementations`, `builtin.lsp_references` and `builtin.lsp_definitions`.

NOTE: I'm using native Neovim tabs, not the plugin [`bufferline`](https://github.com/akinsho/bufferline.nvim).

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- Using [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) for providing LSP features, `tab drop` as `jump_type` option in the following Telescope LSP pickers: `builtin.lsp_type_definitions`, `builtin.lsp_implementations`, `builtin.lsp_references` and `builtin.lsp_definitions`, and `pyright` as my Python language server, I have some files that import things from each other, and I tried to use `builtin.lsp_definitions` feature for going to the definition of some random class defined in other file, and it opened a new tab buffer (like expected). After this, I left the definition tab buffer opened and used the same command for going to the definition, and it jumped to the existing buffer instead of adding a new one. Additionally, I tried some equivalent example in some Golang code using `gopls` as my language server and it worked perfectly as well. It worked well for the remaining LSP pickers.

**Configuration**:
* Neovim version (nvim --version):
  ```
  NVIM v0.9.2
  Build type: Release
  LuaJIT 2.1.1694285958
  ```

* Operating system and version:
  ```
  OS: Manjaro Linux x86_64
  Kernel: 6.1.55-1-MANJARO
  ```

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
