### PR TITLE
Fix jumplist picker resume after bwipeout

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -563,7 +563,10 @@ previewers.vimgrep = defaulter(function(opts)
 
     define_preview = function(self, entry)
       -- builtin.buffers: bypass path validation for terminal buffers that don't have appropriate path
-      local has_buftype = entry.bufnr and vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= "" or false
+      local has_buftype = entry.bufnr
+          and vim.api.nvim_buf_is_valid(entry.bufnr)
+          and vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= ""
+        or false
       local p
       if not has_buftype then
         p = from_entry.path(entry, true)


### PR DESCRIPTION
# Description
With this change we will check if the provided buffer number is valid, before querying its `buftype` option. This is necessary, because currently we would fail with:
```
Error executing vim.schedule lua callback:
...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:473:
Invalid buffer id: X
```
error, if we try to resume a jumplist picker after doing `:bwipeout`.

Fixes #2750

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Use the steps to reproduce from #2750.

## Before
![image](https://github.com/nvim-telescope/telescope.nvim/assets/5741553/ec431610-eafb-4758-b843-a562fa35fc82)

## After
![image](https://github.com/nvim-telescope/telescope.nvim/assets/5741553/77e6123f-3be2-4ffa-99aa-b6f3a9236d02)


**Configuration**:
```
NVIM v0.9.2
Build type: Release
LuaJIT 2.1.0-beta3
```

* Operating system and version: Gentoo Linux, release 2.14

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation (lua annotations)~

cc @Conni2461