### PR TITLE
feat(actions): add delete_mark

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -3309,6 +3309,15 @@ actions.to_fuzzy_refine({prompt_bufnr})  *telescope.actions.to_fuzzy_refine()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
+actions.delete_mark({prompt_bufnr})      *telescope.actions.delete_mark()*
+    Delete the selected mark or all the marks selected using multi
+    selection.
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
 
 ================================================================================
 ACTIONS_STATE                                          *telescope.actions.state*

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1458,14 +1458,14 @@ end
 --- Delete the selected mark or all the marks selected using multi selection.
 ---@param prompt_bufnr number: The prompt bufnr
 actions.delete_mark = function(prompt_bufnr)
-	local current_picker = action_state.get_current_picker(prompt_bufnr)
-	current_picker:delete_selection(function(selection)
-	  local bufname = selection.filename
-	  local bufnr = vim.fn.bufnr(bufname)
-	  local mark = selection.ordinal:sub(1, 1)
-	  local success = pcall(vim.api.nvim_buf_del_mark, bufnr, mark)
-	  return success
-	end)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  current_picker:delete_selection(function(selection)
+    local bufname = selection.filename
+    local bufnr = vim.fn.bufnr(bufname)
+    local mark = selection.ordinal:sub(1, 1)
+    local success = pcall(vim.api.nvim_buf_del_mark, bufnr, mark)
+    return success
+  end)
 end
 
 actions.nop = function(_) end

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1455,6 +1455,19 @@ actions.to_fuzzy_refine = function(prompt_bufnr)
   })
 end
 
+--- Delete the selected mark or all the marks selected using multi selection.
+---@param prompt_bufnr number: The prompt bufnr
+actions.delete_mark = function(prompt_bufnr)
+	local current_picker = action_state.get_current_picker(prompt_bufnr)
+	current_picker:delete_selection(function(selection)
+	  local bufname = selection.filename
+	  local bufnr = vim.fn.bufnr(bufname)
+	  local mark = selection.ordinal:sub(1, 1)
+	  local success = pcall(vim.api.nvim_buf_del_mark, bufnr, mark)
+	  return success
+	end)
+end
+
 actions.nop = function(_) end
 
 -- ==================================================


### PR DESCRIPTION
# Description

This PR adds a `delete_mark` action, which can be used in conjunction with the `builtin.marks` picker. 


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?



**Configuration**:
* Neovim version (nvim --version): `v0.9.4`
* Operating system and version: MacOS Sonoma

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
