### PR TITLE
Implementation of #2783.  Add support for displaying marks according to the mark_type

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1074,7 +1074,17 @@ internal.marks = function(opts)
   local marks_table = {}
   local marks_others = {}
   local bufname = vim.api.nvim_buf_get_name(opts.bufnr)
-  for _, cnf in ipairs { local_marks, global_marks } do
+  local all_marks = {}
+  opts.mark_type = vim.F.if_nil(opts.mark_type, "all")
+  if opts.mark_type == "all" then
+    all_marks = { local_marks, global_marks }
+  elseif opts.mark_type == "local" then
+    all_marks = { local_marks }
+  elseif opts.mark_type == "global" then
+    all_marks = { global_marks }
+  end
+
+  for _, cnf in ipairs(all_marks) do
     for _, v in ipairs(cnf.items) do
       -- strip the first single quote character
       local mark = string.sub(v.mark, 2, 3)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -359,6 +359,7 @@ builtin.colorscheme = require_on_exported_call("telescope.builtin.__internal").c
 --- Lists vim marks and their value, jumps to the mark on `<cr>`
 ---@param opts table: options to pass to the picker
 ---@field file_encoding string: file encoding for the previewer
+---@field mark_type string: filter marks by type (default: "all" available: "local", "global", "all")
 builtin.marks = require_on_exported_call("telescope.builtin.__internal").marks
 
 --- Lists vim registers, pastes the contents of the register on `<cr>`

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -359,7 +359,7 @@ builtin.colorscheme = require_on_exported_call("telescope.builtin.__internal").c
 --- Lists vim marks and their value, jumps to the mark on `<cr>`
 ---@param opts table: options to pass to the picker
 ---@field file_encoding string: file encoding for the previewer
----@field mark_type string: filter marks by type (default: "all" available: "local", "global", "all")
+---@field mark_type "all"|"global"|"local": filter marks by type (default: "all")
 builtin.marks = require_on_exported_call("telescope.builtin.__internal").marks
 
 --- Lists vim registers, pastes the contents of the register on `<cr>`


### PR DESCRIPTION
…sues/2763

# Description

Added new mark_type option for the marks picker as suggested on the issue 

Fixes # (issue)

## Type of change



- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] :Telescope marks mark_type=global
- [ ] :Telescope marks mark_type=local
- [ ] :Telescope marks mark_type=all
- [ ] :Telescope marks 

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.9.2
Build type: Release
LuaJIT 2.1.0-beta3

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/opt/homebrew/Cellar/neovim/0.9.2/share/nvim"

Run :checkhealth for more info



* Operating system and version:
Darwin PWJPG61VXG 22.3.0 Darwin Kernel Version 22.3.0: Thu Jan  5 20:48:54 PST 2023; root:xnu-8792.81.2~2/RELEASE_ARM64_T6000 arm64
# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
