### PR TITLE
chore: add `pull_request` trigger on `docgen`

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches-ignore:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build-sources:


### PR DESCRIPTION
`docgen` doesn't get ran on PRs from forks.
Not sure if this is on purpose.
