### PR TITLE
fix: correct execution of vsp/sp commands

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -134,7 +134,9 @@ local function default_create_layout(picker)
       if vim.api.nvim_win_is_valid(self.prompt.winid) then
         vim.api.nvim_win_close(self.prompt.winid, true)
       end
-      utils.buf_delete(self.prompt.bufnr)
+      vim.schedule(function()
+        utils.buf_delete(self.prompt.bufnr)
+      end)
     end,
     ---@param self TelescopeLayout
     update = function(self)


### PR DESCRIPTION
# Description

Could be helpful. Currently there is an issue with using `vsp/sp` inside telescope(wrong execution)

Fixes #2781 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- Check issue

**Configuration**:
* Neovim version (nvim --version): v0.10.0-dev-98bb1d6
* Operating system and version: Fedora 38

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (lua annotations)
