### PR TITLE
fix(preview): allow arbitrary horizontal scrolling

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -329,6 +329,7 @@ local scroll_horizontal_fn = function(self, direction)
   local count = math.abs(direction)
 
   vim.api.nvim_win_call(self.state.winid, function()
+    vim.api.nvim_win_set_option(self.state.winid, "virtualedit", "all")
     vim.cmd([[normal! ]] .. count .. input)
   end)
 end


### PR DESCRIPTION
# Description

Solves the problem of not scrolling horizontally when the preview buffer has arbitrary short and long lines by setting `virtual edit` as suggested here https://github.com/nvim-telescope/telescope.nvim/issues/2211#issuecomment-1358664622
This solution enables horizontal scrolling on the preview buffer regardless of its content.

Fixes https://github.com/nvim-telescope/telescope.nvim/issues/2243#issuecomment-1358474060

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Horizontally scrolling preview buffers.

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.10.0-dev-1045+g131a1ee82
Build type: RelWithDebInfo
LuaJIT 2.1.1693350652
```
* Operating system and version:
```
OS: Ubuntu Linux x86_64
Kernel: 6.2.0-34-generic
```

**Also tested on OSX:**
* Neovim version (nvim --version):
```
NVIM v0.9.4
Build type: Release
LuaJIT 2.1.1696795921
```
* Operating system and version:
```
OS: macOS arm64
Kernel: 23.1.0 Darwin
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code