### PR TITLE
feat: Support Line Column in file pickers

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -386,7 +386,7 @@ files.find_files = function(opts)
       prompt_title = "Find Files",
       __locations_input = true,
       finder = finders.new_oneshot_job(find_command, opts),
-      previewer = conf.file_previewer(opts),
+      previewer = conf.grep_previewer(opts),
       sorter = conf.file_sorter(opts),
     })
     :find()

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -384,6 +384,7 @@ files.find_files = function(opts)
   pickers
     .new(opts, {
       prompt_title = "Find Files",
+      __locations_input = true,
       finder = finders.new_oneshot_job(find_command, opts),
       previewer = conf.file_previewer(opts),
       sorter = conf.file_sorter(opts),

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -46,6 +46,7 @@ git.files = function(opts)
   pickers
     .new(opts, {
       prompt_title = "Git Files",
+      __locations_input = true,
       finder = finders.new_oneshot_job(
         vim.tbl_flatten {
           opts.git_command,

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -55,7 +55,7 @@ git.files = function(opts)
         },
         opts
       ),
-      previewer = conf.file_previewer(opts),
+      previewer = conf.grep_previewer(opts),
       sorter = conf.file_sorter(opts),
     })
     :find()

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -320,7 +320,7 @@ function Picker:new(opts)
 
     __scrolling_limit = tonumber(vim.F.if_nil(opts.temp__scrolling_limit, 250)),
 
-    __allow_locations_input = opts.__locations_input or false,
+    __locations_input = vim.F.if_nil(opts.__locations_input, false),
   }, self)
 
   obj.create_layout = opts.create_layout or config.values.create_layout or default_create_layout
@@ -628,7 +628,7 @@ function Picker:find()
       local start_time = vim.loop.hrtime()
 
       local prompt = self:_get_next_filtered_prompt()
-      if self.__allow_locations_input == true then
+      if self.__locations_input == true then
         local filename, line_number, column_number = utils.__separate_file_path_location(prompt)
 
         if line_number or column_number then

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -633,17 +633,14 @@ function Picker:find()
 
         if line_number or column_number then
           state.set_global_key("prompt_location", { row = line_number, col = column_number })
-          self:refresh_previewer()
         elseif state.get_global_key "prompt_location" then
           state.set_global_key("prompt_location", nil)
-          self:refresh_previewer()
         end
 
         -- it is important to continue behaving as if there is no location in prompt
         prompt = filename
       elseif state.get_global_key "prompt_location" then
         -- in case new picker that does not support locations is opened clear the location
-        -- without refreshing previewer
         state.set_global_key("prompt_location", nil)
       end
 
@@ -1130,6 +1127,7 @@ function Picker:set_selection(row)
     return
   end
 
+  self:refresh_previewer()
   if old_entry == entry and self._selection_row == row then
     return
   end
@@ -1137,8 +1135,6 @@ function Picker:set_selection(row)
   -- TODO: Get row & text in the same obj
   self._selection_entry = entry
   self._selection_row = row
-
-  self:refresh_previewer()
 
   vim.api.nvim_win_set_cursor(self.results_win, { row + 1, 0 })
 end

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1067,7 +1067,13 @@ function Picker:set_selection(row)
   local prompt_location = state.get_global_key "prompt_location"
   if entry and prompt_location then
     entry.lnum = prompt_location.row or 0
-    entry.col = prompt_location.col or 0
+    if prompt_location.col and prompt_location.col > 0 then
+      entry.col = prompt_location.col
+      entry.colend = prompt_location.col + 1
+    else
+      entry.col = 1 -- we do + 1 here because previewer does -1
+      entry.colend = 0
+    end
   end
 
   state.set_global_key("selected_entry", entry)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -524,10 +524,11 @@ previewers.vimgrep = defaulter(function(opts)
       local lnum, lnend = entry.lnum - 1, (entry.lnend or entry.lnum) - 1
 
       local col, colend = 0, -1
+      -- Both col delimiters should be provided for them to take effect.
+      -- This is to ensure that column range highlighting was opted in, as `col`
+      -- is already used to determine the buffer jump position elsewhere.
       if entry.col and entry.colend then
         col, colend = entry.col - 1, entry.colend - 1
-      elseif entry.col and entry.col > 0 and not entry.colend then
-        col, colend = entry.col - 1, entry.col
       end
 
       for i = lnum, lnend do

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -488,29 +488,6 @@ end
 previewers.cat = defaulter(function(opts)
   opts = opts or {}
   local cwd = opts.cwd or vim.loop.cwd()
-  local function jump_to_line(bufnr, winid)
-    pcall(vim.api.nvim_buf_clear_namespace, bufnr, ns_previewer, 0, -1)
-    local location = global_state.get_global_key "prompt_location"
-
-    if location and location.row > 0 then
-      local highlight_range = location.col and location.col > 0 and { location.col - 1, location.col } or { 0, -1 }
-
-      pcall(
-        vim.api.nvim_buf_add_highlight,
-        bufnr,
-        ns_previewer,
-        "TelescopePreviewLine",
-        location.row - 1,
-        highlight_range[1],
-        highlight_range[2]
-      )
-
-      pcall(vim.api.nvim_win_set_cursor, winid, { location.row, location.col })
-      vim.api.nvim_buf_call(bufnr, function()
-        vim.cmd "norm! zz"
-      end)
-    end
-  end
   return previewers.new_buffer_previewer {
     title = "File Preview",
     dyn_title = function(_, entry)
@@ -531,9 +508,6 @@ previewers.cat = defaulter(function(opts)
         winid = self.state.winid,
         preview = opts.preview,
         file_encoding = opts.file_encoding,
-        callback = function(bufnr)
-          jump_to_line(bufnr, self.state.winid)
-        end,
       })
     end,
   }
@@ -550,11 +524,10 @@ previewers.vimgrep = defaulter(function(opts)
       local lnum, lnend = entry.lnum - 1, (entry.lnend or entry.lnum) - 1
 
       local col, colend = 0, -1
-      -- Both col delimiters should be provided for them to take effect.
-      -- This is to ensure that column range highlighting was opted in, as `col`
-      -- is already used to determine the buffer jump position elsewhere.
       if entry.col and entry.colend then
         col, colend = entry.col - 1, entry.colend - 1
+      elseif entry.col and entry.col > 0 and not entry.colend then
+        col, colend = entry.col - 1, entry.col
       end
 
       for i = lnum, lnend do

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -169,8 +169,8 @@ utils.is_path_hidden = function(opts, path_display)
   path_display = path_display or vim.F.if_nil(opts.path_display, require("telescope.config").values.path_display)
 
   return path_display == nil
-    or path_display == "hidden"
-    or type(path_display) == "table" and (vim.tbl_contains(path_display, "hidden") or path_display.hidden)
+      or path_display == "hidden"
+      or type(path_display) == "table" and (vim.tbl_contains(path_display, "hidden") or path_display.hidden)
 end
 
 utils.is_uri = function(filename)
@@ -183,17 +183,17 @@ utils.is_uri = function(filename)
 
   for i = 2, #filename do
     char = string.byte(filename, i)
-    if char == 58 then -- `:`
+    if char == 58 then                                            -- `:`
       return i < #filename and string.byte(filename, i + 1) ~= 92 -- `\`
     elseif
-      not (
-        (char >= 48 and char <= 57) -- 0-9
-        or (char >= 65 and char <= 90) -- A-Z
-        or (char >= 97 and char <= 122) -- a-z
-        or char == 43 -- `+`
-        or char == 46 -- `.`
-        or char == 45 -- `-`
-      )
+        not (
+          (char >= 48 and char <= 57)     -- 0-9
+          or (char >= 65 and char <= 90)  -- A-Z
+          or (char >= 97 and char <= 122) -- a-z
+          or char == 43                   -- `+`
+          or char == 46                   -- `.`
+          or char == 45                   -- `-`
+        )
     then
       return false
     end
@@ -565,6 +565,42 @@ utils.list_find = function(func, list)
       return i, v
     end
   end
+end
+
+--- Takes the path and parses optional cursor location `$file:$line:$column`
+--- If line or column not present `0` returned.
+--- @param path string
+utils.__separate_file_path_location = function(path)
+  local location_numbers = {}
+  for i = #path, 1, -1 do
+    if path:sub(i, i) == ":" then
+      if i == #path then
+        path = path:sub(1, i - 1)
+      else
+        local location_value = tonumber(path:sub(i + 1))
+        if location_value then
+          table.insert(location_numbers, location_value)
+          path = path:sub(1, i - 1)
+
+          if #location_numbers == 2 then
+            -- There couldn't be more than 2 : separated number
+            break
+          end
+        end
+      end
+    end
+  end
+
+  if #location_numbers == 2 then
+    -- because of the reverse the line number will be second
+    return path, location_numbers[2], location_numbers[1]
+  end
+
+  if #location_numbers == 1 then
+    return path, location_numbers[1], 0
+  end
+
+  return path, 0, 0
 end
 
 return utils

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -169,8 +169,8 @@ utils.is_path_hidden = function(opts, path_display)
   path_display = path_display or vim.F.if_nil(opts.path_display, require("telescope.config").values.path_display)
 
   return path_display == nil
-      or path_display == "hidden"
-      or type(path_display) == "table" and (vim.tbl_contains(path_display, "hidden") or path_display.hidden)
+    or path_display == "hidden"
+    or type(path_display) == "table" and (vim.tbl_contains(path_display, "hidden") or path_display.hidden)
 end
 
 utils.is_uri = function(filename)
@@ -183,17 +183,17 @@ utils.is_uri = function(filename)
 
   for i = 2, #filename do
     char = string.byte(filename, i)
-    if char == 58 then                                            -- `:`
+    if char == 58 then -- `:`
       return i < #filename and string.byte(filename, i + 1) ~= 92 -- `\`
     elseif
-        not (
-          (char >= 48 and char <= 57)     -- 0-9
-          or (char >= 65 and char <= 90)  -- A-Z
-          or (char >= 97 and char <= 122) -- a-z
-          or char == 43                   -- `+`
-          or char == 46                   -- `.`
-          or char == 45                   -- `-`
-        )
+      not (
+        (char >= 48 and char <= 57) -- 0-9
+        or (char >= 65 and char <= 90) -- A-Z
+        or (char >= 97 and char <= 122) -- a-z
+        or char == 43 -- `+`
+        or char == 46 -- `.`
+        or char == 45 -- `-`
+      )
     then
       return false
     end

--- a/lua/tests/automated/utils_spec.lua
+++ b/lua/tests/automated/utils_spec.lua
@@ -78,3 +78,48 @@ describe("is_uri", function()
     end
   end)
 end)
+
+describe("separates file path location", function()
+  local suites = {
+    {
+      input = "file.txt:12:4",
+      file = "file.txt",
+      row = 12,
+      col = 4,
+    },
+    {
+      input = "file.txt:12",
+      file = "file.txt",
+      row = 12,
+      col = 0,
+    },
+    {
+      input = "file:12:4",
+      file = "file",
+      row = 12,
+      col = 4,
+    },
+    {
+      input = "file:12:",
+      file = "file",
+      row = 12,
+      col = 0,
+    },
+    {
+      input = "file:",
+      file = "file",
+      row = 0,
+      col = 0,
+    },
+  }
+
+  for _, suite in ipairs(suites) do
+    it("separtates file path for " .. suite.input, function()
+      local file, row, col = utils.__separate_file_path_location(suite.input)
+
+      assert.are.equal(file, suite.file)
+      assert.are.equal(row, suite.row)
+      assert.are.equal(col, suite.col)
+    end)
+  end
+end)


### PR DESCRIPTION
## Type of change

- New feature (non-breaking change which adds functionality)

## Description

Fixing the original issue: When selecting files in the telescope impossible to copy paths from the compiler, you need to clear the location from the path.

Fixes #2650

This fixes the problem by stripping out the location from the path (important: only for file pickers). And using the location to set the cursor when opening the file.

There is a new option `files_picker` for a `Picker` that needs to be set to true for all file pickers, for now, it basically enables location stripping which makes no sense in another type of pickers.

Watch the video:

https://github.com/nvim-telescope/telescope.nvim/assets/16926049/1ee3b507-4af9-4d0f-abe2-3c67254dfcd9

## Implementation notice

I didn't find another way to put the location stripping because it must happen right after the input and make sure that if the location is set the prompt = input without location. But after we calculated that during selection we can set `entry.lnum` and `entry.col` to the value and reuse all the existing functionality to jump to the cursor

## How it is different from https://github.com/nvim-telescope/telescope.nvim/pull/2312

The PR seems to be abandoned but I need this functionality so much so I updated and changed it myself, made the API closer to the current entry row/linenr selection state which is used in live_grep, implemented support for the column number, added automated tests, and highlighted the line and column in the previewer.

## How Has This Been Tested?

An added test suite that covers the algorithm of stripping the location from the path to the `utils_spec.lua` 

Manual test:

1. Open telescope to find files
2. Enter a:12:1
3. Observer that files with a in the name found
4. Open the file and observe that you are in the :12:1 position

**Configuration**:
* Neovim version (nvim --version):

NVIM v0.9.4
Build type: Release
LuaJIT 2.1.1699180677
* Operating system and version: MacOS 13

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
