### PR TITLE
feat(buffers): add buffers_sort option

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -912,6 +912,10 @@ internal.buffers = function(opts)
     end)
   end
 
+  if opts.sort_buffers then
+    table.sort(bufnrs, opts.sort_buffers)
+  end
+
   local buffers = {}
   local default_selection_idx = 1
   for _, bufnr in ipairs(bufnrs) do

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -912,7 +912,7 @@ internal.buffers = function(opts)
     end)
   end
 
-  if opts.sort_buffers then
+  if type(opts.sort_buffers) == "function" then
     table.sort(bufnrs, opts.sort_buffers)
   end
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -349,6 +349,7 @@ builtin.reloader = require_on_exported_call("telescope.builtin.__internal").relo
 ---@field sort_mru boolean: Sorts all buffers after most recent used. Not just the current and last one (default: false)
 ---@field bufnr_width number: Defines the width of the buffer numbers in front of the filenames  (default: dynamic)
 ---@field file_encoding string: file encoding for the previewer
+---@field sort_buffers function: sort fn(bufnr_a, bufnr_b). true if bufnr_a should go first. Runs after sorting by most recent (if specified)
 builtin.buffers = require_on_exported_call("telescope.builtin.__internal").buffers
 
 --- Lists available colorschemes and applies them on `<cr>`


### PR DESCRIPTION
# Description

Adding `buffers_sort` option to `buffers` to sorts the buffers before displaying the picker.
This allows users to have control on how buffers are displayed in the picker.
It runs after sorting by `sort_mru` to avoid collision.

## Use cases

Users might have specific logic to sort buffers, as example, I want to sort the buffers that I marked (pin) in a global state
```lua
  table.sort(bufnrs, function(bufnr_a, bufnr_b)
    if state.is_buffer_pinned(bufnr_a) then
      return true
    end

    return false
  end)
```
This allows me to have a `harpoon-ish` behaviour.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Only manual test. I haven't found existing tests for the options of this specific picker.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.4 Build type: Release LuaJIT 2.1.1699801871
* Operating system and version: Ubuntu-20.04 (WSL)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
