### PR TITLE
Fix back-quotes pairing in doc

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -6,8 +6,8 @@ filter, find and pick things in Lua.
 
 Getting started with telescope:
   1. Run `:checkhealth telescope` to make sure everything is installed.
-  2. Evaluate it is working with `:Telescope find_files` or `:lua
-     require("telescope.builtin").find_files()`
+  2. Evaluate it is working with `:Telescope find_files` or 
+     `:lua require("telescope.builtin").find_files()`
   3. Put a `require("telescope").setup()` call somewhere in your neovim config.
   4. Read |telescope.setup| to check what config keys are available and what
      you can put inside the setup call
@@ -424,7 +424,7 @@ telescope.setup({opts})                                    *telescope.setup()*
         Caching preserves all previous multi selections and results and
         therefore may result in slowdown or increased RAM occupation
         if too many pickers (`cache_picker.num_pickers`) or entries
-        ('cache_picker.limit_entries`) are cached.
+        (`cache_picker.limit_entries`) are cached.
 
         Fields:
           - num_pickers:      The number of pickers to be cached.
@@ -819,8 +819,8 @@ builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
                                                 `--glob`, e.g. "*.toml", can
                                                 use the opposite "!*.toml"
         {type_filter}         (string)          argument to be used with
-                                                `--type`, e.g. "rust", see `rg
-                                                --type-list`
+                                                `--type`, e.g. "rust", see 
+                                                `rg --type-list`
         {additional_args}     (function|table)  additional arguments to be
                                                 passed on. Can be fn(opts) ->
                                                 tbl
@@ -3235,8 +3235,8 @@ actions.cycle_history_prev({prompt_bufnr}) *telescope.actions.cycle_history_prev
 
 actions.open_qflist({prompt_bufnr})          *telescope.actions.open_qflist()*
     Open the quickfix list. It makes sense to use this in combination with one
-    of the send_to_qflist actions `actions.smart_send_to_qflist +
-    actions.open_qflist`
+    of the send_to_qflist actions 
+    `actions.smart_send_to_qflist + actions.open_qflist`
 
 
     Parameters: ~
@@ -3245,8 +3245,8 @@ actions.open_qflist({prompt_bufnr})          *telescope.actions.open_qflist()*
 
 actions.open_loclist({prompt_bufnr})        *telescope.actions.open_loclist()*
     Open the location list. It makes sense to use this in combination with one
-    of the send_to_loclist actions `actions.smart_send_to_qflist +
-    actions.open_qflist`
+    of the send_to_loclist actions 
+    `actions.smart_send_to_qflist + actions.open_qflist`
 
 
     Parameters: ~
@@ -3556,8 +3556,8 @@ utils.map_selections({prompt_bufnr}, {f}) *telescope.actions.utils.map_selection
 
 
 utils.get_registered_mappings({prompt_bufnr}) *telescope.actions.utils.get_registered_mappings()*
-    Utility to collect mappings of prompt buffer in array of `{mode, keybind,
-    name}`.
+    Utility to collect mappings of prompt buffer in array of 
+    `{mode, keybind, name}`.
 
 
     Parameters: ~
@@ -3815,8 +3815,8 @@ previewers.new_buffer_previewer() *telescope.previewers.new_buffer_previewer()*
         `self.state.bufname` will be nil if the entry was never loaded or the
         unique name when it was loaded once. For example, useful if you have
         one file but multiple entries. This happens for grep and lsp builtins.
-        So to make the cache work only load content if `self.state.bufname ~=
-        entry.your_unique_key`
+        So to make the cache work only load content if 
+        `self.state.bufname ~= entry.your_unique_key`
       - `title` a static title for example "File Preview"
       - `dyn_title(self, entry)` a dynamic title function which gets called 
         when config value `dynamic_preview_title = true`
@@ -3947,8 +3947,8 @@ previewers.git_commit_diff_to_head() *telescope.previewers.git_commit_diff_to_he
 
 previewers.git_commit_diff_as_was() *telescope.previewers.git_commit_diff_as_was()*
     A previewer that shows a diff of a commit as it was.
-    The run command is `git --no-pager show $SHA:$CURRENT_FILE` or `git
-    --no-pager show $SHA`
+    The run command is `git --no-pager show $SHA:$CURRENT_FILE` or 
+    `git --no-pager show $SHA`
 
 
 


### PR DESCRIPTION
# Description

Quick fix doc:
starting single back-quote needs to be on the same line as the ending back-quote
+ also fix a wrong quote

## Type of change

- Update documentation

# Checklist:

- [Y] My code follows the style guidelines of this project (stylua)
- [O] I have performed a self-review of my own code
- [L] I have commented my code, particularly in hard-to-understand areas
- [O] I have made corresponding changes to the documentation (lua annotations)
:)