### PR TITLE
add follow option to live_grep

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -108,6 +108,7 @@ end
 -- Special keys:
 --  opts.search_dirs -- list of directory to search in
 --  opts.grep_open_files -- boolean to restrict search to open files
+--  opts.follow -- boolean to allow search to follow symlinks
 files.live_grep = function(opts)
   local vimgrep_arguments = opts.vimgrep_arguments or conf.vimgrep_arguments
   if not has_rg_program("live_grep", vimgrep_arguments[1]) then
@@ -115,6 +116,7 @@ files.live_grep = function(opts)
   end
   local search_dirs = opts.search_dirs
   local grep_open_files = opts.grep_open_files
+  local follow = opts.follow
   opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
 
   local filelist = get_open_filelist(grep_open_files, opts.cwd)
@@ -135,6 +137,10 @@ files.live_grep = function(opts)
 
   if opts.type_filter then
     additional_args[#additional_args + 1] = "--type=" .. opts.type_filter
+  end
+
+  if opts.follow then
+    additional_args[#additional_args + 1] = "--follow="
   end
 
   if type(opts.glob_pattern) == "string" then


### PR DESCRIPTION
# Description

Hi all, here's what I'm thinking with this PR.

I'm moving from VS Code to Neovim. One of the killer features of VSC for me is workspaces. [Workspaces](https://code.visualstudio.com/docs/editor/workspaces) are a way to group together directories that exist in different places on the file system into a project such that you can find files and grep across them [there is other workspace functionality but file find and grep are what I use it for primarily]. I'm trying to recreate that on Neovim with Telescope.

What I did first was create a workspace directory with symlinks to the separate directories I wanted to include.

So with this as an example filesystem:
```sh
├── dir1
│   └── subdirA
│   └── subdirB
├── dir2
│   └── subdirC
│   └── subdirD
├── dir3
│   └── subdirE
│   └── subdirF
```

A workspace could look something like this:
```sh
├── subdirA -> path/to/dir1/subdirA
├── subdirD -> path/to/dir2/subdirD
├── subdirE -> path/to/dir3/subdirE
```

To get the file find functionality in this workspace, I just used the existing `follow` option for `find_files`:
```lua
keymap("n", "<leader>f", "<cmd>Telescope find_files follow=true<cr> ",  opts)
```

But `live_grep` doesn't have this option. That's where this PR comes in. Now you can run the `live_grep` as follows:
```lua
keymap("n", "<leader>g", "<cmd>Telescope live_grep follow=true<cr> ",  opts)
```

and it will follow symlinks.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally using the following keybinding:

```lua
keymap("n", "<leader>g", "<cmd>Telescope live_grep follow=true<cr> ",  opts)
```

**Configuration**:
* Neovim version (nvim --version): v0.9.4
* Operating system and version: macOS 12.5

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
