### PR TITLE
fix: async job close not working #2797

### DIFF
--- a/lua/telescope/_.lua
+++ b/lua/telescope/_.lua
@@ -54,7 +54,7 @@ function AsyncJob:close(force)
     p:close(force)
   end)
 
-  uv.process_kill(self.handle, "SIGTERM")
+  uv.process_kill(self.handle, "sigterm")
 
   log.debug "[async_job] closed"
 end


### PR DESCRIPTION
# Description

fix the ayncjob:close not actualy close the process

Fixes #2797 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

```
local uv = vim.loop

local _, pid = uv.spawn("bash", {
    args = {
        "-c",
        "while true; do echo \"1\"; sleep 1; done"
    }
})

uv.kill(pid, "SIGTERM")
vim.schedule(function()
    local ret = uv.kill(pid, "sigterm")
    if not ret then
        print(pid.." not found")
    else
        print(pid.." closed")
    end
end)
```

**Configuration**:
* Neovim version (nvim --version):v0.9.4
* Operating system and version:macOS

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
