### PR TITLE
feat(selection-jump): add support for jumping selection by custom amount

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2626,20 +2626,22 @@ can call. These functions include `:replace(f)`, `:replace_if(f, c)`,
 `replace_map(tbl)` and `enhance(tbl)`. More information on these functions can
 be found in the `developers.md` and `lua/tests/automated/action_spec.lua` file.
 
-actions.move_selection_next({prompt_bufnr}) *telescope.actions.move_selection_next()*
+actions.move_selection_next({prompt_bufnr, change}) *telescope.actions.move_selection_next()*
     Move the selection to the next entry
 
 
     Parameters: ~
         {prompt_bufnr} (number)  The prompt bufnr
+        {change} (number) The amount to shift the selection by (default: 1)
 
 
-actions.move_selection_previous({prompt_bufnr}) *telescope.actions.move_selection_previous()*
+actions.move_selection_previous({prompt_bufnr, change}) *telescope.actions.move_selection_previous()*
     Move the selection to the previous entry
 
 
     Parameters: ~
         {prompt_bufnr} (number)  The prompt bufnr
+        {change} (number) The amount to shift the selection by (default: -1)
 
 
 actions.move_selection_worse({prompt_bufnr}) *telescope.actions.move_selection_worse()*

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -83,14 +83,19 @@ end
 
 --- Move the selection to the next entry
 ---@param prompt_bufnr number: The prompt bufnr
-actions.move_selection_next = function(prompt_bufnr)
-  action_set.shift_selection(prompt_bufnr, 1)
+---@param change number: The amount to shift the selection by
+actions.move_selection_next = function(prompt_bufnr, change)
+  action_set.shift_selection(prompt_bufnr, change or 1)
 end
 
 --- Move the selection to the previous entry
 ---@param prompt_bufnr number: The prompt bufnr
-actions.move_selection_previous = function(prompt_bufnr)
-  action_set.shift_selection(prompt_bufnr, -1)
+---@param change number: The amount to shift the selection by
+actions.move_selection_previous = function(prompt_bufnr, change)
+  if change and change > 0 then
+    change = -1 * change
+  end
+  action_set.shift_selection(prompt_bufnr, change or -1)
 end
 
 --- Move the selection to the entry that has a worse score


### PR DESCRIPTION
# Description

This change allows the user to configure an amount to jump the selection by, in the forward or backward direction, default being 1. Example (and my requirement) use case, one mapping to go up and down the selections one by one and another set of mappings to jump selections by an interval of, say 5, to parse through the options somewhat faster.
IMO, this provides a faster way to traverse through possibly large lists of selections (like git logs or search results in large projects).

## Type of change

- New feature (non-breaking change which adds functionality)
	- Add a new optional argument to `move_selection_next` and `move_selection_previous` function, which is passed to `shift_selection` (after checks) to allow setting the jump interval.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Simple/Default keymap config (`actions.move_selection_next` and `actions.move_selection_previous`)
	- Selection jumps by 1, which is default behavior
- [x] Pass value to keymap config via wrapper function (`actions.move_selection_next(bufnr, 3)` and/or `actions.move_selection_previous(bufnr, -3)`/`actions.move_selection_previous(bufnr, 3)`)
	- Selection jumps by given amount
- [x] Pass positive or negative value to `move_selection_previous`
	- Both cases handled

**Configuration**:
* Neovim version (nvim --version): `v0.9.4`
* Operating system and version: Arch Linux (`6.6.2-arch1-1`)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)

# Notes:
- I've added the logic for handling positive or negative values passed to the previous function just to allow the user to pass what logically makes sense to them for indicating backward movement.
- The variable names or terms I've used (like `change`) don't seem the best to me, but they're what came to my mind while writing the code. It could instead be called `interval`/`delta`/`jump` or something else. Open to any suggestions on this :)

Do let me know your thoughts on this.
Thanks!