### PR TITLE
Add horizontal scrolling to normal mode

### DIFF
--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -195,9 +195,13 @@ mappings.default_mappings = config.values.default_mappings
 
       ["<C-u>"] = actions.preview_scrolling_up,
       ["<C-d>"] = actions.preview_scrolling_down,
+      ["<C-f>"] = actions.preview_scrolling_left,
+      ["<C-k>"] = actions.preview_scrolling_right,
 
       ["<PageUp>"] = actions.results_scrolling_up,
       ["<PageDown>"] = actions.results_scrolling_down,
+      ["<M-f>"] = actions.results_scrolling_left,
+      ["<M-k>"] = actions.results_scrolling_right,
 
       ["?"] = actions.which_key,
     },


### PR DESCRIPTION
# Description

This adds horizontal scrolling that was added from PR #2437 to normal mode key bindings.



## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Open `Telescope ...`,  input query, then scroll to the left or to the right in previewer or results window with added key bindings.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.2
* Operating system and version: macOS Ventura v13.6.2

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
