### PR TITLE
Also add untracked files in git viewer

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -41,7 +41,8 @@ git.files = function(opts)
   -- By creating the entry maker after the cwd options,
   -- we ensure the maker uses the cwd options when being created.
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_file(opts))
-  opts.git_command = vim.F.if_nil(opts.git_command, git_command({ "ls-files", "--exclude-standard", "--cached" }, opts))
+  opts.git_command =
+    vim.F.if_nil(opts.git_command, git_command({ "ls-files", "--exclude-standard", "--cached", "--others" }, opts))
 
   pickers
     .new(opts, {


### PR DESCRIPTION
# Description

If you add new files to your project you have to track them first before telescope shows them. This is incovenient so I added a flag --others to display those files immediately.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality), (or bug fix)

# How Has This Been Tested?

I added files and checked if they were immediately visible

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
