### PR TITLE
Close which key on prompt close

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1394,27 +1394,32 @@ builtin.buffers({opts})                          *telescope.builtin.buffers()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {cwd}                   (string)   specify a working directory to
-                                           filter buffers list by
-        {show_all_buffers}      (boolean)  if true, show all buffers,
-                                           including unloaded buffers
-                                           (default: true)
-        {ignore_current_buffer} (boolean)  if true, don't show the current
-                                           buffer in the list (default: false)
-        {only_cwd}              (boolean)  if true, only show buffers in the
-                                           current working directory (default:
-                                           false)
-        {cwd_only}              (boolean)  alias for only_cwd
-        {sort_lastused}         (boolean)  Sorts current and last buffer to
-                                           the top and selects the lastused
-                                           (default: false)
-        {sort_mru}              (boolean)  Sorts all buffers after most recent
-                                           used. Not just the current and last
-                                           one (default: false)
-        {bufnr_width}           (number)   Defines the width of the buffer
-                                           numbers in front of the filenames 
-                                           (default: dynamic)
-        {file_encoding}         (string)   file encoding for the previewer
+        {cwd}                   (string)    specify a working directory to
+                                            filter buffers list by
+        {show_all_buffers}      (boolean)   if true, show all buffers,
+                                            including unloaded buffers
+                                            (default: true)
+        {ignore_current_buffer} (boolean)   if true, don't show the current
+                                            buffer in the list (default:
+                                            false)
+        {only_cwd}              (boolean)   if true, only show buffers in the
+                                            current working directory
+                                            (default: false)
+        {cwd_only}              (boolean)   alias for only_cwd
+        {sort_lastused}         (boolean)   Sorts current and last buffer to
+                                            the top and selects the lastused
+                                            (default: false)
+        {sort_mru}              (boolean)   Sorts all buffers after most
+                                            recent used. Not just the current
+                                            and last one (default: false)
+        {bufnr_width}           (number)    Defines the width of the buffer
+                                            numbers in front of the filenames 
+                                            (default: dynamic)
+        {file_encoding}         (string)    file encoding for the previewer
+        {sort_buffers}          (function)  sort fn(bufnr_a, bufnr_b). true if
+                                            bufnr_a should go first. Runs
+                                            after sorting by most recent (if
+                                            specified)
 
 
 builtin.colorscheme({opts})                  *telescope.builtin.colorscheme()*
@@ -3311,9 +3316,8 @@ actions.to_fuzzy_refine({prompt_bufnr})  *telescope.actions.to_fuzzy_refine()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
-actions.delete_mark({prompt_bufnr})      *telescope.actions.delete_mark()*
-    Delete the selected mark or all the marks selected using multi
-    selection.
+actions.delete_mark({prompt_bufnr})          *telescope.actions.delete_mark()*
+    Delete the selected mark or all the marks selected using multi selection.
 
 
     Parameters: ~

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1413,7 +1413,7 @@ actions.which_key = function(prompt_bufnr, opts)
   if opts.close_with_action then
     close_event, close_pattern, close_buffer = "User", "TelescopeKeymap", nil
   else
-    close_event, close_pattern, close_buffer = "BufDelete", nil, prompt_bufnr
+    close_event, close_pattern, close_buffer = "BufWinLeave", nil, prompt_bufnr
   end
   -- only set up autocommand after showing preview completed
   vim.schedule(function()

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1407,20 +1407,27 @@ actions.which_key = function(prompt_bufnr, opts)
     end
   end
 
-  -- only set up autocommand after showing preview completed
+  -- if close_with_action is true, close the which_key window when any action is triggered
+  -- otherwise close the window when the prompt buffer is closed
+  local close_event, close_pattern, close_buffer
   if opts.close_with_action then
-    vim.schedule(function()
-      vim.api.nvim_create_autocmd("User", {
-        pattern = "TelescopeKeymap",
-        once = true,
-        callback = function()
-          pcall(vim.api.nvim_win_close, km_win_id, true)
-          pcall(vim.api.nvim_win_close, km_opts.border.win_id, true)
-          require("telescope.utils").buf_delete(km_buf)
-        end,
-      })
-    end)
+    close_event, close_pattern, close_buffer = "User", "TelescopeKeymap", nil
+  else
+    close_event, close_pattern, close_buffer = "BufDelete", nil, prompt_bufnr
   end
+  -- only set up autocommand after showing preview completed
+  vim.schedule(function()
+    vim.api.nvim_create_autocmd(close_event, {
+      pattern = close_pattern,
+      buffer = close_buffer,
+      once = true,
+      callback = function()
+        pcall(vim.api.nvim_win_close, km_win_id, true)
+        pcall(vim.api.nvim_win_close, km_opts.border.win_id, true)
+        require("telescope.utils").buf_delete(km_buf)
+      end,
+    })
+  end)
 end
 
 --- Move from a none fuzzy search to a fuzzy one<br>


### PR DESCRIPTION
# Description

Add autocmd to make `which_key` window close on prompt exit.

Currently `actions.which_key` supports a `close_with_action` option (default true). When this is set, the `which_key` window will close after any Telescope action is triggered. This makes sense. However, when it is false, the `which_key` window remains open even after Telescope
closes. This seems like a bug.

This PR fixes this by setting an autocommand when `close_with_action` is false to close on prompt exit.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested this by running `Telescope` and triggering `which_key` with `close_with_action` set to both true and false, observed expected behavior in both cases.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
