### PR TITLE
feat(builtin.diagnostics): add previewer option to diagnostics picker

### DIFF
--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -165,7 +165,7 @@ diagnostics.get = function(opts)
         results = locations,
         entry_maker = opts.entry_maker or make_entry.gen_from_diagnostics(opts),
       },
-      previewer = conf.qflist_previewer(opts),
+      previewer = opts.previewer or conf.qflist_previewer(opts),
       sorter = conf.prefilter_sorter {
         tag = "type",
         sorter = conf.generic_sorter(opts),

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -539,6 +539,7 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 ---@field namespace number: limit your diagnostics to a specific namespace
 ---@field disable_coordinates boolean: don't show the line & row numbers (default: false)
 ---@field sort_by string: sort order of the diagnostics results; see above notes (default: "buffer")
+---@field previewer table|nil: previewer to use for displaying previews of the results
 builtin.diagnostics = require_on_exported_call("telescope.builtin.__diagnostics").get
 
 local apply_config = function(mod)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

https://github.com/nvim-telescope/telescope.nvim/issues/2761#issuecomment-1868556399

Fixes  https://github.com/nvim-telescope/telescope.nvim/issues/2761


One question here: are there any in-flight changes to add the previewer for each picker to the pickers configuration? If not, I think that would be a better approach than doing a one-off fix here, and I'll modify this PR to do that. 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration
- Tested locally by calling as follows

```lua        
vim.keymap.set('n', '<leader>px', function()
            return builtin.diagnostics({
                line_width = "full",
                previewer = require('telescope.previewers').new_buffer_previewer {
                    title = "Diagnostics",
                    dyn_title = function(_, entry)
                        return entry.title
                    end,

                    get_buffer_by_name = function(_, entry)
                        return "diagnostics_" .. tostring(entry.nr)
                    end,

                    define_preview = function(self, entry)
                        vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, { entry.text })
                    end,
                }
            })
        end, {})
```
**Configuration**:
* Neovim version (nvim --version): 
```
NVIM v0.10.0-dev-1746+g5651c1ff2
Build type: RelWithDebInfo
LuaJIT 2.1.1700008891
```
* Operating system and version:
```
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.3 LTS
Release:        22.04
Codename:       jammy
```
# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
