### PR TITLE
Set `default_text` to the `word` being searched for `grep_string`

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -254,6 +254,7 @@ files.grep_string = function(opts)
   pickers
     .new(opts, {
       prompt_title = "Find Word (" .. word:gsub("\n", "\\n") .. ")",
+      default_text = word,  -- Make sure the picker shows the selected word in the prompt
       finder = finders.new_oneshot_job(args, opts),
       previewer = conf.grep_previewer(opts),
       sorter = conf.generic_sorter(opts),


### PR DESCRIPTION
# Description

Adding `default_text` to the word being searched in `grep_string` option. After this PR:

- User will see the word under the cursor as the text in the prompt.
- User can directly play around with the word, and doesn't need to do extra steps.

### Why is this PR needed?

- IMO, I don't see a use-case where this would not be needed (ability to show the text, by default in the prompt).
- Reduces the efforts of the users who want to do a follow-up search.

### How does this PR solve the issue?

- Sets `default_text` to the `word`. `default_text` is available as an argument while intialising a picker using `pickers::new`.

Attempts to fix https://github.com/nvim-telescope/telescope.nvim/issues/2822

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- Local testing. Haven't written / tried testing this except manual testing yet.

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
