### PR TITLE
fix(git_status): keep picker open with no matches

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -390,7 +390,14 @@ git.status = function(opts)
       on_complete = {
         function(self)
           local lines = self.manager:num_results()
-          if lines == 0 then
+
+          -- HACK: unable to `self._get_prompt()` directly
+          local cursor_line = vim.api.nvim_win_get_cursor(self.prompt_win)[1] - 1
+          local prompt = vim.api
+            .nvim_buf_get_lines(self.prompt_bufnr, cursor_line, cursor_line + 1, false)[1]
+            :sub(#self.prompt_prefix + 1)
+
+          if lines == 0 and prompt == "" then
             utils.notify("builtin.git_status", {
               msg = "No changes found",
               level = "ERROR",


### PR DESCRIPTION
Currently, `git_status` with a prompt that has zero matches closes the picker.

Only automatically close the picker if working tree is completely clean. If working tree is not clean, and a prompt is given but no matches are found, keep the picker open. This behavior is consistent with other pickers where lack of matches doesn't result in the picker closing.

closes #2815

