### PR TITLE
Add on_change callback to colorscheme selection

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1433,6 +1433,10 @@ builtin.colorscheme({opts})                  *telescope.builtin.colorscheme()*
 
     Options: ~
         {enable_preview} (boolean)  if true, will preview the selected color
+		
+        {on_change} (function)  Function to call when the colorscheme is
+                        changed that takes (new_value, old_value) 
+                        as arguments
 
 
 builtin.marks({opts})                              *telescope.builtin.marks()*

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1039,6 +1039,11 @@ internal.colorscheme = function(opts)
         actions.close(prompt_bufnr)
         need_restore = false
         vim.cmd("colorscheme " .. selection.value)
+		
+		local on_change_cb = opts.on_change
+        if on_change_cb then
+          on_change_cb(selection.value, before_color)
+        end
       end)
 
       return true

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -356,6 +356,7 @@ builtin.buffers = require_on_exported_call("telescope.builtin.__internal").buffe
 --- Lists available colorschemes and applies them on `<cr>`
 ---@param opts table: options to pass to the picker
 ---@field enable_preview boolean: if true, will preview the selected color
+---@field on_change function: on_change(new_value:string, old_value:string). Runs after a colorscheme is selected (default: nil)
 builtin.colorscheme = require_on_exported_call("telescope.builtin.__internal").colorscheme
 
 --- Lists vim marks and their value, jumps to the mark on `<cr>`


### PR DESCRIPTION
# Description

Adds a new `on_change` callback function option to `pickers.colorscheme`

This function is called when a colorscheme is selected in the colorscheme picker

The arguments passed to this callback function are: `new_value` (string) and `old_value` (string)

Fixes #2826

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Since this is a simple feature, I tested it locally on my neovim instance.

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.9.4
Build type: Release
LuaJIT 2.1.1692716794
```

* Operating system and version:
```
Ubuntu 22.04.3 LTS
Linux 5.15.133.1-microsoft-standard-WSL2 x86_64
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
- [x] I added the corresponding option documentation on `telescope.txt` doc file.
