### PR TITLE
feat(git_status): allow buffer_previewer_maker to receive options

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -979,10 +979,14 @@ previewers.git_file_diff = defaulter(function(opts)
         if p == nil or p == "" then
           return
         end
-        conf.buffer_previewer_maker(p, self.state.bufnr, {
-          bufname = self.state.bufname,
-          winid = self.state.winid,
-        })
+        conf.buffer_previewer_maker(
+          p,
+          self.state.bufnr,
+          vim.tbl_extend("force", opts, {
+            bufname = self.state.bufname,
+            winid = self.state.winid,
+          })
+        )
       else
         local cmd = git_command({ "--no-pager", "diff", "HEAD", "--", entry.value }, opts)
         putils.job_maker(cmd, self.state.bufnr, {

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -598,7 +598,7 @@ end, {})
 
 previewers.qflist = previewers.vimgrep
 
-previewers.ctags = defaulter(function(_)
+previewers.ctags = defaulter(function(opts)
   local determine_jump = function(entry)
     if entry.scode then
       return function(self)
@@ -647,17 +647,19 @@ previewers.ctags = defaulter(function(_)
       conf.buffer_previewer_maker(entry.filename, self.state.bufnr, {
         bufname = self.state.bufname,
         winid = self.state.winid,
+        preview = opts.preview,
         callback = function(bufnr)
           pcall(vim.api.nvim_buf_call, bufnr, function()
             determine_jump(entry)(self, bufnr)
           end)
         end,
+        file_encoding = opts.file_encoding,
       })
     end,
   }
 end, {})
 
-previewers.builtin = defaulter(function(_)
+previewers.builtin = defaulter(function(opts)
   return previewers.new_buffer_previewer {
     title = "Grep Preview",
     teardown = search_teardown,
@@ -678,15 +680,17 @@ previewers.builtin = defaulter(function(_)
       conf.buffer_previewer_maker(entry.filename, self.state.bufnr, {
         bufname = self.state.bufname,
         winid = self.state.winid,
+        preview = opts.preview,
         callback = function(bufnr)
           search_cb_jump(self, bufnr, text)
         end,
+        file_encoding = opts.file_encoding,
       })
     end,
   }
 end, {})
 
-previewers.help = defaulter(function(_)
+previewers.help = defaulter(function(opts)
   return previewers.new_buffer_previewer {
     title = "Help Preview",
     teardown = search_teardown,
@@ -703,10 +707,12 @@ previewers.help = defaulter(function(_)
       conf.buffer_previewer_maker(entry.filename, self.state.bufnr, {
         bufname = self.state.bufname,
         winid = self.state.winid,
+        preview = opts.preview,
         callback = function(bufnr)
           putils.regex_highlighter(bufnr, "help")
           search_cb_jump(self, bufnr, query)
         end,
+        file_encoding = opts.file_encoding,
       })
     end,
   }

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -979,14 +979,12 @@ previewers.git_file_diff = defaulter(function(opts)
         if p == nil or p == "" then
           return
         end
-        conf.buffer_previewer_maker(
-          p,
-          self.state.bufnr,
-          vim.tbl_extend("force", opts, {
-            bufname = self.state.bufname,
-            winid = self.state.winid,
-          })
-        )
+        conf.buffer_previewer_maker(p, self.state.bufnr, {
+          bufname = self.state.bufname,
+          winid = self.state.winid,
+          preview = opts.preview,
+          file_encoding = opts.file_encoding,
+        })
       else
         local cmd = git_command({ "--no-pager", "diff", "HEAD", "--", entry.value }, opts)
         putils.job_maker(cmd, self.state.bufnr, {


### PR DESCRIPTION
# Description

When peviewing new files with git_status, binary files show noises.
This is because the current previewer does not inherit global- or user-options.

My PR passes the option to previewer.
This can be considered as fix and new feature at the same time.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Preview of an image file shows `Binary cannot be previewed` message.

**Configuration**:

* Neovim version (nvim --version):

```
NVIM v0.10.0-dev-1962+gc26dc1f77
Build type: RelWithDebInfo
LuaJIT 2.1.1703358377
Run "nvim -V1 -v" for more info
```

* Operating system and version:

Manjaro Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
