### PR TITLE
Fix wrap option not set when wrap_results is true

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -547,9 +547,7 @@ function Picker:find()
   pcall(a.nvim_buf_set_option, self.results_bufnr, "tabstop", 1) -- #1834
   pcall(a.nvim_buf_set_option, self.prompt_bufnr, "tabstop", 1) -- #1834
   a.nvim_buf_set_option(self.prompt_bufnr, "buftype", "prompt")
-  if not self.wrap_results then
-    a.nvim_win_set_option(self.results_win, "wrap", false)
-  end
+  a.nvim_win_set_option(self.results_win, "wrap", self.wrap_results)
   a.nvim_win_set_option(self.prompt_win, "wrap", true)
   if self.preview_win then
     a.nvim_win_set_option(self.preview_win, "wrap", true)


### PR DESCRIPTION
# Description

Recently noticed wrap_results option is not working and this pr fixes it.

Fixes # (issue)
No issue raised yet I believe. searched but couldn't find an open issue for the same

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Validated on launching git file picker with our java project which has very long paths due to java's package system


**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.4
* Operating system and version: MacOS 14.2.1 Sonoma

# Checklist:

- [x] I have performed a self-review of my own code
