### PR TITLE
feat(builtin.files): Add support for 'bfs' as find_command

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -268,6 +268,9 @@ files.find_files = function(opts)
         return opts.find_command(opts)
       end
       return opts.find_command
+    elseif 1 == vim.fn.executable "bfs" then
+      -- Use https://github.com/tavianator/bfs
+      return { "bfs", "-type", "f", "-nocolor" }
     elseif 1 == vim.fn.executable "rg" then
       return { "rg", "--files", "--color", "never" }
     elseif 1 == vim.fn.executable "fd" then

--- a/lua/telescope/health.lua
+++ b/lua/telescope/health.lua
@@ -21,7 +21,18 @@ local optional_dependencies = {
     },
   },
   {
-    finder_name = "find-files",
+    finder_name = "find-files (bfs)",
+    package = {
+      {
+        name = "bfs",
+        binaries = { "bfs" },
+        url = "[tavianator/bfs](https://github.com/tavianator/bfs)",
+        optional = true,
+      },
+    },
+  },
+  {
+    finder_name = "find-files (fd)",
     package = {
       {
         name = "fd",


### PR DESCRIPTION
See https://tavianator.com/2023/bfs_3.0.html

# Description

This adds support for bfs, which currently is the fastest 'find' implementation.

## Type of change

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Install 'bfs' on your system and run `builtin.find_files`. You can run find_files on a directory with a lot of files like your home directory and in other terminal check if it executes bfs, like:

```
$ ps aufx | grep -A3 nvim
asn      31995  0.0  0.0  11004  8256 pts/1    Sl+  19:41   0:00  |   |   \_ /usr/bin/nvim
asn      31998  4.1  0.7 488616 485288 ?       Rsl  19:41   0:03  |   |       \_ /usr/bin/nvim --embed
asn      32311 65.1  0.0 194172  9880 ?        Sl   19:43   0:00  |   |           \_ bfs -type f -nocolor
```

**Configuration**:
* Neovim version (nvim --version): 0.9.5
* Operating system and version: openSUSE Tumbleweed

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
