### PR TITLE
fix(builtin): quickfix entry maker does not used fixed width for file

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1266,11 +1266,9 @@ builtin.quickfix({opts})                        *telescope.builtin.quickfix()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
-        {nr}          (number)   specify the quickfix list number
+        {show_line} (boolean)  show results text (default: true)
+        {trim_text} (boolean)  trim results text (default: false)
+        {nr}        (number)   specify the quickfix list number
 
 
 builtin.quickfixhistory({opts})          *telescope.builtin.quickfixhistory()*
@@ -1292,10 +1290,8 @@ builtin.loclist({opts})                          *telescope.builtin.loclist()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
+        {show_line} (boolean)  show results text (default: true)
+        {trim_text} (boolean)  trim results text (default: false)
 
 
 builtin.oldfiles({opts})                        *telescope.builtin.oldfiles()*
@@ -1522,10 +1518,8 @@ builtin.tagstack({opts})                        *telescope.builtin.tagstack()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
+        {show_line} (boolean)  show results text (default: true)
+        {trim_text} (boolean)  trim results text (default: false)
 
 
 builtin.jumplist({opts})                        *telescope.builtin.jumplist()*
@@ -1536,10 +1530,8 @@ builtin.jumplist({opts})                        *telescope.builtin.jumplist()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {show_line}   (boolean)  show results text (default: true)
-        {trim_text}   (boolean)  trim results text (default: false)
-        {fname_width} (number)   defines the width of the filename section
-                                 (default: 30)
+        {show_line} (boolean)  show results text (default: true)
+        {trim_text} (boolean)  trim results text (default: false)
 
 
 builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
@@ -1560,8 +1552,6 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
                                           different from the current file,
                                           values: "tab", "tab drop", "split",
                                           "vsplit", "never"
-        {fname_width}          (number)   defines the width of the filename
-                                          section (default: 30)
         {show_line}            (boolean)  show results text (default: true)
         {trim_text}            (boolean)  trim results text (default: false)
         {file_encoding}        (string)   file encoding for the previewer
@@ -1576,8 +1566,6 @@ builtin.lsp_incoming_calls({opts})    *telescope.builtin.lsp_incoming_calls()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {fname_width}   (number)   defines the width of the filename section
-                                   (default: 30)
         {show_line}     (boolean)  show results text (default: true)
         {trim_text}     (boolean)  trim results text (default: false)
         {file_encoding} (string)   file encoding for the previewer
@@ -1592,8 +1580,6 @@ builtin.lsp_outgoing_calls({opts})    *telescope.builtin.lsp_outgoing_calls()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {fname_width}   (number)   defines the width of the filename section
-                                   (default: 30)
         {show_line}     (boolean)  show results text (default: true)
         {trim_text}     (boolean)  trim results text (default: false)
         {file_encoding} (string)   file encoding for the previewer
@@ -1612,8 +1598,6 @@ builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
                                    and the definition file is different from
                                    the current file, values: "tab", "tab
                                    drop", "split", "vsplit", "never"
-        {fname_width}   (number)   defines the width of the filename section
-                                   (default: 30)
         {show_line}     (boolean)  show results text (default: true)
         {trim_text}     (boolean)  trim results text (default: false)
         {reuse_win}     (boolean)  jump to existing window if buffer is
@@ -1634,8 +1618,6 @@ builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
                                    and the definition file is different from
                                    the current file, values: "tab", "tab
                                    drop", "split", "vsplit", "never"
-        {fname_width}   (number)   defines the width of the filename section
-                                   (default: 30)
         {show_line}     (boolean)  show results text (default: true)
         {trim_text}     (boolean)  trim results text (default: false)
         {reuse_win}     (boolean)  jump to existing window if buffer is
@@ -1656,8 +1638,6 @@ builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
                                    one and the definition file is different
                                    from the current file, values: "tab", "tab
                                    drop", "split", "vsplit", "never"
-        {fname_width}   (number)   defines the width of the filename section
-                                   (default: 30)
         {show_line}     (boolean)  show results text (default: true)
         {trim_text}     (boolean)  trim results text (default: false)
         {reuse_win}     (boolean)  jump to existing window if buffer is

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -281,7 +281,6 @@ builtin.commands = require_on_exported_call("telescope.builtin.__internal").comm
 ---@param opts table: options to pass to the picker
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
----@field fname_width number: defines the width of the filename section (default: 30)
 ---@field nr number: specify the quickfix list number
 builtin.quickfix = require_on_exported_call("telescope.builtin.__internal").quickfix
 
@@ -294,7 +293,6 @@ builtin.quickfixhistory = require_on_exported_call("telescope.builtin.__internal
 ---@param opts table: options to pass to the picker
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
----@field fname_width number: defines the width of the filename section (default: 30)
 builtin.loclist = require_on_exported_call("telescope.builtin.__internal").loclist
 
 --- Lists previously open files, opens on `<cr>`
@@ -399,14 +397,12 @@ builtin.spell_suggest = require_on_exported_call("telescope.builtin.__internal")
 ---@param opts table: options to pass to the picker
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
----@field fname_width number: defines the width of the filename section (default: 30)
 builtin.tagstack = require_on_exported_call("telescope.builtin.__internal").tagstack
 
 --- Lists items from Vim's jumplist, jumps to location on `<cr>`
 ---@param opts table: options to pass to the picker
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
----@field fname_width number: defines the width of the filename section (default: 30)
 builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jumplist
 
 --
@@ -420,7 +416,6 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
 ---@field include_current_line boolean: include current line (default: false)
 ---@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
----@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field file_encoding string: file encoding for the previewer
@@ -445,7 +440,6 @@ builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp")
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
----@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
@@ -456,7 +450,6 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 --- otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
----@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
@@ -466,7 +459,6 @@ builtin.lsp_type_definitions = require_on_exported_call("telescope.builtin.__lsp
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
----@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -423,7 +423,6 @@ builtin.lsp_references = require_on_exported_call("telescope.builtin.__lsp").ref
 
 --- Lists LSP incoming calls for word under the cursor, jumps to reference on `<cr>`
 ---@param opts table: options to pass to the picker
----@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field file_encoding string: file encoding for the previewer
@@ -431,7 +430,6 @@ builtin.lsp_incoming_calls = require_on_exported_call("telescope.builtin.__lsp")
 
 --- Lists LSP outgoing calls for word under the cursor, jumps to reference on `<cr>`
 ---@param opts table: options to pass to the picker
----@field fname_width number: defines the width of the filename section (default: 30)
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field file_encoding string: file encoding for the previewer

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -464,7 +464,7 @@ function make_entry.gen_from_quickfix(opts)
     if show_line then
       local text = entry.text
       if opts.trim_text then
-        text = text:gsub("^%s*(.-)%s*$", "%1")
+        text = vim.trim(text)
       end
       text = text:gsub(".* | ", "")
       display_string = display_string .. " " .. text

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -467,7 +467,7 @@ function make_entry.gen_from_quickfix(opts)
         text = vim.trim(text)
       end
       text = text:gsub(".* | ", "")
-      display_string = display_string .. " " .. text
+      display_string = display_string .. ":" .. text
     end
 
     return display_string

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -460,7 +460,6 @@ function make_entry.gen_from_quickfix(opts)
       display_string = string.format("%4d:%2d", entry.lnum, entry.col)
     end
 
-
     if show_line then
       local text = entry.text
       if opts.trim_text then

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -452,26 +452,14 @@ function make_entry.gen_from_quickfix(opts)
   local show_line = vim.F.if_nil(opts.show_line, true)
 
   local hidden = utils.is_path_hidden(opts)
-  local items = {
-    { width = vim.F.if_nil(opts.fname_width, 30) },
-    { remaining = true },
-  }
-  if hidden then
-    items[1] = { width = 8 }
-  end
-  if not show_line then
-    table.remove(items, 1)
-  end
-
-  local displayer = entry_display.create { separator = "▏", items = items }
 
   local make_display = function(entry)
-    local input = {}
-    if not hidden then
-      table.insert(input, string.format("%s:%d:%d", utils.transform_path(opts, entry.filename), entry.lnum, entry.col))
-    else
-      table.insert(input, string.format("%4d:%2d", entry.lnum, entry.col))
+    local display_filename = utils.transform_path(opts, entry.filename)
+    local display_string = string.format("%s:%d:%d", display_filename, entry.lnum, entry.col)
+    if hidden then
+      display_string = string.format("%4d:%2d", entry.lnum, entry.col)
     end
+
 
     if show_line then
       local text = entry.text
@@ -479,10 +467,10 @@ function make_entry.gen_from_quickfix(opts)
         text = text:gsub("^%s*(.-)%s*$", "%1")
       end
       text = text:gsub(".* | ", "")
-      table.insert(input, text)
+      display_string = display_string .. " " .. text
     end
 
-    return displayer(input)
+    return display_string
   end
 
   local get_filename = get_filename_fn()


### PR DESCRIPTION
# Description

Fixes https://github.com/nvim-telescope/telescope.nvim/issues/2838 and https://github.com/nvim-telescope/telescope.nvim/issues/2121

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


- [X] Locally tested using hidden and non-hidden files with LSP references / quickfix / definition
![image](https://github.com/nvim-telescope/telescope.nvim/assets/46619169/5feaa165-a32d-4247-b602-7578eb89ff86)
![image](https://github.com/nvim-telescope/telescope.nvim/assets/46619169/f3328d40-a16e-4321-904a-68b2e37efac4)

    - Hidden directory: 
![image](https://github.com/nvim-telescope/telescope.nvim/assets/46619169/bf294557-e7ab-47ee-8fdf-36eb14cfa70a)

**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.0-dev-2021+gee2127363 
* Operating system and version: Ubuntu 22.04.3 LTS

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations) (N/A)

Apologies if this is a bad solution, I'm still quite new to neovim development. This was something that periodically annoyed me about all of the lists that use the quickfix entry maker 😅 


Questions:
- Is it worth renaming the quickfix entry maker? IMO the name is a bit overloaded now
- Do we need tests for this? From a quick look, it doesn't seem like any of the existing (automated) tests verify display