### PR TITLE
fix(builtin.buffers): better buffer in cwd check

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -886,7 +886,8 @@ internal.buffers = function(opts)
     if cwd:sub(-1) ~= Path.path.sep then
       cwd = cwd .. Path.path.sep
     end
-    return vim.api.nvim_buf_get_name(bufnr):find(cwd) == nil
+    local bufname_prefix = vim.api.nvim_buf_get_name(bufnr):sub(1, #cwd)
+    return bufname_prefix ~= cwd
   end
 
   local bufnrs = vim.tbl_filter(function(bufnr)


### PR DESCRIPTION
Previously, using `string.find`, certain characters were taken as regex special characters leading to bad matches.
New approach takes bufname truncated to the length of cwd and compares the two strings.

ref: https://github.com/nvim-telescope/telescope.nvim/pull/2845#issuecomment-1876227314