### PR TITLE
fix(builtin): use 'normal!' instead of 'normal'

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -194,7 +194,7 @@ files.grep_string = function(opts)
 
   if visual == true then
     local saved_reg = vim.fn.getreg "v"
-    vim.cmd [[noautocmd sil norm "vy]]
+    vim.cmd [[noautocmd sil norm! "vy]]
     local sele = vim.fn.getreg "v"
     vim.fn.setreg("v", saved_reg)
     word = vim.F.if_nil(opts.search, sele)


### PR DESCRIPTION
# Description

Fixes `builin.grepstring` in visual mode for users that have "\\"" or "y" remapped.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Using `require("telescope.builtin").grep_string` on different strings in visual mode ("x"), while "\\"" is mapped to something different.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.0-dev-2048+g367e52cc7
* Operating system and version: Linux 6.1.71-1-lts x86_64

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
