### PR TITLE
chore: add type annotations

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -797,12 +797,8 @@ options you want to use. Here's an example with the live_grep picker:
   })
 <
 
-builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
-    Search for a string and get results live as you type, respects .gitignore
-
-
-    Parameters: ~
-        {opts} (table)  options to pass to the picker
+TelescopeLiveGrepOpts                                  *TelescopeLiveGrepOpts*
+    TelescopeBasePickerOpts
 
     Options: ~
         {cwd}                 (string)          root dir to search from
@@ -812,7 +808,7 @@ builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
         {grep_open_files}     (boolean)         if true, restrict search to
                                                 open files only, mutually
                                                 exclusive with `search_dirs`
-        {search_dirs}         (table)           directory/directories/files to
+        {search_dirs}         (string[])        directory/directories/files to
                                                 search, mutually exclusive
                                                 with `grep_open_files`
         {glob_pattern}        (string|table)    argument to be used with
@@ -829,6 +825,15 @@ builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
                                                 numbers (default: false)
         {file_encoding}       (string)          file encoding for the entry &
                                                 previewer
+        {vimgrep_arguments}   (string[])        cmd to use for the search
+
+
+builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
+    Search for a string and get results live as you type, respects .gitignore
+
+
+    Parameters: ~
+        {opts} (TelescopeLiveGrepOpts)  options to pass to the picker
 
 
 builtin.grep_string({opts})                  *telescope.builtin.grep_string()*

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -105,10 +105,9 @@ local opts_contain_invert = function(args)
   return invert, files_with_matches
 end
 
--- Special keys:
---  opts.search_dirs -- list of directory to search in
---  opts.grep_open_files -- boolean to restrict search to open files
+---@param opts? TelescopeLiveGrepOpts
 files.live_grep = function(opts)
+  opts = opts or {}
   local vimgrep_arguments = opts.vimgrep_arguments or conf.vimgrep_arguments
   if not has_rg_program("live_grep", vimgrep_arguments[1]) then
     return

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -1,3 +1,5 @@
+---@diagnostic disable: undefined-doc-param
+
 ---@tag telescope.builtin
 
 ---@config { ['field_heading'] = "Options", ["module"] = "telescope.builtin" }
@@ -45,17 +47,21 @@ end
 --
 --
 
---- Search for a string and get results live as you type, respects .gitignore
----@param opts table: options to pass to the picker
+---@class TelescopeLiveGrepOpts : TelescopeBasePickerOpts
 ---@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
----@field search_dirs table: directory/directories/files to search, mutually exclusive with `grep_open_files`
+---@field search_dirs string[]: directory/directories/files to search, mutually exclusive with `grep_open_files`
 ---@field glob_pattern string|table: argument to be used with `--glob`, e.g. "*.toml", can use the opposite "!*.toml"
 ---@field type_filter string: argument to be used with `--type`, e.g. "rust", see `rg --type-list`
 ---@field additional_args function|table: additional arguments to be passed on. Can be fn(opts) -> tbl
 ---@field max_results number: define a upper result value
 ---@field disable_coordinates boolean: don't show the line & row numbers (default: false)
 ---@field file_encoding string: file encoding for the entry & previewer
+---@field vimgrep_arguments string[]: cmd to use for the search
+---@field [string] any
+
+--- Search for a string and get results live as you type, respects .gitignore
+---@param opts TelescopeLiveGrepOpts: options to pass to the picker
 builtin.live_grep = require_on_exported_call("telescope.builtin.__files").live_grep
 
 --- Searches for the string under your cursor or the visual selection in your current working directory

--- a/lua/telescope/entry_manager.lua
+++ b/lua/telescope/entry_manager.lua
@@ -2,6 +2,12 @@ local log = require "telescope.log"
 
 local LinkedList = require "telescope.algos.linked_list"
 
+---@class TelescopeEntryManager
+---@field linked_states any
+---@field info any
+---@field max_results any
+---@field set_entry any
+---@field worst_acceptable_score any
 local EntryManager = {}
 EntryManager.__index = EntryManager
 

--- a/lua/telescope/finders.lua
+++ b/lua/telescope/finders.lua
@@ -7,6 +7,10 @@ local async_static_finder = require "telescope.finders.async_static_finder"
 local async_oneshot_finder = require "telescope.finders.async_oneshot_finder"
 local async_job_finder = require "telescope.finders.async_job_finder"
 
+---@class Finder
+---@field results table
+---@field close fun()
+
 local finders = {}
 
 local _callable_obj = function()

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -8,6 +8,8 @@ local ns_telescope_selection = a.nvim_create_namespace "telescope_selection"
 local ns_telescope_multiselection = a.nvim_create_namespace "telescope_multiselection"
 local ns_telescope_entry = a.nvim_create_namespace "telescope_entry"
 
+---@class TelescopeHighlighter
+---@field picker TelescopeBasePicker
 local Highlighter = {}
 Highlighter.__index = Highlighter
 

--- a/lua/telescope/pickers/multi.lua
+++ b/lua/telescope/pickers/multi.lua
@@ -1,3 +1,5 @@
+---@class MultiSelect
+---@field private _entries table
 local MultiSelect = {}
 MultiSelect.__index = MultiSelect
 

--- a/lua/telescope/pickers/scroller.lua
+++ b/lua/telescope/pickers/scroller.lua
@@ -1,5 +1,7 @@
 local scroller = {}
 
+---@class TelescopeScroller
+
 local range_calculators = {
   ascending = function(max_results, num_results)
     return 0, math.min(max_results, num_results)

--- a/lua/telescope/previewers/previewer.lua
+++ b/lua/telescope/previewers/previewer.lua
@@ -1,8 +1,23 @@
 local utils = require "telescope.utils"
 
+---@class Previewer
+---@field state table
+---@field private _title_fn TitleFn
+---@field private _dyn_title_fn TitleFn
+---@field private _setup_func any
+---@field private _teardown_func any
+---@field private _send_input any
+---@field private _scroll_fn any
+---@field private _scroll_horizontal_fn any
+---@field preview_fn any
+---@field private _empty_bufnr any
 local Previewer = {}
 Previewer.__index = Previewer
 
+---@alias TitleFn  fun(self:Previewer?, entry:table?): string
+
+---@param value string | fun(previewer: Previewer, entry: table): string
+---@return TitleFn | nil
 local force_function_wrap = function(value)
   if value ~= nil then
     if type(value) ~= "function" then


### PR DESCRIPTION
trying something out.
I like types and I think it can help with our documentation deficiencies as well (eg. confusions around why you can pass `default_text` to `find_files` and why it's not documented, where to document it, etc, but this might need some enhancements to tree-sitter-lua since the newer luals luacats annotation support is limited).