### PR TITLE
fix(builtin.marks): normalize mark path

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1109,7 +1109,7 @@ internal.marks = function(opts)
         line = line,
         lnum = lnum,
         col = col,
-        filename = v.file or bufname,
+        filename = vim.fs.normalize(v.file or bufname),
       }
       -- non alphanumeric marks goes to last
       if mark:match "%w" then


### PR DESCRIPTION
The `filename` value for quickfix lists expects a normalized/absolute path.
Was previously not normalizing `~/`.