### PR TITLE
feat: support file location in Oldfiles

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -551,12 +551,13 @@ internal.oldfiles = function(opts)
   pickers
     .new(opts, {
       prompt_title = "Oldfiles",
+      __locations_input = true,
       finder = finders.new_table {
         results = results,
         entry_maker = opts.entry_maker or make_entry.gen_from_file(opts),
       },
       sorter = conf.file_sorter(opts),
-      previewer = conf.file_previewer(opts),
+      previewer = conf.grep_previewer(opts),
     })
     :find()
 end


### PR DESCRIPTION
# Description

Small fix to also include the file location option in recent files

Fixes #2862

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've used this in my config for a day, no issues.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.0-dev-2048+g367e52cc7
* Operating system and version: Fedora 39

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)

Extra: I also noticed this was the last place `file_previewer` was still used. Not sure if this means anything, but it's worth mentioning.
