### PR TITLE
fix(pickers): when no lnum given, don't set entry.lnum

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -569,7 +569,10 @@ end
 
 --- Takes the path and parses optional cursor location `$file:$line:$column`
 --- If line or column not present `0` returned.
---- @param path string
+---@param path string
+---@return string path
+---@return integer? lnum
+---@return integer? col
 utils.__separate_file_path_location = function(path)
   local location_numbers = {}
   for i = #path, 1, -1 do
@@ -600,7 +603,7 @@ utils.__separate_file_path_location = function(path)
     return path, location_numbers[1], 0
   end
 
-  return path, 0, 0
+  return path, nil, nil
 end
 
 return utils

--- a/lua/tests/automated/utils_spec.lua
+++ b/lua/tests/automated/utils_spec.lua
@@ -108,8 +108,6 @@ describe("separates file path location", function()
     {
       input = "file:",
       file = "file",
-      row = 0,
-      col = 0,
     },
   }
 


### PR DESCRIPTION
Fixes couple of regressions from #2791 when no line number info is given in the prompt (eg. `file.txt` rather than `file.txt:10`). 
Both issues stemming from the fact that when no line number info is given, the `entry.lnum` was set to `0`. `entry.lnum` is 1-index.
- Sending results to quickfix would send faulty results (closes #2864)
- Will no open the file on the correct (previous) line number
For this, setting the lnum to 1 is still undesirable since this overwrites the lnum priority handling in the `select` action.
