### PR TITLE
fix: fallback to filetype for get_lang for treesitter highlight preview

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -482,7 +482,7 @@ files.current_buffer_fuzzy_find = function(opts)
   end
 
   opts.results_ts_highlight = vim.F.if_nil(opts.results_ts_highlight, true)
-  local lang = vim.treesitter.language.get_lang(filetype)
+  local lang = vim.treesitter.language.get_lang(filetype) or filetype
   if opts.results_ts_highlight and lang and utils.has_ts_parser(lang) then
     local parser = vim.treesitter.get_parser(opts.bufnr, lang)
     local query = vim.treesitter.query.get(lang, "highlights")

--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -167,7 +167,7 @@ end
 -- Attach ts highlighter
 utils.ts_highlighter = function(bufnr, ft)
   if has_filetype(ft) then
-    local lang = vim.treesitter.language.get_lang(ft)
+    local lang = vim.treesitter.language.get_lang(ft) or ft
     if lang and ts_utils.has_ts_parser(lang) then
       return vim.treesitter.start(bufnr, lang)
     end


### PR DESCRIPTION
# Description

`nvim-treesitter` is in the middle of a rewrite, and will switch to the rewrite once Neovim 0.10 is released. In this rewrite, there is something that has changed with registering a language. This introduces an issue in telescope, where it is not always able to provide treesitter highlighting in the preview.

Reading the code in `nvim-treesitter`, it also uses `vim.treesitter.language.get_lang` and always fallback to the filetype if the function doesn't provide any language

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Install the newest `nvim-treesitter` using the `main` branch. Try to open a picker with a previewer, and notice that some languages where the filetype name matches the parser name, and see that it is not properly highlighted.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.0-dev-2076+g2dc439c67
* Operating system and version: macOS Sonoma 14.2.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
