### PR TITLE
feat(actions): add git restore action, use in git_status picker

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -895,6 +895,85 @@ actions.git_staging_toggle = function(prompt_bufnr)
   end
 end
 
+--- Restore selected file
+---@param prompt_bufnr number: The prompt bufnr
+actions.git_restore = function(prompt_bufnr)
+  local cwd = action_state.get_current_picker(prompt_bufnr).cwd
+  local selection = action_state.get_selected_entry()
+  if selection == nil then
+    utils.__warn_no_selection "actions.git_restore"
+    return
+  end
+
+  local canceled_message = function()
+    utils.notify("actions.git_restore", {
+      msg = string.format "action canceled",
+      level = "INFO",
+    })
+  end
+
+  -- check if the file is currently open in a buffer
+  local file_bufnr = vim.fn.bufnr("^" .. selection.path .. "$")
+
+  if file_bufnr ~= -1 then
+    if vim.bo[file_bufnr].mod then -- buffer to restore has unsaved changes!
+      local user_choice =
+        vim.fn.input(string.format("File '%s' has unsaved changes! [s]ave [d]iscard [C]ANCEL: ", selection.value))
+      if user_choice:len() == 0 then -- cancel on empty input
+        canceled_message()
+        return
+      end
+
+      local get_buf_action = function()
+        local choice = user_choice:lower():sub(0, 1)
+        if choice == "s" then
+          return vim.cmd.write
+        end
+        if choice == "d" then
+          return function()
+            vim.cmd.edit { bang = true }
+          end -- :edit! discards changes
+        end
+        return nil
+      end
+
+      local buf_action = get_buf_action()
+      if buf_action == nil then
+        canceled_message()
+        return
+      end
+      vim.api.nvim_buf_call(file_bufnr, buf_action)
+    end
+  end
+
+  if not ask_to_confirm(string.format("Restore file '%s'? [y/N]: ", selection.value), "") then
+    canceled_message()
+    return
+  end
+
+  local _, ret, stderr = utils.get_os_command_output({ "git", "restore", selection.value }, cwd)
+  if ret == 0 then
+    utils.notify("actions.git_restore", {
+      msg = string.format("Restored file: %s", selection.value),
+      level = "INFO",
+    })
+  else
+    utils.notify("actions.git_restore", {
+      msg = string.format(
+        "Error when restoring file: '%s' | Git returned '%s'",
+        selection.value,
+        table.concat(stderr, " ")
+      ),
+      level = "ERROR",
+    })
+  end
+
+  -- since git changes the file externally, use checktime to update buffer
+  vim.cmd.checktime()
+
+  -- TODO: find way to redraw finder content
+end
+
 local entry_to_qf = function(entry)
   local text = entry.text
 

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -420,6 +420,7 @@ git.status = function(opts)
         }
 
         map({ "i", "n" }, "<tab>", actions.git_staging_toggle)
+        map("n", "<del>", actions.git_restore)
         return true
       end,
     })


### PR DESCRIPTION
# Description

Motivation: convenient way to git restore files using telescope.

Add an action to perform a `git restore` on a file. Accessible via the builtin.git_status picker, with \<del\> key.
If there are any unsaved changes, the user can save, discard, or cancel, before choosing to git recover.
If the restore is confirmed by the user, will call `git restore` and immediately refresh the buffers with :checktime in case the file is open.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

To test, open a git repo and make some changes to a file to show in the git status telescope picker.
In the git_status picker, select the file you want to restore and press the \<del\> key (only in normal mode). The possible options are:

- [x] press enter (or type 'n' and enter), nothing happens.
- [x] type 'y' and enter, the file is restored, and immediately refreshed.

If the file is open in a buffer and has unsaved changes:
- [x] press enter, nothing happens.
- [x] type 's' and enter, the file is saved, and you are prompted for the git restore action (if you go to the file and press 'u', the changes are recovered)
- [x] type 'd' and enter, the changes are discarded, and you are prompted for the git restore action (you cannot recover the unsaved changes)


**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.4
* Operating system and version: Windows 10 - 10.0.19045 Build 19045

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
