### PR TITLE
style: Unify markdown formatting

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "line-length": false,
+  "no-multiline-string": false,
+  "no-inline-html": false,
+  "no-bare-urls": false
+}

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ wiki.
 
 - [sharkdp/fd](https://github.com/sharkdp/fd) (finder)
 - [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) (finder/preview)
-- [neovim LSP]( https://neovim.io/doc/user/lsp.html) (picker)
+- [neovim LSP](https://neovim.io/doc/user/lsp.html) (picker)
 - [devicons](https://github.com/nvim-tree/nvim-web-devicons) (icons)
 
 ### Installation
@@ -96,6 +96,7 @@ call dein#add('nvim-lua/plenary.nvim')
 call dein#add('nvim-telescope/telescope.nvim', { 'rev': '0.1.5' })
 " or                                         , { 'rev': '0.1.x' })
 ```
+
 Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
 ```lua
@@ -135,7 +136,7 @@ to get an understanding of how to use Telescope and how to configure it.
 ## Usage
 
 Try the command `:Telescope find_files<cr>`
-  to see if `telescope.nvim` is installed correctly.
+to see if `telescope.nvim` is installed correctly.
 
 Using VimL:
 
@@ -216,13 +217,12 @@ require('telescope').setup{
 ```
 
 To look at what default configuration options exist please read: `:help
-telescope.setup()`.  For picker specific `opts` please read: `:help
+telescope.setup()`. For picker specific `opts` please read: `:help
 telescope.builtin`.
 
-
 To embed the above code snippet in a `.vim` file
-  (for example in `after/plugin/telescope.nvim.vim`),
-  wrap it in `lua << EOF code-snippet EOF`:
+(for example in `after/plugin/telescope.nvim.vim`),
+wrap it in `lua << EOF code-snippet EOF`:
 
 ```lua
 lua << EOF
@@ -238,7 +238,7 @@ Mappings are fully customizable.
 Many familiar mapping patterns are set up as defaults.
 
 | Mappings       | Action                                               |
-|----------------|------------------------------------------------------|
+| -------------- | ---------------------------------------------------- |
 | `<C-n>/<Down>` | Next item                                            |
 | `<C-p>/<Up>`   | Previous item                                        |
 | `j/k`          | Next/previous (in normal mode)                       |
@@ -262,7 +262,6 @@ Many familiar mapping patterns are set up as defaults.
 | `<S-Tab>`      | Toggle selection and move to prev selection          |
 | `<C-q>`        | Send all items not filtered to quickfixlist (qflist) |
 | `<M-q>`        | Send all selected items to qflist                    |
-
 
 To see the full list of mappings, check out `lua/telescope/mappings.lua` and the
 `default_mappings` table.
@@ -304,17 +303,17 @@ Built-in functions. Ready to be bound to any key you like.
 
 ### File Pickers
 
-| Functions                           | Description                                                                                                                                                              |
-|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `builtin.find_files`                | Lists files in your current working directory, respects .gitignore                                                                                                       |
-| `builtin.git_files`                 | Fuzzy search through the output of `git ls-files` command, respects .gitignore                                                                                           |
-| `builtin.grep_string`               | Searches for the string under your cursor or selection in your current working directory                                                                                              |
-| `builtin.live_grep`                 | Search for a string in your current working directory and get results live as you type, respects .gitignore. (Requires [ripgrep](https://github.com/BurntSushi/ripgrep)) |
+| Functions             | Description                                                                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `builtin.find_files`  | Lists files in your current working directory, respects .gitignore                                                                                                       |
+| `builtin.git_files`   | Fuzzy search through the output of `git ls-files` command, respects .gitignore                                                                                           |
+| `builtin.grep_string` | Searches for the string under your cursor or selection in your current working directory                                                                                 |
+| `builtin.live_grep`   | Search for a string in your current working directory and get results live as you type, respects .gitignore. (Requires [ripgrep](https://github.com/BurntSushi/ripgrep)) |
 
 ### Vim Pickers
 
 | Functions                           | Description                                                                                                                                                 |
-|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `builtin.buffers`                   | Lists open buffers in current neovim instance                                                                                                               |
 | `builtin.oldfiles`                  | Lists previously open files                                                                                                                                 |
 | `builtin.commands`                  | Lists available plugin/user commands and runs them on `<cr>`                                                                                                |
@@ -343,56 +342,55 @@ Built-in functions. Ready to be bound to any key you like.
 
 ### Neovim LSP Pickers
 
-| Functions                                   | Description                                                                                                               |
-|---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `builtin.lsp_references`                    | Lists LSP references for word under the cursor                                                                            |
-| `builtin.lsp_incoming_calls`                | Lists LSP incoming calls for word under the cursor                                                                        |
-| `builtin.lsp_outgoing_calls`                | Lists LSP outgoing calls for word under the cursor                                                                        |
-| `builtin.lsp_document_symbols`              | Lists LSP document symbols in the current buffer                                                                          |
-| `builtin.lsp_workspace_symbols`             | Lists LSP document symbols in the current workspace                                                                       |
-| `builtin.lsp_dynamic_workspace_symbols`     | Dynamically Lists LSP for all workspace symbols                                                                           |
-| `builtin.diagnostics`                       | Lists Diagnostics for all open buffers or a specific buffer. Use option `bufnr=0` for current buffer.                     |
-| `builtin.lsp_implementations`               | Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope         |
-| `builtin.lsp_definitions`                   | Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope            |
-| `builtin.lsp_type_definitions`              | Goto the definition of the type of the word under the cursor, if there's only one, otherwise show all options in Telescope|
-
+| Functions                               | Description                                                                                                                |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `builtin.lsp_references`                | Lists LSP references for word under the cursor                                                                             |
+| `builtin.lsp_incoming_calls`            | Lists LSP incoming calls for word under the cursor                                                                         |
+| `builtin.lsp_outgoing_calls`            | Lists LSP outgoing calls for word under the cursor                                                                         |
+| `builtin.lsp_document_symbols`          | Lists LSP document symbols in the current buffer                                                                           |
+| `builtin.lsp_workspace_symbols`         | Lists LSP document symbols in the current workspace                                                                        |
+| `builtin.lsp_dynamic_workspace_symbols` | Dynamically Lists LSP for all workspace symbols                                                                            |
+| `builtin.diagnostics`                   | Lists Diagnostics for all open buffers or a specific buffer. Use option `bufnr=0` for current buffer.                      |
+| `builtin.lsp_implementations`           | Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope          |
+| `builtin.lsp_definitions`               | Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope             |
+| `builtin.lsp_type_definitions`          | Goto the definition of the type of the word under the cursor, if there's only one, otherwise show all options in Telescope |
 
 ### Git Pickers
 
-| Functions                           | Description                                                                                                |
-|-------------------------------------|------------------------------------------------------------------------------------------------------------|
-| `builtin.git_commits`               | Lists git commits with diff preview, checkout action `<cr>`, reset mixed `<C-r>m`, reset soft `<C-r>s` and reset hard `<C-r>h` |
-| `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and checks them out on `<cr>`                                 |
-| `builtin.git_bcommits_range`        | Lists buffer's git commits in a range of lines. Use options `from` and `to` to specify the range. In visual mode, lists commits for the selected lines |
-| `builtin.git_branches`              | Lists all branches with log preview, checkout action `<cr>`, track action `<C-t>`, rebase action`<C-r>`, create action `<C-a>`, switch action `<C-s>`, delete action `<C-d>` and merge action `<C-y>` |
-| `builtin.git_status`                | Lists current changes per file with diff preview and add action. (Multi-selection still WIP)               |
-| `builtin.git_stash`                 | Lists stash items in current repository with ability to apply them on `<cr>`                               |
+| Functions                    | Description                                                                                                                                                                                           |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `builtin.git_commits`        | Lists git commits with diff preview, checkout action `<cr>`, reset mixed `<C-r>m`, reset soft `<C-r>s` and reset hard `<C-r>h`                                                                        |
+| `builtin.git_bcommits`       | Lists buffer's git commits with diff preview and checks them out on `<cr>`                                                                                                                            |
+| `builtin.git_bcommits_range` | Lists buffer's git commits in a range of lines. Use options `from` and `to` to specify the range. In visual mode, lists commits for the selected lines                                                |
+| `builtin.git_branches`       | Lists all branches with log preview, checkout action `<cr>`, track action `<C-t>`, rebase action`<C-r>`, create action `<C-a>`, switch action `<C-s>`, delete action `<C-d>` and merge action `<C-y>` |
+| `builtin.git_status`         | Lists current changes per file with diff preview and add action. (Multi-selection still WIP)                                                                                                          |
+| `builtin.git_stash`          | Lists stash items in current repository with ability to apply them on `<cr>`                                                                                                                          |
 
 ### Treesitter Picker
 
-| Functions                           | Description                                       |
-|-------------------------------------|---------------------------------------------------|
-| `builtin.treesitter`                | Lists Function names, variables, from Treesitter! |
+| Functions            | Description                                       |
+| -------------------- | ------------------------------------------------- |
+| `builtin.treesitter` | Lists Function names, variables, from Treesitter! |
 
 ### Lists Picker
 
-| Functions                           | Description                                                                                                                                                                               |
-|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `builtin.planets`                   | Use the telescope...                                                                                                                                                                      |
-| `builtin.builtin`                   | Lists Built-in pickers and run them on `<cr>`.                                                                                                                                            |
-| `builtin.reloader`                  | Lists Lua modules and reload them on `<cr>`.                                                                                                                                              |
-| `builtin.symbols`                   | Lists symbols inside a file `data/telescope-sources/*.json` found in your rtp. More info and symbol sources can be found [here](https://github.com/nvim-telescope/telescope-symbols.nvim) |
+| Functions          | Description                                                                                                                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `builtin.planets`  | Use the telescope...                                                                                                                                                                      |
+| `builtin.builtin`  | Lists Built-in pickers and run them on `<cr>`.                                                                                                                                            |
+| `builtin.reloader` | Lists Lua modules and reload them on `<cr>`.                                                                                                                                              |
+| `builtin.symbols`  | Lists symbols inside a file `data/telescope-sources/*.json` found in your rtp. More info and symbol sources can be found [here](https://github.com/nvim-telescope/telescope-symbols.nvim) |
 
 ## Previewers
 
-| Previewers                         | Description                                               |
-|------------------------------------|-----------------------------------------------------------|
-| `previewers.vim_buffer_cat.new`    | Default previewer for files. Uses vim buffers             |
-| `previewers.vim_buffer_vimgrep.new`| Default previewer for grep and similar. Uses vim buffers  |
-| `previewers.vim_buffer_qflist.new` | Default previewer for qflist. Uses vim buffers            |
-| `previewers.cat.new`               | Terminal previewer for files. Uses `cat`/`bat`            |
-| `previewers.vimgrep.new`           | Terminal previewer for grep and similar. Uses `cat`/`bat` |
-| `previewers.qflist.new`            | Terminal previewer for qflist. Uses `cat`/`bat`           |
+| Previewers                          | Description                                               |
+| ----------------------------------- | --------------------------------------------------------- |
+| `previewers.vim_buffer_cat.new`     | Default previewer for files. Uses vim buffers             |
+| `previewers.vim_buffer_vimgrep.new` | Default previewer for grep and similar. Uses vim buffers  |
+| `previewers.vim_buffer_qflist.new`  | Default previewer for qflist. Uses vim buffers            |
+| `previewers.cat.new`                | Terminal previewer for files. Uses `cat`/`bat`            |
+| `previewers.vimgrep.new`            | Terminal previewer for grep and similar. Uses `cat`/`bat` |
+| `previewers.qflist.new`             | Terminal previewer for qflist. Uses `cat`/`bat`           |
 
 The default previewers are from now on `vim_buffer_` previewers. They use vim
 buffers for displaying files and use tree-sitter or regex for file highlighting.
@@ -435,7 +433,7 @@ A data field is passed to the callback, which contains the filetype and the buff
 ## Sorters
 
 | Sorters                            | Description                                                     |
-|------------------------------------|-----------------------------------------------------------------|
+| ---------------------------------- | --------------------------------------------------------------- |
 | `sorters.get_fuzzy_file`           | Telescope's default sorter for files                            |
 | `sorters.get_generic_fuzzy_sorter` | Telescope's default sorter for everything else                  |
 | `sorters.get_levenshtein_sorter`   | Using Levenshtein distance algorithm (don't use :D)             |
@@ -465,7 +463,7 @@ For more details on resolving sizes, see `:help telescope.resolve`.
 As an example, if we wanted to specify the layout strategy and width,
 but only for this instance, we could do something like:
 
-```
+```vim
 :lua require('telescope.builtin').find_files({layout_strategy='vertical',layout_config={width=0.5}})
 ```
 
@@ -492,11 +490,11 @@ We have some built in themes but are looking for more cool options.
 
 ![dropdown](https://i.imgur.com/SorAcXv.png)
 
-| Themes                   | Description                                                                                 |
-|--------------------------|---------------------------------------------------------------------------------------------|
-| `themes.get_dropdown`    | A list like centered list. [dropdown](https://i.imgur.com/SorAcXv.png)                      |
-| `themes.get_cursor`      | [A cursor relative list.](https://github.com/nvim-telescope/telescope.nvim/pull/878)        |
-| `themes.get_ivy`         | Bottom panel overlay. [Ivy #771](https://github.com/nvim-telescope/telescope.nvim/pull/771) |
+| Themes                | Description                                                                                 |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `themes.get_dropdown` | A list like centered list. [dropdown](https://i.imgur.com/SorAcXv.png)                      |
+| `themes.get_cursor`   | [A cursor relative list.](https://github.com/nvim-telescope/telescope.nvim/pull/878)        |
+| `themes.get_ivy`      | Bottom panel overlay. [Ivy #771](https://github.com/nvim-telescope/telescope.nvim/pull/771) |
 
 To use a theme, simply append it to a builtin function:
 
@@ -564,7 +562,7 @@ for more information and how to realize more complex commands please read
 Telescope user autocmds:
 
 | Event                           | Description                                             |
-|---------------------------------|---------------------------------------------------------|
+| ------------------------------- | ------------------------------------------------------- |
 | `User TelescopeFindPre`         | Do it before Telescope creates all the floating windows |
 | `User TelescopePreviewerLoaded` | Do it after Telescope previewer window is created       |
 | `User TelescopeResumePost`      | Do it after Telescope resume action is fully completed  |
@@ -575,7 +573,7 @@ Telescope provides the capabilities to create & register extensions, which
 improves telescope in a variety of ways.
 
 Some extensions provide integration with external tools, outside of the scope of
-`builtins`.  Others provide performance enhancements by using compiled C and
+`builtins`. Others provide performance enhancements by using compiled C and
 interfacing directly with Lua over LuaJIT's FFI library.
 
 A list of community extensions can be found in the

--- a/developers.md
+++ b/developers.md
@@ -30,6 +30,7 @@ in the future.
 
 This guide is mainly for telescope so it will assume that you already have some knowledge of the Lua
 programming language. If not then you can find information for Lua here:
+
 - [Lua 5.1 Manual](https://www.lua.org/manual/5.1/)
 - [Getting started using Lua in Neovim](https://github.com/nanotee/nvim-lua-guide)
 
@@ -42,6 +43,7 @@ scratch file, in which we will develop the picker and run it each time using
 ### Requires
 
 The most important includes are the following modules:
+
 ```lua
 local pickers = require "telescope.pickers"
 local finders = require "telescope.finders"
@@ -51,6 +53,7 @@ local conf = require("telescope.config").values
 - `pickers`: main module which is used to create a new picker.
 - `finders`: provides interfaces to fill the picker with items.
 - `config`: `values` table which holds the user's configuration.
+
 So to make it easier we access this table directly in `conf`.
 
 ### First Picker
@@ -137,12 +140,10 @@ local action_state = require "telescope.actions.state"
 ```
 
 - `actions`: holds all actions that can be mapped by a user. We also need it to
-  access the default action so we can replace it. Also see `:help
-  telescope.actions`
+  access the default action so we can replace it. Also see `:help telescope.actions`
 
 - `action_state`: gives us a few utility functions we can use to get the
-  current picker, current selection or current line. Also see `:help
-  telescope.actions.state`
+  current picker, current selection or current line. Also see `:help telescope.actions.state`
 
 So let's replace the default action. For that we need to define a new key value
 pair in our table that we pass into `pickers.new`, for example after `sorter`.
@@ -244,6 +245,7 @@ sorting key.
 
 There are other important keys which can be set, but do not make sense in the
 current context as we are not dealing with files:
+
 - `path`: to set the absolute path of the file to make sure it's always found
 - `lnum`: to specify a line number in the file. This will allow the
   `conf.grep_previewer` to show that line and the default action to jump to
@@ -286,7 +288,7 @@ picker via the `:Telescope` command, the following has to be done.
 
 Structure your plugin as follows, so it can be found by telescope:
 
-```
+```sh
 .
 └── lua
     ├── plugin_name             # Your actual plugin code
@@ -323,7 +325,6 @@ The exports table declares the exported pickers that can then be accessed via
 that you name the key like the plugin, so you can access it with `Telescope
 plugin_name`.
 
-
 ## Technical
 
 ### Picker
@@ -345,7 +346,9 @@ Picker:new{
 ```
 
 ### Finders
+
 <!-- TODO what are finders -->
+
 ```lua
 -- lua/telescope/finders.lua
 Finder:new{
@@ -367,14 +370,14 @@ TODO: Talk about what actions vs actions sets are
 ##### Relevant Files
 
 - `lua/telescope/actions/init.lua`
-    - The most "user-facing" of the files, which has the builtin actions that we provide
+  - The most "user-facing" of the files, which has the builtin actions that we provide
 - `lua/telescope/actions/set.lua`
-    - The second most "user-facing" of the files. This provides actions that are consumed by several builtin actions, which allows for only overriding ONE item, instead of copying the same configuration / function several times.
+  - The second most "user-facing" of the files. This provides actions that are consumed by several builtin actions, which allows for only overriding ONE item, instead of copying the same configuration / function several times.
 - `lua/telescope/actions/state.lua`
-    - Provides APIs for interacting with the state of telescope from within actions.
-    - These are useful for writing your own actions and interacting with telescope
+  - Provides APIs for interacting with the state of telescope from within actions.
+  - These are useful for writing your own actions and interacting with telescope
 - `lua/telescope/actions/mt.lua`
-    - You probably don't need to look at this, but it defines the behavior of actions.
+  - You probably don't need to look at this, but it defines the behavior of actions.
 
 ##### `:replace(function)`
 


### PR DESCRIPTION
# Description

👋🏻 Hi!
I recently got excited about neovim and wanted to contribute to the community in any way I can.

In my LazyVim configuration, I have enabled the markdown module. By default, this module [enables nvim-lint](https://www.lazyvim.org/extras/lang/markdown#nvim-lint-optional) which uses [markdownlint](https://github.com/DavidAnson/markdownlint).

This PR fixes some some warnings I saw when opening the documentation in my neovim:

<img width="1350" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/300791/3606eb24-df83-4257-8858-7513d86b4966">

I also found that when I saved some of the documentation, the file was reformatted. This caused some issues in how some of the text was rendered because it contained a mixture of space and tab characters. Here's some of the changes (in red in the middle of the file):

<img width="1357" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/300791/eba09eca-fba6-4f9b-83a7-79332c4e9e0f">


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

**Configuration**:
* Neovim version (nvim --version):

```sh
NVIM v0.10.0-dev-2086+g965dbd0e0
Build type: Release
LuaJIT 2.1.1703358377
Run "nvim -V1 -v" for more info
```

* Operating system and version:
`OSX 14.2.1`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation (lua annotations)~~
