### PR TITLE
feat(picker): allow appending original window cword to prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ wiki.
 
 - [sharkdp/fd](https://github.com/sharkdp/fd) (finder)
 - [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) (finder/preview)
-- [neovim LSP]( https://neovim.io/doc/user/lsp.html) (picker)
+- [neovim LSP](https://neovim.io/doc/user/lsp.html) (picker)
 - [devicons](https://github.com/nvim-tree/nvim-web-devicons) (icons)
 
 ### Installation
@@ -96,6 +96,7 @@ call dein#add('nvim-lua/plenary.nvim')
 call dein#add('nvim-telescope/telescope.nvim', { 'rev': '0.1.5' })
 " or                                         , { 'rev': '0.1.x' })
 ```
+
 Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
 ```lua
@@ -135,7 +136,7 @@ to get an understanding of how to use Telescope and how to configure it.
 ## Usage
 
 Try the command `:Telescope find_files<cr>`
-  to see if `telescope.nvim` is installed correctly.
+to see if `telescope.nvim` is installed correctly.
 
 Using VimL:
 
@@ -216,13 +217,12 @@ require('telescope').setup{
 ```
 
 To look at what default configuration options exist please read: `:help
-telescope.setup()`.  For picker specific `opts` please read: `:help
+telescope.setup()`. For picker specific `opts` please read: `:help
 telescope.builtin`.
 
-
 To embed the above code snippet in a `.vim` file
-  (for example in `after/plugin/telescope.nvim.vim`),
-  wrap it in `lua << EOF code-snippet EOF`:
+(for example in `after/plugin/telescope.nvim.vim`),
+wrap it in `lua << EOF code-snippet EOF`:
 
 ```lua
 lua << EOF
@@ -237,32 +237,32 @@ EOF
 Mappings are fully customizable.
 Many familiar mapping patterns are set up as defaults.
 
-| Mappings       | Action                                               |
-|----------------|------------------------------------------------------|
-| `<C-n>/<Down>` | Next item                                            |
-| `<C-p>/<Up>`   | Previous item                                        |
-| `j/k`          | Next/previous (in normal mode)                       |
-| `H/M/L`        | Select High/Middle/Low (in normal mode)              |
-| `gg/G`         | Select the first/last item (in normal mode)          |
-| `<CR>`         | Confirm selection                                    |
-| `<C-x>`        | Go to file selection as a split                      |
-| `<C-v>`        | Go to file selection as a vsplit                     |
-| `<C-t>`        | Go to a file in a new tab                            |
-| `<C-u>`        | Scroll up in preview window                          |
-| `<C-d>`        | Scroll down in preview window                        |
-| `<C-f>`        | Scroll left in preview window                        |
-| `<C-k>`        | Scroll right in preview window                       |
-| `<M-f>`        | Scroll left in results window                        |
-| `<M-k>`        | Scroll right in results window                       |
-| `<C-/>`        | Show mappings for picker actions (insert mode)       |
-| `?`            | Show mappings for picker actions (normal mode)       |
-| `<C-c>`        | Close telescope (insert mode)                        |
-| `<Esc>`        | Close telescope (in normal mode)                     |
-| `<Tab>`        | Toggle selection and move to next selection          |
-| `<S-Tab>`      | Toggle selection and move to prev selection          |
-| `<C-q>`        | Send all items not filtered to quickfixlist (qflist) |
-| `<M-q>`        | Send all selected items to qflist                    |
-
+| Mappings       | Action                                                    |
+| -------------- | --------------------------------------------------------- |
+| `<C-n>/<Down>` | Next item                                                 |
+| `<C-p>/<Up>`   | Previous item                                             |
+| `j/k`          | Next/previous (in normal mode)                            |
+| `H/M/L`        | Select High/Middle/Low (in normal mode)                   |
+| `gg/G`         | Select the first/last item (in normal mode)               |
+| `<CR>`         | Confirm selection                                         |
+| `<C-x>`        | Go to file selection as a split                           |
+| `<C-v>`        | Go to file selection as a vsplit                          |
+| `<C-t>`        | Go to a file in a new tab                                 |
+| `<C-u>`        | Scroll up in preview window                               |
+| `<C-d>`        | Scroll down in preview window                             |
+| `<C-f>`        | Scroll left in preview window                             |
+| `<C-k>`        | Scroll right in preview window                            |
+| `<M-f>`        | Scroll left in results window                             |
+| `<M-k>`        | Scroll right in results window                            |
+| `<C-/>`        | Show mappings for picker actions (insert mode)            |
+| `?`            | Show mappings for picker actions (normal mode)            |
+| `<C-c>`        | Close telescope (insert mode)                             |
+| `<Esc>`        | Close telescope (in normal mode)                          |
+| `<Tab>`        | Toggle selection and move to next selection               |
+| `<S-Tab>`      | Toggle selection and move to prev selection               |
+| `<C-q>`        | Send all items not filtered to quickfixlist (qflist)      |
+| `<M-q>`        | Send all selected items to qflist                         |
+| `<C-r><C-w>`   | Insert cword in original window into prompt (insert mode) |
 
 To see the full list of mappings, check out `lua/telescope/mappings.lua` and the
 `default_mappings` table.
@@ -304,17 +304,17 @@ Built-in functions. Ready to be bound to any key you like.
 
 ### File Pickers
 
-| Functions                           | Description                                                                                                                                                              |
-|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `builtin.find_files`                | Lists files in your current working directory, respects .gitignore                                                                                                       |
-| `builtin.git_files`                 | Fuzzy search through the output of `git ls-files` command, respects .gitignore                                                                                           |
-| `builtin.grep_string`               | Searches for the string under your cursor or selection in your current working directory                                                                                              |
-| `builtin.live_grep`                 | Search for a string in your current working directory and get results live as you type, respects .gitignore. (Requires [ripgrep](https://github.com/BurntSushi/ripgrep)) |
+| Functions             | Description                                                                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `builtin.find_files`  | Lists files in your current working directory, respects .gitignore                                                                                                       |
+| `builtin.git_files`   | Fuzzy search through the output of `git ls-files` command, respects .gitignore                                                                                           |
+| `builtin.grep_string` | Searches for the string under your cursor or selection in your current working directory                                                                                 |
+| `builtin.live_grep`   | Search for a string in your current working directory and get results live as you type, respects .gitignore. (Requires [ripgrep](https://github.com/BurntSushi/ripgrep)) |
 
 ### Vim Pickers
 
 | Functions                           | Description                                                                                                                                                 |
-|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `builtin.buffers`                   | Lists open buffers in current neovim instance                                                                                                               |
 | `builtin.oldfiles`                  | Lists previously open files                                                                                                                                 |
 | `builtin.commands`                  | Lists available plugin/user commands and runs them on `<cr>`                                                                                                |
@@ -343,56 +343,55 @@ Built-in functions. Ready to be bound to any key you like.
 
 ### Neovim LSP Pickers
 
-| Functions                                   | Description                                                                                                               |
-|---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `builtin.lsp_references`                    | Lists LSP references for word under the cursor                                                                            |
-| `builtin.lsp_incoming_calls`                | Lists LSP incoming calls for word under the cursor                                                                        |
-| `builtin.lsp_outgoing_calls`                | Lists LSP outgoing calls for word under the cursor                                                                        |
-| `builtin.lsp_document_symbols`              | Lists LSP document symbols in the current buffer                                                                          |
-| `builtin.lsp_workspace_symbols`             | Lists LSP document symbols in the current workspace                                                                       |
-| `builtin.lsp_dynamic_workspace_symbols`     | Dynamically Lists LSP for all workspace symbols                                                                           |
-| `builtin.diagnostics`                       | Lists Diagnostics for all open buffers or a specific buffer. Use option `bufnr=0` for current buffer.                     |
-| `builtin.lsp_implementations`               | Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope         |
-| `builtin.lsp_definitions`                   | Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope            |
-| `builtin.lsp_type_definitions`              | Goto the definition of the type of the word under the cursor, if there's only one, otherwise show all options in Telescope|
-
+| Functions                               | Description                                                                                                                |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `builtin.lsp_references`                | Lists LSP references for word under the cursor                                                                             |
+| `builtin.lsp_incoming_calls`            | Lists LSP incoming calls for word under the cursor                                                                         |
+| `builtin.lsp_outgoing_calls`            | Lists LSP outgoing calls for word under the cursor                                                                         |
+| `builtin.lsp_document_symbols`          | Lists LSP document symbols in the current buffer                                                                           |
+| `builtin.lsp_workspace_symbols`         | Lists LSP document symbols in the current workspace                                                                        |
+| `builtin.lsp_dynamic_workspace_symbols` | Dynamically Lists LSP for all workspace symbols                                                                            |
+| `builtin.diagnostics`                   | Lists Diagnostics for all open buffers or a specific buffer. Use option `bufnr=0` for current buffer.                      |
+| `builtin.lsp_implementations`           | Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope          |
+| `builtin.lsp_definitions`               | Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope             |
+| `builtin.lsp_type_definitions`          | Goto the definition of the type of the word under the cursor, if there's only one, otherwise show all options in Telescope |
 
 ### Git Pickers
 
-| Functions                           | Description                                                                                                |
-|-------------------------------------|------------------------------------------------------------------------------------------------------------|
-| `builtin.git_commits`               | Lists git commits with diff preview, checkout action `<cr>`, reset mixed `<C-r>m`, reset soft `<C-r>s` and reset hard `<C-r>h` |
-| `builtin.git_bcommits`              | Lists buffer's git commits with diff preview and checks them out on `<cr>`                                 |
-| `builtin.git_bcommits_range`        | Lists buffer's git commits in a range of lines. Use options `from` and `to` to specify the range. In visual mode, lists commits for the selected lines |
-| `builtin.git_branches`              | Lists all branches with log preview, checkout action `<cr>`, track action `<C-t>`, rebase action`<C-r>`, create action `<C-a>`, switch action `<C-s>`, delete action `<C-d>` and merge action `<C-y>` |
-| `builtin.git_status`                | Lists current changes per file with diff preview and add action. (Multi-selection still WIP)               |
-| `builtin.git_stash`                 | Lists stash items in current repository with ability to apply them on `<cr>`                               |
+| Functions                    | Description                                                                                                                                                                                           |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `builtin.git_commits`        | Lists git commits with diff preview, checkout action `<cr>`, reset mixed `<C-r>m`, reset soft `<C-r>s` and reset hard `<C-r>h`                                                                        |
+| `builtin.git_bcommits`       | Lists buffer's git commits with diff preview and checks them out on `<cr>`                                                                                                                            |
+| `builtin.git_bcommits_range` | Lists buffer's git commits in a range of lines. Use options `from` and `to` to specify the range. In visual mode, lists commits for the selected lines                                                |
+| `builtin.git_branches`       | Lists all branches with log preview, checkout action `<cr>`, track action `<C-t>`, rebase action`<C-r>`, create action `<C-a>`, switch action `<C-s>`, delete action `<C-d>` and merge action `<C-y>` |
+| `builtin.git_status`         | Lists current changes per file with diff preview and add action. (Multi-selection still WIP)                                                                                                          |
+| `builtin.git_stash`          | Lists stash items in current repository with ability to apply them on `<cr>`                                                                                                                          |
 
 ### Treesitter Picker
 
-| Functions                           | Description                                       |
-|-------------------------------------|---------------------------------------------------|
-| `builtin.treesitter`                | Lists Function names, variables, from Treesitter! |
+| Functions            | Description                                       |
+| -------------------- | ------------------------------------------------- |
+| `builtin.treesitter` | Lists Function names, variables, from Treesitter! |
 
 ### Lists Picker
 
-| Functions                           | Description                                                                                                                                                                               |
-|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `builtin.planets`                   | Use the telescope...                                                                                                                                                                      |
-| `builtin.builtin`                   | Lists Built-in pickers and run them on `<cr>`.                                                                                                                                            |
-| `builtin.reloader`                  | Lists Lua modules and reload them on `<cr>`.                                                                                                                                              |
-| `builtin.symbols`                   | Lists symbols inside a file `data/telescope-sources/*.json` found in your rtp. More info and symbol sources can be found [here](https://github.com/nvim-telescope/telescope-symbols.nvim) |
+| Functions          | Description                                                                                                                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `builtin.planets`  | Use the telescope...                                                                                                                                                                      |
+| `builtin.builtin`  | Lists Built-in pickers and run them on `<cr>`.                                                                                                                                            |
+| `builtin.reloader` | Lists Lua modules and reload them on `<cr>`.                                                                                                                                              |
+| `builtin.symbols`  | Lists symbols inside a file `data/telescope-sources/*.json` found in your rtp. More info and symbol sources can be found [here](https://github.com/nvim-telescope/telescope-symbols.nvim) |
 
 ## Previewers
 
-| Previewers                         | Description                                               |
-|------------------------------------|-----------------------------------------------------------|
-| `previewers.vim_buffer_cat.new`    | Default previewer for files. Uses vim buffers             |
-| `previewers.vim_buffer_vimgrep.new`| Default previewer for grep and similar. Uses vim buffers  |
-| `previewers.vim_buffer_qflist.new` | Default previewer for qflist. Uses vim buffers            |
-| `previewers.cat.new`               | Terminal previewer for files. Uses `cat`/`bat`            |
-| `previewers.vimgrep.new`           | Terminal previewer for grep and similar. Uses `cat`/`bat` |
-| `previewers.qflist.new`            | Terminal previewer for qflist. Uses `cat`/`bat`           |
+| Previewers                          | Description                                               |
+| ----------------------------------- | --------------------------------------------------------- |
+| `previewers.vim_buffer_cat.new`     | Default previewer for files. Uses vim buffers             |
+| `previewers.vim_buffer_vimgrep.new` | Default previewer for grep and similar. Uses vim buffers  |
+| `previewers.vim_buffer_qflist.new`  | Default previewer for qflist. Uses vim buffers            |
+| `previewers.cat.new`                | Terminal previewer for files. Uses `cat`/`bat`            |
+| `previewers.vimgrep.new`            | Terminal previewer for grep and similar. Uses `cat`/`bat` |
+| `previewers.qflist.new`             | Terminal previewer for qflist. Uses `cat`/`bat`           |
 
 The default previewers are from now on `vim_buffer_` previewers. They use vim
 buffers for displaying files and use tree-sitter or regex for file highlighting.
@@ -435,7 +434,7 @@ A data field is passed to the callback, which contains the filetype and the buff
 ## Sorters
 
 | Sorters                            | Description                                                     |
-|------------------------------------|-----------------------------------------------------------------|
+| ---------------------------------- | --------------------------------------------------------------- |
 | `sorters.get_fuzzy_file`           | Telescope's default sorter for files                            |
 | `sorters.get_generic_fuzzy_sorter` | Telescope's default sorter for everything else                  |
 | `sorters.get_levenshtein_sorter`   | Using Levenshtein distance algorithm (don't use :D)             |
@@ -492,11 +491,11 @@ We have some built in themes but are looking for more cool options.
 
 ![dropdown](https://i.imgur.com/SorAcXv.png)
 
-| Themes                   | Description                                                                                 |
-|--------------------------|---------------------------------------------------------------------------------------------|
-| `themes.get_dropdown`    | A list like centered list. [dropdown](https://i.imgur.com/SorAcXv.png)                      |
-| `themes.get_cursor`      | [A cursor relative list.](https://github.com/nvim-telescope/telescope.nvim/pull/878)        |
-| `themes.get_ivy`         | Bottom panel overlay. [Ivy #771](https://github.com/nvim-telescope/telescope.nvim/pull/771) |
+| Themes                | Description                                                                                 |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `themes.get_dropdown` | A list like centered list. [dropdown](https://i.imgur.com/SorAcXv.png)                      |
+| `themes.get_cursor`   | [A cursor relative list.](https://github.com/nvim-telescope/telescope.nvim/pull/878)        |
+| `themes.get_ivy`      | Bottom panel overlay. [Ivy #771](https://github.com/nvim-telescope/telescope.nvim/pull/771) |
 
 To use a theme, simply append it to a builtin function:
 
@@ -564,7 +563,7 @@ for more information and how to realize more complex commands please read
 Telescope user autocmds:
 
 | Event                           | Description                                             |
-|---------------------------------|---------------------------------------------------------|
+| ------------------------------- | ------------------------------------------------------- |
 | `User TelescopeFindPre`         | Do it before Telescope creates all the floating windows |
 | `User TelescopePreviewerLoaded` | Do it after Telescope previewer window is created       |
 | `User TelescopeResumePost`      | Do it after Telescope resume action is fully completed  |
@@ -575,7 +574,7 @@ Telescope provides the capabilities to create & register extensions, which
 improves telescope in a variety of ways.
 
 Some extensions provide integration with external tools, outside of the scope of
-`builtins`.  Others provide performance enhancements by using compiled C and
+`builtins`. Others provide performance enhancements by using compiled C and
 interfacing directly with Lua over LuaJIT's FFI library.
 
 A list of community extensions can be found in the

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -3311,7 +3311,6 @@ actions.insert_original_cword({prompt_bufnr}) *telescope.actions.insert_original
     Insert the word under the cursor of the original (pre-Telescope) window
 
 
-
     Parameters: ~
         {prompt_bufnr} (number)  The prompt bufnr
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -3307,6 +3307,15 @@ actions.delete_mark({prompt_bufnr})          *telescope.actions.delete_mark()*
         {prompt_bufnr} (number)  The prompt bufnr
 
 
+actions.insert_original_cword({prompt_bufnr}) *telescope.actions.insert_original_cword()*
+    Insert the word under the cursor of the original (pre-Telescope) window
+
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
 
 ================================================================================
 ACTIONS_STATE                                          *telescope.actions.state*

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1484,6 +1484,11 @@ actions.delete_mark = function(prompt_bufnr)
   end)
 end
 
+actions.insert_original_cword = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  current_picker:set_prompt(current_picker.original_cword, false)
+end
+
 actions.nop = function(_) end
 
 -- ==================================================

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1484,7 +1484,7 @@ actions.delete_mark = function(prompt_bufnr)
   end)
 end
 
---- Insert the word under the cursor of the original (pre-Telescope) window<br>
+--- Insert the word under the cursor of the original (pre-Telescope) window
 ---@param prompt_bufnr number: The prompt bufnr
 actions.insert_original_cword = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1484,6 +1484,8 @@ actions.delete_mark = function(prompt_bufnr)
   end)
 end
 
+--- Insert the word under the cursor of the original (pre-Telescope) window<br>
+---@param prompt_bufnr number: The prompt bufnr
 actions.insert_original_cword = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   current_picker:set_prompt(current_picker.original_cword, false)

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -164,6 +164,7 @@ mappings.default_mappings = config.values.default_mappings
       ["<C-/>"] = actions.which_key,
       ["<C-_>"] = actions.which_key, -- keys from pressing <C-/>
       ["<C-w>"] = { "<c-s-w>", type = "command" },
+      ["<C-r><C-w>"] = actions.insert_original_cword,
 
       -- disable c-j because we dont want to allow new lines #2123
       ["<C-j>"] = actions.nop,

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -529,6 +529,7 @@ function Picker:find()
   self:reset_selection()
 
   self.original_win_id = a.nvim_get_current_win()
+  self.original_cword = vim.fn.expand "<cword>"
 
   -- User autocmd run it before create Telescope window
   vim.api.nvim_exec_autocmds("User", { pattern = "TelescopeFindPre" })
@@ -845,7 +846,13 @@ function Picker:delete_selection(delete_cb)
   end, 50)
 end
 
-function Picker:set_prompt(text)
+---@param text string text to set as prompt
+---@param reset boolean? whether to replace prompt with text entirely or just append
+function Picker:set_prompt(text, reset)
+  reset = vim.F.if_nil(reset, true)
+  if not reset then
+    text = self:_get_prompt() .. text
+  end
   self:reset_prompt(text)
 end
 


### PR DESCRIPTION
Store `<cword>` on picker:find and create new action `insert_original_cword` (maybe just `insert_cword`?) to insert/append the cword of the original window/buffer under telescope into the prompt buffer.

Allows for similar behaviors to `c_CTRL-R_CTRL-W`.
closes https://github.com/nvim-telescope/telescope.nvim/issues/2730