### PR TITLE
feat(builtin): initial support for cscope

### DIFF
--- a/lua/telescope/builtin/__cscope.lua
+++ b/lua/telescope/builtin/__cscope.lua
@@ -1,0 +1,112 @@
+local pickers = require "telescope.pickers"
+local finders = require "telescope.finders"
+local make_entry = require "telescope.make_entry"
+local utils = require "telescope.utils"
+
+local conf = require("telescope.config").values
+
+local cscope = {}
+
+local cscope_find = function(opts, type_num)
+  local dir = opts.cwd
+  local word = vim.F.if_nil(opts.search, vim.fn.expand "<cword>")
+  -- local search = opts.use_regex and word or escape_chars(word)
+  local search = word
+
+  local output =
+     utils.get_os_command_output({ "cscope", "-d", "-L", "-" .. tostring(type_num), search }, dir)
+
+  if #output == 0 then
+    utils.notify("builtin.cscope", {
+      msg = "No results found. Need to build cscope database?",
+      level = "ERROR",
+    })
+    return
+  end
+
+  local results = {}
+
+  local parse_line = function (line)
+    local fields = vim.split(line, " ")
+    local index = #results + 1
+    table.insert(results, index, fields[1]..":"..fields[3])
+  end
+
+  local i = 0
+  for _, line in ipairs(output) do
+    i = i + 1
+    parse_line(line)
+  end
+
+  local type = {
+    "find this C symbol ",
+    "find this definition ",
+    "find functions called by this function ",
+    "find functions calling this function ",
+  }
+
+  -- By creating the entry maker after the cwd options,
+  -- we ensure the maker uses the cwd options when being created.
+  opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_file(opts))
+
+  pickers
+    .new(opts, {
+      prompt_title = "Cscope: " .. type[type_num + 1] .. "(" .. word .. ")",
+      finder = finders.new_table {
+        results = results,
+        entry_maker = function(entry)
+          local f = vim.split(entry, ":")
+
+          return {
+            value = entry,
+            ordinal = entry,
+            display = entry,
+            path = dir..'/'..f[1],
+            lnum = tonumber(f[2]),
+          }
+        end,
+      },
+      previewer = conf.grep_previewer(opts),
+      sorter = conf.generic_sorter(opts)
+    })
+    :find()
+end
+
+cscope.references = function (opts)
+  cscope_find(opts, 0)
+end
+
+cscope.definitions = function (opts)
+  cscope_find(opts, 1)
+end
+
+cscope.called_by_this_function = function (opts)
+  cscope_find(opts, 2)
+end
+
+cscope.calling_this_function = function (opts)
+  cscope_find(opts, 3)
+end
+
+local set_opts_cwd = function(opts)
+  if opts.cwd then
+    opts.cwd = vim.fn.expand(opts.cwd)
+  else
+    opts.cwd = vim.loop.cwd()
+  end
+end
+
+local function apply_checks(mod)
+  for k, v in pairs(mod) do
+    mod[k] = function(opts)
+      opts = vim.F.if_nil(opts, {})
+
+      set_opts_cwd(opts)
+      v(opts)
+    end
+  end
+
+  return mod
+end
+
+return apply_checks(cscope)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -231,6 +231,32 @@ builtin.git_stash = require_on_exported_call("telescope.builtin.__git").stash
 
 --
 --
+-- Cscope Pickers
+--
+--
+
+--- Lists tags in current directory with tag location file preview (users are required to run ctags -R to generate tags
+--- or update when introducing new changes)
+---@param opts table: options to pass to the picker
+---@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
+builtin.cscope_references = require_on_exported_call("telescope.builtin.__cscope").references
+
+--- Lists tags in current directory with tag location file preview (users are required to run ctags -R to generate tags
+--- or update when introducing new changes)
+---@param opts table: options to pass to the picker
+---@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
+builtin.cscope_definitions = require_on_exported_call("telescope.builtin.__cscope").definitions
+
+---@param opts table: options to pass to the picker
+---@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
+builtin.cscope_called_by_this_function = require_on_exported_call("telescope.builtin.__cscope").called_by_this_function
+
+---@param opts table: options to pass to the picker
+---@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
+builtin.cscope_calling_this_function = require_on_exported_call("telescope.builtin.__cscope").calling_this_function
+
+--
+--
 -- Internal and Vim-related Pickers
 --
 --


### PR DESCRIPTION
# Description

There are some benefits when using cscope for big C projects:

 * LSP definition/references do not show entries that are conditionally compiled using macros.
 * Finding all references is faster than ripgrep.
 * Cscope database can be fine tuned to skip files developer is not interested in.

In general cscope can be used as complement to LSP and ripgrep, to improve navigation on large C code base. I'm using all three to navigate in linux kernel and cscope is helpful.

TODO:
 * Implement jump if just one entry was found.
 * Improve showing functions called by this function.
 * Add configuration options similar to LSP picker.

## Type of change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update (Maybe ?)

# How Has This Been Tested?
- Used when working on linux kernel with cscope database build there using 'make cscope'. 

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.10.0-dev
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3

* Operating system and version:
Ubuntu 22.04.3 LTS

# Checklist:

- [?] My code follows the style guidelines of this project (stylua)
- [x ] I have performed a self-review of my own code
- [?] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation (lua annotations)
