### PR TITLE
feat(find_files): prefer fd over rg

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -268,10 +268,10 @@ files.find_files = function(opts)
         return opts.find_command(opts)
       end
       return opts.find_command
-    elseif 1 == vim.fn.executable "rg" then
-      return { "rg", "--files", "--color", "never" }
     elseif 1 == vim.fn.executable "fd" then
       return { "fd", "--type", "f", "--color", "never" }
+    elseif 1 == vim.fn.executable "rg" then
+      return { "rg", "--files", "--color", "never" }
     elseif 1 == vim.fn.executable "fdfind" then
       return { "fdfind", "--type", "f", "--color", "never" }
     elseif 1 == vim.fn.executable "find" and vim.fn.has "win32" == 0 then


### PR DESCRIPTION
feat(find_files): prefer fd over rg

Summary:
`fd` and `rg --files` are pretty much the same thing, but `fd` is purpose-built
for finding files
