### PR TITLE
Revert "doc(layout_strategies): document shared options for `bottom_pane`"

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2357,21 +2357,6 @@ layout_strategies.bottom_pane()               *telescope.layout.bottom_pane()*
 
     For an easy ivy configuration, see |themes.get_ivy()|
 
-    `picker.layout_config` shared options:
-      - height:
-        - How tall to make Telescope's entire layout
-        - See |resolver.resolve_height()|
-      - mirror: Flip the location of the results/prompt and preview windows
-      - prompt_position:
-        - Where to place prompt window.
-        - Available Values: 'bottom', 'top'
-      - scroll_speed: The number of lines to scroll through the previewer
-
-    `picker.layout_config` unique options:
-      - preview_cutoff: When columns are less than this value, the preview will be disabled
-      - preview_width:
-        - Change the width of Telescope's preview window
-        - See |resolver.resolve_width()|
 
 
 

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -847,15 +847,9 @@ end)
 --- Bottom pane can be used to create layouts similar to "ivy".
 ---
 --- For an easy ivy configuration, see |themes.get_ivy()|
----@eval { ["description"] = require("telescope.pickers.layout_strategies")._format("bottom_pane") }
 layout_strategies.bottom_pane = make_documented_layout(
   "bottom_pane",
-  vim.tbl_extend("error", {
-    height = shared_options.height,
-    mirror = shared_options.mirror,
-    scroll_speed = shared_options.scroll_speed,
-    prompt_position = shared_options.prompt_position,
-  }, {
+  vim.tbl_extend("error", shared_options, {
     preview_width = { "Change the width of Telescope's preview window", "See |resolver.resolve_width()|" },
     preview_cutoff = "When columns are less than this value, the preview will be disabled",
   }),


### PR DESCRIPTION
Reverts nvim-telescope/telescope.nvim#2887


This PR made `width` a non-valid option for the `bottom_pane` layout strategy (which it is).
But if you had
```lua
require("telescope").setup({
  defaults = {
    layout_config = {
      width = 120,
    }
  }
})
```
since you want all layouts that support it to use width 120, you'd get an error using `bottom_pane`.

I think we should only throw errors if we're setting invalid options specific to the strategy being used.
ie
```lua
require("telescope").setup({
  defaults = {
    layout_config = {
      bottom_pane = {
        width = 120, -- invalid, throw error
      },
      width = 120, -- allow this since not strategy specific
    }
  }
})
```

Something to do later.