### PR TITLE
doc(action_state): improve description of action_state.get_current_line

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -3329,7 +3329,7 @@ action_state.get_selected_entry() *telescope.actions.state.get_selected_entry()*
 
 
 action_state.get_current_line()   *telescope.actions.state.get_current_line()*
-    Gets the current line
+    Gets the current line in the search prompt
 
 
 

--- a/lua/telescope/actions/state.lua
+++ b/lua/telescope/actions/state.lua
@@ -17,7 +17,7 @@ function action_state.get_selected_entry()
   return global_state.get_global_key "selected_entry"
 end
 
---- Gets the current line
+--- Gets the current line in the search prompt
 function action_state.get_current_line()
   return global_state.get_global_key "current_line" or ""
 end


### PR DESCRIPTION
# Description

I have been trying for quite some time to find this method in docs, but it was nearly improssible. The description should contain either "input" or "prompt", because those are the keywords that most people would search for when trying to find this method.



## Type of change

Please delete options that are not relevant.


- This change requires a documentation update

# How Has This Been Tested?

No test, just docs update

**Configuration**:
NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1702233742



# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (lua annotations)
