### PR TITLE
feat(action): add `type` into qf entry when calling `entry_to_qf` function

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -912,6 +912,7 @@ local entry_to_qf = function(entry)
     lnum = vim.F.if_nil(entry.lnum, 1),
     col = vim.F.if_nil(entry.col, 1),
     text = text,
+    type = entry.qf_type,
   }
 end
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1121,12 +1121,12 @@ end
 function make_entry.gen_from_diagnostics(opts)
   opts = opts or {}
 
+  local type_diagnostic = vim.diagnostic.severity
   local signs = (function()
     if opts.no_sign then
       return
     end
     local signs = {}
-    local type_diagnostic = vim.diagnostic.severity
     for _, severity in ipairs(type_diagnostic) do
       local status, sign = pcall(function()
         -- only the first char is upper all others are lowercalse
@@ -1183,6 +1183,13 @@ function make_entry.gen_from_diagnostics(opts)
     }
   end
 
+  local errlist_type_map = {
+    [type_diagnostic.ERROR] = "E",
+    [type_diagnostic.WARN] = "W",
+    [type_diagnostic.INFO] = "I",
+    [type_diagnostic.HINT] = "N",
+  }
+
   return function(entry)
     return make_entry.set_default_entry_mt({
       value = entry,
@@ -1193,6 +1200,7 @@ function make_entry.gen_from_diagnostics(opts)
       lnum = entry.lnum,
       col = entry.col,
       text = entry.text,
+      qf_type = errlist_type_map[type_diagnostic[entry.type]],
     }, opts)
   end
 end


### PR DESCRIPTION
When calling `send_to_qflist` for `builtin.diagnostics`, this `text` field of the qf entry could be set to describe the error type.

before:
<img width="1383" alt="Screenshot 2024-01-27 at 12 37 24" src="https://github.com/nvim-telescope/telescope.nvim/assets/46311996/1d24fac2-f503-4d43-a7a8-9e406bc22b78">

after:
<img width="1383" alt="Screenshot 2024-01-27 at 12 36 00" src="https://github.com/nvim-telescope/telescope.nvim/assets/46311996/0024fd16-f67c-4c73-880a-f9b32ef375cf">
