### PR TITLE
fix: terminal buffer previews not initially scrolled

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -579,7 +579,10 @@ previewers.vimgrep = defaulter(function(opts)
       if entry.bufnr and (p == "[No Name]" or has_buftype) then
         local lines = vim.api.nvim_buf_get_lines(entry.bufnr, 0, -1, false)
         vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
-        jump_to_line(self, self.state.bufnr, entry)
+        -- schedule so that the lines are actually there and can be jumped onto when we call jump_to_line
+        vim.schedule(function()
+          jump_to_line(self, self.state.bufnr, entry)
+        end)
       else
         conf.buffer_previewer_maker(p, self.state.bufnr, {
           bufname = self.state.bufname,


### PR DESCRIPTION
# Description

When you preview a terminal buffer for the first time after `:Telescope buffers`, the preview is not scrolled to and centered to the line the cursor is on, unlike normal buffers that have a file associated with them.
This PR fixes the issue so that the preview for a terminal buffer is correctly scrolled.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Steps to reproduce the issue

1. Start neovim
2. Create a terminal buffer (`:terminal`) and inside it, run `seq 1000` (or something else that produces lots of lines)
3. Open a random file
4. Run `:Telescope buffers`
  - The first time you preview the terminal buffer, the preview is not scrolled to the line the cursor is on.
  - Preview the other entry (the file you opened) and preview the terminal buffer again. Now the preview is correctly scrolled.
  - After this PR is applied, the preview is correctly scrolled from the first time on.

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1692716794
```

* Operating system and version: Ubuntu 22.04 (inside docker container)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
