### PR TITLE
feat(builtin.current_buffer_fuzzy_find): jump to first matched char

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -527,8 +527,6 @@ files.current_buffer_fuzzy_find = function(opts)
     opts.line_highlights = line_highlights
   end
 
-  local column = 0
-
   pickers
     .new(opts, {
       prompt_title = "Current Buffer Fuzzy",
@@ -539,26 +537,21 @@ files.current_buffer_fuzzy_find = function(opts)
       sorter = conf.generic_sorter(opts),
       previewer = conf.grep_previewer(opts),
       attach_mappings = function()
-        action_set.select:enhance {
-          pre = function(bufnr)
-            local selection = action_state.get_selected_entry()
-            if not selection then
-              return
-            end
-            local current_picker = action_state.get_current_picker(bufnr)
-            local searched_for = require("telescope.actions.state").get_current_line()
-            local highlighted = current_picker.sorter:highlighter(searched_for, selection.ordinal)
-            column = highlighted[1]
-          end,
-          post = function()
-            local selection = action_state.get_selected_entry()
-            if not selection then
-              return
-            end
-
-            vim.api.nvim_win_set_cursor(0, { selection.lnum, column or 0 })
-          end,
-        }
+        actions.select_default:replace(function(prompt_bufnr)
+          local selection = action_state.get_selected_entry()
+          if not selection then
+            utils.__warn_no_selection "builtin.current_buffer_fuzzy_find"
+            return
+          end
+          local current_picker = action_state.get_current_picker(prompt_bufnr)
+          local searched_for = require("telescope.actions.state").get_current_line()
+          local highlighted = current_picker.sorter:highlighter(searched_for, selection.ordinal)
+          local column = math.min(unpack(highlighted)) or 0
+          actions.close(prompt_bufnr)
+          vim.schedule(function()
+            vim.api.nvim_win_set_cursor(0, { selection.lnum, column })
+          end)
+        end)
 
         return true
       end,

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -546,7 +546,13 @@ files.current_buffer_fuzzy_find = function(opts)
           local current_picker = action_state.get_current_picker(prompt_bufnr)
           local searched_for = require("telescope.actions.state").get_current_line()
           local highlighted = current_picker.sorter:highlighter(searched_for, selection.ordinal)
-          local column = math.min(unpack(highlighted)) or 0
+          local column = math.min(unpack(highlighted))
+          if column then
+            column = column - 1
+          else
+            column = 0
+          end
+
           actions.close(prompt_bufnr)
           vim.schedule(function()
             vim.api.nvim_win_set_cursor(0, { selection.lnum, column })

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -546,12 +546,7 @@ files.current_buffer_fuzzy_find = function(opts)
           local current_picker = action_state.get_current_picker(prompt_bufnr)
           local searched_for = require("telescope.actions.state").get_current_line()
           local highlighted = current_picker.sorter:highlighter(searched_for, selection.ordinal)
-          local column = math.min(unpack(highlighted))
-          if column then
-            column = column - 1
-          else
-            column = 0
-          end
+          local column = math.min(unpack(highlighted) or 1) - 1
 
           actions.close(prompt_bufnr)
           vim.schedule(function()

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -544,7 +544,20 @@ files.current_buffer_fuzzy_find = function(opts)
               return
             end
 
-            vim.api.nvim_win_set_cursor(0, { selection.lnum, 0 })
+            local searched_for = require("telescope.actions.state").get_current_line()
+            local first_search_char = string.sub(searched_for, 1, 1)
+
+            local column_as_is = string.find(selection.text, first_search_char)
+            local reversed_char
+            if first_search_char == string.upper(first_search_char) then
+              reversed_char = string.lower(first_search_char)
+            else
+              reversed_char = string.upper(first_search_char)
+            end
+            local column_reversed = string.find(selection.text, reversed_char)
+            local column = math.min(column_as_is or math.huge, column_reversed or math.huge)
+
+            vim.api.nvim_win_set_cursor(0, { selection.lnum, column })
           end,
         }
 


### PR DESCRIPTION
# Description

Currently the in buffer fuzzy search always jumps to the first character of the selected line. This PR enhances it to jump to the first same character on the line as the first character from the search. See demo below.

Motivation: I assume people use this helper as an enhanced version of <kbd>/</kbd> or <kbd>?</kbd>. Alternatively this is as useful as <kbd>cmd/ctrl</kbd><kbd>f</kbd> from modern GUI editors and IDEs. Both jump to the match instead of the beginning of the line.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

1. Open any file
2. Run `:Telescope current_buffer_fuzzy_find`
3. Search for something that is not on the first character on the line that you want to go to
4. Expect cursor to land on the first character in your search on this line

**Before** 

https://github.com/nvim-telescope/telescope.nvim/assets/5817809/a237499f-2859-4ae6-9250-d8da7c22ee9c

**After**

https://github.com/nvim-telescope/telescope.nvim/assets/5817809/3a91cc57-0c21-41b5-90a5-fd3032ed9579

**Configuration**:
* Neovim version (nvim --version): VIM v0.9.5
* Operating system and version: MacOS 14.2.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] NA ~~I have made corresponding changes to the documentation (lua annotations)~~
