### PR TITLE
fix: do not change the jumplist when using to a line in a file

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -591,7 +591,7 @@ files.tags = function(opts)
                 return "\\" .. x
               end)
 
-              vim.cmd "norm! gg"
+              vim.cmd "keepjumps norm! gg"
               vim.fn.search(scode)
               vim.cmd "norm! zz"
             else

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -293,7 +293,7 @@ local search_cb_jump = function(self, bufnr, query)
   end
   vim.api.nvim_buf_call(bufnr, function()
     pcall(vim.fn.matchdelete, self.state.hl_id, self.state.winid)
-    vim.cmd "norm! gg"
+    vim.cmd "keepjumps norm! gg"
     vim.fn.search(query, "W")
     vim.cmd "norm! zz"
 
@@ -612,7 +612,7 @@ previewers.ctags = defaulter(function(opts)
         end)
 
         pcall(vim.fn.matchdelete, self.state.hl_id, self.state.winid)
-        vim.cmd "norm! gg"
+        vim.cmd "keepjumps norm! gg"
         vim.fn.search(scode, "W")
         vim.cmd "norm! zz"
 
@@ -1115,7 +1115,7 @@ previewers.highlights = defaulter(function(_)
 
       vim.schedule(function()
         vim.api.nvim_buf_call(self.state.bufnr, function()
-          vim.cmd "norm! gg"
+          vim.cmd "keepjumps norm! gg"
           vim.fn.search(entry.value .. " ")
           local lnum = vim.api.nvim_win_get_cursor(self.state.winid)[1]
           -- That one is actually a match but its better to use it like that then matchadd


### PR DESCRIPTION
# Description

While using some Telescope commands that jump directly to a line in a file (like `tags`), the function first opens the file, then call `norm! gg` and search for the target line.
This will include the top of the file in the jumplist.

Since the top of the file is not jumped-to by user, it's not a position that the user cares about; it would make sense to not include this position in the jumplist.

# Reproduce the bug

To see this behaviour, open a file, call the `Telescope tags` command, select and confirm any tag that is in the middle of a big file (i.e. when the target tag is jumped-to, the top of the file (line 1) should ideally not be visible), then press `Ctrl-O` to go back in the first file you edited just before the `Telescope tags` invocation.
This will not set you back in the first file, but at the top of the file containing the target tag.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've used this patch for a while in my normal workflow, to ensure no obvious problems arise.

# Configuration
NVIM v0.9.5
AppImage

Debian 12
