### PR TITLE
feat(pickers): custom results height for centered layout

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2289,6 +2289,7 @@ layout_strategies.center()                         *telescope.layout.center()*
 
     `picker.layout_config` unique options:
       - preview_cutoff: When lines are less than this value, the preview will be disabled
+      - results_height: Optional height specifically for results window
 
 
 layout_strategies.cursor()                         *telescope.layout.cursor()*

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -431,6 +431,7 @@ layout_strategies.center = make_documented_layout(
   "center",
   vim.tbl_extend("error", shared_options, {
     preview_cutoff = "When lines are less than this value, the preview will be disabled",
+    results_height = "Optional height specifically for results window",
   }),
   function(self, max_columns, max_lines, layout_config)
     local initial_options = p_window.get_initial_window_options(self)
@@ -518,6 +519,17 @@ layout_strategies.center = make_documented_layout(
       prompt.line = prompt.line + 1
       results.line = results.line + 1
       preview.line = preview.line + 1
+    end
+
+    -- set the height of the results window if specified
+    if layout_config.results_height then
+      local diff = results.height - resolve.resolve_height(layout_config.results_height)(self, max_columns, max_lines)
+      results.height = results.height - diff
+      results.line = results.line + diff
+      preview.height = preview.height + diff
+      if layout_config.prompt_position == "top" then
+        prompt.line = prompt.line + diff
+      end
     end
 
     return {


### PR DESCRIPTION
# Description

I really like the `center` layout strategy, but I wish I had more control of the height of the individual sections. This PR adds a `results_height` option to the strategy that will set the height of the results window, and fill the rest of the height with the `preview` window. This can be especially nice for things like `bcommits` where the results window really doesn't need to be that large, and you mostly want to see your commit previews in all of their glory.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Setting the new option to a value less than 1 and greater than 0 (so it should be a percentage value)
- [x] Setting the option to an absolute height value

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1702233742
* Operating system and version: Arch Linux x86_64, 6.7.1-arch1-1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)

