### PR TITLE
feat(builtin.autocommands): support jumping to lua callback src

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1311,6 +1311,19 @@ internal.autocommands = function(opts)
             return false
           end
           local val = selection.value
+          local cb = val.callback
+          if vim.is_callable(cb) then
+            if type(cb) ~= "string" then
+              local f = type(cb) == "function" and cb or rawget(getmetatable(cb), "__call")
+              local info = debug.getinfo(f, "S")
+              local file = info.source:match "^@(.+)"
+              local lnum = info.linedefined
+              if file and (lnum or 0) > 0 then
+                selection.filename, selection.lnum, selection.col = file, lnum, 1
+                return false
+              end
+            end
+          end
           local group_name = val.group_name ~= "<anonymous>" and val.group_name or ""
           local output =
             vim.fn.execute("verb autocmd " .. group_name .. " " .. val.event .. " " .. val.pattern, "silent")

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1232,6 +1232,7 @@ function make_entry.gen_from_autocommands(opts)
         group_name = group_name,
         pattern = entry.pattern,
         command = command,
+        callback = entry.callback,
       },
       --
       ordinal = entry.event .. " " .. group_name .. " " .. entry.pattern .. " " .. entry.command,


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context -->

Better support for lua callback autocmds: you can now jump to the source/definition of these type of autocmds (as well). Simple change.

Fixes # (issue) (couldn't find any related issues?)

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Manually tested

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration -->

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
