### PR TITLE
buffers picker: add select_current option

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1419,6 +1419,8 @@ builtin.buffers({opts})                          *telescope.builtin.buffers()*
                                             bufnr_a should go first. Runs
                                             after sorting by most recent (if
                                             specified)
+        {select_current}        (boolean)   select current buffer (default:
+                                            false)
 
 
 builtin.colorscheme({opts})                  *telescope.builtin.colorscheme()*

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -949,6 +949,9 @@ internal.buffers = function(opts)
       local idx = ((buffers[1] ~= nil and buffers[1].flag == "%") and 2 or 1)
       table.insert(buffers, idx, element)
     else
+      if opts.select_current and flag == "%" then
+        default_selection_idx = bufnr
+      end
       table.insert(buffers, element)
     end
   end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -349,6 +349,7 @@ builtin.reloader = require_on_exported_call("telescope.builtin.__internal").relo
 ---@field bufnr_width number: Defines the width of the buffer numbers in front of the filenames  (default: dynamic)
 ---@field file_encoding string: file encoding for the previewer
 ---@field sort_buffers function: sort fn(bufnr_a, bufnr_b). true if bufnr_a should go first. Runs after sorting by most recent (if specified)
+---@field select_current boolean: select current buffer (default: false)
 builtin.buffers = require_on_exported_call("telescope.builtin.__internal").buffers
 
 --- Lists available colorschemes and applies them on `<cr>`


### PR DESCRIPTION

# Description

With the buffers picker I'd like the current buffer to be pre-selected, but I don't like the buffer list to be mru sorted.
So that I can either navigate to nearby buffers using arrow keys or do a fuzzy search as usual.

The change adds a select_current option to the buffers picker.

If select_current is true then the the buffers picker will pre-select the current buffer (%) instead of the first one. Useful if you want to use arrow keys to select a nearby buffer. Best used in combination with selection_strategy = 'closest' so that when you start typing the first option is selected.


Fixes #2917

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

how do I update the docs, running `make docgen` fails with:
```
nvim --headless --noplugin -u scripts/minimal_init.vim -c "luafile ./scripts/gendocs.lua" -c 'qa'
Error detected while processing command line:
E5113: Error while calling lua chunk: ./lua/telescope/config.lua:1: module 'plenary.strings' not found:
	no field package.preload['plenary.strings']
	no file './plenary/strings.lua'
...
stack traceback:
	[C]: in function 'require'
	./lua/telescope/config.lua:1: in main chunk
	[C]: in function 'require'
	./lua/telescope/init.lua:133: in function 'setup'
	./scripts/gendocs.lua:5: in main chunk
```


# How Has This Been Tested?

- [ ] Example usage:
```
  vim.keymap.set('n', '<M-b>', function()
    require('telescope.builtin').buffers {
      select_current = true,
      selection_strategy = 'closest',
    }
  end, { desc = 'Buffer list' })
```

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.5
* Operating system and version: fedora 39

# Checklist:

- [x ] My code follows the style guidelines of this project (stylua)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation (lua annotations)

(but the docs file not updated)
