### PR TITLE
Fix highlight of commit hash in git branches preview

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -748,8 +748,8 @@ previewers.git_branch_log = defaulter(function(opts)
     for i = 1, #content do
       local line = content[i]
       local _, hstart = line:find "[%*%s|]*"
+      local _, hend, _ = line:find "[%*%s|]*%s(%w*)"
       if hstart then
-        local hend = hstart + 7
         if hend < #line then
           pcall(
             vim.api.nvim_buf_add_highlight,

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -747,8 +747,7 @@ previewers.git_branch_log = defaulter(function(opts)
   local highlight_buffer = function(bufnr, content)
     for i = 1, #content do
       local line = content[i]
-      local _, hstart = line:find "[%*%s|]*"
-      local _, hend, _ = line:find "[%*%s|]*%s(%w*)"
+      local hstart, hend = line:find "[0-9a-fA-F]+"
       if hstart then
         if hend < #line then
           pcall(


### PR DESCRIPTION
# Description

In repos with many commits, git log flag `--abbrev-commit` will increase the number of characters from 7 to 8 to ensure unicity. The git branches preview highlight is therefore off by one in this case.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Before and after:
![image](https://github.com/nvim-telescope/telescope.nvim/assets/2583971/69a7e8f0-5b5a-4f9b-a0cb-889fe9c7786c)
![image](https://github.com/nvim-telescope/telescope.nvim/assets/2583971/d80fba92-1214-4bf4-b033-9cb67b5aca18)


**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.0-dev-2361+ga376d979bd
* Operating system and version: Arch Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
