### PR TITLE
fix(builtin.current_buffer_fuzzy_find): manually go through highlight…

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -546,7 +546,18 @@ files.current_buffer_fuzzy_find = function(opts)
           local current_picker = action_state.get_current_picker(prompt_bufnr)
           local searched_for = require("telescope.actions.state").get_current_line()
           local highlighted = current_picker.sorter:highlighter(searched_for, selection.ordinal)
-          local column = math.min(unpack(highlighted) or 1) - 1
+          highlighted = highlighted or {}
+          local column = highlighted[1]
+          for _, v in ipairs(highlighted) do
+            if v < column then
+              column = v
+            end
+          end
+          if column then
+            column = column - 1
+          else
+            column = 0
+          end
 
           actions.close(prompt_bufnr)
           vim.schedule(function()


### PR DESCRIPTION
…ed chars to pick smallest one

# Description

This is a follow up PR, apparently for fzf extension it goes to the last matched character instead of a first one

Fixes # (issue) mentioned in this [comment](https://github.com/nvim-telescope/telescope.nvim/pull/2909#issuecomment-1945485080)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

tested with native telescope finder and fzf native extension by searching for a specific string that is in a middle of the line, in the beginning of a line and not selection


https://github.com/nvim-telescope/telescope.nvim/assets/5817809/26335b59-e688-4c28-b43a-85ce6a827b9f



**Configuration**:
* Neovim version (nvim --version): v0.9.5 and v0.10.0-dev-2334+g6282f894a-dirty
* Operating system and version: MacOS

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
