### PR TITLE
feat(lsp_workspace_symbols): add option `ignore_folders` (fixes #2920)

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -333,6 +333,20 @@ lsp.workspace_symbols = function(opts)
     end
 
     local locations = vim.lsp.util.symbols_to_items(server_result or {}, opts.bufnr) or {}
+
+    -- Filter specific folders from the results. Only works with full folder
+    -- names, and not glob patterns for performance reasons in big projects.
+    locations = vim.tbl_filter(function(l)
+      local dir = vim.fs.dirname(l.filename)
+      local parent_folders = vim.split(dir, "/")
+      for _, folder in ipairs(parent_folders) do
+        if vim.tbl_contains(opts.ignore_folders or {}, folder) then
+          return false
+        end
+      end
+      return true
+    end, locations)
+
     locations = utils.filter_symbols(locations, opts, symbols_sorter)
     if locations == nil then
       -- error message already printed in `utils.filter_symbols`

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -338,7 +338,8 @@ lsp.workspace_symbols = function(opts)
     -- names, and not glob patterns for performance reasons in big projects.
     locations = vim.tbl_filter(function(l)
       local dir = vim.fs.dirname(l.filename)
-      local parent_folders = vim.split(dir, "/")
+      local osPathSep = package.config:sub(1, 1)
+      local parent_folders = vim.split(dir, osPathSep)
       for _, folder in ipairs(parent_folders) do
         if vim.tbl_contains(opts.ignore_folders or {}, folder) then
           return false

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -490,6 +490,7 @@ builtin.lsp_document_symbols = require_on_exported_call("telescope.builtin.__lsp
 ---@field ignore_symbols string|table: list of symbols to ignore
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
 ---@field file_encoding string: file encoding for the previewer
+---@field ignore_folders table: list of folder names to ignore. Does not support glob patterns for performance reasons. (default: {})
 builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.__lsp").workspace_symbols
 
 --- Dynamically lists LSP for all workspace symbols


### PR DESCRIPTION
# Description

Adds an option `ignore_folders` for the built-in picker `lsp_workspace_symbols`. This option is a string array of folder names which is used to filter the results from the workspace symbols. 

Motivation for this option is that workspace symbols includes *everything* in the workspace, such as everything in `node_modules`. This unnecessarily clogs up the search results (adding a few thousand results), making `lsp_workspace_symbols` almost unusable in larger projects.

Fixes #2920 (and partially #2113).

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?
I have tested with various LSPs that I use. To reproduce my test:

1. open a js/ts project
2. have `tsserver` running
3. Run the following code:

```lua
require("telescope.builtin").lsp_workspace_symbols {
	ignore_folders = { "node_modules" },
}
```

Furthermore, the option defaults to an empty list, making this an opt-in feature. That means no user is affected who does not actively use this feature.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.5
* Operating system and version: macOS 14.1.2 (arm)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
