### PR TITLE
feat(builtin.live_grep): live_grep entry_maker can receive display as…

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -312,7 +312,7 @@ do
     mt_vimgrep_entry = {
       cwd = vim.fn.expand(opts.cwd or vim.loop.cwd()),
 
-      display = function(entry)
+      display = opts.make_entry_display or function(entry)
         local display_filename = utils.transform_path(opts, entry.filename)
 
         local coordinates = ":"


### PR DESCRIPTION
# Description

Added the ability to provide the live_grep entry_maker display function as an opt. Trying to override the whole entry maker causes problems with the grep preview, this is much easier for the purpose of customizing the display text according to the scenario.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested overriding the display option in my configuration to provide class and function name in the display text for Solidity.

**Configuration**:
* Neovim version (nvim --version): v0.9.5
* Operating system and version: Debian 12

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
