### PR TITLE
fix(picker): actually set prompt win to text wrap

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -553,7 +553,6 @@ function Picker:find()
   pcall(a.nvim_buf_set_option, self.prompt_bufnr, "tabstop", 1) -- #1834
   a.nvim_buf_set_option(self.prompt_bufnr, "buftype", "prompt")
   a.nvim_win_set_option(self.results_win, "wrap", self.wrap_results)
-  a.nvim_win_set_option(self.prompt_win, "wrap", true)
   if self.preview_win then
     a.nvim_win_set_option(self.preview_win, "wrap", true)
   end
@@ -607,6 +606,7 @@ function Picker:find()
     -- Do filetype last, so that users can register at the last second.
     pcall(a.nvim_buf_set_option, self.prompt_bufnr, "filetype", "TelescopePrompt")
     pcall(a.nvim_buf_set_option, self.results_bufnr, "filetype", "TelescopeResults")
+    a.nvim_win_set_option(self.prompt_win, "wrap", true)
 
     await_schedule()
 


### PR DESCRIPTION
Despite setting `wrap=true` for the prompt window earlier, after setting `filetype=TelescopePrompt` in the main loop, `wrap` gets set to false.

I haven't determined the root cause of this. I can't reproduce this with a simple neovim api only config. I suspect there's something funny going on with the async main loop.

Maybe this isn't worth fixing though. I think we've been using prompt window `wrap=false` for a while now and I don't see any issues with it.
