### PR TITLE
feat(git_files): support emoji/unicode in filenames

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -41,7 +41,10 @@ git.files = function(opts)
   -- By creating the entry maker after the cwd options,
   -- we ensure the maker uses the cwd options when being created.
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_file(opts))
-  opts.git_command = vim.F.if_nil(opts.git_command, git_command({ "ls-files", "--exclude-standard", "--cached" }, opts))
+  opts.git_command = vim.F.if_nil(
+    opts.git_command,
+    git_command({ "-c", "core.quotepath=false", "ls-files", "--exclude-standard", "--cached" }, opts)
+  )
 
   pickers
     .new(opts, {


### PR DESCRIPTION
Pass `core.quotepath=false` to achieve this.
Could alternatively pass `-z` but that uses `\0` line termination and complicates things.

I think this is minor enough to just use as default. Shouldn't impact most people anyways.

Closes #2900

