### PR TITLE
feat(jumplist): add select_last_used option (closes #2947)

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1537,8 +1537,10 @@ builtin.jumplist({opts})                        *telescope.builtin.jumplist()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {show_line} (boolean)  show results text (default: true)
-        {trim_text} (boolean)  trim results text (default: false)
+        {show_line}        (boolean)  show results text (default: true)
+        {trim_text}        (boolean)  trim results text (default: false)
+        {select_last_used} (boolean)  select last used jump position
+                                      (default: false)
 
 
 builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*


### PR DESCRIPTION
just like buffers picker has select_current option (#2918)

# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

Fixes #2947

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Test the last used position becomes a default selection index by
    1. start Neovim
    2. Do `require("telescope.builtin").jumplist({ select_last_used = true })` and confirm the default selection index is `1`
    3. Do `<C-O>`
    2. Do `require("telescope.builtin").jumplist({ select_last_used = true })` and confirm the default selection index is `2`

**Configuration**:
* Neovim version (nvim --version):

NVIM v0.10.0-dev-2273+g21df0cdb8
Build type: RelWithDebInfo
LuaJIT 2.1.1706708390
Run "nvim -V1 -v" for more info

* Operating system and version:

Manjaro Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
