### PR TITLE
Change get_substr_matcher's behavior with 'smartcase'

### DIFF
--- a/lua/tests/automated/sorters_spec.lua
+++ b/lua/tests/automated/sorters_spec.lua
@@ -1,0 +1,84 @@
+local sorters = require "telescope.sorters"
+
+describe("get_substr_matcher", function()
+  local function with_smartcase(smartcase, case)
+    local original = vim.o.smartcase
+    vim.o.smartcase = smartcase
+
+    describe("scoring_function", function()
+      it(case.msg, function()
+        local matcher = sorters.get_substr_matcher()
+        assert.are.same(case.expected_score, matcher.scoring_function(_, case.prompt, _, case.entry))
+      end)
+    end)
+
+    describe("highlighter", function()
+      it("returns valid highlights", function()
+        local matcher = sorters.get_substr_matcher()
+        local highlights = matcher.highlighter(_, case.prompt, case.entry.ordinal)
+        table.sort(highlights, function(a, b)
+          return a.start < b.start
+        end)
+        assert.are.same(case.expected_highlights, highlights)
+      end)
+    end)
+
+    vim.o.smartcase = original
+  end
+
+  describe("when smartcase=OFF", function()
+    for _, case in ipairs {
+      {
+        msg = "doesn't match",
+        prompt = "abc def",
+        entry = { index = 3, ordinal = "abc d" },
+        expected_score = -1,
+        expected_highlights = { { start = 1, finish = 3 } },
+      },
+      {
+        msg = "matches with lower case letters only",
+        prompt = "abc def",
+        entry = { index = 3, ordinal = "abc def ghi" },
+        expected_score = 3,
+        expected_highlights = { { start = 1, finish = 3 }, { start = 5, finish = 7 } },
+      },
+      {
+        msg = "doesn't match with upper case letters",
+        prompt = "ABC def",
+        entry = { index = 3, ordinal = "ABC def ghi" },
+        expected_score = -1,
+        expected_highlights = { { start = 5, finish = 7 } },
+      },
+    } do
+      with_smartcase(false, case)
+    end
+  end)
+
+  describe("when smartcase=OFF", function()
+    for _, case in ipairs {
+      {
+        msg = "doesn't match",
+        prompt = "abc def",
+        entry = { index = 3, ordinal = "abc d" },
+        expected_score = -1,
+        expected_highlights = { { start = 1, finish = 3 } },
+      },
+      {
+        msg = "matches with lower case letters only",
+        prompt = "abc def",
+        entry = { index = 3, ordinal = "abc def ghi" },
+        expected_score = 3,
+        expected_highlights = { { start = 1, finish = 3 }, { start = 5, finish = 7 } },
+      },
+      {
+        msg = "matches with upper case letters",
+        prompt = "ABC def",
+        entry = { index = 3, ordinal = "ABC def ghi" },
+        expected_score = 3,
+        expected_highlights = { { start = 1, finish = 3 }, { start = 5, finish = 7 } },
+      },
+    } do
+      with_smartcase(true, case)
+    end
+  end)
+end)


### PR DESCRIPTION
# Description

ref https://github.com/nvim-telescope/telescope-frecency.nvim/pull/177
ref https://github.com/nvim-telescope/telescope-frecency.nvim/issues/36

[telescope-frecency][] has used `get_substr_matcher` to match input string. This matcher always makes display string be lower case, so we cannot match against upper case letters as it is.

[telescope-frecency]: https://github.com/nvim-telescope/telescope-frecency.nvim

I introduced a customized matcher to solve this problem. → nvim-telescope/telescope-frecency.nvim#177 This makes it match upper case letters only when `'smartcase'` is ON and input string includes one upper case letter at least. I think this change is useful also in telescope.nvim itself, so I created this PR.

## Type of change

- New feature (non-breaking change which adds functionality)

When candidates `abc`, `ABC`, `aBc` exist, the matches will change with this PR
as below.

| input string | `'smartcase'` | current             | with this PR          |
|--------------|---------------|---------------------|-----------------------|
| `abc`        | OFF           | `abc`, `ABC`, `aBc` | `abc`, `ABC`, `aBc`   |
| `abc`        | ON            | `abc`, `ABC`, `aBc` | `abc`, `ABC`, `aBc`  |
| `ABC`        | OFF           | none                | none                  |
| `ABC`        | ON            | none                | `ABC`                 |
| `aBc`        | OFF           | none                | none                  |
| `aBc`        | ON            | none                | `aBc`                 |

# How Has This Been Tested?

- [x] added `sorters_spec.lua` and testing on CI

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
