### PR TITLE
fix: remove duplicate item in colorscheme

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -988,7 +988,7 @@ internal.colorscheme = function(opts)
   colors = vim.list_extend(
     colors,
     vim.tbl_filter(function(color)
-      return color ~= before_color
+      return not vim.tbl_contains(colors, color)
     end, vim.fn.getcompletion("", "color"))
   )
 


### PR DESCRIPTION
# Description

When using lazy.nvim's lazy loading colorscheme, Telescope's colorscheme cannot see the lazily loaded colorscheme. 
In this case, I used the colors parameter to add the colorscheme. 
```
require("telescope.builtin").colorscheme({
    colors = {"rose-pine-dawn", "everforest", }
})
```
If I open the Telescope's colorscheme twice(first time select `rose-pine-dawn`), duplicate entries will appear.
![1](https://github.com/nvim-telescope/telescope.nvim/assets/106934/952c8034-30cd-414e-9d88-b838c187ff58)
![2](https://github.com/nvim-telescope/telescope.nvim/assets/106934/d6c64e56-c800-4aab-ac4b-04976c45aa70)

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
