### PR TITLE
feat(lsp_jump_type): jump type can be passed as a function

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1558,7 +1558,9 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
                                           only one and the definition file is
                                           different from the current file,
                                           values: "tab", "tab drop", "split",
-                                          "vsplit", "never"
+                                          "vsplit", "never" or a function,
+					  which will be executed before the
+					  jump
         {show_line}            (boolean)  show results text (default: true)
         {trim_text}            (boolean)  trim results text (default: false)
         {file_encoding}        (string)   file encoding for the previewer
@@ -1604,7 +1606,9 @@ builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
         {jump_type}     (string)   how to goto definition if there is only one
                                    and the definition file is different from
                                    the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never"
+                                   drop", "split", "vsplit", "never" or a function,
+				   which will be executed before the
+				   jump
         {show_line}     (boolean)  show results text (default: true)
         {trim_text}     (boolean)  trim results text (default: false)
         {reuse_win}     (boolean)  jump to existing window if buffer is
@@ -1624,7 +1628,9 @@ builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
         {jump_type}     (string)   how to goto definition if there is only one
                                    and the definition file is different from
                                    the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never"
+                                   drop", "split", "vsplit", "never" or a function,
+				   which will be executed before the
+				   jump
         {show_line}     (boolean)  show results text (default: true)
         {trim_text}     (boolean)  trim results text (default: false)
         {reuse_win}     (boolean)  jump to existing window if buffer is
@@ -1644,7 +1650,9 @@ builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
         {jump_type}     (string)   how to goto implementation if there is only
                                    one and the definition file is different
                                    from the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never"
+                                   drop", "split", "vsplit", "never" or a function,
+				   which will be executed before the
+				   jump
         {show_line}     (boolean)  show results text (default: true)
         {trim_text}     (boolean)  trim results text (default: false)
         {reuse_win}     (boolean)  jump to existing window if buffer is

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -162,6 +162,8 @@ local function list_or_jump(action, title, params, opts)
         elseif opts.jump_type == "tab drop" then
           local file_path = vim.uri_to_fname(target_uri)
           vim.cmd("tab drop " .. file_path)
+        elseif type(opts.jump_type) == "function" then
+          opts.jump_type()
         end
       end
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -416,7 +416,7 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@param opts table: options to pass to the picker
 ---@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
 ---@field include_current_line boolean: include current line (default: false)
----@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
+---@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field file_encoding string: file encoding for the previewer
@@ -438,7 +438,7 @@ builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp")
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
+---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
@@ -448,7 +448,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 --- Goto the definition of the type of the word under the cursor, if there's only one,
 --- otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
+---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
@@ -457,7 +457,7 @@ builtin.lsp_type_definitions = require_on_exported_call("telescope.builtin.__lsp
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
+---@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)


### PR DESCRIPTION
# Description

For builtin LSP actions, there is a parameter called `jump_type`, which allows choosing how `goto_reference` will be executed when only one entity is found in another file: "tab", "tab drop", "split", "vsplit", "never".

In this PR, I've added the ability to pass a function as the `jump_type` parameter. This function will be executed instead of using the predefined commands.

### Motivation:
I have the following use case: I want to have the ability to choose the window in which a reference will be opened when navigating to it via `lsp_definitions`. Currently, when multiple definitions are found, I can achieve this by using a window-picker after opening the telescope. However, when only one definition is found, I don't have this option.

With this PR, I'll be able to solve my problem by using the following invocation:

```lua
require('telescope.builtin').lsp_definitions(
    {
      get_selection_window = function()
        local window = require('window-picker').pick_window({ include_current_win = true });
        return window
      end,
      jump_type = function ()
        local window = require('window-picker').pick_window({ include_current_win = true });
        vim.api.nvim_set_current_win(window)
      end
    })
```


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Thoroughly tested manually with aforementioned config

- [x] Opening while many references has been found is working as before
- [x] Opening while one reference has been found execution window-picker and then opening reference it selected window

**Configuration**:
* Neovim version (nvim --version):
```
nvim --version
NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1703358377
```
* Operating system and version: MacOS Monterey 12.6.8

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
