### PR TITLE
fix(picker): wrap vim.fn.expand cword in pcall to avoid Vim:E348

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -529,7 +529,7 @@ function Picker:find()
   self:reset_selection()
 
   self.original_win_id = a.nvim_get_current_win()
-  _, self.original_cword = pcall(vim.fn.expand,"<cword>")
+  _, self.original_cword = pcall(vim.fn.expand, "<cword>")
 
   -- User autocmd run it before create Telescope window
   vim.api.nvim_exec_autocmds("User", { pattern = "TelescopeFindPre" })

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -529,7 +529,7 @@ function Picker:find()
   self:reset_selection()
 
   self.original_win_id = a.nvim_get_current_win()
-  self.original_cword = vim.fn.expand "<cword>"
+  _, self.original_cword = pcall(vim.fn.expand,"<cword>")
 
   -- User autocmd run it before create Telescope window
   vim.api.nvim_exec_autocmds("User", { pattern = "TelescopeFindPre" })


### PR DESCRIPTION
# Description

the `vim.fn.expand <cword>`  was throwing error whenever any picker was invoked on an empty line,

The addition of this `pcall` would make sure that never happens.

---

# Fixes (Vim:E348: No string under cursor)

```elixir
Error executing Lua callback: Vim:E348: No string under cursor
stack traceback:
        [C]: in function 'expand'
        ...vim/pack/plugins/opt/telescope/lua/telescope/pickers.lua:532: in function 'find'
        .../plugins/opt/telescope/lua/telescope/builtin/__files.lua:392: in function 'v'
        .../plugins/opt/telescope/lua/telescope/builtin/__files.lua:641: in function 'v'
        ...ack/plugins/opt/telescope/lua/telescope/builtin/init.lua:579: in function <...ack/plugins/opt/telescope/lua/telescope/builtin/init.lua:538>
        ...vim/pack/plugins/opt/telescope/lua/telescope/command.lua:188: in function 'run_command'
        ...vim/pack/plugins/opt/telescope/lua/telescope/command.lua:259: in function 'load_command'
        ...fig/nvim/pack/plugins/opt/telescope/plugin/telescope.lua:108: in function <...fig/nvim/pack/plugins/opt/telescope/plugin/telescope.lua:107>
```

---

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

---

# How Has This Been Tested?

### Tests
- [ ] invoking `oldfiles`
- [ ] invoking `live_grep`
- [ ] invoking other pickers that expand `<cword>` 

### Telescope Config
default `telescope` config with only few mapping and layout overrides

### Reproduce
- issue is reproducible when invoking most pickers on an empty line

---

### Neovim Configuration
**vanilla**, using native `:h packadd` with  ~20 packages

* Neovim version (nvim --version):
```elixir
NVIM v0.10.0-dev-2451+g8b4e26915
Build type: RelWithDebInfo
LuaJIT 2.1.1707061634
```

---

* Operating system and version:
```elixir
$ hostnamectl

Static hostname: mxc
       Icon name: computer-laptop
         Chassis: laptop 💻
      Machine ID: 40fd81b10766********************
         Boot ID: e7153a5a9035********************
Operating System: Arch Linux                      
          Kernel: Linux 6.7.6-arch1-1
    Architecture: x86-64
 Hardware Vendor: Dell Inc.
  Hardware Model: XPS 13 9370
Firmware Version: 1.11.1
   Firmware Date: Thu 2019-07-11
    Firmware Age: 4y 7month 2w 6d  
```

---

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
