### PR TITLE
fix(config): set default `cache_picker.ignore_empty_prompt` to false

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -526,7 +526,7 @@ append(
   {
     num_pickers = 1,
     limit_entries = 1000,
-    ignore_empty_prompt = true,
+    ignore_empty_prompt = false,
   },
   [[
     This field handles the configuration for picker caching.
@@ -551,7 +551,7 @@ append(
       - ignore_empty_prompt:  If true, the picker will not be cached if
                               the prompt is empty (i.e., no text has been
                               typed at the time of closing the prompt).
-                              Default: true
+                              Default: false
     ]]
 )
 


### PR DESCRIPTION
Flip the default for `cache_picker.ignore_empty_prompt` to false owing to some finding it unintuitive with some pickers.

closes https://github.com/nvim-telescope/telescope.nvim/issues/2952 