### PR TITLE
No regex highlighting in previewers

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -711,7 +711,7 @@ previewers.help = defaulter(function(opts)
         winid = self.state.winid,
         preview = opts.preview,
         callback = function(bufnr)
-          putils.regex_highlighter(bufnr, "help")
+          putils.highlighter(bufnr, "help")
           search_cb_jump(self, bufnr, query)
         end,
         file_encoding = opts.file_encoding,
@@ -738,7 +738,7 @@ previewers.man = defaulter(function(opts)
         value = entry.value .. "/" .. entry.section,
         bufname = self.state.bufname,
       })
-      putils.regex_highlighter(self.state.bufnr, "man")
+      putils.highlighter(self.state.bufnr, "man")
     end,
   }
 end)
@@ -838,7 +838,7 @@ previewers.git_stash_diff = defaulter(function(opts)
         cwd = opts.cwd,
         callback = function(bufnr)
           if vim.api.nvim_buf_is_valid(bufnr) then
-            putils.regex_highlighter(bufnr, "diff")
+            putils.highlighter(bufnr, "diff")
           end
         end,
       })
@@ -868,7 +868,7 @@ previewers.git_commit_diff_to_parent = defaulter(function(opts)
         callback = function(bufnr)
           if vim.api.nvim_buf_is_valid(bufnr) then
             search_cb_jump(self, bufnr, opts.current_line)
-            putils.regex_highlighter(bufnr, "diff")
+            putils.highlighter(bufnr, "diff")
           end
         end,
       })
@@ -899,7 +899,7 @@ previewers.git_commit_diff_to_head = defaulter(function(opts)
         callback = function(bufnr)
           if vim.api.nvim_buf_is_valid(bufnr) then
             search_cb_jump(self, bufnr, opts.current_line)
-            putils.regex_highlighter(bufnr, "diff")
+            putils.highlighter(bufnr, "diff")
           end
         end,
       })
@@ -930,7 +930,7 @@ previewers.git_commit_diff_as_was = defaulter(function(opts)
         callback = function(bufnr)
           if vim.api.nvim_buf_is_valid(bufnr) then
             search_cb_jump(self, bufnr, opts.current_line)
-            putils.regex_highlighter(bufnr, ft)
+            putils.highlighter(bufnr, ft)
           end
         end,
       })
@@ -1000,7 +1000,7 @@ previewers.git_file_diff = defaulter(function(opts)
           cwd = opts.cwd,
           callback = function(bufnr)
             if vim.api.nvim_buf_is_valid(bufnr) then
-              putils.regex_highlighter(bufnr, "diff")
+              putils.highlighter(bufnr, "diff")
             end
           end,
         })

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -711,7 +711,7 @@ previewers.help = defaulter(function(opts)
         winid = self.state.winid,
         preview = opts.preview,
         callback = function(bufnr)
-          putils.highlighter(bufnr, "help")
+          putils.highlighter(bufnr, "help", opts)
           search_cb_jump(self, bufnr, query)
         end,
         file_encoding = opts.file_encoding,
@@ -738,7 +738,7 @@ previewers.man = defaulter(function(opts)
         value = entry.value .. "/" .. entry.section,
         bufname = self.state.bufname,
       })
-      putils.highlighter(self.state.bufnr, "man")
+      putils.highlighter(self.state.bufnr, "man", opts)
     end,
   }
 end)
@@ -838,7 +838,7 @@ previewers.git_stash_diff = defaulter(function(opts)
         cwd = opts.cwd,
         callback = function(bufnr)
           if vim.api.nvim_buf_is_valid(bufnr) then
-            putils.highlighter(bufnr, "diff")
+            putils.highlighter(bufnr, "diff", opts)
           end
         end,
       })
@@ -868,7 +868,7 @@ previewers.git_commit_diff_to_parent = defaulter(function(opts)
         callback = function(bufnr)
           if vim.api.nvim_buf_is_valid(bufnr) then
             search_cb_jump(self, bufnr, opts.current_line)
-            putils.highlighter(bufnr, "diff")
+            putils.highlighter(bufnr, "diff", opts)
           end
         end,
       })
@@ -899,7 +899,7 @@ previewers.git_commit_diff_to_head = defaulter(function(opts)
         callback = function(bufnr)
           if vim.api.nvim_buf_is_valid(bufnr) then
             search_cb_jump(self, bufnr, opts.current_line)
-            putils.highlighter(bufnr, "diff")
+            putils.highlighter(bufnr, "diff", opts)
           end
         end,
       })
@@ -930,7 +930,7 @@ previewers.git_commit_diff_as_was = defaulter(function(opts)
         callback = function(bufnr)
           if vim.api.nvim_buf_is_valid(bufnr) then
             search_cb_jump(self, bufnr, opts.current_line)
-            putils.highlighter(bufnr, ft)
+            putils.highlighter(bufnr, ft, opts)
           end
         end,
       })
@@ -1000,7 +1000,7 @@ previewers.git_file_diff = defaulter(function(opts)
           cwd = opts.cwd,
           callback = function(bufnr)
             if vim.api.nvim_buf_is_valid(bufnr) then
-              putils.highlighter(bufnr, "diff")
+              putils.highlighter(bufnr, "diff", opts)
             end
           end,
         })


### PR DESCRIPTION
# Description

I was digging into why my colorscheme wasn't displaying the correct diff colours for Telescope buffers, and I found that it was using the regex highlighter instead of tree-sitter based highlighting. This lead to it using the deprecated `diffAdded` and `diffRemoved` highlight groups. Another fix would've been to add a link for these deprecated groups, and that's still an OK option for me. I just wasn't sure if it's maybe better to use the tree-sitter highlighter anyways? Why was it forced to regex in those cases?

## Type of change

(I'm not sure if this is a bug-fix or breaking change, is tree-sitter a bad default that might break people?)

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] I checked all affected previewers, the git but also the `help` and `man` previewers manually.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.9.5
* Operating system and version: macOS 14.3.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
