### PR TITLE
fix: `action_layout.toggle_prompt_position`

### DIFF
--- a/lua/telescope/actions/layout.lua
+++ b/lua/telescope/actions/layout.lua
@@ -64,7 +64,10 @@ action_layout.toggle_prompt_position = function(prompt_bufnr)
   if picker.layout_strategy == "flex" then
     picker.layout_config.flex.horizontal = picker.layout_config.flex.horizontal or {}
     picker.layout_config.flex.vertical = picker.layout_config.flex.vertical or {}
-    local old_pos = picker.layout_config.flex[picker.__flex_strategy].prompt_position
+    local old_pos = vim.F.if_nil(
+      picker.layout_config.flex[picker.__flex_strategy].prompt_position,
+      picker.layout_config[picker.__flex_strategy].prompt_position
+    )
     local new_pos = old_pos == "top" and "bottom" or "top"
     picker.layout_config[picker.__flex_strategy].prompt_position = new_pos
     picker.layout_config.flex[picker.__flex_strategy].prompt_position = new_pos


### PR DESCRIPTION
# Description

If you set config
```
defaults.layout_strategy = "flex"
defaults.layout_config.prompt_position = "top"
```
Then call `toggle_prompt_position` it will did nothing at first time, because old_pos return nil.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Set default config to
```
defaults.layout_strategy = "flex"
defaults.layout_config.prompt_position = "top"
```

**Configuration**:
* Neovim version: nvim v0.9.5
* Operating system and version: Any

# Checklist:

- [ ✓] My code follows the style guidelines of this project (stylua)
- [ ✓] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
