### PR TITLE
fix(builtin.git): check if we're in git repo

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -494,6 +494,15 @@ local function apply_checks(mod)
     mod[k] = function(opts)
       opts = vim.F.if_nil(opts, {})
 
+      local status, ret = utils.get_os_command_output({ "git", "status" })
+      if ret ~= 0 then
+        utils.notify("apply_checks", {
+          msg = (vim.fn.expand "%:p:h") .. " is not a git directory",
+          level = "WARN",
+        })
+        return {}
+      end
+
       set_opts_cwd(opts)
       v(opts)
     end


### PR DESCRIPTION
# Description

**Change: Check in git repo before assuming so and then propagating an error up to nvim.**

When running any git builtin like, git_commits or something outside of a git repo, this would produce an error() that would not be caught and propagated up to the user. This will check if we're even in a git repo before running any git related pickers.

**Note: This is my first commit to telescope and this has been bothering me for a while, but I'm not sure if the `return {}` I placed is the correct way to handle it. If anyone can double check it, i'd appreciate it.** _It did work when testing. > \_ >_

Before:
![image](https://github.com/nvim-telescope/telescope.nvim/assets/52585984/33867f0c-e084-4394-b56e-89ebf7433614)

After:
![image](https://github.com/nvim-telescope/telescope.nvim/assets/52585984/b7a8bf3c-31cf-4d72-9a5a-17047540d3c6)


# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
