### PR TITLE
fix(builtin.marks): expand mark path

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1063,7 +1063,7 @@ internal.marks = function(opts)
         line = line,
         lnum = lnum,
         col = col,
-        filename = v.file or bufname,
+        filename = vim.fn.expand(v.file or bufname),
       }
       -- non alphanumeric marks goes to last
       if mark:match "%w" then


### PR DESCRIPTION
Neovim 0.7 compatible version of https://github.com/nvim-telescope/telescope.nvim/commit/5550bbb1b6406926fa5b23768c0b0ca9242281bb