### PR TITLE
Removed unnecessary tag from command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ to get an understanding of how to use Telescope and how to configure it.
 
 ## Usage
 
-Try the command `:Telescope find_files<cr>`
+Try the command `:Telescope find_files`
 to see if `telescope.nvim` is installed correctly.
 
 Using VimL:


### PR DESCRIPTION
# Description

Minor change in the README file to remove unnecessary `<cr>` tag on an example usage command.

## Type of change

- Documentation improvement

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
