### PR TITLE
fix(picker): ensure that the selected result matches the screen display in ascending sort order

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1458,6 +1458,8 @@ function Picker:get_result_completor(results_bufnr, find_id, prompt, status_upda
       local visible_result_rows = vim.api.nvim_win_get_height(self.results_win)
       vim.api.nvim_win_set_cursor(self.results_win, { self.max_results - visible_result_rows, 1 })
       vim.api.nvim_win_set_cursor(self.results_win, { self.max_results, 1 })
+    else
+      vim.api.nvim_win_set_cursor(self.results_win, { 1, 0 })
     end
     self:_on_complete()
   end)


### PR DESCRIPTION
# Description

The current stable version (v0.9.5) and the nightly version have different results for the cursor position on the displayed content, I don't know exactly why.

After debugging, I found that this line of code causes the cursor to move down(row+1) when `sorting_strategy=ascending`,this result is consistent in v0.9.5 and nightly.
https://github.com/nvim-telescope/telescope.nvim/blob/67c598fdd4fca113224281c85721c4d8a6df055e/lua/telescope/pickers.lua#L436

However, when the result is displayed, the highlighted row and the cursor position are not the same, so it cannot be displayed in nightly version(by default, the second result is displayed at the top, in the same position as the cursor.).

So I think putting the cursor to the first line (i.e. highest score) again in `Picker:get_result_completor` fixes the problem and doesn't affect older versions.

Fixes # (issue)
#2697 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
