### PR TITLE
fix(builtin.lsp): bad check for `jump_type` option

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -165,14 +165,11 @@ local function list_or_jump(action, title, params, opts)
           cmd = "vnew"
         elseif opts.jump_type == "tab drop" then
           cmd = "tab drop"
-        else
-          utils.notify(
-            "list_or_jump",
-            { msg = string.format("Invalid jump_type for %s picker", title), level = "ERROR" }
-          )
-          return
         end
-        vim.cmd(string.format("%s %s", cmd, file_path))
+
+        if cmd then
+          vim.cmd(string.format("%s %s", cmd, file_path))
+        end
       end
 
       vim.lsp.util.jump_to_location(flattened_results[1], offset_encoding, opts.reuse_win)


### PR DESCRIPTION
addresses https://github.com/nvim-telescope/telescope.nvim/pull/2990#issuecomment-2004178710