### PR TITLE
fix(utils.path_expand): improve windows support

### DIFF
--- a/lua/tests/automated/utils_spec.lua
+++ b/lua/tests/automated/utils_spec.lua
@@ -1,5 +1,30 @@
 local utils = require "telescope.utils"
 
+describe("path_expand()", function()
+  it("removes trailing /", function()
+    assert.is.equal("/home/user", utils.path_expand "/home/user/")
+  end)
+
+  it("works with /", function()
+    assert.is.equal("/", utils.path_expand "/")
+  end)
+
+  it("works with ~", function()
+    assert.is.equal(vim.loop.os_homedir() .. "/src/foo", utils.path_expand "~/src/foo")
+  end)
+
+  it("handles duplicate /", function()
+    assert.is.equal("/home/user", utils.path_expand "/home///user")
+  end)
+
+  it("preserves fake whitespace characters and whitespace", function()
+    local path_space = "/home/user/hello world"
+    assert.is.equal(path_space, utils.path_expand(path_space))
+    local path_newline = [[/home/user/hello\nworld]]
+    assert.is.equal(path_newline, utils.path_expand(path_newline))
+  end)
+end)
+
 describe("is_uri", function()
   describe("detects valid uris", function()
     local uris = {
@@ -79,7 +104,7 @@ describe("is_uri", function()
   end)
 end)
 
-describe("separates file path location", function()
+describe("__separates_file_path_location", function()
   local suites = {
     {
       input = "file.txt:12:4",


### PR DESCRIPTION
In order to maintain plenary compatibility (for now, and slightly for other edge case reasons), avoid converting backslashes to forward slashes.


Aside: would be nice to add windows as part of the ci testing.