### PR TITLE
fix(set_preview_message): check line height of previewer before setting message

### DIFF
--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -188,9 +188,10 @@ utils.set_preview_message = function(bufnr, winid, message, fillchar)
   )
   local anon_ns = vim.api.nvim_create_namespace ""
   local padding = table.concat(ts_utils.repeated_table(#message + 4, " "), "")
+  local formatted_message = "  " .. message .. "  "
   local lines = {
     padding,
-    "  " .. message .. "  ",
+    formatted_message,
     padding,
   }
   vim.api.nvim_buf_set_extmark(
@@ -201,14 +202,30 @@ utils.set_preview_message = function(bufnr, winid, message, fillchar)
     { end_line = height, hl_group = "TelescopePreviewMessageFillchar" }
   )
   local col = math.floor((width - strings.strdisplaywidth(lines[2])) / 2)
-  for i, line in ipairs(lines) do
+  if height <= 2 then -- Display message on first line in buffer preview
     vim.api.nvim_buf_set_extmark(
       bufnr,
       anon_ns,
-      math.floor(height / 2) - 1 + i,
       0,
-      { virt_text = { { line, "TelescopePreviewMessage" } }, virt_text_pos = "overlay", virt_text_win_col = col }
+      0,
+      {
+        virt_text = { { formatted_message, "TelescopePreviewMessage" } },
+        virt_text_pos = "overlay",
+        virt_text_win_col =
+            col
+      }
     )
+  else
+    for i, line in ipairs(lines) do
+      local line_pos = math.floor(height / 2) - 1 + i
+      vim.api.nvim_buf_set_extmark(
+        bufnr,
+        anon_ns,
+        math.floor(height / 2) - 1 + i,
+        0,
+        { virt_text = { { line, "TelescopePreviewMessage" } }, virt_text_pos = "overlay", virt_text_win_col = col }
+      )
+    end
   end
 end
 

--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -191,8 +191,7 @@ utils.set_preview_message = function(bufnr, winid, message, fillchar)
   local formatted_message = "  " .. message .. "  "
   -- Populate lines table based on height
   local lines = {}
-  if height == 1
-  then
+  if height == 1 then
     lines[1] = formatted_message
   else
     for i = 1, math.min(height, 3), 1 do

--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -189,11 +189,20 @@ utils.set_preview_message = function(bufnr, winid, message, fillchar)
   local anon_ns = vim.api.nvim_create_namespace ""
   local padding = table.concat(ts_utils.repeated_table(#message + 4, " "), "")
   local formatted_message = "  " .. message .. "  "
-  local lines = {
-    padding,
-    formatted_message,
-    padding,
-  }
+  -- Populate lines table based on height
+  local lines = {}
+  if height == 1
+  then
+    lines[1] = formatted_message
+  else
+    for i = 1, math.min(height, 3), 1 do
+      if i % 2 == 0 then
+        lines[i] = formatted_message
+      else
+        lines[i] = padding
+      end
+    end
+  end
   vim.api.nvim_buf_set_extmark(
     bufnr,
     anon_ns,
@@ -201,23 +210,16 @@ utils.set_preview_message = function(bufnr, winid, message, fillchar)
     0,
     { end_line = height, hl_group = "TelescopePreviewMessageFillchar" }
   )
-  local col = math.floor((width - strings.strdisplaywidth(lines[2])) / 2)
-  if height <= 2 then -- Display message on first line in buffer preview
-    vim.api.nvim_buf_set_extmark(bufnr, anon_ns, 0, 0, {
-      virt_text = { { formatted_message, "TelescopePreviewMessage" } },
-      virt_text_pos = "overlay",
-      virt_text_win_col = col,
-    })
-  else
-    for i, line in ipairs(lines) do
-      vim.api.nvim_buf_set_extmark(
-        bufnr,
-        anon_ns,
-        math.floor(height / 2) - 1 + i,
-        0,
-        { virt_text = { { line, "TelescopePreviewMessage" } }, virt_text_pos = "overlay", virt_text_win_col = col }
-      )
-    end
+  local col = math.floor((width - strings.strdisplaywidth(formatted_message)) / 2)
+  for i, line in ipairs(lines) do
+    local line_pos = math.floor(height / 2) - 2 + i
+    vim.api.nvim_buf_set_extmark(
+      bufnr,
+      anon_ns,
+      math.max(line_pos, 0),
+      0,
+      { virt_text = { { line, "TelescopePreviewMessage" } }, virt_text_pos = "overlay", virt_text_win_col = col }
+    )
   end
 end
 

--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -203,21 +203,13 @@ utils.set_preview_message = function(bufnr, winid, message, fillchar)
   )
   local col = math.floor((width - strings.strdisplaywidth(lines[2])) / 2)
   if height <= 2 then -- Display message on first line in buffer preview
-    vim.api.nvim_buf_set_extmark(
-      bufnr,
-      anon_ns,
-      0,
-      0,
-      {
-        virt_text = { { formatted_message, "TelescopePreviewMessage" } },
-        virt_text_pos = "overlay",
-        virt_text_win_col =
-            col
-      }
-    )
+    vim.api.nvim_buf_set_extmark(bufnr, anon_ns, 0, 0, {
+      virt_text = { { formatted_message, "TelescopePreviewMessage" } },
+      virt_text_pos = "overlay",
+      virt_text_win_col = col,
+    })
   else
     for i, line in ipairs(lines) do
-      local line_pos = math.floor(height / 2) - 1 + i
       vim.api.nvim_buf_set_extmark(
         bufnr,
         anon_ns,


### PR DESCRIPTION
# Description

Handles edge case where buffer preview window is of line height 2 or less. Current preview message is at 3 lines long.
The fix adds in a check to handle a line height of 2 or less and shows only the preview message on the first line.

Fixes #3001

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Configuration can be referred to in issue #3001.

Testing steps:
- Navigate to a directory with non-text files
- Open file browser
- Navigate selection to non-text file
- Preview message should be shown on the first line without throwing any errors

<img width="664" alt="Screenshot 2024-03-23 at 10 58 12" src="https://github.com/nvim-telescope/telescope.nvim/assets/19703014/18616738-95da-49e0-b0a9-1114dff073e4">


**Configuration**:
* Neovim version (nvim --version):
NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1710088188
* Operating system and version:
macOS 14.4

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
