### PR TITLE
Adds option to reverse the path_display

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -274,6 +274,7 @@ telescope.setup({opts})                                    *telescope.setup()*
         - "truncate"  truncates the start of the path when the whole path will
                       not fit. To increase the gap between the path and the edge,
                       set truncate to number `truncate = 3`
+        - "reverse"   reverses the path so that file names are in front
 
         You can also specify the number of characters of each directory name
         to keep by setting `path_display.shorten = num`.

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -298,6 +298,18 @@ telescope.setup({opts})                                    *telescope.setup()*
           will give a path like:
             `al/beta/gamma/de`
 
+
+        path_display can also be set to 'reverse' string to reverse the path.
+        The following options can be set to customise the result:
+
+          path_display = {
+            reverse = {
+              file_sep = " ",
+              dir_open_sep = "(",
+              dir_close_sep = ")",
+            }
+          },
+
         path_display can also be set to 'hidden' string to hide file names
 
         path_display can also be set to a function for custom formatting of

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -303,7 +303,7 @@ append(
   - "truncate"  truncates the start of the path when the whole path will
                 not fit. To increase the gap between the path and the edge,
                 set truncate to number `truncate = 3`
-  - "reverse"   reverses the path
+  - "reverse"   reverses the path so that file names are in front
 
   You can also specify the number of characters of each directory name
   to keep by setting `path_display.shorten = num`.
@@ -327,6 +327,17 @@ append(
     setting `path_display.shorten = { len = 2, exclude = {2, -2} }`
     will give a path like:
       `al/beta/gamma/de`
+
+  path_display can also be set to 'reverse' string to reverse the path.
+  The following options can be set to customise the result:
+
+    path_display = {
+      reverse = {
+        file_sep = " ",
+        dir_open_sep = "(",
+        dir_close_sep = ")",
+      }
+    },
 
   path_display can also be set to 'hidden' string to hide file names
 

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -303,6 +303,7 @@ append(
   - "truncate"  truncates the start of the path when the whole path will
                 not fit. To increase the gap between the path and the edge,
                 set truncate to number `truncate = 3`
+  - "reverse"   reverses the path
 
   You can also specify the number of characters of each directory name
   to keep by setting `path_display.shorten = num`.

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -130,6 +130,29 @@ utils.filter_symbols = function(results, opts)
   end
 end
 
+utils.path_reverse = (function(filepath)
+  local dirs = vim.split(filepath, "/")
+  local reversed_path = ""
+
+  for i, dir in ipairs(dirs) do
+    if 1 == #dirs then
+      reversed_path = dir .. reversed_path
+    elseif i == 2 and i == #dirs then
+      reversed_path = dir .. " (/" .. reversed_path .. ")"
+    elseif i == 2 then
+      reversed_path = dir .. "/" .. reversed_path .. ")"
+    elseif i == #dirs then
+      reversed_path = dir .. " (/" .. reversed_path
+    else
+      reversed_path = dir .. "/" .. reversed_path
+    end
+  end
+
+  vim.print(reversed_path)
+
+  return reversed_path
+end)
+
 utils.path_smart = (function()
   local paths = {}
   return function(filepath)
@@ -272,6 +295,10 @@ utils.transform_path = function(opts, path)
         transformed_path = Path:new(transformed_path):make_relative(cwd)
       end
 
+      if vim.tbl_contains(path_display, "reverse") or path_display["reverse"] ~= nil then
+        transformed_path = utils.path_reverse(transformed_path)
+      end
+
       if vim.tbl_contains(path_display, "shorten") or path_display["shorten"] ~= nil then
         if type(path_display["shorten"]) == "table" then
           local shorten = path_display["shorten"]
@@ -280,6 +307,7 @@ utils.transform_path = function(opts, path)
           transformed_path = Path:new(transformed_path):shorten(path_display["shorten"])
         end
       end
+
       if vim.tbl_contains(path_display, "truncate") or path_display.truncate then
         if opts.__length == nil then
           opts.__length = calc_result_length(path_display.truncate)

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -130,7 +130,7 @@ utils.filter_symbols = function(results, opts)
   end
 end
 
-utils.path_reverse = (function(filepath)
+utils.path_reverse = (function(filepath, file_sep, dir_open_sep, dir_close_sep)
   local dirs = vim.split(filepath, "/")
   local reversed_path = ""
 
@@ -138,11 +138,11 @@ utils.path_reverse = (function(filepath)
     if 1 == #dirs then
       reversed_path = dir .. reversed_path
     elseif i == 2 and i == #dirs then
-      reversed_path = dir .. " (/" .. reversed_path .. ")"
+      reversed_path = dir .. file_sep .. dir_open_sep .. "/" .. reversed_path .. dir_close_sep
     elseif i == 2 then
-      reversed_path = dir .. "/" .. reversed_path .. ")"
+      reversed_path = dir .. "/" .. reversed_path .. dir_close_sep
     elseif i == #dirs then
-      reversed_path = dir .. " (/" .. reversed_path
+      reversed_path = dir .. file_sep .. dir_open_sep .. "/" .. reversed_path
     else
       reversed_path = dir .. "/" .. reversed_path
     end
@@ -296,7 +296,15 @@ utils.transform_path = function(opts, path)
       end
 
       if vim.tbl_contains(path_display, "reverse") or path_display["reverse"] ~= nil then
-        transformed_path = utils.path_reverse(transformed_path)
+        if type(path_display["reverse"]) == "table" then
+          local reverse = path_display["reverse"]
+          transformed_path = utils.path_reverse(transformed_path, reverse.file_sep, reverse.dir_open_sep, reverse.dir_close_sep)
+        else
+          local file_sep = ""
+          local dir_open_sep = ""
+          local dir_close_sep = ""
+          transformed_path = utils.path_reverse(transformed_path, file_sep, dir_open_sep, dir_close_sep)
+        end
       end
 
       if vim.tbl_contains(path_display, "shorten") or path_display["shorten"] ~= nil then


### PR DESCRIPTION
# Description

Long paths make it sometimes difficult to see the file name. You can create a custom formatter, but I thought it would be great if we can have a format similar to Intelij, where the file name is in front.

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've tested my code with the following configurations:

**Simple config:**
```lua
          path_display = {
            "reverse"
          },
```

<img width="999" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/7d95026f-c341-437c-8524-beeba8c0efe0">

**Extended config:**
```lua
          path_display = {
            reverse = {
              file_sep = " ",
              dir_open_sep = "(",
              dir_close_sep = ")",
            }
          },
```

<img width="1001" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/78488452-420b-442f-9996-3a58b8b32af9">

**Configuration**:

* Neovim version (nvim --version): NVIM v0.9.5 | Build type: Release | LuaJIT 2.1.1710088188
* Operating system and version: MacOs 13.6.4 (22G513)

# Checklist:

- [ x ] My code follows the style guidelines of this project (stylua)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation (lua annotations)
