### PR TITLE
Selecting a spell suggestion now uses z{index}= 

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1374,7 +1374,7 @@ internal.spell_suggest = function(opts)
 
           action_state.get_current_picker(prompt_bufnr)._original_mode = "i"
           actions.close(prompt_bufnr)
-          vim.cmd("normal! ciw" .. selection[1])
+          vim.cmd("normal! " .. selection.index .. "z=")
           vim.cmd "stopinsert"
         end)
         return true


### PR DESCRIPTION
Selecting a spell suggestion now uses z{index}= instead of ciw.
This fixes `spellrepall` command not working
z{index}= is the same than typing z= and then typing the index with the native spell plugin

# Description

#3019 

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Open a file such as a.md with "Hey yelterdai yelterdai was good" 
`Telescope spell_suggest` on the first mistyped yesterday choose one element then type `:spellrepall` and it will apply to the second element (and all others if applicable) 

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.10.0-dev-2723+g981301d11
* Operating system and version:
windows 11 WSL ubuntu 22
# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
