### PR TITLE
Fix over-normalization, only normalize when a filename starts with "~"

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1114,9 +1114,7 @@ internal.marks = function(opts)
       -- same format to :marks command
       local line = string.format("%s %6d %4d %s", mark, lnum, col - 1, name)
       local filename = v.file or bufname
-      if filename:sub(1, 1) == '~' then
-        filename = vim.fs.normalize(filename)
-      end
+      filename = utils.path_expand(filename)
       local row = {
         line = line,
         lnum = lnum,

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1113,11 +1113,15 @@ internal.marks = function(opts)
       local name = cnf.name_func(mark, lnum)
       -- same format to :marks command
       local line = string.format("%s %6d %4d %s", mark, lnum, col - 1, name)
+      local filename = v.file or bufname
+      if filename:sub(1, 1) == '~' then
+        filename = vim.fs.normalize(filename)
+      end
       local row = {
         line = line,
         lnum = lnum,
         col = col,
-        filename = vim.fs.normalize(v.file or bufname),
+        filename = filename,
       }
       -- non alphanumeric marks goes to last
       if mark:match "%w" then

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -39,6 +39,10 @@ utils.path_expand = function(path)
     path = { path, { "string" } },
   }
 
+  if utils.is_uri(path) then
+    return path
+  end
+
   if path:match "^[%%#<]" then
     path = vim.fn.expand(path)
   end

--- a/lua/tests/automated/utils_spec.lua
+++ b/lua/tests/automated/utils_spec.lua
@@ -38,6 +38,26 @@ describe("path_expand()", function()
     local path_newline = [[/home/user/hello\nworld]]
     eq(path_newline, utils.path_expand(path_newline))
   end)
+  it("early return for uri", function()
+    local uris = {
+      [[https://www.example.com/index.html]],
+      [[ftp://ftp.example.com/files/document.pdf]],
+      [[mailto:user@example.com]],
+      [[tel:+1234567890]],
+      [[file:///home/user/documents/report.docx]],
+      [[news:comp.lang.python]],
+      [[ldap://ldap.example.com:389/dc=example,dc=com]],
+      [[git://github.com/user/repo.git]],
+      [[steam://run/123456]],
+      [[magnet:?xt=urn:btih:6B4C3343E1C63A1BC36AEB8A3D1F52C4EDEEB096]],
+    }
+
+    for _, uri in ipairs(uris) do
+      it(uri, function()
+        eq(uri, utils.path_expand(uri))
+      end)
+    end
+  end)
 end)
 
 describe("is_uri", function()


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

Fixes #3023

This commit maintains the normalization of `~/{path}` as intended by #2859, but stops the normalization process for other paths to avoid unintended effects.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Original marked oil and fugitive buffers are opened as expected.

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1703358377
```
* Operating system and version:
```
macOS 14.4.1
```
# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ n/a] I have commented my code, particularly in hard-to-understand areas
- [ n/a] I have made corresponding changes to the documentation (lua annotations)
