### PR TITLE
fix(scrolling): enhance and simplify scrolling

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1494,56 +1494,6 @@ end
 
 actions.nop = function(_) end
 
-actions.mouse_scroll_up = function(prompt_bufnr)
-  local picker = action_state.get_current_picker(prompt_bufnr)
-
-  local mouse_win = vim.fn.getmousepos().winid
-  if picker.results_win == mouse_win then
-    vim.schedule(function()
-      actions.move_selection_next(prompt_bufnr)
-    end)
-    return ""
-  else
-    return "<ScrollWheelDown>"
-  end
-end
-
-actions.mouse_scroll_down = function(prompt_bufnr)
-  local picker = action_state.get_current_picker(prompt_bufnr)
-
-  local mouse_win = vim.fn.getmousepos().winid
-  if mouse_win == picker.results_win then
-    vim.schedule(function()
-      actions.move_selection_previous(prompt_bufnr)
-    end)
-    return ""
-  else
-    return "<ScrollWheelUp>"
-  end
-end
-
-actions.mouse_scroll_right = function(prompt_bufnr)
-  local picker = action_state.get_current_picker(prompt_bufnr)
-
-  local mouse_win = vim.fn.getmousepos().winid
-  if mouse_win == picker.results_win then
-    return ""
-  else
-    return "<ScrollWheelLeft>"
-  end
-end
-
-actions.mouse_scroll_left = function(prompt_bufnr)
-  local picker = action_state.get_current_picker(prompt_bufnr)
-
-  local mouse_win = vim.fn.getmousepos().winid
-  if mouse_win == picker.results_win then
-    return ""
-  else
-    return "<ScrollWheelRight>"
-  end
-end
-
 actions.mouse_click = function(prompt_bufnr)
   local picker = action_state.get_current_picker(prompt_bufnr)
 

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -133,26 +133,6 @@ local mappings = {}
 mappings.default_mappings = config.values.default_mappings
   or {
     i = {
-      ["<ScrollWheelDown>"] = {
-        actions.mouse_scroll_up,
-        type = "action",
-        opts = { expr = true },
-      },
-      ["<ScrollWheelUp>"] = {
-        actions.mouse_scroll_down,
-        type = "action",
-        opts = { expr = true },
-      },
-      ["<ScrollWheelLeft>"] = {
-        actions.mouse_scroll_right,
-        type = "action",
-        opts = { expr = true },
-      },
-      ["<ScrollWheelRight>"] = {
-        actions.mouse_scroll_left,
-        type = "action",
-        opts = { expr = true },
-      },
       ["<LeftMouse>"] = {
         actions.mouse_click,
         type = "action",
@@ -201,26 +181,6 @@ mappings.default_mappings = config.values.default_mappings
       ["<C-j>"] = actions.nop,
     },
     n = {
-      ["<ScrollWheelDown>"] = {
-        actions.mouse_scroll_up,
-        type = "action",
-        opts = { expr = true },
-      },
-      ["<ScrollWheelUp>"] = {
-        actions.mouse_scroll_down,
-        type = "action",
-        opts = { expr = true },
-      },
-      ["<ScrollWheelLeft>"] = {
-        actions.mouse_scroll_right,
-        type = "action",
-        opts = { expr = true },
-      },
-      ["<ScrollWheelRight>"] = {
-        actions.mouse_scroll_left,
-        type = "action",
-        opts = { expr = true },
-      },
       ["<LeftMouse>"] = {
         actions.mouse_click,
         type = "action",


### PR DESCRIPTION
# Description

The previous scrolling implementation (#2687) moved the result selection by one item at a time, which isn't technically scrolling (ie. moving the view) and feels quite slow.

Let the neovim builtin scrolling do its thing, so using the scroll wheel feels like scrolling and is functionally scrolling, too. Scrolling does not move the selection so after scrolling it typically makes sense to click. Moving the selection with keyboard takes you back to where you were. This is in line with typical desktop user interfaces.

(No issue created for this, as it was trivial to change. I'll make a bug report if you wish.)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Open a telescope window with eg. `:Telescope find_files`. Move the mouse cursor on top of the results list. Scroll up, down, left and right with the mouse.

**Configuration**:
* Neovim version (nvim --version): v0.9.5
* Operating system and version:  Arch Linux, 6.8.2-arch2-1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
