### PR TITLE
feat(layout_config) Adds the option to configure additional lines of padding around the anchor of the layout (#2851)

### DIFF
--- a/lua/telescope/config/resolve.lua
+++ b/lua/telescope/config/resolve.lua
@@ -251,21 +251,21 @@ end
 ---   - Compass directions:<br>
 ---     the picker will move to the corresponding edge/corner
 ---     e.g. "NW" -> "top left corner", "E" -> "right edge", "S" -> "bottom edge"
-resolver.resolve_anchor_pos = function(anchor, p_width, p_height, max_columns, max_lines)
+resolver.resolve_anchor_pos = function(anchor, p_width, p_height, max_columns, max_lines, anchor_padding)
   anchor = anchor:upper()
   local pos = { 0, 0 }
   if anchor == "CENTER" then
     return pos
   end
   if anchor:find "W" then
-    pos[1] = math.ceil((p_width - max_columns) / 2) + 1
+    pos[1] = math.ceil((p_width - max_columns) / 2) + anchor_padding
   elseif anchor:find "E" then
-    pos[1] = math.ceil((max_columns - p_width) / 2) - 1
+    pos[1] = math.ceil((max_columns - p_width) / 2) - anchor_padding
   end
   if anchor:find "N" then
-    pos[2] = math.ceil((p_height - max_lines) / 2) + 1
+    pos[2] = math.ceil((p_height - max_lines) / 2) + anchor_padding
   elseif anchor:find "S" then
-    pos[2] = math.ceil((max_lines - p_height) / 2) - 1
+    pos[2] = math.ceil((max_lines - p_height) / 2) - anchor_padding
   end
   return pos
 end

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -194,6 +194,10 @@ local shared_options = {
   scroll_speed = "The number of lines to scroll through the previewer",
   prompt_position = { "Where to place prompt window.", "Available Values: 'bottom', 'top'" },
   anchor = { "Which edge/corner to pin the picker to", "See |resolver.resolve_anchor_pos()|" },
+  anchor_padding = {
+    "Specifies an amount of additional padding around the anchor",
+    "Values should be a positive integer",
+  },
 }
 
 -- Used for generating vim help documentation.
@@ -375,7 +379,10 @@ layout_strategies.horizontal = make_documented_layout(
       error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
     end
 
-    local anchor_pos = resolve.resolve_anchor_pos(layout_config.anchor or "", width, height, max_columns, max_lines)
+    local anchor = layout_config.anchor or ""
+    local anchor_padding = layout_config.anchor_padding or 1
+
+    local anchor_pos = resolve.resolve_anchor_pos(anchor, width, height, max_columns, max_lines, anchor_padding)
     adjust_pos(anchor_pos, prompt, results, preview)
 
     if tbln then
@@ -486,7 +493,9 @@ layout_strategies.center = make_documented_layout(
     results.col, preview.col, prompt.col = width_padding, width_padding, width_padding
 
     local anchor = layout_config.anchor or ""
-    local anchor_pos = resolve.resolve_anchor_pos(anchor, width, height, max_columns, max_lines)
+    local anchor_padding = layout_config.anchor_padding or 1
+
+    local anchor_pos = resolve.resolve_anchor_pos(anchor, width, height, max_columns, max_lines, anchor_padding)
     adjust_pos(anchor_pos, prompt, results, preview)
 
     -- Vertical anchoring (S or N variations) ignores layout_config.mirror
@@ -740,7 +749,10 @@ layout_strategies.vertical = make_documented_layout(
       end
     end
 
-    local anchor_pos = resolve.resolve_anchor_pos(layout_config.anchor or "", width, height, max_columns, max_lines)
+    local anchor = layout_config.anchor or ""
+    local anchor_padding = layout_config.anchor_padding or 1
+
+    local anchor_pos = resolve.resolve_anchor_pos(anchor, width, height, max_columns, max_lines, anchor_padding)
     adjust_pos(anchor_pos, prompt, results, preview)
 
     if tbln then

--- a/lua/tests/automated/resolver_spec.lua
+++ b/lua/tests/automated/resolver_spec.lua
@@ -127,12 +127,12 @@ describe("telescope.config.resolve", function()
 
   describe("resolve_anchor_pos", function()
     local test_sizes = {
-      { 6, 7, 8, 9 },
-      { 10, 20, 30, 40 },
-      { 15, 15, 16, 16 },
-      { 17, 19, 23, 31 },
-      { 21, 18, 26, 24 },
-      { 50, 100, 150, 200 },
+      { 6, 7, 8, 9, 1 },
+      { 10, 20, 30, 40, 1 },
+      { 15, 15, 16, 16, 1 },
+      { 17, 19, 23, 31, 1 },
+      { 21, 18, 26, 24, 1 },
+      { 50, 100, 150, 200, 1 },
     }
 
     it([[should not adjust when "CENTER" or "" is the anchor]], function()
@@ -145,7 +145,7 @@ describe("telescope.config.resolve", function()
 
     it([[should end up at top when "N" in the anchor]], function()
       local top_test = function(anchor, p_width, p_height, max_columns, max_lines)
-        local pos = resolve.resolve_anchor_pos(anchor, p_width, p_height, max_columns, max_lines)
+        local pos = resolve.resolve_anchor_pos(anchor, p_width, p_height, max_columns, max_lines, 1)
         eq(1, pos[2] + math.floor((max_lines - p_height) / 2))
       end
       for _, s in ipairs(test_sizes) do
@@ -157,7 +157,7 @@ describe("telescope.config.resolve", function()
 
     it([[should end up at left when "W" in the anchor]], function()
       local left_test = function(anchor, p_width, p_height, max_columns, max_lines)
-        local pos = resolve.resolve_anchor_pos(anchor, p_width, p_height, max_columns, max_lines)
+        local pos = resolve.resolve_anchor_pos(anchor, p_width, p_height, max_columns, max_lines, 1)
         eq(1, pos[1] + math.floor((max_columns - p_width) / 2))
       end
       for _, s in ipairs(test_sizes) do
@@ -169,7 +169,7 @@ describe("telescope.config.resolve", function()
 
     it([[should end up at bottom when "S" in the anchor]], function()
       local bot_test = function(anchor, p_width, p_height, max_columns, max_lines)
-        local pos = resolve.resolve_anchor_pos(anchor, p_width, p_height, max_columns, max_lines)
+        local pos = resolve.resolve_anchor_pos(anchor, p_width, p_height, max_columns, max_lines, 1)
         eq(max_lines - 1, pos[2] + p_height + math.floor((max_lines - p_height) / 2))
       end
       for _, s in ipairs(test_sizes) do
@@ -181,7 +181,7 @@ describe("telescope.config.resolve", function()
 
     it([[should end up at right when "E" in the anchor]], function()
       local right_test = function(anchor, p_width, p_height, max_columns, max_lines)
-        local pos = resolve.resolve_anchor_pos(anchor, p_width, p_height, max_columns, max_lines)
+        local pos = resolve.resolve_anchor_pos(anchor, p_width, p_height, max_columns, max_lines, 1)
         eq(max_columns - 1, pos[1] + p_width + math.floor((max_columns - p_width) / 2))
       end
       for _, s in ipairs(test_sizes) do
@@ -193,8 +193,8 @@ describe("telescope.config.resolve", function()
 
     it([[should ignore casing of the anchor]], function()
       local case_test = function(a1, a2, p_width, p_height, max_columns, max_lines)
-        local pos1 = resolve.resolve_anchor_pos(a1, p_width, p_height, max_columns, max_lines)
-        local pos2 = resolve.resolve_anchor_pos(a2, p_width, p_height, max_columns, max_lines)
+        local pos1 = resolve.resolve_anchor_pos(a1, p_width, p_height, max_columns, max_lines, 1)
+        local pos2 = resolve.resolve_anchor_pos(a2, p_width, p_height, max_columns, max_lines, 1)
         eq(pos1, pos2)
       end
       for _, s in ipairs(test_sizes) do


### PR DESCRIPTION
# Description

This PR adds a new option to layout_config called anchor_padding. When set to a positive integer, it adds 
additional lines of padding around the anchor of a layout.

Fixes #2851

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Test for anchor south and with high padding:

```lua
local telescope = require("telescope")

local vertical_config = {
	config = {
		vertical = { width = 0.5 },
		anchor = "S",
		prompt_position = "bottom",
		width = { padding = 0 },
		height = 0.5,
		anchor_padding = 10,
	},
}
telescope.setup({
	pickers = {},
	extensions = {},
	defaults =config,
})
```
This results in the following layout:
![Test_10_Vertical](https://github.com/Weyaaron/telescope.nvim/assets/52529582/55d9a34d-468f-4306-8506-675def9acdaf)

The result we care about is the ten lines of additional space between the bottom of the screen and the start of the layout.

- Test for anchor north and with low padding:

```lua
local telescope = require("telescope")
local config = {
	layout_config = {
		vertical = { width = 0.5 },
		anchor = "N",
		prompt_position = "bottom",
		width = { padding = 0 },
		height = 0.5,
		anchor_padding = 2,
	},
}
telescope.setup({
	pickers = {},
	extensions = {},
	defaults =config,
})
```
This results in the following layout:
![Test_10_North](https://github.com/Weyaaron/telescope.nvim/assets/52529582/c0569022-de0d-4657-9933-d69928cca747)

The result we care about is the two lines of additional space between the top of the screen and the start of the layout.

**Configuration**:
* Neovim version (nvim --version):  v0.9.4
* Operating system and version: 
OS: Manjaro Linux x86_64 
 Host: Laptop (12th Gen Intel Core) A4 
 Kernel: 6.1.80-1-MANJARO 

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)

I am not quite sure what this last point is about, so I left it open.

# Open question:
I have not provided additional tests. I have changed the existing tests to mimic the previous behavior by setting anchorpadding to 1 where applicable. Since this is my first contribution, I am unsure about this. Additional feedback is appreciated. 