### PR TITLE
refactor: add types to diagnostics-related pickers

### DIFF
--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -512,15 +512,7 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 --
 --
 
---- Lists diagnostics
---- - Fields:
----   - `All severity flags can be passed as `string` or `number` as per `:vim.diagnostic.severity:`
---- - Default keymaps:
----   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
---- - sort_by option:
----   - "buffer": order by bufnr (prioritizing current bufnr), severity, lnum
----   - "severity": order by severity, bufnr (prioritizing current bufnr), lnum
----@param opts table: options to pass to the picker
+---@class TelescopeBuiltinLspDiagnosticsOpts
 ---@field bufnr number|nil: Buffer number to get diagnostics from. Use 0 for current buffer or nil for all buffers
 ---@field severity string|number: filter diagnostics by severity name (string) or id (number)
 ---@field severity_limit string|number: keep diagnostics equal or more severe wrt severity name (string) or id (number)
@@ -532,6 +524,16 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 ---@field namespace number: limit your diagnostics to a specific namespace
 ---@field disable_coordinates boolean: don't show the line & row numbers (default: false)
 ---@field sort_by string: sort order of the diagnostics results; see above notes (default: "buffer")
+
+--- Lists diagnostics
+--- - Fields:
+---   - `All severity flags can be passed as `string` or `number` as per `:vim.diagnostic.severity:`
+--- - Default keymaps:
+---   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
+--- - sort_by option:
+---   - "buffer": order by bufnr (prioritizing current bufnr), severity, lnum
+---   - "severity": order by severity, bufnr (prioritizing current bufnr), lnum
+---@type fun(opts?: TelescopeBuiltinLspDiagnosticsOpts): nil
 builtin.diagnostics = require_on_exported_call("telescope.builtin.__diagnostics").get
 
 local apply_config = function(mod)


### PR DESCRIPTION
# Description

This is similar to https://github.com/nvim-telescope/telescope.nvim/pull/3036.

I added types to the entire file, but because it's a very long file, I decided to split it into 5 pull requests (otherwise it's very difficult to review etc).