### PR TITLE
add zindex option for popup `action.which_key`

### DIFF
--- a/lua/telescope/actions/generate.lua
+++ b/lua/telescope/actions/generate.lua
@@ -52,6 +52,7 @@ local action_generate = {}
 ---@field normal_hl string: winhl of "Normal" for keymap hints floating window (default: "TelescopePrompt")
 ---@field border_hl string: winhl of "Normal" for keymap borders (default: "TelescopePromptBorder")
 ---@field winblend number: pseudo-transparency of keymap hints floating window
+---@field zindex number: z-index of keymap hints floating window (default: 100)
 action_generate.which_key = function(opts)
   local which_key = function(prompt_bufnr)
     actions.which_key(prompt_bufnr, opts)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1245,6 +1245,7 @@ actions.which_key = function(prompt_bufnr, opts)
   if type(opts.winblend) == "function" then
     opts.winblend = opts.winblend()
   end
+  opts.zindex = vim.F.if_nil(opts.zindex, 100)
   opts.column_padding = vim.F.if_nil(opts.column_padding, "  ")
 
   -- Assigning into 'opts.column_indent' would override a number with a string and
@@ -1363,6 +1364,7 @@ actions.which_key = function(prompt_bufnr, opts)
     borderchars = { prompt_pos and "─" or " ", "", not prompt_pos and "─" or " ", "", "", "", "", "" },
     noautocmd = true,
     title = { { text = title_text, pos = prompt_pos and "N" or "S" } },
+    zindex = opts.zindex,
   }
   local km_win_id, km_opts = popup.create("", popup_opts)
   local km_buf = a.nvim_win_get_buf(km_win_id)


### PR DESCRIPTION
# Description

add zindex option for `action.which_key`. The current value is 50 which sometimes conflicted with picker window. 

Fixes #2976

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran several test (over 50, below 50) in neovide by adding code below and it works as expected.

```lua
local action_generate = require 'telescope.actions.generate'
require('telescope').setup {
  defaults = {
    mappings = {
      i = { 
        ['<c-/>'] = action_generate.which_key {
          zindex = 60,
        },
      },
    },
  },
}
```


**Configuration**:
* Neovim version (nvim --version): 0.9.5
* Operating system and version: darwin-arm64

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
