### PR TITLE
feat(actions): New `select_vertical_if_wide_enough` action

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -301,6 +301,33 @@ actions.select_vertical = {
   end,
 }
 
+--- Perform 'vertical' or `horizontal` action based on the number of windows opened and
+--- its width, usually something like<br>
+---`:vnew <selection>` or `:new <selection>`
+---
+--- i.e. open the selection in a new vertical split if there is only one window with width > 160,
+--- and open in a new horizontal split otherwise
+---@param prompt_bufnr number: The prompt bufnr
+actions.select_vertical_if_wide_enough = {
+  pre = append_to_history,
+  action = function(prompt_bufnr)
+    local wins = vim.api.nvim_tabpage_list_wins(0)
+
+    local winbufs = vim.tbl_map(function(win)
+      return { win, vim.api.nvim_win_get_buf(win) }
+    end, wins)
+
+    local listed_winbufs = vim.tbl_filter(function(winbuf)
+      return vim.api.nvim_buf_get_option(winbuf[2], "buflisted")
+    end, winbufs)
+
+    if #listed_winbufs == 1 and vim.api.nvim_win_get_width(listed_winbufs[1][1]) > 160 then
+      return action_set.select(prompt_bufnr, "vertical")
+    end
+    return action_set.select(prompt_bufnr, "horizontal")
+  end,
+}
+
 --- Perform 'tab' action on selection, usually something like<br>
 ---`:tabedit <selection>`
 ---


### PR DESCRIPTION
# Description

The action opens the selected item in a new vertical split if the current tab page has only one window with a listed buffer, and the window is wide enough (width > 160). Otherwise, defaults to horizontal split.

This is especially helpful when working with multiple tmux panes on a small laptop screen.

Fixes # (issue)

This action reduces the mental effort required to decide whether to open a selected item (e.g., help_tags) in a vertical or horizontal split, potentially eliminating the inconvenience of rearranging Vim windows to make panes more legible. 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Set `help_tags` picker mapping to the new action as below: 
```lua
local actions = require("telescope.actions")
require("telescope").setup({
	-- ...
	pickers = {
	    help_tags = {
	        mappings = {
	            i = { ["<CR>"] = actions.select_vertical_if_wide_enough, },
	            n = { ["<CR>"] = actions.select_vertical_if_wide_enough, }
	        }
	    }
	}
}
```

When there is only one window in the current tab page with an editor width greater than 160, the help opens in a vertical split. If there are multiple windows open or the editor width is less than or equal to 160, the help will open horizontally.

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
