### PR TITLE
fix(actions): make which_key always appear on top

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1363,6 +1363,7 @@ actions.which_key = function(prompt_bufnr, opts)
     borderchars = { prompt_pos and "─" or " ", "", not prompt_pos and "─" or " ", "", "", "", "", "" },
     noautocmd = true,
     title = { { text = title_text, pos = prompt_pos and "N" or "S" } },
+    zindex = 60,
   }
   local km_win_id, km_opts = popup.create("", popup_opts)
   local km_buf = a.nvim_win_get_buf(km_win_id)


### PR DESCRIPTION
# Description

Fix displaying the which-key window on top of the main telescope window with at least the neovide GUI.
The default z-index is 50, setting 60 to guarantee displaying on top of the main telescope window.
The current behavior works correctly with the normal neovim implementation by luck only.

Fixes #2976

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

I also believe this fix should be applied to the 0.1.0 branch.

# How Has This Been Tested?

- [x] Ran neovide telescope and triggered which-key with and without the change, confirming the fix works. Also triggered which-key in the neovim CLI and checked it still worked.

**Configuration**:
* Neovim version (nvim --version): 0.9.5
* Operating system and version: fedora 39

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
