### PR TITLE
fix(picker): set `current_line` state earlier

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -636,6 +636,8 @@ function Picker:find()
       local start_time = vim.loop.hrtime()
 
       local prompt = self:_get_next_filtered_prompt()
+      state.set_global_key("current_line", prompt)
+
       if self.__locations_input == true then
         local filename, line_number, column_number = utils.__separate_file_path_location(prompt)
 
@@ -1455,7 +1457,6 @@ function Picker:get_result_completor(results_bufnr, find_id, prompt, status_upda
 
     self:_do_selection(prompt)
 
-    state.set_global_key("current_line", self:_get_prompt())
     status_updater { completed = true }
 
     self:clear_extra_rows(results_bufnr)


### PR DESCRIPTION
Sets the `current_line` global state earlier in the event loop rather than in `get_results_completor`. This makes it safer to access `current_line` earlier (eg. for building an entry).

closes #3051

I'm not super confident this is safe to do without some unintended side effects. I've experienced some finicky race conditions with the `picker:_get_prompt` before so I'll use this branch for a bit. 