### PR TITLE
fix(which_key): close window on mouse click action

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -3678,6 +3678,8 @@ action_generate.which_key({opts})     *telescope.actions.generate.which_key()*
                                             "TelescopePromptBorder")
         {winblend}               (number)   pseudo-transparency of keymap
                                             hints floating window
+        {zindex}                 (number)   z-index of keymap hints floating
+                                            window (default: 100)
 
 
 

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1428,9 +1428,11 @@ actions.which_key = function(prompt_bufnr, opts)
       buffer = close_buffer,
       once = true,
       callback = function()
-        pcall(vim.api.nvim_win_close, km_win_id, true)
-        pcall(vim.api.nvim_win_close, km_opts.border.win_id, true)
-        require("telescope.utils").buf_delete(km_buf)
+        vim.schedule(function()
+          pcall(vim.api.nvim_win_close, km_win_id, true)
+          pcall(vim.api.nvim_win_close, km_opts.border.win_id, true)
+          utils.buf_delete(km_buf)
+        end)
       end,
     })
   end)


### PR DESCRIPTION
`nvim_buf_delete` is not allowed during text change or window change. Window switching with left mouse click was leading to race condition/error.

closes https://github.com/nvim-telescope/telescope.nvim/issues/3034