### PR TITLE
fix: do not setup more than once

### DIFF
--- a/lua/telescope/_extensions/init.lua
+++ b/lua/telescope/_extensions/init.lua
@@ -3,6 +3,7 @@ local extensions = {}
 extensions._loaded = {}
 extensions._config = {}
 extensions._health = {}
+extensions._has_setup = {}
 
 local load_extension = function(name)
   local ok, ext = pcall(require, "telescope._extensions." .. name)
@@ -16,8 +17,9 @@ extensions.manager = setmetatable({}, {
   __index = function(t, k)
     local ext = load_extension(k)
     t[k] = ext.exports or {}
-    if ext.setup then
+    if ext.setup and not extensions._has_setup[k] then
       ext.setup(extensions._config[k] or {}, require("telescope.config").values)
+      extensions._has_setup[k] = true
     end
     extensions._health[k] = ext.health
 
@@ -60,8 +62,9 @@ end
 
 extensions.load = function(name)
   local ext = load_extension(name)
-  if ext.setup then
+  if ext.setup and not extensions._has_setup[name] then
     ext.setup(extensions._config[name] or {}, require("telescope.config").values)
+    extensions._has_setup[name] = true
   end
   return extensions.manager[name]
 end


### PR DESCRIPTION
# Description

related: #1628 

Extensions, e.g. `file_browser`, merge default key mappings and user defined ones in their `setup`s. the mappings contain actions which typically have `__call` and other metamethods.

However, when merging tables, `vim.tbl_extend` returns a table without a metatable. Thus `vim.tbl_deep_extend({n = {g = action1}}, {n = {g = action2}})` will try to merge `action1` and `action2`, but the returned table doesn't have metatables.

This is mainly an issue of `vim.tbl_extend`. I have opened an issue there, but it would be nice to also have things work without having to upgrade neovim.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Example config:
```
require('telescope').setup({
  extensions = {
    file_browser = {
      mappings = {n = {g = actions.close + my_action}}
    }
  }
})
telescope.load_extension("file_browser")
```

Trying to trigger the action will get an error: `mappings.lua:290: attempt to call upvalue 'key_func' (a table value)`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
