### PR TITLE
dev: POC proposal on_selection_callback for builtins

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -388,6 +388,20 @@ files.find_files = function(opts)
       finder = finders.new_oneshot_job(find_command, opts),
       previewer = conf.grep_previewer(opts),
       sorter = conf.file_sorter(opts),
+      attach_mappings = function(bufnr)
+        actions.select_default:replace(function()
+          actions.close(bufnr)
+          local selection = action_state.get_selected_entry()
+          local on_selection_callback_result = true
+          if type(opts.on_selection_callback) == "function" then
+            on_selection_callback_result = opts.on_selection_callback(selection.value)
+          end
+          if on_selection_callback_result then
+            vim.cmd.edit(selection.value)
+          end
+        end)
+        return true
+      end,
     })
     :find()
 end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -84,6 +84,7 @@ builtin.grep_string = require_on_exported_call("telescope.builtin.__files").grep
 ---@field search_dirs table: directory/directories/files to search
 ---@field search_file string: specify a filename to search for
 ---@field file_encoding string: file encoding for the previewer
+---@field on_selection_callback function: run a function after selection completed
 builtin.find_files = require_on_exported_call("telescope.builtin.__files").find_files
 
 --- This is an alias for the `find_files` picker


### PR DESCRIPTION
# Description

It would be nice to be able to re-use the core handling of the builtin functions only adding a simple callback function when there's a selected result. In case of selected result, the consumer could optionally override the default handling.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

I'm not really attempting to merge this code as is, but it works for POC purposes. With some guiding feedback and confirmed interest I could flesh out a more proper PR.
