### PR TITLE
Moves filename_first to last position to fix issues with composing other options

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -327,6 +327,8 @@ utils.transform_path = function(opts, path)
         transformed_path = truncate(transformed_path, opts.__length - opts.__prefix, nil, -1)
       end
 
+      -- IMPORTANT: filename_first needs to be the last option. Otherwise the
+      -- other options will not be displayed correctly.
       if vim.tbl_contains(path_display, "filename_first") or path_display["filename_first"] ~= nil then
         local reverse_directories = false
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -307,6 +307,26 @@ utils.transform_path = function(opts, path)
         transformed_path = Path:new(transformed_path):make_relative(cwd)
       end
 
+      if vim.tbl_contains(path_display, "shorten") or path_display["shorten"] ~= nil then
+        if type(path_display["shorten"]) == "table" then
+          local shorten = path_display["shorten"]
+          transformed_path = Path:new(transformed_path):shorten(shorten.len, shorten.exclude)
+        else
+          local length = type(path_display["shorten"]) == "number" and path_display["shorten"]
+          transformed_path = Path:new(transformed_path):shorten(length)
+        end
+      end
+
+      if vim.tbl_contains(path_display, "truncate") or path_display.truncate then
+        if opts.__length == nil then
+          opts.__length = calc_result_length(path_display.truncate)
+        end
+        if opts.__prefix == nil then
+          opts.__prefix = 0
+        end
+        transformed_path = truncate(transformed_path, opts.__length - opts.__prefix, nil, -1)
+      end
+
       if vim.tbl_contains(path_display, "filename_first") or path_display["filename_first"] ~= nil then
         local reverse_directories = false
 
@@ -336,26 +356,6 @@ utils.transform_path = function(opts, path)
         transformed_path = vim.trim(filename .. " " .. tail)
 
         path_style = { { { #filename, #transformed_path }, "TelescopeResultsComment" } }
-      end
-
-      if vim.tbl_contains(path_display, "shorten") or path_display["shorten"] ~= nil then
-        if type(path_display["shorten"]) == "table" then
-          local shorten = path_display["shorten"]
-          transformed_path = Path:new(transformed_path):shorten(shorten.len, shorten.exclude)
-        else
-          local length = type(path_display["shorten"]) == "number" and path_display["shorten"]
-          transformed_path = Path:new(transformed_path):shorten(length)
-        end
-      end
-
-      if vim.tbl_contains(path_display, "truncate") or path_display.truncate then
-        if opts.__length == nil then
-          opts.__length = calc_result_length(path_display.truncate)
-        end
-        if opts.__prefix == nil then
-          opts.__prefix = 0
-        end
-        transformed_path = truncate(transformed_path, opts.__length - opts.__prefix, nil, -1)
       end
     end
 


### PR DESCRIPTION
This fixes the issue where some of the other options that are composable didn't display correctly. For now, `filename_first` needs to be the last option.

<img width="988" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/72ad5fa0-08eb-443d-8917-2fb4fb87bc03">

<img width="987" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/466410fa-daca-4893-80b2-9b9e66b0e081">
