### PR TITLE
chore(ci): tweak docgen event

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches-ignore:
       - master
-  pull_request:
+  pull_request_target:
     branches:
       - master
 


### PR DESCRIPTION
Change `pull_request` -> `pull_request_target`

This should allow forks of non-members to generate docs with the docgen workflow.
Unlike the `pull_request` event which only grants read access to `GITHUB_TOKEN`, `pull_request_target` grants read/write. This should still be safe as unlike `pull_request`, `pull_request_target` runs in the context of the base of the pull request rather than the pull request itself. So someone can't update docgen.yml to something malicious in the PR and have that docgen workflow run.