### PR TITLE
fix(#3076): no preview showing when `set nomodifiable`

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -427,6 +427,7 @@ previewers.new_buffer_previewer = function(opts)
     else
       local bufnr = vim.api.nvim_create_buf(false, true)
       set_bufnr(self, bufnr)
+      vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
 
       vim.schedule(function()
         if vim.api.nvim_buf_is_valid(bufnr) then


### PR DESCRIPTION
# Description

Not showing a preview with the new changes in the latest changes of [plenary.nvim PR
#575](https://github.com/nvim-lua/plenary.nvim/pull/575).

The error occurs when changing from `nomodifiable` to `modifiable`. Telescope itself works, but the previews don't render. Thanks to @Conni2461 for telling me where the error occurred.

Fixes #3076

> [!note]
> All the visual evidences are in #3076 and [plenary.nvim PR
#575](https://github.com/nvim-lua/plenary.nvim/pull/575)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [X] `PlenaryBustedDirectory lua/tests`

<details>
<summary>Test results</summary>

```lua
========================================
Testing:        /Users/aome/dev/nvim_plugins/telescope.nvim/lua/tests/automated/linked_list_spec.lua
Success ||      LinkedList can create a list
Success ||      LinkedList can add a single entry to the list
Success ||      LinkedList can iterate over one item
Success ||      LinkedList iterates in order
Success ||      LinkedList iterates in order, for prepend
Success ||      LinkedList iterates in order, for combo
Success ||      LinkedList has ipairs
Success ||      LinkedList track_at should update tracked when only appending
Success ||      LinkedList track_at should update tracked when first some prepend and then append
Success ||      LinkedList track_at should update when only prepending
Success ||      LinkedList track_at should update when lots of prepend and append

Success:        11
Failed :        0
Errors :        0
========================================
Error detected while processing /Users/aome/.dotfiles/roles/neovim/files/init.lua:
E5113: Error while calling lua chunk: /Users/aome/.config/nvim/lua/aome/init.lua:6: Vim:E185: Cannot find color scheme 'rose-pine'
stack traceback:
        [C]: in function 'colorscheme'
        /Users/aome/.config/nvim/lua/aome/init.lua:6: in main chunk
        [C]: in function 'require'
        /Users/aome/.dotfiles/roles/neovim/files/init.lua:1: in main chunk

========================================
Testing:        /Users/aome/dev/nvim_plugins/telescope.nvim/lua/tests/automated/entry_manager_spec.lua
Success ||      process_result works with one entry
Success ||      process_result works with two entries
Success ||      process_result calls functions when inserting
Success ||      process_result calls functions when inserting twice
Success ||      process_result correctly sorts lower scores
Success ||      process_result respects max results
Success ||      process_result should allow simple entries
Success ||      process_result should not loop a bunch
Success ||      process_result should not loop a bunch, part 2
Success ||      process_result should update worst score in all append case
Success ||      process_result should update worst score in all prepend case
Success ||      process_result should call tiebreaker if score is the same, sort length
Success ||      process_result should call tiebreaker if score is the same, keep initial

Success:        13
Failed :        0
Errors :        0
========================================
Error detected while processing /Users/aome/.dotfiles/roles/neovim/files/init.lua:
E5113: Error while calling lua chunk: /Users/aome/.config/nvim/lua/aome/init.lua:6: Vim:E185: Cannot find color scheme 'rose-pine'
stack traceback:
        [C]: in function 'colorscheme'
        /Users/aome/.config/nvim/lua/aome/init.lua:6: in main chunk
        [C]: in function 'require'
        /Users/aome/.dotfiles/roles/neovim/files/init.lua:1: in main chunk

========================================
Testing:        /Users/aome/dev/nvim_plugins/telescope.nvim/lua/tests/automated/scroller_spec.lua
Success ||      scroller ascending cycle should return values within the max results
Success ||      scroller ascending cycle should return 0 at 0
Success ||      scroller ascending cycle should cycle you to the top when you go below 0
Success ||      scroller ascending cycle should cycle you to 0 when you go past the results
Success ||      scroller ascending cycle should cycle when current results is less than max_results
Success ||      scroller ascending limit should return values within the max results
Success ||      scroller ascending limit should return 0 at 0
Success ||      scroller ascending limit should not cycle
Success ||      scroller ascending limit should not cycle you to 0 when you go past the results
Success ||      scroller ascending limit should stay at current results when current results is less than max_results
Success ||      scroller descending cycle should return values within the max results
Success ||      scroller descending cycle should return max_results - 1 at 0
Success ||      scroller descending cycle should cycle you to the bot when you go below 0
Success ||      scroller descending cycle should cycle you to 0 when you go past the results
Success ||      scroller descending cycle should cycle when current results is less than max_results
Success ||      scroller descending limit should return values within the max results
Success ||      scroller descending limit should return 0 at 0
Success ||      scroller descending limit should not cycle
Success ||      scroller descending limit should not cycle you to 0 when you go past the results
Success ||      scroller descending limit should stay at current results when current results is less than max_results
Success ||      scroller https://github.com/nvim-telescope/telescope.nvim/pull/293#issuecomment-751463224 should handle having many more results than necessary
Success ||      scroller should give top, middle and bottom index should handle ascending
Success ||      scroller should give top, middle and bottom index should handle descending

Success:        23
Failed :        0
Errors :        0
========================================
Error detected while processing /Users/aome/.dotfiles/roles/neovim/files/init.lua:
E5113: Error while calling lua chunk: /Users/aome/.config/nvim/lua/aome/init.lua:6: Vim:E185: Cannot find color scheme 'rose-pine'
stack traceback:
        [C]: in function 'colorscheme'
        /Users/aome/.config/nvim/lua/aome/init.lua:6: in main chunk
        [C]: in function 'require'
        /Users/aome/.dotfiles/roles/neovim/files/init.lua:1: in main chunk

========================================
Testing:        /Users/aome/dev/nvim_plugins/telescope.nvim/lua/tests/automated/resolver_spec.lua
Success ||      telescope.config.resolve win_option should resolve for percentages
Success ||      telescope.config.resolve win_option should resolve for percentages with default
Success ||      telescope.config.resolve win_option should resolve table values
Success ||      telescope.config.resolve win_option should allow overrides for different wins
Success ||      telescope.config.resolve win_option should allow overrides for all wins
Success ||      telescope.config.resolve win_option should allow some specified with a simple default
Success ||      telescope.config.resolve resolve_height/width should handle percentages
Success ||      telescope.config.resolve resolve_height/width should handle percentages with min/max boundary
Success ||      telescope.config.resolve resolve_height/width should handle fixed size
Success ||      telescope.config.resolve resolve_height/width should handle functions
Success ||      telescope.config.resolve resolve_height/width should handle padding
Success ||      telescope.config.resolve resolve_anchor_pos should not adjust when "CENTER" or "" is the anchor
Success ||      telescope.config.resolve resolve_anchor_pos should end up at top when "N" in the anchor
Success ||      telescope.config.resolve resolve_anchor_pos should end up at left when "W" in the anchor
Success ||      telescope.config.resolve resolve_anchor_pos should end up at bottom when "S" in the anchor
Success ||      telescope.config.resolve resolve_anchor_pos should end up at right when "E" in the anchor
Success ||      telescope.config.resolve resolve_anchor_pos should ignore casing of the anchor

Success:        17
Failed :        0
Errors :        0
========================================
Error detected while processing /Users/aome/.dotfiles/roles/neovim/files/init.lua:
E5113: Error while calling lua chunk: /Users/aome/.config/nvim/lua/aome/init.lua:6: Vim:E185: Cannot find color scheme 'rose-pine'
stack traceback:
        [C]: in function 'colorscheme'
        /Users/aome/.config/nvim/lua/aome/init.lua:6: in main chunk
        [C]: in function 'require'
        /Users/aome/.dotfiles/roles/neovim/files/init.lua:1: in main chunk

========================================
Testing:        /Users/aome/dev/nvim_plugins/telescope.nvim/lua/tests/automated/sorters_spec.lua
Success ||      get_substr_matcher when smartcase=OFF scoring_function doesn't match
Success ||      get_substr_matcher when smartcase=OFF highlighter returns valid highlights
Success ||      get_substr_matcher when smartcase=OFF scoring_function matches with lower case letters only
Success ||      get_substr_matcher when smartcase=OFF highlighter returns valid highlights
Success ||      get_substr_matcher when smartcase=OFF scoring_function doesn't match with upper case letters
Success ||      get_substr_matcher when smartcase=OFF highlighter returns valid highlights
Success ||      get_substr_matcher when smartcase=OFF scoring_function doesn't match
Success ||      get_substr_matcher when smartcase=OFF highlighter returns valid highlights
Success ||      get_substr_matcher when smartcase=OFF scoring_function matches with lower case letters only
Success ||      get_substr_matcher when smartcase=OFF highlighter returns valid highlights
Success ||      get_substr_matcher when smartcase=OFF scoring_function matches with upper case letters
Success ||      get_substr_matcher when smartcase=OFF highlighter returns valid highlights

Success:        12
Failed :        0
Errors :        0
========================================
Error detected while processing /Users/aome/.dotfiles/roles/neovim/files/init.lua:
E5113: Error while calling lua chunk: /Users/aome/.config/nvim/lua/aome/init.lua:6: Vim:E185: Cannot find color scheme 'rose-pine'
stack traceback:
        [C]: in function 'colorscheme'
        /Users/aome/.config/nvim/lua/aome/init.lua:6: in main chunk
        [C]: in function 'require'
        /Users/aome/.dotfiles/roles/neovim/files/init.lua:1: in main chunk

========================================
Testing:        /Users/aome/dev/nvim_plugins/telescope.nvim/lua/tests/automated/entry_display_spec.lua
Success ||      truncate can truncate: ambiwidth = single, [abcde, 6] -> abcde
Success ||      truncate can truncate: ambiwidth = single, [abcde, 5] -> abcde
Success ||      truncate can truncate: ambiwidth = single, [abcde, 4] -> abc…
Success ||      truncate can truncate: ambiwidth = single, [アイウエオ, 11] -> アイウエオ
Success ||      truncate can truncate: ambiwidth = single, [アイウエオ, 10] -> アイウエオ
Success ||      truncate can truncate: ambiwidth = single, [アイウエオ, 9] -> アイウエ…
Success ||      truncate can truncate: ambiwidth = single, [アイウエオ, 8] -> アイウ…
Success ||      truncate can truncate: ambiwidth = single, [├─┤, 7] -> ├─┤
Success ||      truncate can truncate: ambiwidth = single, [├─┤, 6] -> ├─┤
Success ||      truncate can truncate: ambiwidth = single, [├─┤, 5] -> ├─┤
Success ||      truncate can truncate: ambiwidth = single, [├─┤, 4] -> ├─┤
Success ||      truncate can truncate: ambiwidth = single, [├─┤, 3] -> ├─┤
Success ||      truncate can truncate: ambiwidth = single, [├─┤, 2] -> ├…
Success ||      truncate can truncate: ambiwidth = double, [abcde, 6] -> abcde
Success ||      truncate can truncate: ambiwidth = double, [abcde, 5] -> abcde
Success ||      truncate can truncate: ambiwidth = double, [abcde, 4] -> ab…
Success ||      truncate can truncate: ambiwidth = double, [アイウエオ, 11] -> アイウエオ
Success ||      truncate can truncate: ambiwidth = double, [アイウエオ, 10] -> アイウエオ
Success ||      truncate can truncate: ambiwidth = double, [アイウエオ, 9] -> アイウ…
Success ||      truncate can truncate: ambiwidth = double, [アイウエオ, 8] -> アイウ…
Success ||      truncate can truncate: ambiwidth = double, [├─┤, 7] -> ├─┤
Success ||      truncate can truncate: ambiwidth = double, [├─┤, 6] -> ├─┤
Success ||      truncate can truncate: ambiwidth = double, [├─┤, 5] -> ├…
Success ||      truncate can truncate: ambiwidth = double, [├─┤, 4] -> ├…
Success ||      truncate can truncate: ambiwidth = double, [├─┤, 3] -> …
Success ||      truncate can truncate: ambiwidth = double, [├─┤, 2] -> …

Success:        26
Failed :        0
Errors :        0
========================================
Error detected while processing /Users/aome/.dotfiles/roles/neovim/files/init.lua:
E5113: Error while calling lua chunk: /Users/aome/.config/nvim/lua/aome/init.lua:6: Vim:E185: Cannot find color scheme 'rose-pine'
stack traceback:
        [C]: in function 'colorscheme'
        /Users/aome/.config/nvim/lua/aome/init.lua:6: in main chunk
        [C]: in function 'require'
        /Users/aome/.dotfiles/roles/neovim/files/init.lua:1: in main chunk

========================================
Testing:        /Users/aome/dev/nvim_plugins/telescope.nvim/lua/tests/automated/command_spec.lua
Success ||      command_parser should handle cwd
Success ||      command_parser should handle find_command 1
Success ||      command_parser should handle find_command 2
Success ||      command_parser should handle find_command 3
Success ||      command_parser should handle layout_config viml 1
Success ||      command_parser should handle layout_config viml 2
Success ||      command_parser should handle layout_config viml 3
Success ||      command_parser should handle layout_config viml 4
Success ||      command_parser should handle layout_config lua 1
Success ||      command_parser should handle layout_config lua 2
Success ||      command_parser should handle symbols commas list
Success ||      command_parser should handle symbols viml list
Success ||      command_parser should handle symbols lua list
Success ||      command_parser should handle booleans 1
Success ||      command_parser should handle booleans 2
Success ||      command_parser should handle numbers 1
Success ||      command_parser should handle numbers 2
Success ||      command_parser should handle numbers 3
Success ||      command_parser should handle multiple options 1
Success ||      command_parser should handle multiple options 2

Success:        20
Failed :        0
Errors :        0
========================================
Error detected while processing /Users/aome/.dotfiles/roles/neovim/files/init.lua:
E5113: Error while calling lua chunk: /Users/aome/.config/nvim/lua/aome/init.lua:6: Vim:E185: Cannot find color scheme 'rose-pine'
stack traceback:
        [C]: in function 'colorscheme'
        /Users/aome/.config/nvim/lua/aome/init.lua:6: in main chunk
        [C]: in function 'require'
        /Users/aome/.dotfiles/roles/neovim/files/init.lua:1: in main chunk

========================================
Testing:        /Users/aome/dev/nvim_plugins/telescope.nvim/lua/tests/automated/action_spec.lua
Success ||      actions should allow creating custom actions
Success ||      actions allows adding actions
Success ||      actions ignores nils from added actions
Success ||      actions allows overriding an action
Success ||      actions allows overriding an action only in specific cases with if
Success ||      actions allows overriding an action only in specific cases with mod
Success ||      actions continuous replacement
Success ||      actions enhance.pre
Success ||      actions enhance.post
Success ||      actions static_pre static_post
Success ||      actions can call both
Success ||      actions can call both even when combined
Success ||      actions can call replace fn even when combined before replace registered the fn (because that happens with mappings)
Success ||      actions can call enhance fn even when combined before enhance registed fns (because that happens with mappings)
Success ||      actions clears enhance
Success ||      actions handles passing arguments
Success ||      actions handles add with two different tables
Success ||      actions handles tripple concat with static pre post
Success ||      actions action_set can replace `action_set.edit`
Pending ||      actions action_set handles backwards compat with select and edit files

Success:        19
Failed :        0
Errors :        0
========================================
Error detected while processing /Users/aome/.dotfiles/roles/neovim/files/init.lua:
E5113: Error while calling lua chunk: /Users/aome/.config/nvim/lua/aome/init.lua:6: Vim:E185: Cannot find color scheme 'rose-pine'
stack traceback:
        [C]: in function 'colorscheme'
        /Users/aome/.config/nvim/lua/aome/init.lua:6: in main chunk
        [C]: in function 'require'
        /Users/aome/.dotfiles/roles/neovim/files/init.lua:1: in main chunk

========================================
Testing:        /Users/aome/dev/nvim_plugins/telescope.nvim/lua/tests/automated/utils_spec.lua
Success ||      path_expand() removes trailing os_sep
Success ||      path_expand() works with root dir
Success ||      path_expand() works with ~
Success ||      path_expand() handles duplicate os_sep
Success ||      path_expand() preserves fake whitespace characters and whitespace
Success ||      path_expand() early return for uri https://www.example.com/index.html
Success ||      path_expand() early return for uri ftp://ftp.example.com/files/document.pdf
Success ||      path_expand() early return for uri mailto:user@example.com
Success ||      path_expand() early return for uri tel:+1234567890
Success ||      path_expand() early return for uri file:///home/user/documents/report.docx
Success ||      path_expand() early return for uri news:comp.lang.python
Success ||      path_expand() early return for uri ldap://ldap.example.com:389/dc=example,dc=com
Success ||      path_expand() early return for uri git://github.com/user/repo.git
Success ||      path_expand() early return for uri steam://run/123456
Success ||      path_expand() early return for uri magnet:?xt=urn:btih:6B4C3343E1C63A1BC36AEB8A3D1F52C4EDEEB096
Success ||      is_uri detects valid uris https://www.example.com/index.html
Success ||      is_uri detects valid uris ftp://ftp.example.com/files/document.pdf
Success ||      is_uri detects valid uris mailto:user@example.com
Success ||      is_uri detects valid uris tel:+1234567890
Success ||      is_uri detects valid uris file:///home/user/documents/report.docx
Success ||      is_uri detects valid uris news:comp.lang.python
Success ||      is_uri detects valid uris ldap://ldap.example.com:389/dc=example,dc=com
Success ||      is_uri detects valid uris git://github.com/user/repo.git
Success ||      is_uri detects valid uris steam://run/123456
Success ||      is_uri detects valid uris magnet:?xt=urn:btih:6B4C3343E1C63A1BC36AEB8A3D1F52C4EDEEB096
Success ||      is_uri detects invalid uris/paths hello
Success ||      is_uri detects invalid uris/paths hello:
Success ||      is_uri detects invalid uris/paths 123
Success ||      is_uri detects invalid uris/paths 
Success ||      is_uri handles windows paths C:\Users\Usuario\Documents\archivo.txt
Success ||      is_uri handles windows paths D:\Projects\project_folder\source_code.py
Success ||      is_uri handles windows paths E:\Music\song.mp3
Success ||      is_uri handles linux paths /home/usuario/documents/archivo.txt
Success ||      is_uri handles linux paths /var/www/html/index.html
Success ||      is_uri handles linux paths /mnt/backup/backup_file.tar.gz
Success ||      is_uri handles macos paths /Users/Usuario/Documents/archivo.txt
Success ||      is_uri handles macos paths /Applications/App.app/Contents/MacOS/app_executable
Success ||      is_uri handles macos paths /Volumes/ExternalDrive/Data/file.xlsx
Success ||      __separates_file_path_location separtates file path for file.txt:12:4
Success ||      __separates_file_path_location separtates file path for file.txt:12
Success ||      __separates_file_path_location separtates file path for file:12:4
Success ||      __separates_file_path_location separtates file path for file:12:
Success ||      __separates_file_path_location separtates file path for file:
Success ||      transform_path handles nil path
Success ||      transform_path returns back uri
Success ||      transform_path handles 'hidden' path_display
Success ||      transform_path returns relative path for default opts
Success ||      transform_path handles 'tail' path_display
Success ||      transform_path handles 'smart' path_display
Success ||      transform_path handles 'absolute' path_display
Success ||      transform_path handles default 'shorten' path_display
Success ||      transform_path handles 'shorten' with number
Success ||      transform_path handles 'shorten' with option table
Success ||      transform_path handles default 'truncate' path_display
Success ||      transform_path handles 'filename_first' path_display
Success ||      transform_path handles 'filename_first' path_display with the option to reverse directories

Success:        56
Failed :        0
Errors :        0
========================================
Error detected while processing /Users/aome/.dotfiles/roles/neovim/files/init.lua:
E5113: Error while calling lua chunk: /Users/aome/.config/nvim/lua/aome/init.lua:6: Vim:E185: Cannot find color scheme 'rose-pine'
stack traceback:
        [C]: in function 'colorscheme'
        /Users/aome/.config/nvim/lua/aome/init.lua:6: in main chunk
        [C]: in function 'require'
        /Users/aome/.dotfiles/roles/neovim/files/init.lua:1: in main chunk

========================================
Testing:        /Users/aome/dev/nvim_plugins/telescope.nvim/lua/tests/automated/layout_strategies_spec.lua
Success ||      layout_strategies should have validator
Success ||      layout_strategies should handle numbers
Success ||      layout_strategies should handle percentage: 100
Success ||      layout_strategies should handle percentage: 110
Success ||      layout_strategies should call functions: simple
Success ||      layout_strategies should call functions: percentage
Success ||      layout_strategies should use ours if theirs and override don't give the key
Success ||      layout_strategies should use ours if theirs and override don't give the key for this strategy
Success ||      layout_strategies should use theirs if override doesn't give the key
Success ||      layout_strategies should use override if key given
Success ||      layout_strategies should use override if key given for this strategy
Success ||      layout_strategies should use theirs if override doesn't give key (even if ours has strategy specific)
Success ||      layout_strategies should use override (even if ours has strategy specific)
Success ||      layout_strategies should use override (even if theirs has strategy specific)
Success ||      layout_strategies should use override (even if ours and theirs have strategy specific)
Success ||      layout_strategies should handle user config overriding a table with a number
Success ||      layout_strategies should handle user oneshot overriding a table with a number

Success:        17
Failed :        0
Errors :        0
========================================
Error detected while processing /Users/aome/.dotfiles/roles/neovim/files/init.lua:
E5113: Error while calling lua chunk: /Users/aome/.config/nvim/lua/aome/init.lua:6: Vim:E185: Cannot find color scheme 'rose-pine'
stack traceback:
        [C]: in function 'colorscheme'
        /Users/aome/.config/nvim/lua/aome/init.lua:6: in main chunk
        [C]: in function 'require'
        /Users/aome/.dotfiles/roles/neovim/files/init.lua:1: in main chunk

========================================
Testing:        /Users/aome/dev/nvim_plugins/telescope.nvim/lua/tests/automated/telescope_spec.lua
Success ||      telescope Picker window_dimensions 
Success ||      telescope Picker attach_mappings should allow for passing in a function
Success ||      telescope Picker attach_mappings should override an attach mappings passed in by opts
Success ||      telescope Sorters generic_fuzzy_sorter sort matches well
Success ||      telescope Sorters generic_fuzzy_sorter sorts multiple finds better
Success ||      telescope Sorters fuzzy_file sort matches well
Success ||      telescope Sorters fuzzy_file sorts matches after last os sep better
Pending ||      telescope Sorters fuzzy_file sorts multiple finds better
Success ||      telescope Sorters fzy matches exact matches
Success ||      telescope Sorters fzy matches ignore case
Success ||      telescope Sorters fzy matches partial matches
Success ||      telescope Sorters fzy matches with delimiters between
Success ||      telescope Sorters fzy matches with empty query
Success ||      telescope Sorters fzy matches rejects non-matches
Success ||      telescope Sorters fzy scoring prefers beginnings of words
Success ||      telescope Sorters fzy scoring prefers consecutive letters
Success ||      telescope Sorters fzy scoring prefers contiguous over letter following period
Success ||      telescope Sorters fzy scoring prefers shorter matches
Success ||      telescope Sorters fzy scoring prefers shorter candidates
Success ||      telescope Sorters fzy scoring prefers matches at the beginning
Success ||      telescope Sorters fzy scoring prefers matches at some locations
Success ||      telescope Sorters fzy positioning favors consecutive positions
Success ||      telescope Sorters fzy positioning favors word beginnings
Success ||      telescope Sorters fzy positioning works when there are no bonuses
Success ||      telescope Sorters fzy positioning favors smaller groupings of positions
Success ||      telescope Sorters fzy positioning handles exact matches
Success ||      telescope Sorters fzy positioning ignores empty requests
Success ||      telescope Sorters layout_strategies center should handle large terminals

Success:        27
Failed :        0
Errors :        0
========================================
```
</details>
**Configuration**:
* Neovim version (nvim --version):

NVIM v0.9.5
Build type: RelWithDebInfo
LuaJIT 2.1.1692716794

* Operating system and version: macOS 14.4.1

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
