### PR TITLE
fix(previewer): improve binary mime type check

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -325,13 +325,38 @@ telescope.setup({opts})                                    *telescope.setup()*
         path_display can also be set to 'hidden' string to hide file names
 
         path_display can also be set to a function for custom formatting of
-        the path display. Example:
+        the path display with the following signature
+
+        Signature: fun(opts: table, path: string): string, table?
+
+        The optional table is an list of positions and highlight groups to
+        set the highlighting of the return path string.
+
+        Example:
 
             -- Format path as "file.txt (path\to\file\)"
             path_display = function(opts, path)
               local tail = require("telescope.utils").path_tail(path)
               return string.format("%s (%s)", tail, path)
             end,
+
+            -- Format path and add custom highlighting
+            path_display = function(opts, path)
+              local tail = require("telescope.utils").path_tail(path)
+              path = string.format("%s (%s)", tail, path)
+
+              local highlights = {
+                {
+                  {
+                    0, -- highlight start position
+                    #path, -- highlight end position
+                  },
+                  "Comment", -- highlight group name
+                },
+              }
+
+              return path, highlights
+            end
 
         Default: {}
 

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -168,9 +168,8 @@ local handle_file_preview = function(filepath, bufnr, stat, opts)
     end
     if opts.preview.check_mime_type == true and has_file and (opts.ft == nil or opts.ft == "") then
       -- avoid SIGABRT in buffer previewer happening with utils.get_os_command_output
-      local output = capture(string.format([[file --mime-type -b "%s"]], filepath))
-      local mime_type = vim.split(output, "/")
-      if mime_type[1] ~= "text" and mime_type[1] ~= "inode" and mime_type[2] ~= "json" then
+      local mime_type = capture(string.format([[file --mime-type -b "%s"]], filepath))
+      if putils.binary_mime_type(mime_type) then
         if type(opts.preview.mime_hook) == "function" then
           opts.preview.mime_hook(filepath, bufnr, opts)
           return

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -3,6 +3,7 @@ local utils = require "telescope.utils"
 local Path = require "plenary.path"
 local from_entry = require "telescope.from_entry"
 local Previewer = require "telescope.previewers.previewer"
+local putil = require "telescope.previewers.utils"
 
 local defaulter = utils.make_default_callable
 
@@ -65,9 +66,8 @@ local cat_maker = function(filename, _, start, _)
   end
 
   if 1 == vim.fn.executable "file" then
-    local output = utils.get_os_command_output { "file", "--mime-type", "-b", filename }
-    local mime_type = vim.split(output[1], "/")[1]
-    if mime_type ~= "text" then
+    local mime_type = utils.get_os_command_output({ "file", "--mime-type", "-b", filename })[1]
+    if putil.binary_mime_type(mime_type) then
       return { "echo", "Binary file found. These files cannot be displayed!" }
     end
   end

--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -222,4 +222,21 @@ utils.set_preview_message = function(bufnr, winid, message, fillchar)
   end
 end
 
+--- Check if mime type is binary.
+--- NOT an exhaustive check, may get false negatives. Ideally should check
+--- filetype with `vim.filetype.match` or `filetype_detect` first for filetype
+--- info.
+---@param mime_type string
+---@return boolean
+utils.binary_mime_type = function(mime_type)
+  local type_, subtype = unpack(vim.split(mime_type, "/"))
+  if vim.tbl_contains({ "text", "inode" }, type_) then
+    return false
+  end
+  if vim.tbl_contains({ "json", "javascript" }, subtype) then
+    return false
+  end
+  return true
+end
+
 return utils


### PR DESCRIPTION
Problem: mime type for a ts/js file can either return `text/plain` or `application/javascript` based on the contents of the file. Previously, this meant `application/javascript` would be considered "possibly binary". This, in conjunction with how `vim.filetype.match` does not give a result for a filename that ends in `.ts`, would lead to a typescript file taking the path of `check_mime_type` and eventually `mime_hook`.

Solution: Include `application/javascript` as a non-binary file type during mime type check.


closes #3068 