### PR TITLE
fix(builtin.commands): Don't remap feedkeys

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -394,7 +394,7 @@ internal.commands = function(opts)
             cmd = cmd .. cr
           end
           vim.cmd [[stopinsert]]
-          vim.api.nvim_feedkeys(cmd, "t", false)
+          vim.api.nvim_feedkeys(cmd, "nt", false)
         end)
 
         return true


### PR DESCRIPTION
# Description

If the user remapped `:`, the `builtin.commands` picker would use the remapped `:` instead of inserting a command, which would lead to unintended behavior. My configuration swaps `;` and `:` around, which would lead to the keys in the command being inputted as normal mode commands. To make sure a command is inputted as expected, adding the `n` flag to `feedkeys` makes sure nvim uses the defaults.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Interactive test, both on my full config and on a minimal config

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.9.5
Build type: RelWithDebInfo
LuaJIT 2.1.1692716794
```
* Operating system and version: Arch Linux x86_64, `6.8.5-arch1-1`
