### PR TITLE
Fix jump regression in LSP references action handler

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -100,11 +100,12 @@ end
 ---@type { [string]: fun(results: table, opts: table): table }
 local action_handlers = {
   ["textDocument/references"] = function(results, opts)
-    if opts.include_current_line == false then
+    if not opts.include_current_line then
       results = vim.tbl_filter(function(result)
+        local item = vim.lsp.util.locations_to_items({ result })[1]
         return not (
-          result.filename == vim.api.nvim_buf_get_name(opts.bufnr)
-          and result.lnum == vim.api.nvim_win_get_cursor(opts.winnr)
+          item.filename == vim.api.nvim_buf_get_name(opts.bufnr)
+          and item.lnum == vim.api.nvim_win_get_cursor(opts.winnr)[1]
         )
       end, results)
     end

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -99,10 +99,10 @@ end
 
 ---@type { [string]: fun(results: table, opts: table): table }
 local action_handlers = {
-  ["textDocument/references"] = function(results, opts)
+  ["textDocument/references"] = function(results, opts, offset_encoding)
     if not opts.include_current_line then
       results = vim.tbl_filter(function(result)
-        local item = vim.lsp.util.locations_to_items({ result })[1]
+        local item = vim.lsp.util.locations_to_items({ result }, offset_encoding)[1]
         return not (
           item.filename == vim.api.nvim_buf_get_name(opts.bufnr)
           and item.lnum == vim.api.nvim_win_get_cursor(opts.winnr)[1]
@@ -117,10 +117,10 @@ local action_handlers = {
 ---@param results table
 ---@param opts table
 ---@return table results
-local apply_action_handler = function(action, results, opts)
+local apply_action_handler = function(action, results, opts, offset_encoding)
   local handler = action_handlers[action]
   if handler then
-    return handler(results, opts)
+    return handler(results, opts, offset_encoding)
   end
   return results
 end
@@ -146,9 +146,9 @@ local function list_or_jump(action, title, params, opts)
     end
     vim.list_extend(flattened_results, result)
 
-    flattened_results = apply_action_handler(action, flattened_results, opts)
-
     local offset_encoding = vim.lsp.get_client_by_id(ctx.client_id).offset_encoding
+
+    flattened_results = apply_action_handler(action, flattened_results, opts, offset_encoding)
 
     if vim.tbl_isempty(flattened_results) then
       return

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -165,7 +165,9 @@ local function list_or_jump(action, title, params, opts)
 
     if vim.tbl_isempty(locations) then
       return
-    elseif #locations == 1 and opts.jump_type ~= "never" then
+    end
+
+    if #locations == 1 and opts.jump_type ~= "never" then
       local current_uri = params.textDocument.uri
       local target_uri = locations[1].uri or locations[1].targetUri
       if current_uri ~= target_uri then


### PR DESCRIPTION
# Description

This change restores the possibility to exclude the current line when invoking the `lsp_references` picker.

- `opts.include_current_line` is by default unset, so the previous equality check would fail unless the option was set explicitly.
- `vim.api.nvim_win_get_cursor()` returns both line and column, so it can't be directly compared with the returned line number.
- The actual comparison was expecting quickfix-like items, when in actuality, we were dealing with raw LSP location objects.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Triggering `lsp_references` on a symbol which is only referenced in one other location jumps directly to that location.
- Triggering `lsp_references` on a symbol which is referenced in multiple other locations lists reference locations. References on the cursor line where the picker was triggered are excluded.
- Triggering `lsp_references` with `opts = { include_current_line = true }` yields the same behavior as it does today.

**Configuration**:
* Neovim version (nvim --version):
	> NVIM v0.9.5
	> Build type: Release
	> LuaJIT 2.1.1713773202

* Operating system and version:
	> macOs 14.4.1 (23E224)

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation (lua annotations)~ N/A, I think?
