### PR TITLE
:bug: Windows: allow binary without extension

### DIFF
--- a/lua/telescope/health.lua
+++ b/lua/telescope/health.lua
@@ -102,8 +102,9 @@ M.check = function()
           )
         end
       else
-        local eol = version:find "\n" or 1
-        ok(("%s: found %s"):format(package.name, version:sub(0, eol - 1) or "(unknown version)"))
+        local eol = version:find "\n"
+        local ver = eol and version:sub(0, eol - 1) or "(unknown version)"
+        ok(("%s: found %s"):format(package.name, ver))
       end
     end
   end

--- a/lua/telescope/health.lua
+++ b/lua/telescope/health.lua
@@ -45,10 +45,12 @@ local required_plugins = {
 local check_binary_installed = function(package)
   local binaries = package.binaries or { package.name }
   for _, binary in ipairs(binaries) do
-    if is_win then
+    local found = vim.fn.executable(binary) == 1
+    if not found and is_win then
       binary = binary .. ".exe"
+      found = vim.fn.executable(binary) == 1
     end
-    if vim.fn.executable(binary) == 1 then
+    if found then
       local handle = io.popen(binary .. " --version")
       local binary_version = handle:read "*a"
       handle:close()
@@ -100,7 +102,7 @@ M.check = function()
           )
         end
       else
-        local eol = version:find "\n"
+        local eol = version:find "\n" or 1
         ok(("%s: found %s"):format(package.name, version:sub(0, eol - 1) or "(unknown version)"))
       end
     end


### PR DESCRIPTION
# Description

In Windows, if only `rg` without extension is installed and `rg.exe` is not for some reason, checkhealth had failed previously.
This PR allows binaries without extensions to be recognised in Windows.

**FIXME**: In Windows environment, `io.popen(binary .. " --version")` does not return any outputs. How can I fix it?

```plaintext
Checking external dependencies ~
- OK rg: found 
- OK fd: found 
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] confirm that binaries without extensions are recognised in Windows

**Configuration**:
* Neovim version (nvim --version): v0.9.5
* Operating system and version: Windows 11

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
