### PR TITLE
fix(builtin.oldfiles): fix cwd_only for windows

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -551,7 +551,6 @@ internal.oldfiles = function(opts)
   if opts.cwd_only or opts.cwd then
     local cwd = opts.cwd_only and vim.loop.cwd() or opts.cwd
     cwd = cwd .. utils.get_separator()
-    cwd = cwd:gsub([[\]], [[\\]])
     results = vim.tbl_filter(function(file)
       return buf_in_cwd(file, cwd)
     end, results)


### PR DESCRIPTION
Remove backslash escaping in oldfiles picker, which was needed before the code was changed to use substring comparison instead of regex matching. (Commit b3ff5f33)

# Description

When using the `cwd_only` option for the `builtin.oldfiles` picker, no results were returned under windows.
The broken code replaces all backslashes by `\\`. This is not needed anymore, as the cwd-check now uses a substring match instead of matching via `matchstrpos()`.
Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- Switch to some directory under windows
- edit some files
- call `:Telescope oldfiles cwd_only=true`
- No results appear

**Configuration**:
* Neovim version (nvim --version): 0.9.5
* Operating system and version: Windows 10

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
