### PR TITLE
fix: enable_preview true

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1000,45 +1000,20 @@ internal.colorscheme = function(opts)
     local bufnr = vim.api.nvim_get_current_buf()
     local p = vim.api.nvim_buf_get_name(bufnr)
 
-    -- don't need previewer
-    if vim.fn.buflisted(bufnr) ~= 1 then
-      local deleted = false
-      local function del_win(win_id)
-        if win_id and vim.api.nvim_win_is_valid(win_id) then
-          utils.buf_delete(vim.api.nvim_win_get_buf(win_id))
-          pcall(vim.api.nvim_win_close, win_id, true)
+    -- show current buffer content in previewer
+    previewer = previewers.new_buffer_previewer {
+      get_buffer_by_name = function()
+        return p
+      end,
+      define_preview = function(self)
+        if vim.loop.fs_stat(p) then
+          conf.buffer_previewer_maker(p, self.state.bufnr, { bufname = self.state.bufname })
+        else
+          local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+          vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
         end
-      end
-
-      previewer = previewers.new {
-        preview_fn = function(_, entry, status)
-          if not deleted then
-            deleted = true
-            if status.layout.preview then
-              del_win(status.layout.preview.winid)
-              del_win(status.layout.preview.border.winid)
-            end
-          end
-          vim.cmd.colorscheme(entry.value)
-        end,
-      }
-    else
-      -- show current buffer content in previewer
-      previewer = previewers.new_buffer_previewer {
-        get_buffer_by_name = function()
-          return p
-        end,
-        define_preview = function(self, entry)
-          if vim.loop.fs_stat(p) then
-            conf.buffer_previewer_maker(p, self.state.bufnr, { bufname = self.state.bufname })
-          else
-            local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-            vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
-          end
-          vim.cmd.colorscheme(entry.value)
-        end,
-      }
-    end
+      end,
+    }
   end
 
   local picker = pickers.new(opts, {

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1060,9 +1060,39 @@ internal.colorscheme = function(opts)
         need_restore = false
         vim.cmd.colorscheme(selection.value)
       end)
-
+      action_set.shift_selection:enhance {
+        post = function()
+          local selection = action_state.get_selected_entry()
+          if selection == nil then
+            utils.__warn_no_selection "builtin.colorscheme"
+            return
+          end
+          need_restore = true
+          if opts.enable_preview then
+            vim.cmd.colorscheme(selection.value)
+          end
+        end,
+      }
+      actions.close:enhance {
+        post = function()
+          if need_restore then
+            vim.cmd.colorscheme(before_color)
+          end
+        end,
+      }
       return true
     end,
+    on_complete = {
+      function()
+        local selection = action_state.get_selected_entry()
+        if selection == nil then
+          utils.__warn_no_selection "builtin.colorscheme"
+          return
+        end
+        need_restore = true
+        vim.cmd.colorscheme(selection.value)
+      end,
+    },
   })
 
   if opts.enable_preview then


### PR DESCRIPTION
# Description

This fix aims to resolve the issue about the "enable_preview" feature that wasn't working. 
Now if you call:
`:Telescope colorscheme enable_preview=true`
while scrolling through the different color scheme options, the live preview is working (change color scheme accordingly)

Fixes #2966

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

I tried two different scenarios:

- :Telescope colorscheme enable_preview=true --> When scrolling through the different color schemes, the theme changes accordingly
- :Telescope colorscheme enable_preview=false -->  When scrolling through the different color schemes, the theme doesn't change

**Configuration**:
* Neovim version (nvim --version): 0.9.4
* Operating system and version: ubuntu 22.04

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
