### PR TITLE
fix(oldfiles) : delete duplicated items in Windows

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -525,17 +525,24 @@ end
 internal.oldfiles = function(opts)
   opts = apply_cwd_only_aliases(opts)
   opts.include_current_session = vim.F.if_nil(opts.include_current_session, true)
+  local has_win = vim.fn.has('win32') == 1
 
   local current_buffer = vim.api.nvim_get_current_buf()
   local current_file = vim.api.nvim_buf_get_name(current_buffer)
   local results = {}
 
+  -- add gsub() : if output of nvim_buf_get_name() has '/' in the string, file~=current_file cannot filter the path properly
+  if has_win then current_file = current_file:gsub('/','\\') end
+
+  -- in here, results has absolute paths in current open session
   if opts.include_current_session then
     for _, buffer in ipairs(vim.split(vim.fn.execute ":buffers! t", "\n")) do
       local match = tonumber(string.match(buffer, "%s*(%d+)"))
       local open_by_lsp = string.match(buffer, "line 0$")
       if match and not open_by_lsp then
         local file = vim.api.nvim_buf_get_name(match)
+		  -- add gsub() : if output of nvim_buf_get_name() has '/' in the string, file~=current_file cannot filter the path properly
+		if has_win then file = file:gsub('/','\\') end
         if vim.loop.fs_stat(file) and match ~= current_buffer then
           table.insert(results, file)
         end
@@ -543,12 +550,25 @@ internal.oldfiles = function(opts)
     end
   end
 
+  -- in here, add path in oldfiles which is not included in current session, current file
+  -- (Problem)Previous code adds the list to the 'results' variable which includes files in current session already. 
+  -- It makes the oldfiles picker show files which are loaded current session. 
+  -- (Solution)so 'results' and 'results_other' are separated
+  --
+  -- (Problem) sometimes the list has duplicated directory. 
+  -- (Solution) so I add a condition which checks whether the file are added in 'results_other'
+  local results_other = {}
   for _, file in ipairs(vim.v.oldfiles) do
+	  -- (problem) sometimes path in vim.v.oldfiles has '/' as delimiters caused by neovim. 
+	  -- (solution) the '/' replaced by '\\'
+	if has_win then file = file:gsub('/','\\') end
     local file_stat = vim.loop.fs_stat(file)
-    if file_stat and file_stat.type == "file" and not vim.tbl_contains(results, file) and file ~= current_file then
-      table.insert(results, file)
+    if file_stat and file_stat.type == "file" and not vim.tbl_contains(results, file)
+		and not vim.tbl_contains(results_other, file) and file ~= current_file then
+      table.insert(results_other, file)
     end
   end
+  results = results_other
 
   if opts.cwd_only or opts.cwd then
     local cwd = opts.cwd_only and vim.loop.cwd() or opts.cwd


### PR DESCRIPTION
# Description

1) Duplicated items are listed in oldfiles because of neovim problem.
   Example is like below.
```
   c:\Users\USERS\test\telescope.lua
   c:\Users\USERS/test/telescope.lua
   c:/Users/USERS/test/telescope.lua
```
   slash(/) makes neovim lua api cannot work properly in windows.
   and string comparison don't distinguish it is the same path

   This makes `file ~= current_file` condition cannot filter although it is same with the file

2) oldfiles show current session files in the list also.

Fixes #1683

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1) Taking gsub('/', '\\') all files from neovim lua api. 
2) Add additional condition which checks whether the file is listed in results (='results_other') 

3) separate `results` variable to 2 parts.
    First, 'results' as current session file list
    Second, 'results_other' as old file list which are filtered unnecessary file

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

There is nothing for the user to configure.
- [x] At startup which has no opened buffer
- [x] Some buffers are opened
- [x] Load from saved session.   

**Configuration**:
* Neovim version (nvim --version): v0.9.5   and nvim-qt v0.2.17
* Operating system and version: Windows 10

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)