### PR TITLE
Remove no-longer-existant references to scrolling left and right

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,6 @@ Many familiar mapping patterns are set up as defaults.
 | `<C-t>`        | Go to a file in a new tab                                 |
 | `<C-u>`        | Scroll up in preview window                               |
 | `<C-d>`        | Scroll down in preview window                             |
-| `<C-f>`        | Scroll left in preview window                             |
-| `<C-k>`        | Scroll right in preview window                            |
-| `<M-f>`        | Scroll left in results window                             |
-| `<M-k>`        | Scroll right in results window                            |
 | `<C-/>`        | Show mappings for picker actions (insert mode)            |
 | `?`            | Show mappings for picker actions (normal mode)            |
 | `<C-c>`        | Close telescope (insert mode)                             |

--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ Many familiar mapping patterns are set up as defaults.
 | `<C-t>`        | Go to a file in a new tab                                 |
 | `<C-u>`        | Scroll up in preview window                               |
 | `<C-d>`        | Scroll down in preview window                             |
+| `<PageUp>`     | Scroll up in results window                               |
+| `<PageDown>`   | Scroll down in results window                             |
 | `<C-/>`        | Show mappings for picker actions (insert mode)            |
 | `?`            | Show mappings for picker actions (normal mode)            |
 | `<C-c>`        | Close telescope (insert mode)                             |


### PR DESCRIPTION
# Description

While the help documentation has been updated, the README still mentioned actions for scrolling left and right. I have removed that. Furthermore, I have added a mention of the current default bindings for scrolling the results window.

## Type of change

Please delete options that are not relevant.

- N/A - This changes only the README

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Test A
- [ ] Test B

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1713773202

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/share/nvim"
```
* Operating system and version:
```
$ uname -r
6.8.9-arch1-1
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
