### PR TITLE
Add option to customize length of symbols for make_entry.gen_from_treesitter

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -970,6 +970,8 @@ builtin.treesitter()                          *telescope.builtin.treesitter()*
         {bufnr}             (number)        specify the buffer number where
                                             treesitter should run. (default:
                                             current buffer)
+        {symbol_width}      (number)        defines the width of the symbol
+                                            section (default: 25)
         {symbols}           (string|table)  filter results by symbol kind(s)
         {ignore_symbols}    (string|table)  list of symbols to ignore
         {symbol_highlights} (table)         string -> string. Matches symbol

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -94,6 +94,7 @@ builtin.fd = builtin.find_files
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by kind of ts node you want to see (i.e. `:var:`)
 ---@field show_line boolean: if true, shows the row:column that the result is found at (default: true)
 ---@field bufnr number: specify the buffer number where treesitter should run. (default: current buffer)
+---@field symbol_width number: defines the width of the symbol section (default: 25)
 ---@field symbols string|table: filter results by symbol kind(s)
 ---@field ignore_symbols string|table: list of symbols to ignore
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -664,7 +664,7 @@ function make_entry.gen_from_treesitter(opts)
   }
 
   if opts.show_line then
-    table.insert(display_items, 2, { width = opts.symbol_type_width or 8 })
+    table.insert(display_items, 2, { width = 6 })
   end
 
   local displayer = entry_display.create {

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -658,13 +658,13 @@ function make_entry.gen_from_treesitter(opts)
   local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
 
   local display_items = {
-    { width = 25 },
+    { width = opts.symbol_width or 25 },
     { width = 10 },
     { remaining = true },
   }
 
   if opts.show_line then
-    table.insert(display_items, 2, { width = 6 })
+    table.insert(display_items, 2, { width = opts.symbol_type_width or 8 })
   end
 
   local displayer = entry_display.create {


### PR DESCRIPTION
# Description

This adds the same options which already exist for `gen_from_lsp_symbols` to control the allocated space for symbols in `make_entry.gen_from_treesitter`.

Added options:
* `symbol_width`: controls the space for the symbol (defaults to 25)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Simply provide `symbol_width` as an option and observe how the space for the symbol in the treesitter picker grows and shrinks.

**Configuration**:
* Neovim version (nvim --version): 0.9.5
* Operating system and version: Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
