### PR TITLE
fix: adapt to Nvim deprecations in 0.10

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -12,7 +12,7 @@ local log = require "telescope.log"
 
 local Path = require "plenary.path"
 
-local flatten = vim.tbl_flatten
+local flatten = utils.flatten
 local filter = vim.tbl_filter
 
 local files = {}

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -51,7 +51,7 @@ git.files = function(opts)
       prompt_title = "Git Files",
       __locations_input = true,
       finder = finders.new_oneshot_job(
-        vim.tbl_flatten {
+        utils.flatten {
           opts.git_command,
           show_untracked and "--others" or nil,
           recurse_submodules and "--recurse-submodules" or nil,
@@ -193,7 +193,7 @@ git.bcommits = function(opts)
 
   local title = "Git BCommits"
   local finder = finders.new_oneshot_job(
-    vim.tbl_flatten {
+    utils.flatten {
       opts.git_command,
       opts.current_file,
     },
@@ -234,7 +234,7 @@ git.bcommits_range = function(opts)
 
   local title = "Git BCommits in range"
   local finder = finders.new_oneshot_job(
-    vim.tbl_flatten {
+    utils.flatten {
       opts.git_command,
       line_range,
     },
@@ -432,7 +432,7 @@ end
 local try_worktrees = function(opts)
   local worktrees = conf.git_worktrees
 
-  if vim.tbl_islist(worktrees) then
+  if utils.islist(worktrees) then
     for _, wt in ipairs(worktrees) do
       if vim.startswith(opts.cwd, wt.toplevel) then
         opts.toplevel = wt.toplevel

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -793,7 +793,7 @@ end
 
 internal.man_pages = function(opts)
   opts.sections = vim.F.if_nil(opts.sections, { "1" })
-  assert(vim.tbl_islist(opts.sections), "sections should be a list")
+  assert(utils.islist(opts.sections), "sections should be a list")
   opts.man_cmd = utils.get_lazy_default(opts.man_cmd, function()
     local uname = vim.loop.os_uname()
     local sysname = string.lower(uname.sysname)

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -153,7 +153,7 @@ local function list_or_jump(action, title, params, opts)
     end
 
     local locations = {}
-    if not vim.tbl_islist(result) then
+    if not utils.islist(result) then
       locations = { result }
     end
     vim.list_extend(locations, result)
@@ -393,7 +393,9 @@ lsp.dynamic_workspace_symbols = function(opts)
 end
 
 local function check_capabilities(method, bufnr)
-  local clients = vim.lsp.get_active_clients { bufnr = bufnr }
+  --TODO(clason): remove when dropping support for Nvim 0.9
+  local get_clients = vim.fn.has "nvim-0.10" and vim.lsp.get_clients or vim.lsp.get_active_clients
+  local clients = get_clients { bufnr = bufnr }
 
   for _, client in pairs(clients) do
     if client.supports_method(method, { bufnr = bufnr }) then

--- a/lua/telescope/config/resolve.lua
+++ b/lua/telescope/config/resolve.lua
@@ -270,6 +270,7 @@ resolver.resolve_anchor_pos = function(anchor, p_width, p_height, max_columns, m
   return pos
 end
 
+-- duplicate from utils.lua to keep self-contained
 -- Win option always returns a table with preview, results, and prompt.
 -- It handles many different ways. Some examples are as follows:
 --
@@ -292,7 +293,8 @@ end
 --   prompt = {...},
 -- }
 resolver.win_option = function(val, default)
-  if type(val) ~= "table" or vim.tbl_islist(val) then
+  local islist = require("telescope.utils").islist
+  if type(val) ~= "table" or islist(val) then
     if val == nil then
       val = default
     end
@@ -303,7 +305,7 @@ resolver.win_option = function(val, default)
       prompt = val,
     }
   elseif type(val) == "table" then
-    assert(not vim.tbl_islist(val))
+    assert(not islist(val))
 
     local val_to_set = val[1]
     if val_to_set == nil then

--- a/lua/telescope/finders/async_static_finder.lua
+++ b/lua/telescope/finders/async_static_finder.lua
@@ -4,7 +4,7 @@ local make_entry = require "telescope.make_entry"
 
 return function(opts)
   local input_results
-  if vim.tbl_islist(opts) then
+  if require("telescope.utils").islist(opts) then
     input_results = opts
   else
     input_results = opts.results

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -602,10 +602,10 @@ function Picker:find()
     end
     a.nvim_feedkeys(a.nvim_replace_termcodes(keys, true, false, true), "ni", true)
   else
-    utils.notify(
-      "pickers.find",
-      { msg = "`initial_mode` should be one of ['normal', 'insert'] but passed " .. self.initial_mode, level = "ERROR" }
-    )
+    utils.notify("pickers.find", {
+      msg = "`initial_mode` should be one of ['normal', 'insert'] but passed " .. self.initial_mode,
+      level = "ERROR",
+    })
   end
 
   local main_loop = async.void(function()

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -52,7 +52,7 @@ local bat_maker = function(filename, lnum, start, finish)
     end
   end
 
-  return vim.tbl_flatten {
+  return utils.flatten {
     command,
     bat_options,
     "--",

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -17,6 +17,13 @@ local utils = {}
 
 utils.iswin = vim.loop.os_uname().sysname == "Windows_NT"
 
+--TODO(clason): Remove when dropping support for Nvim 0.9
+utils.islist = vim.fn.has "nvim-0.10" == 1 and vim.islist or vim.tbl_islist
+local flatten = function(t)
+  return vim.iter(t):flatten():totable()
+end
+utils.flatten = vim.fn.has "nvim-0.10" == 1 and flatten or vim.tbl_flatten
+
 --- Hybrid of `vim.fn.expand()` and custom `vim.fs.normalize()`
 ---
 --- Paths starting with '%', '#' or '<' are expanded with `vim.fn.expand()`.

--- a/plugin/telescope.lua
+++ b/plugin/telescope.lua
@@ -116,7 +116,13 @@ end, {
     local n = #l - 2
 
     if n == 0 then
-      local commands = vim.tbl_flatten { builtin_list, extensions_list }
+      local commands = { builtin_list, extensions_list }
+      -- TODO(clason): remove when dropping support for Nvim 0.9
+      if vim.fn.has "nvim-0.10" then
+        commands = vim.iter(commands):flatten():totable()
+      else
+        commands = vim.tbl_flatten(commands)
+      end
       table.sort(commands)
 
       return vim.tbl_filter(function(val)


### PR DESCRIPTION
Fixes #3108

Note that `islist()` checks for a specific type of table: indexed by integers without holes (so `{ 1 = 'a', 3 = 'b' }` is _not_ a list); the intention is to ensure that `ipairs` and `#` (length) are well-defined. I did not check whether that is indeed intended in each case here; if not, consider simply replacing by `type(t) == 'table'`.

On a related note, the new `flatten()` only works correctly for lists; `{1,2,nil,3}` will _not_ be flattened to `{1,2,3}`. I don't know if that is an issue here, either. **EDIT** looks like it.
**EDIT2:** will be fixed upstream.

(Long-term, I would recommend moving to the new `vim.iter` API that allows efficiently chaining iterators. But this is of course a major refactoring effort.)