### PR TITLE
fix(builtin.buffers): previews with specified `cwd` option

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -618,9 +618,8 @@ function make_entry.gen_from_buffer(opts)
   end
 
   return function(entry)
-    local bufname = entry.info.name ~= "" and entry.info.name or "[No Name]"
-    -- if bufname is inside the cwd, trim that part of the string
-    bufname = Path:new(bufname):normalize(cwd)
+    local filename = entry.info.name ~= "" and entry.info.name or nil
+    local bufname = filename and Path:new(filename):normalize(cwd) or "[No Name]"
 
     local hidden = entry.info.hidden == 1 and "h" or "a"
     local readonly = vim.api.nvim_buf_get_option(entry.bufnr, "readonly") and "=" or " "
@@ -643,8 +642,8 @@ function make_entry.gen_from_buffer(opts)
       value = bufname,
       ordinal = entry.bufnr .. " : " .. bufname,
       display = make_display,
-
       bufnr = entry.bufnr,
+      path = filename,
       filename = bufname,
       lnum = lnum,
       indicator = indicator,


### PR DESCRIPTION
Currently, the buffer name is normalized to the `cwd` option value. This buffer name is then used as the filename, which is used as the file path for the previewer. But if the `cwd` value is not the actual cwd, the buffer path can no longer be found by the previewer (relative to the true cwd).

This is fixed by adding a `path` value to the entry that's the full path of the buffer. The previewer will then use this full path to find the file to preview.

closes https://github.com/nvim-telescope/telescope.nvim/issues/3102