### PR TITLE
fixup: adapt to deprecations in Nvim 0.10

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -22,7 +22,7 @@ utils.islist = vim.fn.has "nvim-0.10" == 1 and vim.islist or vim.tbl_islist
 local flatten = function(t)
   return vim.iter(t):flatten():totable()
 end
-utils.flatten = vim.fn.has "nvim-0.10" == 1 and flatten or vim.tbl_flatten
+utils.flatten = vim.fn.has "nvim-0.11" == 1 and flatten or vim.tbl_flatten
 
 --- Hybrid of `vim.fn.expand()` and custom `vim.fs.normalize()`
 ---

--- a/plugin/telescope.lua
+++ b/plugin/telescope.lua
@@ -118,7 +118,7 @@ end, {
     if n == 0 then
       local commands = { builtin_list, extensions_list }
       -- TODO(clason): remove when dropping support for Nvim 0.9
-      if vim.fn.has "nvim-0.10" == 1 then
+      if vim.fn.has "nvim-0.11" == 1 then
         commands = vim.iter(commands):flatten():totable()
       else
         commands = vim.tbl_flatten(commands)


### PR DESCRIPTION
vim.iter.flatten() is not a full replacement (does not support arrays
with `nil`); a fix may be backported but for now only use it on nightly
(0.10 has no warnings yet).
