### PR TITLE
fix: 0.11-nightly warnings of deprecated functions

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -18,7 +18,7 @@ local utils = {}
 utils.iswin = vim.loop.os_uname().sysname == "Windows_NT"
 
 --TODO(clason): Remove when dropping support for Nvim 0.9
-utils.islist = vim.fn.has "nvim-0.10" == 1 and vim.islist or vim.tbl_islist
+utils.islist = vim.version().minor >= 10 and vim.islist or vim.tbl_islist
 local flatten = function(t)
   return vim.iter(t):flatten():totable()
 end


### PR DESCRIPTION
# Description

on a recent PR [(this one)](https://github.com/nvim-telescope/telescope.nvim/pull/3109), `vim.islist` started to be used if version was 0.10, otherwise `vim.tbl_islist` would be used. This makes so 0.11 nightly builds get the deprecation warning.

## Type of change

Please delete options that are not relevant.

- Handling deprecations

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
