### PR TITLE
fix: black hole zequals

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1380,7 +1380,7 @@ internal.spell_suggest = function(opts)
 
           action_state.get_current_picker(prompt_bufnr)._original_mode = "i"
           actions.close(prompt_bufnr)
-          vim.cmd("normal! ciw" .. selection[1])
+          vim.cmd('normal! "_ciw' .. selection[1])
           vim.cmd "stopinsert"
         end)
         return true


### PR DESCRIPTION
# Description

This makes the telescope spellcheck picker more equivalent with a z= command. With the implementation before the misspelt word would end up in your register. This is not the behaviour of a z= in vim or neovim

Fixes # N/A

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- Spell word wrong
- Fix it
- Paste - Buffer not overwritten

**Configuration**:
* Neovim version (nvim --version): Nightly
* Operating system and version: NixOS

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
