### PR TITLE
feat(builtin.git_diff): new picker for diff hunks

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -4046,6 +4046,12 @@ previewers.git_file_diff()              *telescope.previewers.git_file_diff()*
 
 
 
+previewers.git_hunk_diff()              *telescope.previewers.git_hunk_diff()*
+    A previewer that shows the current diff hunk. Used in git_diff.
+
+
+
+
 previewers.display_content()          *telescope.previewers.display_content()*
     A deprecated way of displaying content more easily. Was written at a time,
     where the buffer_previewer interface wasn't present. Nowadays it's easier

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -429,6 +429,112 @@ git.status = function(opts)
     :find()
 end
 
+git.diff = function(opts)
+  if opts.is_bare then
+    utils.notify("builtin.git_diff", {
+      msg = "This operation must be run in a work tree",
+      level = "ERROR",
+    })
+    return
+  end
+  local args = { "diff" }
+  if opts.additional_args then
+    vim.list_extend(args, opts.additional_args)
+  end
+  local git_cmd = git_command(args, opts)
+  local output = vim.fn.systemlist(git_cmd)
+
+  local results = {}
+  local filename = nil
+  local linenumber = nil
+  local hunk_lines = {}
+
+  for _, line in ipairs(output) do
+    -- new file
+    if vim.startswith(line, 'diff') then
+      -- Start of a new hunk
+      if hunk_lines[1] ~= nil then
+        table.insert(results, { filename = filename, lnum = linenumber, raw_lines = hunk_lines })
+      end
+
+      local _, filepath_, _ = line:match('^diff (.*) a/(.*) b/(.*)$')
+
+      filename = filepath_
+      linenumber = nil
+
+      hunk_lines = {}
+    elseif vim.startswith(line, '@') then
+      if filename ~= nil and linenumber ~= nil and #hunk_lines > 0 then
+        table.insert(results, { filename = filename, lnum = linenumber, raw_lines = hunk_lines })
+        hunk_lines = {}
+      end
+      -- Hunk header
+      -- @example "@@ -157,20 +157,6 @@ some content"
+      local _, _, c, _ = string.match(line, '@@ %-(.*),(.*) %+(.*),(.*) @@')
+      linenumber = tonumber(c)
+      hunk_lines = {}
+      table.insert(hunk_lines, line)
+    else
+      table.insert(hunk_lines, line)
+    end
+  end
+  -- Add the last hunk to the table
+  if hunk_lines[1] ~= nil then
+    table.insert(results, { filename = filename, lnum = linenumber, raw_lines = hunk_lines })
+  end
+
+  local function get_diff_line_idx(lines)
+    for i, line in ipairs(lines) do
+      if vim.startswith(line, '-') or vim.startswith(line, '+') then
+        return i
+      end
+    end
+    return -1
+  end
+
+  -- lnum in diff hunks points a few lines off actually changed line
+  -- update results to point at changed lines to be precise
+  for _, v in ipairs(results) do
+    local diff_line_idx = get_diff_line_idx(v.raw_lines)
+    diff_line_idx = math.max(
+      -- first line is header, next one is already handled
+      diff_line_idx - 2,
+      0
+    )
+    v.lnum = v.lnum + diff_line_idx
+  end
+
+  pickers
+    .new({}, {
+      prompt_title = 'Git Diff',
+      finder = finders.new_table({
+        results = results,
+        entry_maker = function(entry)
+          entry.value = entry.filename
+          entry.ordinal = entry.filename .. ':' .. entry.lnum
+          entry.display = entry.filename .. ':' .. entry.lnum
+          return entry
+        end,
+      }),
+      previewer = previewers.git_hunk_diff.new(opts),
+      sorter = conf.file_sorter({}),
+      on_complete = {
+        function(self)
+          local lines = self.manager:num_results()
+          local prompt = action_state.get_current_line()
+          if lines == 0 and prompt == "" then
+            utils.notify("builtin.git_diff", {
+              msg = "No changes found",
+              level = "ERROR",
+            })
+            actions.close(self.prompt_bufnr)
+          end
+        end,
+      },
+    })
+    :find()
+end
+
 local try_worktrees = function(opts)
   local worktrees = conf.git_worktrees
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -219,6 +219,8 @@ builtin.git_branches = require_on_exported_call("telescope.builtin.__git").branc
 ---@field expand_dir boolean: pass flag `-uall` to show files in untracked directories (default: true)
 builtin.git_status = require_on_exported_call("telescope.builtin.__git").status
 
+builtin.git_diff = require_on_exported_call("telescope.builtin.__git").diff
+
 --- Lists stash items in current repository
 --- - Default keymaps:
 ---   - `<cr>`: runs `git apply` for currently selected stash

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -823,6 +823,21 @@ previewers.git_branch_log = defaulter(function(opts)
   }
 end, {})
 
+previewers.git_hunk_diff = defaulter(function()
+  return previewers.new_buffer_previewer {
+    title = "Git Diff Preview",
+    get_buffer_by_name = function(_, entry)
+      return entry.value
+    end,
+
+    define_preview = function(self, entry, _)
+      local lines = entry.raw_lines or { 'empty' }
+      vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+      putils.regex_highlighter(self.state.bufnr, 'diff')
+    end,
+  }
+end, {})
+
 previewers.git_stash_diff = defaulter(function(opts)
   return previewers.new_buffer_previewer {
     title = "Git Stash Preview",

--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -301,6 +301,9 @@ previewers.git_commit_message = buffer_previewer.git_commit_message
 --- The run command is `git --no-pager diff $FILE`
 previewers.git_file_diff = buffer_previewer.git_file_diff
 
+--- A previewer that shows the current diff hunk. Used in git_diff.<br>
+previewers.git_hunk_diff = buffer_previewer.git_hunk_diff
+
 previewers.ctags = buffer_previewer.ctags
 previewers.builtin = buffer_previewer.builtin
 previewers.help = buffer_previewer.help


### PR DESCRIPTION
# Description

This PR adds a picker for git diff hunks. The new picker may seem similar to git_status picker at first. However, it allows to view multiple hunks in a single file as separate entries; when a hunk is selected it jumps the cursor to the changes line instead of a first line of a file. You can also supply additinal arguments such as `--ignore-all-space` which can make hunks seem even more granular and easier to review when navigating via telescope. I have been testing this picker in my configuration for the past few months and think that other telescope users will find this useful.

I understand that at the time of first publishing this PR is in a pretty raw shape as it requires documentation updates and is currently using vim.fn.systemlist instead of an entry maker as entries cannot be inferred from a single line of output. I could not figure out a way to make the way the git diff output is parsed to work similar to how other pickers work. I if you think this is a welcome change I am happy to make appropriate changes to get this PR to a mergeable state. 

Demo:

https://github.com/nvim-telescope/telescope.nvim/assets/5817809/d0966aaf-ba35-465f-b210-12a10eaf5cf0



Look forward to see what you think about this feature.
## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- [x] Has hunks
  - Make changes in a git repository
  - run `:Teelscope git_diff`
  - expect to see a picker with diff hunks (multiple entries for single file with multiple hunks)
  - when an entry is selected it jumps to changed lines
- [x] Clean git repositry
  - run `:Teelscope git_diff`
  - no picker, error message ""

**Configuration**:
* Neovim version (nvim --version): v0.10
* Operating system and version: macos 14.4

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)

