### PR TITLE
fix vim.tbl_islist is deprecated error.

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -17,8 +17,7 @@ local utils = {}
 
 utils.iswin = vim.loop.os_uname().sysname == "Windows_NT"
 
---TODO(clason): Remove when dropping support for Nvim 0.9
-utils.islist = vim.fn.has "nvim-0.10" == 1 and vim.islist or vim.tbl_islist
+utils.islist = vim.fn.has "nvim-0.11" == 1 and vim.islist or vim.tbl_islist
 local flatten = function(t)
   return vim.iter(t):flatten():totable()
 end


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Test A
- [ ] Test B

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
