### PR TITLE
feat(picker): allow appending original window `<cWORD>`, `<cfile>` and `cursor line` to prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,9 @@ Many familiar mapping patterns are set up as defaults.
 | `<C-q>`        | Send all items not filtered to quickfixlist (qflist)      |
 | `<M-q>`        | Send all selected items to qflist                         |
 | `<C-r><C-w>`   | Insert cword in original window into prompt (insert mode) |
-| `<C-r><C-e>`   | Insert cWORD in original window into prompt (insert mode) |
-| `<C-r><C-l>`   | Insert  line in original window into prompt (insert mode) |
+| `<C-r><C-a>`   | Insert cWORD in original window into prompt (insert mode) |
+| `<C-r><C-f>`   | Insert cfile in original window into prompt (insert mode) |
+| `<C-r><C-l>`   | Insert cline in original window into prompt (insert mode) |
 
 To see the full list of mappings, check out `lua/telescope/mappings.lua` and the
 `default_mappings` table.

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Many familiar mapping patterns are set up as defaults.
 | `<C-q>`        | Send all items not filtered to quickfixlist (qflist)      |
 | `<M-q>`        | Send all selected items to qflist                         |
 | `<C-r><C-w>`   | Insert cword in original window into prompt (insert mode) |
+| `<C-r><C-e>`   | Insert cWORD in original window into prompt (insert mode) |
+| `<C-r><C-l>`   | Insert  line in original window into prompt (insert mode) |
 
 To see the full list of mappings, check out `lua/telescope/mappings.lua` and the
 `default_mappings` table.

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -3393,6 +3393,30 @@ actions.insert_original_cword({prompt_bufnr}) *telescope.actions.insert_original
         {prompt_bufnr} (number)  The prompt bufnr
 
 
+actions.insert_original_cWORD({prompt_bufnr}) *telescope.actions.insert_original_cWORD()*
+    Insert the WORD under the cursor of the original (pre-Telescope) window
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.insert_original_cfile({prompt_bufnr}) *telescope.actions.insert_original_cfile()*
+    Insert the file under the cursor of the original (pre-Telescope) window
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
+actions.insert_original_cline({prompt_bufnr}) *telescope.actions.insert_original_cline()*
+    Insert the line under the cursor of the original (pre-Telescope) window
+
+
+    Parameters: ~
+        {prompt_bufnr} (number)  The prompt bufnr
+
+
 
 ================================================================================
 ACTIONS_STATE                                          *telescope.actions.state*

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1496,11 +1496,15 @@ actions.insert_original_cword = function(prompt_bufnr)
   current_picker:set_prompt(current_picker.original_cword, false)
 end
 
+--- Insert the WORD under the cursor of the original (pre-Telescope) window
+---@param prompt_bufnr number: The prompt bufnr
 actions.insert_original_cWORD = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   current_picker:set_prompt(current_picker.original_cWORD, false)
 end
 
+--- Insert the line under the cursor of the original (pre-Telescope) window
+---@param prompt_bufnr number: The prompt bufnr
 actions.insert_original_cline = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   current_picker:set_prompt(current_picker.original_cline, false)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1503,6 +1503,13 @@ actions.insert_original_cWORD = function(prompt_bufnr)
   current_picker:set_prompt(current_picker.original_cWORD, false)
 end
 
+--- Insert the file under the cursor of the original (pre-Telescope) window
+---@param prompt_bufnr number: The prompt bufnr
+actions.insert_original_cfile = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  current_picker:set_prompt(current_picker.original_cfile, false)
+end
+
 --- Insert the line under the cursor of the original (pre-Telescope) window
 ---@param prompt_bufnr number: The prompt bufnr
 actions.insert_original_cline = function(prompt_bufnr)

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1496,6 +1496,16 @@ actions.insert_original_cword = function(prompt_bufnr)
   current_picker:set_prompt(current_picker.original_cword, false)
 end
 
+actions.insert_original_cWORD = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  current_picker:set_prompt(current_picker.original_cWORD, false)
+end
+
+actions.insert_original_cline = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  current_picker:set_prompt(current_picker.original_cline, false)
+end
+
 actions.nop = function(_) end
 
 actions.mouse_click = function(prompt_bufnr)

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -176,7 +176,8 @@ mappings.default_mappings = config.values.default_mappings
       ["<C-_>"] = actions.which_key, -- keys from pressing <C-/>
       ["<C-w>"] = { "<c-s-w>", type = "command" },
       ["<C-r><C-w>"] = actions.insert_original_cword,
-      ["<C-r><C-e>"] = actions.insert_original_cWORD,
+      ["<C-r><C-a>"] = actions.insert_original_cWORD,
+      ["<C-r><C-f>"] = actions.insert_original_cfile,
       ["<C-r><C-l>"] = actions.insert_original_cline,
 
       -- disable c-j because we dont want to allow new lines #2123

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -176,6 +176,8 @@ mappings.default_mappings = config.values.default_mappings
       ["<C-_>"] = actions.which_key, -- keys from pressing <C-/>
       ["<C-w>"] = { "<c-s-w>", type = "command" },
       ["<C-r><C-w>"] = actions.insert_original_cword,
+      ["<C-r><C-e>"] = actions.insert_original_cWORD,
+      ["<C-r><C-l>"] = actions.insert_original_cline,
 
       -- disable c-j because we dont want to allow new lines #2123
       ["<C-j>"] = actions.nop,

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -537,6 +537,8 @@ function Picker:find()
 
   self.original_win_id = a.nvim_get_current_win()
   _, self.original_cword = pcall(vim.fn.expand, "<cword>")
+  _, self.original_cWORD = pcall(vim.fn.expand, "<cWORD>")
+  _, self.original_cline = pcall(vim.trim, vim.api.nvim_get_current_line())
 
   -- User autocmd run it before create Telescope window
   vim.api.nvim_exec_autocmds("User", { pattern = "TelescopeFindPre" })

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -538,6 +538,7 @@ function Picker:find()
   self.original_win_id = a.nvim_get_current_win()
   _, self.original_cword = pcall(vim.fn.expand, "<cword>")
   _, self.original_cWORD = pcall(vim.fn.expand, "<cWORD>")
+  _, self.original_cfile = pcall(vim.fn.expand, "<cfile>")
   _, self.original_cline = pcall(vim.trim, vim.api.nvim_get_current_line())
 
   -- User autocmd run it before create Telescope window

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -539,7 +539,8 @@ function Picker:find()
   _, self.original_cword = pcall(vim.fn.expand, "<cword>")
   _, self.original_cWORD = pcall(vim.fn.expand, "<cWORD>")
   _, self.original_cfile = pcall(vim.fn.expand, "<cfile>")
-  _, self.original_cline = pcall(vim.trim, vim.api.nvim_get_current_line())
+  _, self.original_cline = pcall(vim.api.nvim_get_current_line)
+  _, self.original_cline = pcall(vim.trim, self.original_cline)
 
   -- User autocmd run it before create Telescope window
   vim.api.nvim_exec_autocmds("User", { pattern = "TelescopeFindPre" })


### PR DESCRIPTION
# Description

Store the `<cWORD>`, `<cfile>` and `cursor line` of the original window before showing up telescope window, and create new action to insert/append the them into the telescope prompt buffer.

Allows for similar behaviors to c_CTRL-R_CTRL-W.
follows: #2878 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
