### PR TITLE
fix(lsp.reference): single reference direct jump

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1607,6 +1607,8 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
                                           "vsplit", "never"
         {show_line}            (boolean)  show results text (default: true)
         {trim_text}            (boolean)  trim results text (default: false)
+        {reuse_win}            (boolean)  jump to existing window if buffer is
+                                          already opened (default: false)
         {file_encoding}        (string)   file encoding for the previewer
 
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -421,6 +421,7 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
+---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
 ---@field file_encoding string: file encoding for the previewer
 builtin.lsp_references = require_on_exported_call("telescope.builtin.__lsp").references
 


### PR DESCRIPTION
follow up to https://github.com/nvim-telescope/telescope.nvim/pull/3099
> clean up `list_to_jump` to work mostly with `vim.lsp.util.locations_to_items` output from the get-go

and closes https://github.com/nvim-telescope/telescope.nvim/issues/3118