### PR TITLE
fix(make_entry): improve `filename_first` support

### DIFF
--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -132,11 +132,11 @@ diagnostics.get = function(opts)
   if opts.bufnr ~= 0 then
     opts.bufnr = nil
   end
-  if opts.bufnr == nil then
-    opts.path_display = vim.F.if_nil(opts.path_display, {})
-  end
   if type(opts.bufnr) == "string" then
     opts.bufnr = tonumber(opts.bufnr)
+  end
+  if opts.bufnr ~= nil then
+    opts.path_display = vim.F.if_nil(opts.path_display, "hidden")
   end
 
   local locations = diagnostics_to_tbl(opts)
@@ -157,7 +157,6 @@ diagnostics.get = function(opts)
     return
   end
 
-  opts.path_display = vim.F.if_nil(opts.path_display, "hidden")
   pickers
     .new(opts, {
       prompt_title = opts.bufnr == nil and "Workspace Diagnostics" or "Document Diagnostics",

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -184,7 +184,7 @@ do
 
       if k == "path" then
         local retpath = Path:new({ t.cwd, t.value }):absolute()
-        if not vim.loop.fs_access(retpath, "R", nil) then
+        if not vim.loop.fs_access(retpath, "R") then
           retpath = t.value
         end
         return retpath
@@ -540,8 +540,14 @@ function make_entry.gen_from_lsp_symbols(opts)
         msg,
       }
     else
+      local display_path, path_style = utils.transform_path(opts, entry.filename)
       return displayer {
-        utils.transform_path(opts, entry.filename),
+        {
+          display_path,
+          function()
+            return path_style
+          end,
+        },
         entry.symbol_name,
         { entry.symbol_type:lower(), type_highlight[entry.symbol_type] },
         msg,
@@ -1043,7 +1049,7 @@ function make_entry.gen_from_ctags(opts)
   }
 
   local make_display = function(entry)
-    local filename = utils.transform_path(opts, entry.filename)
+    local display_path, path_style = utils.transform_path(opts, entry.filename)
 
     local scode
     if opts.show_line then
@@ -1057,7 +1063,12 @@ function make_entry.gen_from_ctags(opts)
       }
     else
       return displayer {
-        filename,
+        {
+          display_path,
+          function()
+            return path_style
+          end,
+        },
         entry.tag,
         scode,
       }
@@ -1073,7 +1084,7 @@ function make_entry.gen_from_ctags(opts)
 
     if k == "path" then
       local retpath = Path:new({ t.filename }):absolute()
-      if not vim.loop.fs_access(retpath, "R", nil) then
+      if not vim.loop.fs_access(retpath, "R") then
         retpath = t.filename
       end
       return retpath
@@ -1174,7 +1185,7 @@ function make_entry.gen_from_diagnostics(opts)
   }
 
   local make_display = function(entry)
-    local filename = utils.transform_path(opts, entry.filename)
+    local display_path, path_style = utils.transform_path(opts, entry.filename)
 
     -- add styling of entries
     local pos = string.format("%4d:%2d", entry.lnum, entry.col)
@@ -1187,7 +1198,12 @@ function make_entry.gen_from_diagnostics(opts)
     return displayer {
       line_info,
       entry.text,
-      filename,
+      {
+        display_path,
+        function()
+          return path_style
+        end,
+      },
     }
   end
 
@@ -1345,11 +1361,18 @@ function make_entry.gen_from_git_status(opts)
     local status_x = git_abbrev[x] or {}
     local status_y = git_abbrev[y] or {}
 
+    local display_path, path_style = utils.transform_path(opts, entry.path)
+
     local empty_space = " "
     return displayer {
       { status_x.icon or empty_space, status_x.hl },
       { status_y.icon or empty_space, status_y.hl },
-      utils.transform_path(opts, entry.path),
+      {
+        display_path,
+        function()
+          return path_style
+        end,
+      },
     }
   end
 


### PR DESCRIPTION
Few pickers with entry makers that relied on `entry_display.create` were not properly passing the highlight table returned by `transform_path`. This made the `filename_first` `path_display` option not work as expected for these pickers.

pickers touched:
- diagnostics
- lsp_workspace_symbols & lsp_dynamic_workspace_symbols
- tags & current_buffer_tags
- git_status

closes https://github.com/nvim-telescope/telescope.nvim/issues/3106