### PR TITLE
fix(lsp): handle URI in `item_to_location`

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -106,8 +106,27 @@ end
 local function item_to_location(item, offset_encoding)
   local line = item.lnum - 1
   local character = vim.lsp.util._str_utfindex_enc(item.text, item.col, offset_encoding) - 1
+  -- get URI from filename with the same approach used in `vim.uri_from_bufnr`
+  local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):.*'
+  local WINDOWS_URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):[a-zA-Z]:.*'
+  local uri
+  local fname = item.filename
+  local volume_path = fname:match('^([a-zA-Z]:).*')
+  local is_windows = volume_path ~= nil
+  local scheme
+  if is_windows then
+    fname = fname:gsub('\\', '/')
+    scheme = fname:match(WINDOWS_URI_SCHEME_PATTERN)
+  else
+    scheme = fname:match(URI_SCHEME_PATTERN)
+  end
+  if scheme then
+    uri = fname
+  else
+    uri = vim.uri_from_fname(fname)
+  end
   return {
-    uri = vim.uri_from_fname(item.filename),
+    uri = uri,
     range = {
       start = {
         line = line,

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -106,24 +106,11 @@ end
 local function item_to_location(item, offset_encoding)
   local line = item.lnum - 1
   local character = vim.lsp.util._str_utfindex_enc(item.text, item.col, offset_encoding) - 1
-  -- get URI from filename with the same approach used in `vim.uri_from_bufnr`
-  local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):.*'
-  local WINDOWS_URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):[a-zA-Z]:.*'
   local uri
-  local fname = item.filename
-  local volume_path = fname:match('^([a-zA-Z]:).*')
-  local is_windows = volume_path ~= nil
-  local scheme
-  if is_windows then
-    fname = fname:gsub('\\', '/')
-    scheme = fname:match(WINDOWS_URI_SCHEME_PATTERN)
+  if utils.is_uri(item.filename) then
+    uri = item.filename
   else
-    scheme = fname:match(URI_SCHEME_PATTERN)
-  end
-  if scheme then
-    uri = fname
-  else
-    uri = vim.uri_from_fname(fname)
+    uri = vim.uri_from_fname(item.filename)
   end
   return {
     uri = uri,


### PR DESCRIPTION
# Description

Following up on my comment in #3137 regarding the broken jump to Java classes such as `java.lang.String` because the JDT URI is not a file name. With `item.filename` being `jdt://contents/java.base/java.lang/String.class...`, the call `vim.uri_from_fname(item.filename)` in `item_to_location` would convert the JDT URI into an invalid URI by adding `file://` in front of `jdt://` and encode the already encoded URI again. The jump would fail as a result.

This is an attempt to fix the issue by applying filename to URI transformation only if `item.filename` is not a URI.

Error message:
```
Error executing vim.schedule lua callback: /usr/share/nvim/runtime/lua/vim/lsp/util.lua:1136: Cursor position outside buffer
stack traceback:
	[C]: in function 'nvim_win_set_cursor'
	/usr/share/nvim/runtime/lua/vim/lsp/util.lua:1136: in function 'jump_to_location'
	...nvim/lazy/telescope.nvim/lua/telescope/builtin/__lsp.lua:197: in function 'handler'
	/usr/share/nvim/runtime/lua/vim/lsp/client.lua:685: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Test a jump to `java.lang.String` (JDT URI handled by nvim-jdtls)
- [x] Test a jump to normal Java source file in workspace
- [x] Test a jump to normal Lua source file in workspace

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.10.0
Build type: RelWithDebInfo
LuaJIT 2.1.1707061634

* Operating system and version:
Linux (Fedora 40)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
