### PR TITLE
feat(builtin.buffers): enhance and bind `delete_buffer` action

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1434,6 +1434,8 @@ builtin.reloader({opts})                        *telescope.builtin.reloader()*
 builtin.buffers({opts})                          *telescope.builtin.buffers()*
     Lists open buffers in current neovim instance, opens selected buffer on
     `<cr>`
+    - Default keymaps:
+      - `<M-d>`: delete the currently selected buffer
 
 
     Parameters: ~

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -972,6 +972,9 @@ internal.buffers = function(opts)
       previewer = conf.grep_previewer(opts),
       sorter = conf.generic_sorter(opts),
       default_selection_index = default_selection_idx,
+      attach_mappings = function(_, map)
+        map({ "i", "n" }, "<C-x>", actions.delete_buffer)
+      end,
     })
     :find()
 end

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -973,7 +973,7 @@ internal.buffers = function(opts)
       sorter = conf.generic_sorter(opts),
       default_selection_index = default_selection_idx,
       attach_mappings = function(_, map)
-        map({ "i", "n" }, "<C-x>", actions.delete_buffer)
+        map({ "i", "n" }, "<M-d>", actions.delete_buffer)
       end,
     })
     :find()

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -339,6 +339,8 @@ builtin.man_pages = require_on_exported_call("telescope.builtin.__internal").man
 builtin.reloader = require_on_exported_call("telescope.builtin.__internal").reloader
 
 --- Lists open buffers in current neovim instance, opens selected buffer on `<cr>`
+--- - Default keymaps:
+---   - `<M-d>`: delete the currently selected buffer
 ---@param opts table: options to pass to the picker
 ---@field cwd string: specify a working directory to filter buffers list by
 ---@field show_all_buffers boolean: if true, show all buffers, including unloaded buffers (default: true)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -535,6 +535,7 @@ function Picker:find()
   self.__original_mousemoveevent = vim.o.mousemoveevent
   vim.o.mousemoveevent = true
 
+  self.original_bufnr = a.nvim_get_current_buf()
   self.original_win_id = a.nvim_get_current_win()
   _, self.original_cword = pcall(vim.fn.expand, "<cword>")
   _, self.original_cWORD = pcall(vim.fn.expand, "<cWORD>")


### PR DESCRIPTION
Binds the `delete_buffer` action to `<C-x>` by default for the `buffers` pickers.

closes https://github.com/nvim-telescope/telescope.nvim/issues/3128

Also enhances the `delete_buffer` action to have a "cleaner" behavior for deleting the current buffer (the buffer under telescope). Previously, when deleting the current buffer, the buffer would be removed from the buflist but closing the picker would put you right back into the buffer you just deleted.
From `:h bdelete`:
> If buffer [N] is the current buffer, another buffer will be displayed instead.  This is the most recent entry in the jump list that points into a loaded buffer.

Since the telescope prompt buffer is technically the current buffer, this "another buffer will be displayed behavior" wasn't actually triggering.
With this newest change, Telescope will manually get the buffer of the most recent entry in the jumplist and change the window behind telescope to this new buffer.

closes https://github.com/nvim-telescope/telescope.nvim/issues/2643