### PR TITLE
fix(buffers): select_current not selecting current buffer index

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -933,7 +933,7 @@ internal.buffers = function(opts)
 
   local buffers = {}
   local default_selection_idx = 1
-  for _, bufnr in ipairs(bufnrs) do
+  for i, bufnr in ipairs(bufnrs) do
     local flag = bufnr == vim.fn.bufnr "" and "%" or (bufnr == vim.fn.bufnr "#" and "#" or " ")
 
     if opts.sort_lastused and not opts.ignore_current_buffer and flag == "#" then
@@ -951,7 +951,7 @@ internal.buffers = function(opts)
       table.insert(buffers, idx, element)
     else
       if opts.select_current and flag == "%" then
-        default_selection_idx = bufnr
+        default_selection_idx = i
       end
       table.insert(buffers, element)
     end


### PR DESCRIPTION
# Description

When using builtin.buffers with `select_current = true`, it is not selecting current buffer.
This is because the current implementation tries to set the `default_selection_idx` using buffer number instead of buffer index.

The solution is to set `default_selection_idx` using buffer index.

Fixes #2917

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
:lua require('telescope.builtin').buffers({ select_current = true })
```

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.10.0
Build type: Release
LuaJIT 2.1.1713484068
```
* Operating system and version: Windows 11 / WSL
# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
