### PR TITLE
fix(layout_strategies): odd flex layout default behavior

### DIFF
--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -771,10 +771,10 @@ layout_strategies.flex = make_documented_layout(
     horizontal = "Options to pass when switching to horizontal layout",
   }),
   function(self, max_columns, max_lines, layout_config)
-    local flip_columns = vim.F.if_nil(layout_config.flip_columns, 100)
-    local flip_lines = vim.F.if_nil(layout_config.flip_lines, 20)
+    local flip_columns = vim.F.if_nil(layout_config.flip_columns, layout_config.horizontal.preview_cutoff)
+    local flip_lines = vim.F.if_nil(layout_config.flip_lines, layout_config.vertical.preview_cutoff)
 
-    if max_columns < flip_columns and max_lines > flip_lines then
+    if max_columns < flip_columns and max_lines >= flip_lines then
       self.__flex_strategy = "vertical"
       self.layout_config.flip_columns = nil
       self.layout_config.flip_lines = nil


### PR DESCRIPTION
# Description

This PR fixes an issue with the flex layout by changing the default values for `flip_columns` and `flip_lines` to match the `preview_cutoff` values for the horizontal and vertical layouts. This should improve the user experience for users who have their default layout set to 'flex'. See the issue description linked below for more information.

Fixes #3138

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The change implemented in this PR was tested using the following two tests:

- [ ] Test A: Set default `layout_strategy` to `'flex'` with no additional configuration. Run `:Telescope live_grep` and resize window. Observe that layout changes to vertical when `width < 120` given `height >= 40`.
- [ ] Test B: Set default `layout_strategy` to `'flex'` and `layout_config.horizontal.preview_cutoff` and `layout_config.vertical.preview_cutoff` to custom values. Run `:Telescope live_grep` and resize window. Observe that layout changes to vertical when the window size matches the `preview_cutoff` values set.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.0
* Operating system and version: Linux 6.8.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
