### PR TITLE
fix(action): edit action when path starts with "../"

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -196,7 +196,11 @@ action_set.edit = function(prompt_bufnr, command)
     -- check if we didn't pick a different buffer
     -- prevents restarting lsp server
     if vim.api.nvim_buf_get_name(0) ~= filename or command ~= "edit" then
-      filename = Path:new(filename):normalize(vim.loop.cwd())
+      if not vim.startswith(filename, "../") then
+        -- Path:normalize() removes "../" from front which breaks jump
+        -- so, do not normalize if path starts with "../"
+        filename = Path:new(filename):normalize(vim.loop.cwd())
+      end
       pcall(vim.cmd, string.format("%s %s", command, vim.fn.fnameescape(filename)))
     end
   end


### PR DESCRIPTION
# Description
Path:normalize() removes "../" from front which breaks enter action so, do not normalize if path starts with "../"

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested by providing path starting with `../` and enter action works.

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.10.0
Build type: Release
LuaJIT 2.1.1713484068
Run "nvim -V1 -v" for more info

* Operating system and version:
Ubuntu 22.04

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
