### PR TITLE
feat: refactors transform_path and allow `smart` to be used in conjunction with `filename_first`

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -532,9 +532,6 @@ function utils.data_directory()
   return Path:new({ base_directory, "data" }):absolute() .. Path.path.sep
 end
 
--- IMPORTANT: This function should have been a local function as it's only used
--- in this file, but the code was already exported a long time ago. By making it
--- local we would potential break consumers of this method.
 function utils.buffer_dir()
   return vim.fn.expand "%:p:h"
 end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -402,7 +402,6 @@ utils.transform_path = function(opts, path)
 
     if vim.tbl_contains(path_display, "filename_first") or path_display["filename_first"] ~= nil then
       transformed_path, path_style = utils.path_filename_first(transformed_path, path_display)
-      return transformed_path, path_style
     end
 
     return transformed_path, path_style

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -182,10 +182,10 @@ local path_filename_first = function(path, reverse_directories)
   end
 
   local tail = table.concat(dirs, utils.get_separator())
+  -- Trim prevents a top-level filename to have a trailing white space
   local transformed_path = vim.trim(filename .. " " .. tail)
   local path_style = { { { #filename, #transformed_path }, "TelescopeResultsComment" } }
 
-  -- Trim prevents a top-level filename to have a trailing white space
   return transformed_path, path_style
 end
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -170,7 +170,7 @@ utils.filter_symbols = function(results, opts, post_filter)
   end
 end
 
-utils.path_filename_first = function(path, reverse_directories)
+local path_filename_first = function(path, reverse_directories)
   local dirs = vim.split(path, utils.get_separator())
   local filename
 
@@ -195,7 +195,7 @@ local calc_result_length = function(truncate_len)
   return type(truncate_len) == "number" and len - truncate_len or len
 end
 
-utils.path_truncate = function(path, truncate_len, opts)
+local path_truncate = function(path, truncate_len, opts)
   if opts.__length == nil then
     opts.__length = calc_result_length(truncate_len)
   end
@@ -205,7 +205,7 @@ utils.path_truncate = function(path, truncate_len, opts)
   return truncate(path, opts.__length - opts.__prefix, nil, -1)
 end
 
-utils.path_shorten = function(path, length, exclude)
+local path_shorten = function(path, length, exclude)
   if exclude ~= nil then
     return Path:new(path):shorten(length, exclude)
   else
@@ -213,8 +213,7 @@ utils.path_shorten = function(path, length, exclude)
   end
 end
 
----@param path string: The path that should be formatted
-utils.path_abs = function(path, opts)
+local path_abs = function(path, opts)
   local cwd
   if opts.cwd then
     cwd = opts.cwd
@@ -227,7 +226,7 @@ utils.path_abs = function(path, opts)
   return Path:new(path):make_relative(cwd)
 end
 
-utils.path_smart = (function()
+local path_smart = (function()
   local paths = {}
   local os_sep = utils.get_separator()
   return function(filepath)
@@ -367,11 +366,11 @@ utils.transform_path = function(opts, path)
     end
 
     if not vim.tbl_contains(path_display, "absolute") and not path_display.absolute then
-      transformed_path = utils.path_abs(transformed_path, opts)
+      transformed_path = path_abs(transformed_path, opts)
     end
 
     if vim.tbl_contains(path_display, "smart") or path_display.smart then
-      transformed_path = utils.path_smart(transformed_path)
+      transformed_path = path_smart(transformed_path)
     end
 
     if vim.tbl_contains(path_display, "shorten") or path_display["shorten"] ~= nil then
@@ -386,11 +385,11 @@ utils.transform_path = function(opts, path)
         length = type(path_display["shorten"]) == "number" and path_display["shorten"]
       end
 
-      transformed_path = utils.path_shorten(transformed_path, length, exclude)
+      transformed_path = path_shorten(transformed_path, length, exclude)
     end
 
     if vim.tbl_contains(path_display, "truncate") or path_display.truncate then
-      transformed_path = utils.path_truncate(transformed_path, path_display.truncate, opts)
+      transformed_path = path_truncate(transformed_path, path_display.truncate, opts)
     end
 
     if vim.tbl_contains(path_display, "filename_first") or path_display["filename_first"] ~= nil then
@@ -406,7 +405,7 @@ utils.transform_path = function(opts, path)
         end
       end
 
-      transformed_path, path_style = utils.path_filename_first(transformed_path, reverse_directories)
+      transformed_path, path_style = path_filename_first(transformed_path, reverse_directories)
     end
 
     return transformed_path, path_style

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -381,7 +381,7 @@ utils.transform_path = function(opts, path)
     return "", path_style
   elseif type(path_display) == "table" then
     if vim.tbl_contains(path_display, "tail") or path_display.tail then
-      transformed_path = utils.path_tail(transformed_path)
+      return utils.path_tail(transformed_path), path_style
     end
 
     if not vim.tbl_contains(path_display, "absolute") and not path_display.absolute then

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -170,56 +170,46 @@ utils.filter_symbols = function(results, opts, post_filter)
   end
 end
 
-utils.path_filename_first = (function()
-  return function(path, path_display)
-    local reverse_directories = false
+utils.path_filename_first = function(path, path_display)
+  local reverse_directories = false
 
-    if type(path_display["filename_first"]) == "table" then
-      local filename_first_opts = path_display["filename_first"]
+  if type(path_display["filename_first"]) == "table" then
+    local filename_first_opts = path_display["filename_first"]
 
-      if filename_first_opts.reverse_directories == nil or filename_first_opts.reverse_directories == false then
-        reverse_directories = false
-      else
-        reverse_directories = filename_first_opts.reverse_directories
-      end
-    end
-
-    local dirs = vim.split(path, utils.get_separator())
-    local filename
-
-    if reverse_directories then
-      dirs = utils.reverse_table(dirs)
-      filename = table.remove(dirs, 1)
+    if filename_first_opts.reverse_directories == nil or filename_first_opts.reverse_directories == false then
+      reverse_directories = false
     else
-      filename = table.remove(dirs, #dirs)
+      reverse_directories = filename_first_opts.reverse_directories
     end
-
-    local tail = table.concat(dirs, utils.get_separator())
-    local transformed_path = vim.trim(filename .. " " .. tail)
-    local path_style = { { { #filename, #transformed_path }, "TelescopeResultsComment" } }
-
-    -- Trim prevents a top-level filename to have a trailing white space
-    return transformed_path, path_style
-  end
-end)()
-
-utils.path_truncate = (function()
-  local calc_result_length = function(truncate_len)
-    local status = get_status(vim.api.nvim_get_current_buf())
-    local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
-    return type(truncate_len) == "number" and len - truncate_len or len
   end
 
-  return function(path, path_display, opts)
-    if opts.__length == nil then
-      opts.__length = calc_result_length(path_display.truncate)
-    end
-    if opts.__prefix == nil then
-      opts.__prefix = 0
-    end
-    return truncate(path, opts.__length - opts.__prefix, nil, -1)
+  local dirs = vim.split(path, utils.get_separator())
+  local filename
+
+  if reverse_directories then
+    dirs = utils.reverse_table(dirs)
+    filename = table.remove(dirs, 1)
+  else
+    filename = table.remove(dirs, #dirs)
   end
-end)()
+
+  local tail = table.concat(dirs, utils.get_separator())
+  local transformed_path = vim.trim(filename .. " " .. tail)
+  local path_style = { { { #filename, #transformed_path }, "TelescopeResultsComment" } }
+
+  -- Trim prevents a top-level filename to have a trailing white space
+  return transformed_path, path_style
+end
+
+utils.path_truncate = function(path, path_display, opts)
+  if opts.__length == nil then
+    opts.__length = calc_result_length(path_display.truncate)
+  end
+  if opts.__prefix == nil then
+    opts.__prefix = 0
+  end
+  return truncate(path, opts.__length - opts.__prefix, nil, -1)
+end
 
 utils.path_shorten = function(path, path_display)
   if type(path_display["shorten"]) == "table" then
@@ -347,6 +337,12 @@ utils.is_uri = function(filename)
     end
   end
   return false
+end
+
+local calc_result_length = function(truncate_len)
+  local status = get_status(vim.api.nvim_get_current_buf())
+  local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
+  return type(truncate_len) == "number" and len - truncate_len or len
 end
 
 --- Transform path is a util function that formats a path based on path_display

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -226,6 +226,9 @@ local path_abs = function(path, opts)
   return Path:new(path):make_relative(cwd)
 end
 
+-- IMPORTANT: This function should have been a local function as it's only used
+-- in this file, but the code was already exported a long time ago. By making it
+-- local we would potential break consumers of this method.
 utils.path_smart = (function()
   local paths = {}
   local os_sep = utils.get_separator()
@@ -519,6 +522,9 @@ function utils.max_split(s, pattern, maxsplit)
   return t
 end
 
+-- IMPORTANT: This function should have been a local function as it's only used
+-- in this file, but the code was already exported a long time ago. By making it
+-- local we would potential break consumers of this method.
 function utils.data_directory()
   local sourced_file = require("plenary.debug_utils").sourced_filepath()
   local base_directory = vim.fn.fnamemodify(sourced_file, ":h:h:h")
@@ -526,6 +532,9 @@ function utils.data_directory()
   return Path:new({ base_directory, "data" }):absolute() .. Path.path.sep
 end
 
+-- IMPORTANT: This function should have been a local function as it's only used
+-- in this file, but the code was already exported a long time ago. By making it
+-- local we would potential break consumers of this method.
 function utils.buffer_dir()
   return vim.fn.expand "%:p:h"
 end
@@ -573,6 +582,9 @@ local load_once = function(f)
   end
 end
 
+-- IMPORTANT: This function should have been a local function as it's only used
+-- in this file, but the code was already exported a long time ago. By making it
+-- local we would potential break consumers of this method.
 utils.file_extension = function(filename)
   local parts = vim.split(filename, "%.")
   -- this check enables us to get multi-part extensions, like *.test.js for example
@@ -756,6 +768,9 @@ utils.merge_styles = function(style1, style2, offset)
   return style1
 end
 
+-- IMPORTANT: This function should have been a local function as it's only used
+-- in this file, but the code was already exported a long time ago. By making it
+-- local we would potential break consumers of this method.
 utils.reverse_table = function(input_table)
   local temp_table = {}
   for index = 0, #input_table do

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -170,48 +170,6 @@ utils.filter_symbols = function(results, opts, post_filter)
   end
 end
 
-utils.is_path_hidden = function(opts, path_display)
-  path_display = path_display or vim.F.if_nil(opts.path_display, require("telescope.config").values.path_display)
-
-  return path_display == nil
-    or path_display == "hidden"
-    or type(path_display) == "table" and (vim.tbl_contains(path_display, "hidden") or path_display.hidden)
-end
-
-utils.is_uri = function(filename)
-  local char = string.byte(filename, 1) or 0
-
-  -- is alpha?
-  if char < 65 or (char > 90 and char < 97) or char > 122 then
-    return false
-  end
-
-  for i = 2, #filename do
-    char = string.byte(filename, i)
-    if char == 58 then -- `:`
-      return i < #filename and string.byte(filename, i + 1) ~= 92 -- `\`
-    elseif
-      not (
-        (char >= 48 and char <= 57) -- 0-9
-        or (char >= 65 and char <= 90) -- A-Z
-        or (char >= 97 and char <= 122) -- a-z
-        or char == 43 -- `+`
-        or char == 46 -- `.`
-        or char == 45 -- `-`
-      )
-    then
-      return false
-    end
-  end
-  return false
-end
-
-local calc_result_length = function(truncate_len)
-  local status = get_status(vim.api.nvim_get_current_buf())
-  local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
-  return type(truncate_len) == "number" and len - truncate_len or len
-end
-
 utils.path_filename_first = function(path, path_display)
   local reverse_directories = false
 
@@ -241,6 +199,12 @@ utils.path_filename_first = function(path, path_display)
 
   -- Trim prevents a top-level filename to have a trailing white space
   return transformed_path, path_style
+end
+
+local calc_result_length = function(truncate_len)
+  local status = get_status(vim.api.nvim_get_current_buf())
+  local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
+  return type(truncate_len) == "number" and len - truncate_len or len
 end
 
 utils.path_truncate = function(path, path_display, opts)
@@ -344,6 +308,42 @@ utils.path_tail = (function()
     end
   end
 end)()
+
+utils.is_path_hidden = function(opts, path_display)
+  path_display = path_display or vim.F.if_nil(opts.path_display, require("telescope.config").values.path_display)
+
+  return path_display == nil
+    or path_display == "hidden"
+    or type(path_display) == "table" and (vim.tbl_contains(path_display, "hidden") or path_display.hidden)
+end
+
+utils.is_uri = function(filename)
+  local char = string.byte(filename, 1) or 0
+
+  -- is alpha?
+  if char < 65 or (char > 90 and char < 97) or char > 122 then
+    return false
+  end
+
+  for i = 2, #filename do
+    char = string.byte(filename, i)
+    if char == 58 then -- `:`
+      return i < #filename and string.byte(filename, i + 1) ~= 92 -- `\`
+    elseif
+      not (
+        (char >= 48 and char <= 57) -- 0-9
+        or (char >= 65 and char <= 90) -- A-Z
+        or (char >= 97 and char <= 122) -- a-z
+        or char == 43 -- `+`
+        or char == 46 -- `.`
+        or char == 45 -- `-`
+      )
+    then
+      return false
+    end
+  end
+  return false
+end
 
 --- Transform path is a util function that formats a path based on path_display
 --- found in `opts` or the default value from config.

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -226,7 +226,7 @@ local path_abs = function(path, opts)
   return Path:new(path):make_relative(cwd)
 end
 
-local path_smart = (function()
+utils.path_smart = (function()
   local paths = {}
   local os_sep = utils.get_separator()
   return function(filepath)
@@ -370,7 +370,7 @@ utils.transform_path = function(opts, path)
     end
 
     if vim.tbl_contains(path_display, "smart") or path_display.smart then
-      transformed_path = path_smart(transformed_path)
+      transformed_path = utils.path_smart(transformed_path)
     end
 
     if vim.tbl_contains(path_display, "shorten") or path_display["shorten"] ~= nil then


### PR DESCRIPTION
# Description
I've cleaned up `transform_path`:
- Extracted code into functions: `path_filename_first`, `path_truncate`, etc.
- By returning early for `smart` we would not be able to run `filename_first` afterwards.

## Smart pre-PR
<img width="1136" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/755c61f0-0b5f-466c-acf1-ba2978237bfe">

## Smart post-PR
The directory can now be separated with the following configuration:

```
path_display = {
  "smart",
  "filename_first",
},
```

<img width="1136" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/204bfcfb-3bec-4204-8125-e511b11e8915">

## Type of change

- Feature: allowing `smart` to be used in conjunction with `filename_first`

# How Has This Been Tested?

- [x] Local tests are green
- [x] Ran Telescope in Neovim locally

**Configuration**:
* Neovim version (nvim --version):

> NVIM v0.10.0
> Build type: Release
> LuaJIT 2.1.1716656478

* Operating system and version:

OSX Sonoma 14.4.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
