### PR TITLE
Feature: highlighting of path coordinates

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -462,11 +462,16 @@ function make_entry.gen_from_quickfix(opts)
   local hidden = utils.is_path_hidden(opts)
 
   local make_display = function(entry)
-    local display_filename, path_style = utils.transform_path(opts, entry.filename)
+    local display_filename, style = utils.transform_path(opts, entry.filename)
     local display_string = string.format("%s:%d:%d", display_filename, entry.lnum, entry.col)
     if hidden then
       display_string = string.format("%4d:%2d", entry.lnum, entry.col)
     end
+
+    -- Adds styling to the coordinates
+    style = utils.merge_styles(
+      { { { #display_filename, #display_string }, "TelescopeResultsComment" } }, style, 0
+    )
 
     if show_line then
       local text = entry.text
@@ -474,10 +479,16 @@ function make_entry.gen_from_quickfix(opts)
         text = vim.trim(text)
       end
       text = text:gsub(".* | ", "")
+
+      -- Accounts for the added ":" after the display_string
+      style = utils.merge_styles(
+        { { { #display_string, #display_string + 1 }, "TelescopeResultsComment" } }, style, 0
+      )
+
       display_string = display_string .. ":" .. text
     end
 
-    return display_string, path_style
+    return display_string, style
   end
 
   local get_filename = get_filename_fn()

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -330,7 +330,7 @@ do
 
         -- Adds styling to the coordinates
         style = utils.merge_styles(
-          { { { #display_filename, #display_filename + #coordinates }, "TelescopeResultsComment" } }, style, 0
+          { { { #display_filename, #display_filename + #coordinates }, "TelescopeResultsLineNr" } }, style, 0
         )
 
         local display, hl_group, icon = utils.transform_devicons(
@@ -470,7 +470,7 @@ function make_entry.gen_from_quickfix(opts)
 
     -- Adds styling to the coordinates
     style = utils.merge_styles(
-      { { { #display_filename, #display_string }, "TelescopeResultsComment" } }, style, 0
+      { { { #display_filename, #display_string }, "TelescopeResultsLineNr" } }, style, 0
     )
 
     if show_line then
@@ -482,7 +482,7 @@ function make_entry.gen_from_quickfix(opts)
 
       -- Accounts for the added ":" after the display_string
       style = utils.merge_styles(
-        { { { #display_string, #display_string + 1 }, "TelescopeResultsComment" } }, style, 0
+        { { { #display_string, #display_string + 1 }, "TelescopeResultsLineNr" } }, style, 0
       )
 
       display_string = display_string .. ":" .. text
@@ -628,7 +628,7 @@ function make_entry.gen_from_buffer(opts)
 
     -- Adds styling to the coordinates
     style = utils.merge_styles(
-      { { { #display_bufname, #display_bufname + #coordinates }, "TelescopeResultsComment" } }, style, 0
+      { { { #display_bufname, #display_bufname + #coordinates }, "TelescopeResultsLineNr" } }, style, 0
     )
 
     return displayer {

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -622,17 +622,23 @@ function make_entry.gen_from_buffer(opts)
   local make_display = function(entry)
     -- bufnr_width + modes + icon + 3 spaces + : + lnum
     opts.__prefix = opts.bufnr_width + 4 + icon_width + 3 + 1 + #tostring(entry.lnum)
-    local display_bufname, path_style = utils.transform_path(opts, entry.filename)
+    local display_bufname, style = utils.transform_path(opts, entry.filename)
+    local coordinates = ":" .. entry.lnum
     local icon, hl_group = utils.get_devicons(entry.filename, disable_devicons)
 
+    -- Adds styling to the coordinates
+    style = utils.merge_styles(
+      { { { #display_bufname, #display_bufname + #coordinates }, "TelescopeResultsComment" } }, style, 0
+    )
+
     return displayer {
-      { entry.bufnr, "TelescopeResultsNumber" },
+      { entry.bufnr,     "TelescopeResultsNumber" },
       { entry.indicator, "TelescopeResultsComment" },
-      { icon, hl_group },
+      { icon,            hl_group },
       {
-        display_bufname .. ":" .. entry.lnum,
+        display_bufname .. coordinates,
         function()
-          return path_style
+          return style
         end,
       },
     }

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -315,7 +315,7 @@ do
       cwd = utils.path_expand(opts.cwd or vim.loop.cwd()),
 
       display = function(entry)
-        local display_filename, path_style = utils.transform_path(opts, entry.filename)
+        local display_filename, style = utils.transform_path(opts, entry.filename)
 
         local coordinates = ":"
         if not disable_coordinates then
@@ -328,6 +328,11 @@ do
           end
         end
 
+        -- Adds styling to the coordinates
+        style = utils.merge_styles(
+          { { { #display_filename, #display_filename + #coordinates }, "TelescopeResultsComment" } }, style, 0
+        )
+
         local display, hl_group, icon = utils.transform_devicons(
           entry.filename,
           string.format(display_string, display_filename, coordinates, entry.text),
@@ -335,11 +340,10 @@ do
         )
 
         if hl_group then
-          local style = { { { 0, #icon }, hl_group } }
-          style = utils.merge_styles(style, path_style, #icon + 1)
+          style = utils.merge_styles({ { { 0, #icon }, hl_group } }, style, #icon + 1)
           return display, style
         else
-          return display, path_style
+          return display, style
         end
       end,
 


### PR DESCRIPTION
# Description

Adds highlighting of path coordinates by using the existing highlight group `TelescopeResultsLineNr`.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots of affected windows

### Live Grep

<img width="1136" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/ac158be6-4340-4955-a47e-857f4a6370e1">

### Grep Word

<img width="1136" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/e2bfecfe-43c6-412a-9b4e-8fa427b16d33">

### Buffers

<img width="1136" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/6290f042-e93a-4ecc-b25f-81d196472ff5">

### LSP definitions

<img width="1136" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/bf1aebe3-2c5c-43f3-a8d1-5190713d5be0">

### LSP references

<img width="1136" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/f29d2a95-4493-4655-9ef8-1a183a7012d0">

### LSP type definitions

<img width="1136" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/c48d960e-f6ef-498c-a230-1ee5d2560443">

### Jumplist

![image](https://github.com/nvim-telescope/telescope.nvim/assets/6285202/2f97e89c-8895-435e-985a-433abe11025f)

### Loclist

<img width="1136" alt="image" src="https://github.com/nvim-telescope/telescope.nvim/assets/6285202/5dbee5db-6c12-40a9-8dab-e9d6c5508098">

# How Has This Been Tested?

This has been tested manually (see screenshots)

- [x] Live Grep
- [x] Grep Word
- [x] Buffers
- [x] LSP definitions
- [x] LSP references
- [x] Jumplist
- [x] Loclist

**Configuration**:
* Neovim version (nvim --version):

> NVIM v0.10.0
> Build type: Release
> LuaJIT 2.1.1716656478

* Operating system and version:

> Sonoma 14.4.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
