### PR TITLE
fix(lsp.reference): Only filter the current line of the current filname

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -140,8 +140,9 @@ end
 local apply_action_handler = function(action, items, opts)
   if action == "textDocument/references" and not opts.include_current_line then
     local lnum = vim.api.nvim_win_get_cursor(opts.winnr)[1]
+    local cur_filename = vim.api.nvim_buf_get_name(opts.bufnr)
     items = vim.tbl_filter(function(v)
-      return not (v.filename and v.lnum == lnum)
+      return not (v.filename == cur_filename and v.lnum == lnum)
     end, items)
   end
 

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -140,9 +140,8 @@ end
 local apply_action_handler = function(action, items, opts)
   if action == "textDocument/references" and not opts.include_current_line then
     local lnum = vim.api.nvim_win_get_cursor(opts.winnr)[1]
-    local cur_filename = vim.api.nvim_buf_get_name(opts.bufnr)
     items = vim.tbl_filter(function(v)
-      return not (v.filename == cur_filename and v.lnum == lnum)
+      return not (v.filename == opts.curr_filepath and v.lnum == lnum)
     end, items)
   end
 
@@ -155,8 +154,8 @@ end
 ---@param opts table
 local function list_or_jump(action, title, params, opts)
   opts.reuse_win = vim.F.if_nil(opts.reuse_win, false)
-
-  local curr_filepath = vim.api.nvim_buf_get_name(opts.bufnr)
+  opts.curr_filepath = vim.api.nvim_buf_get_name(opts.bufnr)
+  
   vim.lsp.buf_request(opts.bufnr, action, params, function(err, result, ctx, _)
     if err then
       vim.api.nvim_err_writeln("Error when executing " .. action .. " : " .. err.message)
@@ -183,7 +182,7 @@ local function list_or_jump(action, title, params, opts)
 
     if #items == 1 and opts.jump_type ~= "never" then
       local item = items[1]
-      if curr_filepath ~= item.filename then
+      if opts.curr_filepath ~= item.filename then
         local cmd
         if opts.jump_type == "tab" then
           cmd = "tabedit"

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -155,7 +155,7 @@ end
 local function list_or_jump(action, title, params, opts)
   opts.reuse_win = vim.F.if_nil(opts.reuse_win, false)
   opts.curr_filepath = vim.api.nvim_buf_get_name(opts.bufnr)
-  
+
   vim.lsp.buf_request(opts.bufnr, action, params, function(err, result, ctx, _)
     if err then
       vim.api.nvim_err_writeln("Error when executing " .. action .. " : " .. err.message)


### PR DESCRIPTION
fix(lsp.reference): Only filter the current line of the current filname when include_current_line=false

# Description

Lsp references with the same number of lines in different files will be filtered when include_current_line=false

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Lsp references have the same number of lines in different files (with gopls)

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.10.0
Build type: Release
LuaJIT 2.1.1713773202
Run "nvim -V1 -v" for more info

* Operating system and version:
MacOs (14.5)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
