### PR TITLE
feat(builtin.colorscheme): add option `ignore_builtins`

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1478,11 +1478,11 @@ builtin.colorscheme({opts})                  *telescope.builtin.colorscheme()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {colors}         (table)     a list of additional colorschemes to
+        {colors}          (table)    a list of additional colorschemes to
                                      explicitly make available to telescope
                                      (default: {})
-        {enable_preview} (boolean)   if true, will preview the selected color
-        {ignore_builtins} (boolean)  if true, builtin colorschemes are not 
+        {enable_preview}  (boolean)  if true, will preview the selected color
+        {ignore_builtins} (boolean)  if true, builtin colorschemes are not
                                      listed
 
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1478,10 +1478,12 @@ builtin.colorscheme({opts})                  *telescope.builtin.colorscheme()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {colors}         (table)    a list of additional colorschemes to
-                                    explicitly make available to telescope
-                                    (default: {})
-        {enable_preview} (boolean)  if true, will preview the selected color
+        {colors}         (table)     a list of additional colorschemes to
+                                     explicitly make available to telescope
+                                     (default: {})
+        {enable_preview} (boolean)   if true, will preview the selected color
+        {ignore_builtins} (boolean)  if true, builtin colorschemes are not 
+                                     listed
 
 
 builtin.marks({opts})                              *telescope.builtin.marks()*

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -993,6 +993,19 @@ internal.colorscheme = function(opts)
     end, vim.fn.getcompletion("", "color"))
   )
 
+  if opts.ignore_builtins then
+    -- stylua: ignore
+    local builtins = {
+      "zellner", "torte", "slate", "shine", "ron", "quiet", "peachpuff",
+      "pablo", "murphy", "lunaperche", "koehler", "industry", "evening",
+      "elflord", "desert", "delek", "darkblue", "blue", "morning", "vim",
+      "habamax", "retrobox", "sorbet", "zaibatsu", "wildcharm", "default",
+    }
+    colors = vim.tbl_filter(function(color)
+      return not vim.tbl_contains(builtins, color)
+    end, colors)
+  end
+
   local previewer
   if opts.enable_preview then
     -- define previewer

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -996,10 +996,10 @@ internal.colorscheme = function(opts)
   if opts.ignore_builtins then
     -- stylua: ignore
     local builtins = {
-      "zellner", "torte", "slate", "shine", "ron", "quiet", "peachpuff",
-      "pablo", "murphy", "lunaperche", "koehler", "industry", "evening",
-      "elflord", "desert", "delek", "darkblue", "blue", "morning", "vim",
-      "habamax", "retrobox", "sorbet", "zaibatsu", "wildcharm", "default",
+      "blue", "darkblue", "default", "delek", "desert", "elflord", "evening",
+      "habamax", "industry", "koehler", "lunaperche", "morning", "murphy",
+      "pablo", "peachpuff", "quiet", "retrobox", "ron", "shine", "slate",
+      "sorbet", "torte", "vim", "wildcharm", "zaibatsu", "zellner",
     }
     colors = vim.tbl_filter(function(color)
       return not vim.tbl_contains(builtins, color)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -357,6 +357,7 @@ builtin.buffers = require_on_exported_call("telescope.builtin.__internal").buffe
 ---@param opts table: options to pass to the picker
 ---@field colors table: a list of additional colorschemes to explicitly make available to telescope (default: {})
 ---@field enable_preview boolean: if true, will preview the selected color
+---@field ignore_builtins boolean: if true, builtin colorschemes are not listed
 builtin.colorscheme = require_on_exported_call("telescope.builtin.__internal").colorscheme
 
 --- Lists vim marks and their value, jumps to the mark on `<cr>`


### PR DESCRIPTION
# Description

Add an option `ignore_builtins` for the builtin colorscheme picker. Can't seem to find one in the issue search, but I remember that this topic regularly came up, e.g., on reddit.  

## Type of change

- New feature
- This change requires a documentation update

# How Has This Been Tested?

```lua
-- run this
require("telescope.builtin").colorscheme { ignore_builtins = true }
```

**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.0
* Operating system and version: macOS 14.4.1 (arm)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
