### PR TITLE
chore(developers.md): change comma typo

### DIFF
--- a/developers.md
+++ b/developers.md
@@ -217,7 +217,7 @@ more interesting. We will end up with the following new code for `finders.new_ta
 ```
 
 With the new snippet, we no longer have an array of strings but an array of
-tables. Each table has a color, name, and the color's hex value.
+tables. Each table has a color name and the color's hex value.
 
 `entry_maker` is a function that will receive each table and then we can set the
 values we need. It's best practice to have a `value` reference to the


### PR DESCRIPTION
# Description

This is a small change in developers.md documentation. 
the table `results` in 
```
 results = {
        { "red", "#ff0000" },
        { "green", "#00ff00" },
        { "blue", "#0000ff" },
      },
```
contains the name AND the hex code. With the previous text, it seemed that the table had a "color", a "name" and the "hex code" and I found it confusing.

I understand that this is an extremely small nit picking so its up to you guys if you want to move ahead and skip this PR :)

## Type of change

- Just a documentation update

# How Has This Been Tested?

N/A

**Configuration**:
* Neovim version (nvim --version): NVIM v0.11.0-dev+212-gd8e384b7b
* Operating system and version: Fedora 40

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
