### PR TITLE
fixup(builtin.buffers): enable default mappings

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -974,6 +974,7 @@ internal.buffers = function(opts)
       default_selection_index = default_selection_idx,
       attach_mappings = function(_, map)
         map({ "i", "n" }, "<M-d>", actions.delete_buffer)
+        return true
       end,
     })
     :find()


### PR DESCRIPTION
# Description

See https://github.com/nvim-telescope/telescope.nvim/pull/3145#issuecomment-2170287850

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Launch neovim and run `:Telescope buffers`. Mappings work just fine :)

**Configuration**:
* Neovim version (nvim --version): NVIM v0.11.0-dev-242+gba70404c55
* Operating system and version: Arch Linux 6.9.2

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
