### PR TITLE
fix(builtin.buffers): missing return in attach_mappings

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -974,6 +974,7 @@ internal.buffers = function(opts)
       default_selection_index = default_selection_idx,
       attach_mappings = function(_, map)
         map({ "i", "n" }, "<M-d>", actions.delete_buffer)
+        return true
       end,
     })
     :find()


### PR DESCRIPTION
closes https://github.com/nvim-telescope/telescope.nvim/issues/3171

