### PR TITLE
fix(builtin.live_grep, builtin.treesitter): not adding jumps to jumplist

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -180,6 +180,7 @@ files.live_grep = function(opts)
         map("i", "<c-space>", actions.to_fuzzy_refine)
         return true
       end,
+      push_cursor_on_edit = true,
     })
     :find()
 end
@@ -460,6 +461,7 @@ files.treesitter = function(opts)
         tag = "kind",
         sorter = conf.generic_sorter(opts),
       },
+      push_cursor_on_edit = true,
     })
     :find()
 end

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -258,6 +258,7 @@ files.grep_string = function(opts)
       finder = finders.new_oneshot_job(args, opts),
       previewer = conf.grep_previewer(opts),
       sorter = conf.generic_sorter(opts),
+      push_cursor_on_edit = true,
     })
     :find()
 end


### PR DESCRIPTION
# Description

Whenever a picker, that can jump to a different location in the same buffer does so it should have `push_cursor_on_edit` otherwise the jump won't be recorded.

Maybe this affects other pickers too, but I only noticed it on grep and treesitter since I use those two a lot.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
