### PR TITLE
feat: add user autocmd TelescopePickerClose

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,11 +565,12 @@ for more information and how to realize more complex commands please read
 
 Telescope user autocmds:
 
-| Event                           | Description                                             |
-| ------------------------------- | ------------------------------------------------------- |
-| `User TelescopeFindPre`         | Do it before Telescope creates all the floating windows |
-| `User TelescopePreviewerLoaded` | Do it after Telescope previewer window is created       |
-| `User TelescopeResumePost`      | Do it after Telescope resume action is fully completed  |
+| Event                           | Description                                              |
+| ------------------------------- | -------------------------------------------------------- |
+| `User TelescopeFindPre`         | Do it before Telescope creates all the floating windows  |
+| `User TelescopePreviewerLoaded` | Do it after Telescope previewer window is created        |
+| `User TelescopePickerClose`     | Do it before Telescope picker is closed (for any reason) |
+| `User TelescopeResumePost`      | Do it after Telescope resume action is fully completed   |
 
 ## Extensions
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -139,6 +139,12 @@ local function default_create_layout(picker)
       end
       vim.schedule(function()
         utils.buf_delete(self.prompt.bufnr)
+        vim.api.nvim_exec_autocmds("User", {
+          pattern = "TelescopePickerClose",
+          data = {
+            prompt_bufnr = self.prompt.bufnr,
+          },
+        })
       end)
     end,
     ---@param self TelescopeLayout


### PR DESCRIPTION
# Description

Add a new user autocommand when the picker is closed.

I couldn't find a way to get notified when the telescope picker is closed because the picker "lost focus", in other words the user switched to another window.

I need this feature to fix: https://github.com/stevearc/dressing.nvim/issues/150

In that case we need to invoke some code when the picker is closed, for any reason whatsoever. Currently dressing.nvim is broken if the user closes the picker by jumping to another window.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] open telescope, close it by jumping to another window, the autocommand is invoked.
- [x] open telescope, close it by pressing escape, the autocommand is invoked.
- [x] open telescope, close it by accepting the selected entry (enter), the autocommand is invoked.

**Configuration**:
* Neovim version (nvim --version): 0.10.0
* Operating system and version: linux fedora 40

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
