### PR TITLE
fix(action.delete_buffer): enhance behavior with splits

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -462,7 +462,6 @@ actions.edit_register = function(prompt_bufnr)
       v.content = updated_value
     end
   end
-  -- print(vim.inspect(picker.finder.results))
 end
 
 --- Paste the selected register into the buffer
@@ -1184,13 +1183,28 @@ actions.delete_buffer = function(prompt_bufnr)
     -- If the current buffer is deleted, switch to the previous buffer
     -- according to bdelete behavior
     if ok and selection.bufnr == current_picker.original_bufnr then
-      local jumplist = vim.fn.getjumplist(current_picker.original_win_id)[1]
-      for i = #jumplist, 1, -1 do
-        if jumplist[i].bufnr ~= selection.bufnr and vim.fn.bufloaded(jumplist[i].bufnr) == 1 then
-          vim.api.nvim_win_set_buf(current_picker.original_win_id, jumplist[i].bufnr)
-          break
+      if vim.api.nvim_win_is_valid(current_picker.original_win_id) then
+        local jumplist = vim.fn.getjumplist(current_picker.original_win_id)[1]
+        for i = #jumplist, 1, -1 do
+          if jumplist[i].bufnr ~= selection.bufnr and vim.fn.bufloaded(jumplist[i].bufnr) == 1 then
+            vim.api.nvim_win_set_buf(current_picker.original_win_id, jumplist[i].bufnr)
+            current_picker.original_bufnr = jumplist[i].bufnr
+            return ok
+          end
         end
+
+        -- no more valid buffers in jumplist, create an empty buffer
+        local empty_buf = vim.api.nvim_create_buf(true, true)
+        vim.api.nvim_win_set_buf(current_picker.original_win_id, empty_buf)
+        current_picker.original_bufnr = empty_buf
+        vim.api.nvim_buf_delete(selection.bufnr, { force = true })
+        return ok
       end
+
+      -- window of the selected buffer got wiped, switch to first valid window
+      local win_id = vim.fn.win_getid(1, current_picker.original_tabpage)
+      current_picker.original_win_id = win_id
+      current_picker.original_bufnr = vim.api.nvim_win_get_buf(win_id)
     end
     return ok
   end)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -537,6 +537,7 @@ function Picker:find()
 
   self.original_bufnr = a.nvim_get_current_buf()
   self.original_win_id = a.nvim_get_current_win()
+  self.original_tabpage = a.nvim_get_current_tabpage()
   _, self.original_cword = pcall(vim.fn.expand, "<cword>")
   _, self.original_cWORD = pcall(vim.fn.expand, "<cWORD>")
   _, self.original_cfile = pcall(vim.fn.expand, "<cfile>")


### PR DESCRIPTION
Previously, when having window splits, with deleting a buffer involving deleting a window, getting the jumplist for said deleted window would result in an invalid jumplist. Trying to iterate over this invalid jumplist would error out.

When there are split, there's no need to find a valid buffer to switch the current window to (as the window is deleted). Instead, what's needed is the updating of telescope's `picker.original_win_id` state. This is important for when chaining buffer deletes (ie. closing many splits).

Also improve behavior when the "current" buffer is the only valid buffer -> it will now open an empty buffer (same as when doing `:bdelete`).


closes https://github.com/nvim-telescope/telescope.nvim/issues/3193

