### PR TITLE
feat(pickers): default attach_mappings for all pickers

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -728,6 +728,15 @@ append(
 )
 
 append(
+  "attach_mappings",
+  nil,
+  [[
+    Defines the `attach_mappings` function that will be used as default for all pickers
+    If you define `attach_mappings` on specific picker, that'll be used instead.
+    Default: nil ]]
+)
+
+append(
   "use_less",
   true,
   [[

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1535,8 +1535,10 @@ end
 ---@return Picker
 pickers.new = function(opts, defaults)
   opts = opts or {}
+  opts.attach_mappings = opts.attach_mappings or config.values.attach_mappings
   defaults = defaults or {}
   local result = {}
+  -- Inspect(opts)
 
   for k, v in pairs(opts) do
     assert(type(k) == "string" or type(k) == "number", "Should be string or number, found: " .. type(k))


### PR DESCRIPTION
# Description

Allows `attach_mappings` function to be defined in ``telescope.defaults`` that will be used as default for all pickers
If you define `attach_mappings` on specific picker, that'll be used instead. 

Use case is that it was needed to perform some operations using ``prompt_bufnr`` as soon as the picker started.
It was ideal to perform that for all pickers and just override when necessary, but saw no way of doing that.
Example: 

```lua
-- Defaulting to turn off winbleding specifically on the prompt window, (everything else was on windblend 20)
      ...
      defaults = {

        attach_mappings = function(prompt_bufnr, map)
          local prompt_win = vim.fn.bufwinid(prompt_bufnr)
          if prompt_win ~= -1 then
            vim.schedule(function()
              vim.api.nvim_win_set_option(prompt_win, 'winblend', 0) -- Set the desired winblend for the prompt window
            end)
          end
          return true
        end,
      }
      ...
        
```

# Testing
Should see 'We are balling' when a picker is opened.
```lua
require('telescope').setup {
  defaults = {
    attach_mappings = function(prompt_bufnr, map)
      local prompt_win = vim.fn.bufwinid(prompt_bufnr)
      if prompt_win ~= -1 then
        vim.schedule(function()
          print 'We are balling'
        end)
      end
      return true
    end,
  },
}
```

