### PR TITLE
fix(edit action): update jumlist when moving in same file

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -220,6 +220,9 @@ action_set.edit = function(prompt_bufnr, command)
   end
 
   if row and col then
+    if vim.api.nvim_buf_get_name(0) == filename then
+      vim.cmd [[normal! m']]
+    end
     local ok, err_msg = pcall(a.nvim_win_set_cursor, 0, { row, col })
     if not ok then
       log.debug("Failed to move to cursor:", err_msg, row, col)


### PR DESCRIPTION
C-o behaves unintuitively when same file is selected at diffrent position.

# Description

Jumplist is not updated when moving to different position in same file. 

When absolute paths are used in entry maker it causes `:edit` to be skipped for same file.
Check here -
https://github.com/nvim-telescope/telescope.nvim/blob/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a/lua/telescope/actions/set.lua#L198

Since `:edit` is skipped, jumplist is not updated. 

This patch updates jumplist when moving to diff position in same file

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- tested with

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.10.0
Build type: Release
LuaJIT 2.1.1713484068
Run "nvim -V1 -v" for more info
```
* Operating system and version:
Fedora 40

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
