### PR TITLE
feat: support devicons in lsp_references picker

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -457,6 +457,8 @@ function make_entry.gen_from_quickfix(opts)
 
   local hidden = utils.is_path_hidden(opts)
 
+  local disable_devicons = opts.disable_devicons
+
   local make_display = function(entry)
     local display_filename, path_style = utils.transform_path(opts, entry.filename)
     local display_string = string.format("%s:%d:%d", display_filename, entry.lnum, entry.col)
@@ -473,7 +475,16 @@ function make_entry.gen_from_quickfix(opts)
       display_string = display_string .. ":" .. text
     end
 
-    return display_string, path_style
+    local hl_group, icon
+    display_string, hl_group, icon = utils.transform_devicons(entry.filename, display_string, disable_devicons)
+
+    if hl_group then
+      local style = { { { 0, #icon + 1 }, hl_group } }
+      style = utils.merge_styles(style, path_style, #icon + 1)
+      return display_string, style
+    else
+      return display_string, path_style
+    end
   end
 
   local get_filename = get_filename_fn()


### PR DESCRIPTION
# Description

Support devicons in lsp_references picker.

Fixes #3086

## Type of change

- New feature (non-breaking change which adds functionality)

# Test

```
:Telescope lsp_references<CR>
```

<img width="2025" alt="Screenshot 2024-07-15 at 14 31 38" src="https://github.com/user-attachments/assets/5a784443-45c9-470c-8d1d-f5e9cb3fa03d">

**Configuration**:
* Neovim version (nvim --version): `NVIM v0.9.5`
* Operating system and version: `macOS 14.4.1`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
