### PR TITLE
Mention default value of `follow` option for `find_files`

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -933,7 +933,8 @@ builtin.find_files({opts})                    *telescope.builtin.find_files()*
                                                 `find_command`
         {follow}              (boolean)         if true, follows symlinks
                                                 (i.e. uses `-L` flag for the
-                                                `find` command)
+                                                `find` command) (default:
+                                                false)
         {hidden}              (boolean)         determines whether to show
                                                 hidden files or not (default:
                                                 false)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -77,7 +77,7 @@ builtin.grep_string = require_on_exported_call("telescope.builtin.__files").grep
 ---@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
 ---@field find_command function|table: cmd to use for the search. Can be a fn(opts) -> tbl (default: autodetect)
 ---@field file_entry_encoding string: encoding of output of `find_command`
----@field follow boolean: if true, follows symlinks (i.e. uses `-L` flag for the `find` command)
+---@field follow boolean: if true, follows symlinks (i.e. uses `-L` flag for the `find` command) (default: false)
 ---@field hidden boolean: determines whether to show hidden files or not (default: false)
 ---@field no_ignore boolean: show files ignored by .gitignore, .ignore, etc. (default: false)
 ---@field no_ignore_parent boolean: show files ignored by .gitignore, .ignore, etc. in parent dirs. (default: false)


### PR DESCRIPTION
# Description

https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/builtin/__files.lua#L298

It seems the default value is `false`, and unlike other options, the default value of `follow` option is not mentioned.

## Type of change

Documentation improvement.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
