### PR TITLE
Fetch results from multiple LSPs

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -184,7 +184,7 @@ local function list_or_jump_all(action, title, funname, params, opts)
     for client_id, result_or_error in pairs(results_per_client) do
       local error, result = result_or_error.error, result_or_error.result
       if error then
-        vim.api.nvim_err_writeln("Error when executing " .. action .. " : " .. err.message)
+        vim.api.nvim_err_writeln("Error when executing " .. action .. " : " .. error.message)
         return
       end
 

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -173,6 +173,97 @@ end
 ---@param funname string: name of the calling function
 ---@param params lsp.TextDocumentPositionParams
 ---@param opts table
+local function list_or_jump_all(action, title, funname, params, opts)
+  opts.reuse_win = vim.F.if_nil(opts.reuse_win, false)
+  opts.curr_filepath = vim.api.nvim_buf_get_name(opts.bufnr)
+
+  vim.lsp.buf_request_all(opts.bufnr, action, params, function(results_per_client)
+    local items = {}
+    local first_encoding
+
+    for client_id, result_or_error in pairs(results_per_client) do
+      local error, result = result_or_error.error, result_or_error.result
+      if error then
+        vim.api.nvim_err_writeln("Error when executing " .. action .. " : " .. err.message)
+        return
+      end
+
+      if result == nil then
+        return
+      end
+
+      local locations = {}
+
+      if not utils.islist(result) then
+        vim.list_extend(locations, { result })
+      else
+        vim.list_extend(locations, result)
+      end
+
+      local offset_encoding = vim.lsp.get_client_by_id(client_id).offset_encoding
+
+      if not vim.tbl_isempty(result) then
+        first_encoding = offset_encoding
+      end
+
+      vim.list_extend(items, vim.lsp.util.locations_to_items(locations, offset_encoding))
+    end
+
+    items = apply_action_handler(action, items, opts)
+    items = filter_file_ignore_patters(items, opts)
+
+    if vim.tbl_isempty(items) then
+      utils.notify(funname, {
+        msg = string.format("No %s found", title),
+        level = "INFO",
+      })
+      return
+    end
+
+    if #items == 1 and opts.jump_type ~= "never" then
+      local item = items[1]
+      if opts.curr_filepath ~= item.filename then
+        local cmd
+        if opts.jump_type == "tab" then
+          cmd = "tabedit"
+        elseif opts.jump_type == "split" then
+          cmd = "new"
+        elseif opts.jump_type == "vsplit" then
+          cmd = "vnew"
+        elseif opts.jump_type == "tab drop" then
+          cmd = "tab drop"
+        end
+
+        if cmd then
+          vim.cmd(string.format("%s %s", cmd, item.filename))
+        end
+      end
+
+      local location = item_to_location(item, first_encoding)
+      vim.lsp.util.jump_to_location(location, first_encoding, opts.reuse_win)
+    else
+      pickers
+          .new(opts, {
+            prompt_title = title,
+            finder = finders.new_table {
+              results = items,
+              entry_maker = opts.entry_maker or make_entry.gen_from_quickfix(opts),
+            },
+            previewer = conf.qflist_previewer(opts),
+            sorter = conf.generic_sorter(opts),
+            push_cursor_on_edit = true,
+            push_tagstack_on_edit = true,
+          })
+          :find()
+    end
+  end)
+end
+
+---@param action telescope.lsp.list_or_jump_action
+---@param title string prompt title
+---@param funname string: name of the calling function
+---@param params lsp.TextDocumentPositionParams
+---@param opts table
 local function list_or_jump(action, title, funname, params, opts)
   opts.reuse_win = vim.F.if_nil(opts.reuse_win, false)
   opts.curr_filepath = vim.api.nvim_buf_get_name(opts.bufnr)
@@ -249,17 +340,17 @@ lsp.references = function(opts)
   opts.include_current_line = vim.F.if_nil(opts.include_current_line, false)
   local params = vim.lsp.util.make_position_params(opts.winnr)
   params.context = { includeDeclaration = vim.F.if_nil(opts.include_declaration, true) }
-  return list_or_jump("textDocument/references", "LSP References", "builtin.lsp_references", params, opts)
+  return list_or_jump_all("textDocument/references", "LSP References", "builtin.lsp_references", params, opts)
 end
 
 lsp.definitions = function(opts)
   local params = vim.lsp.util.make_position_params(opts.winnr)
-  return list_or_jump("textDocument/definition", "LSP Definitions", "builtin.lsp_definitions", params, opts)
+  return list_or_jump_all("textDocument/definition", "LSP Definitions", "builtin.lsp_definitions", params, opts)
 end
 
 lsp.type_definitions = function(opts)
   local params = vim.lsp.util.make_position_params(opts.winnr)
-  return list_or_jump(
+  return list_or_jump_all(
     "textDocument/typeDefinition",
     "LSP Type Definitions",
     "builtin.lsp_type_definitions",
@@ -270,7 +361,8 @@ end
 
 lsp.implementations = function(opts)
   local params = vim.lsp.util.make_position_params(opts.winnr)
-  return list_or_jump("textDocument/implementation", "LSP Implementations", "builtin.lsp_implementations", params, opts)
+  return list_or_jump_all("textDocument/implementation", "LSP Implementations", "builtin.lsp_implementations", params,
+    opts)
 end
 
 local symbols_sorter = function(symbols)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

Fixes https://github.com/nvim-telescope/telescope.nvim/pull/2342

Right now, when you have two LSPs connected to one buffer and you want to, let's say, go to a definition, there's a race condition / non-deterministic behavior in which Telescope uses the answer of the first LSP that responds

As an example (and the actual reason for me submitting this change), if you have a ruby application that uses sorbet, and you're running the Sorbet LSP and RubyLSP for the same buffer (which is pretty useful), what you'll see for `telescope.builtin.lsp_definitions` will be:

![Kapture 2024-07-18 at 12 32 12](https://github.com/user-attachments/assets/6c4c298a-0018-4395-8669-ef1239bc4163)

The first two times, it used the locations from RubyLSP, and the third one from Sorbet

With this change applied, this is what happens:

![Kapture 2024-07-18 at 12 36 46](https://github.com/user-attachments/assets/b9d91be3-9dc7-4d5d-8227-d09f45404b1e)

You've got all the results from both LSPs consistently

This leaves us with the issue of what happens if both LSPs returning overlapping locations, so deduplication could be in order
But since this isn't my case and I suspect not a lot of people use multiple LSPs that return the same stuff, I prefer to get your feedback first and maybe implement it later

Also, we should probably remove the `list_or_jump` implementation since this makes it obsolete I think, but again, I prefer to get feedback first

Apologies if the code is not up to standard, I'm a complete Lua illiterate

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually, as my knowledge of lua is very limited and mostly learned by tinkering with neovim plugins and config

**Configuration**:
* Neovim version (nvim --version): v0.10.0
* Operating system and version: macOS 14.5 build 23F79

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
