### PR TITLE
fix(actions.insert_symbol): schedule to insert in correct position

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -488,7 +488,9 @@ end
 actions.insert_symbol = function(prompt_bufnr)
   local symbol = action_state.get_selected_entry().value[1]
   actions.close(prompt_bufnr)
-  vim.api.nvim_put({ symbol }, "", true, true)
+  vim.schedule(function()
+    vim.api.nvim_put({ symbol }, "", true, true)
+  end)
 end
 
 --- Insert a symbol into the current buffer and keeping the insert mode.


### PR DESCRIPTION
Cursor position stuff after closing picker should pretty much always be `vim.schedule`d.

related: https://github.com/nvim-telescope/telescope.nvim/pull/2850

closes #3217 