### PR TITLE
fix(current_buffer_fuzzy_find): push cursor on edit

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -567,13 +567,13 @@ files.current_buffer_fuzzy_find = function(opts)
 
           actions.close(prompt_bufnr)
           vim.schedule(function()
+            vim.cmd "normal! m'"
             vim.api.nvim_win_set_cursor(0, { selection.lnum, first_col })
           end)
         end)
 
         return true
       end,
-      push_cursor_on_edit = true,
     })
     :find()
 end


### PR DESCRIPTION
Setting `push_cursor_on_edit = true` wasn't actually doing anything as the picker replaces `select_default`.

Instead, call `normal! m'` manually in the replacement `select_default`.
