### PR TITLE
fix(builtin.builtin): schedule opening next picker

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -109,16 +109,18 @@ internal.builtin = function(opts)
           end
 
           actions.close(prompt_bufnr)
-          if string.match(selection.text, " : ") then
-            -- Call appropriate function from extensions
-            local split_string = vim.split(selection.text, " : ")
-            local ext = split_string[1]
-            local func = split_string[2]
-            require("telescope").extensions[ext][func](picker_opts)
-          else
-            -- Call appropriate telescope builtin
-            require("telescope.builtin")[selection.text](picker_opts)
-          end
+          vim.schedule(function()
+            if string.match(selection.text, " : ") then
+              -- Call appropriate function from extensions
+              local split_string = vim.split(selection.text, " : ")
+              local ext = split_string[1]
+              local func = split_string[2]
+              require("telescope").extensions[ext][func](picker_opts)
+            else
+              -- Call appropriate telescope builtin
+              require("telescope.builtin")[selection.text](picker_opts)
+            end
+          end)
         end)
         return true
       end,


### PR DESCRIPTION
Without scheduling, lots of vim state will be related to the builtin picker when the new picker is opened despite closing the builtin picker first and then opening a new picker.

This impacts state like `vim.fn.mode()`. If the builtin picker was closed in insert mode, the closing action _should_ put you back in normal mode. But without scheduling, the next picker is opened before it does. So doing `vim.fn.mode()` in the subsequent picker will tell you, you're still in insert mode. Typically, when chaining pickers, you want the pre-telescope state, making the transitions between pickers seemless.

closes #3217 
