### PR TITLE
Allow passing env to `new_termopen_previewer`

### DIFF
--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -90,13 +90,16 @@ end
 --- Additionally you can define:
 --- - `title` a static title for example "File Preview"
 --- - `dyn_title(self, entry)` a dynamic title function which gets called
+--- - `env` table: define environment variables to forward to the terminal
+---    process. Example:
+---   - `{ ['PAGER'] = '', ['MANWIDTH'] = 50 }`
 --- when config value `dynamic_preview_title = true`
 ---
 --- It's an easy way to get your first previewer going and it integrates well
 --- with `bat` and `less`. Providing out of the box scrolling if the command
 --- uses less.
 ---
---- Furthermore, it will forward all `config.set_env` environment variables to
+--- Furthermore, if `env` is not set, it will forward all `config.set_env` environment variables to
 --- that terminal process.
 previewers.new_termopen_previewer = term_previewer.new_termopen_previewer
 

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -202,7 +202,7 @@ previewers.new_termopen_previewer = function(opts)
 
       local term_opts = {
         cwd = opts.cwd or vim.loop.cwd(),
-        env = conf.set_env,
+        env = opts.env or conf.set_env,
       }
 
       local cmd = opts.get_command(entry, status)


### PR DESCRIPTION
# Description

I'm trying to use [difft](https://github.com/Wilfred/difftastic/tree/master) for a custom picker and regular git diff on another. 
Using the global `set_env` for telescope becomes too aggressive, just like in `utils.job_maker` I'd like to be able to pass `env` in the same format to do this: 

```lua

previewer = prev.new_termopen_previewer({
    title = "Difft preview",
    env = { ['GIT_EXTERNAL_DIFF'] = '~/.local/bin/difft' },
    get_command = function(entry)
        local merge_base = git.git_show_merge_base()
        return { "git", "diff", merge_base, entry.value }
    end
})
```

Since it's a term command, being able to pass custom envs seems appropriate, the implementation is trivial and similar to what's done in `utils.job_maker`.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- [x] Run with local build from main using `set_env = { GIT_EXTERNAL_DIFF = '~/.local/bin/difft' }`, see difft diff
- [x] Run with local build from main not using `set_env`, see regular diff
- [x] Run with local build with my changes using `set_env = { GIT_EXTERNAL_DIFF = '~/.local/bin/difft' }`, see difft diff
- [x] Run with local build with my changes not using `set_env`, see regular diff
- [x] Run with local build with my changes not using `set_env`, passing no opts, see regular diff
- [x] Run with local build with my changes not using `set_env`, passing `opts.env = { GIT_EXTERNAL_DIFF = '~/.local/bin/difft' }`, see difft diff

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.10.0
Build type: Release
LuaJIT 2.1.1716656478
```
* Operating system and version:
```
Linux 6.10.0-gentoo x86_64 GNU/Linux
```
# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)

## Ps.

Create draft to see if CI adds docs to my PR, reworks https://github.com/nvim-telescope/telescope.nvim/pull/3223

## Pps.

Any ideas on why the docs aren't changing?