### PR TITLE
Ensure terms close

### DIFF
--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -102,9 +102,6 @@ local get_maker = function(opts)
   return maker
 end
 
--- TODO: We shoudl make sure that all our terminals close all the way.
---          Otherwise it could be bad if they're just sitting around, waiting to be closed.
---          I don't think that's the problem, but it could be?
 previewers.new_termopen_previewer = function(opts)
   opts = opts or {}
 
@@ -192,7 +189,7 @@ previewers.new_termopen_previewer = function(opts)
 
     local prev_bufnr = get_bufnr_by_bufentry(self, entry)
     if prev_bufnr then
-      self.state.termopen_bufnr = prev_bufnr
+      set_bufnr(self, prev_bufnr)
       utils.win_set_buf_noautocmd(preview_winid, self.state.termopen_bufnr)
       self.state.termopen_id = term_ids[self.state.termopen_bufnr]
     else


### PR DESCRIPTION
# Description

In some cases terminals from `new_termopen_previewer` don't close.  I think I've figured why this happens, here's some repro steps

1. Run a termopen previewer that results in more than 1 preview with terminals running interactively
2. Select (don't enter) multiple of the choices, so that the previews load, then go back to one of the previous ones
3. Close telescope without picking a choice
4. Try to quit with :wqa

Results are that nvim complains about an open buffer and won't close. 

This is only noticable on things like `less` or `git` with a pager (in my testing).

This happens because `old_bufs` wasn't properly updated in the case that a selection was bade back to a previous buffer, 
if telescope is exited at that point, the terminal connected to the last buffer won't be closed on default teardown.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Repro before and after

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.10.0
Build type: Release
LuaJIT 2.1.1716656478
```
* Operating system and version:
`Linux 6.10.0-gentoo GNU/Linux`

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
