### PR TITLE
docs(previewer): term_preview `env` option

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -3855,13 +3855,16 @@ previewers.new_termopen_previewer() *telescope.previewers.new_termopen_previewer
     - `title` a static title for example "File Preview"
     - `dyn_title(self, entry)` a dynamic title function which gets called when
       config value `dynamic_preview_title = true`
+    - `env` table: define environment variables to forward to the terminal 
+      process. Example:
+      - `{ ['PAGER'] = '', ['MANWIDTH'] = 50 }`
 
     It's an easy way to get your first previewer going and it integrates well
     with `bat` and `less`. Providing out of the box scrolling if the command
     uses less.
 
-    Furthermore, it will forward all `config.set_env` environment variables to
-    that terminal process.
+    Furthermore, if `env` is not set, it will forward all `config.set_env`
+    environment variables to that terminal process.
 
 
 

--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -90,10 +90,10 @@ end
 --- Additionally you can define:
 --- - `title` a static title for example "File Preview"
 --- - `dyn_title(self, entry)` a dynamic title function which gets called
+--- when config value `dynamic_preview_title = true`
 --- - `env` table: define environment variables to forward to the terminal
 ---    process. Example:
 ---   - `{ ['PAGER'] = '', ['MANWIDTH'] = 50 }`
---- when config value `dynamic_preview_title = true`
 ---
 --- It's an easy way to get your first previewer going and it integrates well
 --- with `bat` and `less`. Providing out of the box scrolling if the command


### PR DESCRIPTION
for https://github.com/nvim-telescope/telescope.nvim/pull/3224

seems like docgen still not working for non-maintainers