### PR TITLE
docs: switch out docgen tool

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            url: https://github.com/neovim/neovim/releases/download/v0.9.5/nvim-linux64.tar.gz
+            url: https://github.com/neovim/neovim/releases/download/stable/nvim-linux-x86_64.tar.gz
     steps:
       - uses: actions/checkout@v6
       - run: date +%F > todays-date
@@ -33,16 +33,7 @@ jobs:
           }
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
-          git clone https://github.com/tjdevries/tree-sitter-lua ~/.local/share/nvim/site/pack/vendor/start/tree-sitter-lua
           ln -s $(pwd) ~/.local/share/nvim/site/pack/vendor/start
-
-      - name: Build parser
-        run: |
-          # We have to build the parser every single time to keep up with parser changes
-          cd ~/.local/share/nvim/site/pack/vendor/start/tree-sitter-lua
-          git checkout 86f74dfb69c570f0749b241f8f5489f8f50adbea
-          make dist
-          cd -
 
       - name: Generating docs
         run: |

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -1,4 +1,4 @@
-name: Generate docs
+name: Check docs
 
 on:
   pull_request:
@@ -8,51 +8,28 @@ on:
 
 jobs:
   build-sources:
-    name: Generate docs
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            url: https://github.com/neovim/neovim/releases/download/stable/nvim-linux-x86_64.tar.gz
+    name: Check docs
+    runs-on: ubuntu-latest
+    env:
+      NVIM_URL: https://github.com/neovim/neovim/releases/download/stable/nvim-linux-x86_64.tar.gz
+
     steps:
       - uses: actions/checkout@v6
-      - run: date +%F > todays-date
-      - name: Restore cache for today's nightly.
-        uses: actions/cache@v5
-        with:
-          path: _neovim
-          key: ${{ runner.os }}-${{ matrix.url }}-${{ hashFiles('todays-date') }}
 
       - name: Prepare
         run: |
           test -d _neovim || {
             mkdir -p _neovim
-            curl -sL ${{ matrix.url }} | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
+            curl -sL ${{ env.NVIM_URL }} | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
           }
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
           ln -s $(pwd) ~/.local/share/nvim/site/pack/vendor/start
 
-      - name: Generating docs
+      - name: Check docs
         run: |
           export PATH="${PWD}/_neovim/bin:${PATH}"
           export VIM="${PWD}/_neovim/share/nvim/runtime"
           nvim --version
           make docgen
-
-      # inspired by nvim-lspconfigs
-      - name: Update documentation
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMIT_MSG: |
-            [docgen] Update doc/telescope.txt
-            skip-checks: true
-        run: |
-          git config user.email "actions@github"
-          git config user.name "Github Actions"
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git add doc/
-          # Only commit and push if we have changes
-          git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin HEAD:${GITHUB_REF})
+          git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.deps
 build/
 doc/tags
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,65 +17,6 @@ If you're submitting a new feature, it is a good idea to create an issue first t
 
 To learn how we go about writing documentation for this project, keep reading below!
 
-## Documentation with treesitter
+## Documentation
 
-We are generating docs based on the tree sitter syntax tree. TJ wrote a grammar that includes the documentation in this syntax tree so we can do take this function header documentation and transform it into vim documentation. All documentation that is part of the returning module will be exported. For example:
-
-```lua
-local m = {}
-
---- Test Header
---@return 1: Returns always 1
-function m.a() -- or m:a()
-  return 1
-end
-
---- Documentation
-function m.__b() -- or m:__b()
-  return 2
-end
-
---- Documentation
-local c = function()
-  return 2
-end
-
-return m
-```
-
-This will export function `a` with header documentation and the return value. Module function `b` and local function `c` will not be exported.
-
-For a more in-depth look at how to write documentation take a look at this guide: [how to](https://github.com/tjdevries/tree-sitter-lua/blob/master/HOWTO.md)
-This guide contains all annotations and we will update it when we add new annotations.
-
-## What is missing?
-
-The docgen has some problems on which people can work. This would happen in [tree-sitter-lua](https://github.com/tjdevries/tree-sitter-lua) and documentation of some modules here.
-I would suggest we are documenting lua/telescope/builtin/init.lua rather than the files itself. We can use that init.lua file as "header" file, so we are not cluttering the other files.
-How to help out with documentation:
-
-## Auto-updates from CI
-
-The easy way would be:
-
-- write some docs
-- commit, push and create draft PR
-- wait a minute until the CI generates a new commit with the changes
-- Look at this commit and the changes
-- Modify documentation until its perfect. You can do `git commit --amend` and `git push --force` to remove the github ci commit again
-
-## Generate on your local machine
-
-The other option would be setting up <https://github.com/tjdevries/tree-sitter-lua>
-
-- Install Treesitter, either with package manager or with github release
-- Install plugin as usual
-- cd to plugin
-- `mkdir -p build parser` sadly those don't exist
-- `make build_parser`
-- `ln -s ../build/parser.so parser/lua.so` We need the shared object in parser/ so it gets picked up by neovim. Either copy or symbolic link
-- Make sure that nvim-treesitter lua parser is not installed and also delete the lua queries in that repository. `queries/lua/*`. If you are not doing that you will have a bad time!
-- cd into this project
-- Write doc
-- Run `make docgen`
-- Repeat last two steps
+The docs are generated from the code using emmylua annotations. To update them after making changes to the code, run `make docgen`. A "Check docs" workflow in CI ensures that the documentation matches any change to the code and its annotations.

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ lint:
 	luacheck lua/telescope
 
 docgen:
-	nvim --headless --noplugin -u scripts/minimal_init.vim -c "luafile ./scripts/gendocs.lua" -c 'qa'
+	nvim -l scripts/gendocs.lua

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,8 @@ test:
 lint:
 	luacheck lua/telescope
 
-docgen:
+.deps/docgen.nvim:
+	git clone --depth 1 --branch v1.0.1 https://github.com/jamestrew/docgen.nvim $@
+
+docgen: .deps/docgen.nvim
 	nvim -l scripts/gendocs.lua

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1,19 +1,19 @@
-================================================================================
-INTRODUCTION                                                    *telescope.nvim*
+==============================================================================
+INTRODUCTION                                                  *telescope.nvim*
 
 Telescope.nvim is a plugin for fuzzy finding and neovim. It helps you search,
 filter, find and pick things in Lua.
 
 Getting started with telescope:
-  1. Run `:checkhealth telescope` to make sure everything is installed.
-  2. Evaluate it is working with `:Telescope find_files` or `:lua
-     require("telescope.builtin").find_files()`
-  3. Put a `require("telescope").setup()` call somewhere in your neovim config.
-  4. Read |telescope.setup| to check what config keys are available and what
-     you can put inside the setup call
-  5. Read |telescope.builtin| to check which builtin pickers are offered and
-     what options these implement
-  6. Profit
+1. Run `:checkhealth telescope` to make sure everything is installed.
+2. Evaluate it is working with `:Telescope find_files` or
+   `:lua require("telescope.builtin").find_files()`
+3. Put a `require("telescope").setup()` call somewhere in your neovim config.
+4. Read |telescope.setup| to check what config keys are available and what you
+   can put inside the setup call
+5. Read |telescope.builtin| to check which builtin pickers are offered and
+   what options these implement
+6. Profit
 
 The below flow chart illustrates a simplified telescope architecture:
 ┌───────────────────────────────────────────────────────────┐
@@ -81,8 +81,7 @@ telescope.setup({opts})                                    *telescope.setup()*
     Setup function to be run by user. Configures the defaults, pickers and
     extensions of telescope.
 
-    Usage:
-    >
+    Usage: >lua
     require('telescope').setup{
       defaults = {
         -- Default configuration for telescope goes here:
@@ -107,7 +106,6 @@ telescope.setup({opts})                                    *telescope.setup()*
       }
     }
 <
-
 
     Valid keys for {opts.defaults}
 
@@ -750,58 +748,55 @@ telescope.setup({opts})                                    *telescope.setup()*
         Default: require("telescope.previewers").buffer_previewer_maker
 
     Parameters: ~
-        {opts} (table)  Configuration opts. Keys: defaults, pickers,
-                        extensions
-
+      • {opts}  (`table`) Configuration opts. Keys: defaults, pickers,
+                extensions
 
 telescope.load_extension({name})                  *telescope.load_extension()*
     Load an extension.
-    - Notes:
-      - Loading triggers ext setup via the config passed in |telescope.setup|
 
+    Note: ~
+      • Loading triggers ext setup via the config passed in |telescope.setup|
 
     Parameters: ~
-        {name} (string)  Name of the extension
-
+      • {name}  (`string`) Name of the extension
 
 telescope.register_extension({mod})           *telescope.register_extension()*
     Register an extension. To be used by plugin authors.
 
-
     Parameters: ~
-        {mod} (table)  Module
+      • {mod}  (`table`) Module
 
-
-telescope.extensions()                                *telescope.extensions()*
+telescope.extensions                                    *telescope.extensions*
     Use telescope.extensions to reference any extensions within your
     configuration.
     While the docs currently generate this as a function, it's actually a
     table. Sorry.
 
 
-
-
-================================================================================
-COMMAND                                                      *telescope.command*
+==============================================================================
+COMMAND                                                    *telescope.command*
 
 Telescope commands can be called through two apis, the lua api and the viml
 api.
 
 The lua api is the more direct way to interact with Telescope, as you directly
 call the lua functions that Telescope defines. It can be called in a lua file
-using commands like:
-`require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
+using commands like: >lua
+    require("telescope.builtin").find_files { hidden = true, layout_config = { prompt_position = "top" } }
+<
 If you want to use this api from a vim file you should prepend `lua` to the
-command, as below:
-`lua require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
+command, as below: >vim
+    lua require("telescope.builtin").find_files { hidden = true, layout_config = { prompt_position = "top" } }
+<
 If you want to use this api from a neovim command line you should prepend
-`:lua` to the command, as below:
-`:lua require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
-
+`:lua` to the command, as below: >vim
+    :lua require("telescope.builtin").find_files { hidden = true, layout_config = { prompt_position = "top" } }
+<
 The viml api is more indirect, as first the command must be parsed to the
 relevant lua equivalent, which brings some limitations. The viml api can be
-called using commands like:
-`:Telescope find_files hidden=true layout_config={"prompt_position":"top"}`
+called using commands like: >vim
+    :Telescope find_files hidden=true layout_config={"prompt_position":"top"}
+<
 This involves setting options using an `=` and using viml syntax for lists and
 dictionaries when the corresponding lua function requires a table.
 
@@ -810,1100 +805,863 @@ options. For example, if you want to use the `cwd` option for `find_files` to
 specify that you only want to search within the folder `/foo bar/subfolder/`
 you could not do that using the viml api, as the path name contains a space.
 Similarly, you could NOT set the `prompt_position` to `"top"` using the
-following command:
-`:Telescope find_files layout_config={ "prompt_position" : "top" }`
+following command: >vim
+    :Telescope find_files layout_config={ "prompt_position" : "top" }
+<
 as there are spaces in the option.
 
-
-
-================================================================================
-BUILTIN                                                      *telescope.builtin*
+==============================================================================
+BUILTIN                                                    *telescope.builtin*
 
 Telescope Builtins is a collection of community maintained pickers to support
 common workflows. It can be used as reference when writing PRs, Telescope
-extensions, your own custom pickers, or just as a discovery tool for all of the
-amazing pickers already shipped with Telescope!
+extensions, your own custom pickers, or just as a discovery tool for all of
+the amazing pickers already shipped with Telescope!
 
-Any of these functions can just be called directly by doing:
-
-:lua require('telescope.builtin').$NAME_OF_PICKER()
-
+Any of these functions can just be called directly by doing: >vim
+    :lua require('telescope.builtin').$NAME_OF_PICKER()
+<
 To use any of Telescope's default options or any picker-specific options, call
 your desired picker by passing a lua table to the picker with all of the
-options you want to use. Here's an example with the live_grep picker:
-
->
-  :lua require('telescope.builtin').live_grep({
-    prompt_title = 'find string in open buffers...',
-    grep_open_files = true
-  })
-  -- or with dropdown theme
-  :lua require('telescope.builtin').find_files(require('telescope.themes').get_dropdown{
-    previewer = false
-  })
+options you want to use. Here's an example with the live_grep picker: >lua
+    require('telescope.builtin').live_grep({
+      prompt_title = 'find string in open buffers...',
+      grep_open_files = true
+    })
+    -- or with dropdown theme
+    require("telescope.builtin").find_files(
+      require("telescope.themes").get_dropdown { previewer = false }
+    )
 <
 
 builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
     Search for a string and get results live as you type, respects .gitignore
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}                 (string)          root dir to search from
-                                                (default: cwd, use
-                                                utils.buffer_dir() to search
-                                                relative to open buffer)
-        {grep_open_files}     (boolean)         if true, restrict search to
-                                                open files only, mutually
-                                                exclusive with `search_dirs`
-        {search_dirs}         (table)           directory/directories/files to
-                                                search, mutually exclusive
-                                                with `grep_open_files`
-        {glob_pattern}        (string|table)    argument to be used with
-                                                `--glob`, e.g. "*.toml", can
-                                                use the opposite "!*.toml"
-        {type_filter}         (string)          argument to be used with
-                                                `--type`, e.g. "rust", see `rg
-                                                --type-list`
-        {additional_args}     (function|table)  additional arguments to be
-                                                passed on. Can be fn(opts) ->
-                                                tbl
-        {max_results}         (number)          define a upper result value
-        {disable_coordinates} (boolean)         don't show the line & row
-                                                numbers (default: false)
-        {show_line}           (boolean)         if true, shows the content of
-                                                the line in the picker
-                                                (default: true)
-        {file_encoding}       (string)          file encoding for the entry &
-                                                previewer
-        {hidden}              (boolean)         if true, hidden directories
-                                                and files will be searched
-                                                (default: false)
-
+      • {opts}  (`table?`)
+                • {cwd}? (`string`, default: cwd, use utils.buffer_dir() to
+                  search relative to open buffer) root dir to search from
+                • {grep_open_files}? (`boolean`) if true, restrict search to
+                  open files only, mutually exclusive with `search_dirs`
+                • {search_dirs}? (`table`) directory/directories/files to
+                  search, mutually exclusive with `grep_open_files`
+                • {glob_pattern}? (`string|string[]`) argument to be used with
+                  `--glob`, e.g. `*.toml`, can use the opposite `!*.toml`
+                • {type_filter}? (`string`) argument to be used with `--type`,
+                  e.g. "rust", see `rg --type-list`
+                • {additional_args}? (`(fun(opts: table): string[])|table`)
+                  additional arguments to be passed on.
+                • {disable_coordinates}? (`boolean`, default: `false`) don't
+                  show the line & row numbers
+                • {file_encoding}? (`string`) file encoding for the entry &
+                  previewer
 
 builtin.grep_string({opts})                  *telescope.builtin.grep_string()*
     Searches for the string under your cursor or the visual selection in your
     current working directory
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}                 (string)          root dir to search from
-                                                (default: cwd, use
-                                                utils.buffer_dir() to search
-                                                relative to open buffer)
-        {search}              (string)          the query to search
-        {grep_open_files}     (boolean)         if true, restrict search to
-                                                open files only, mutually
-                                                exclusive with `search_dirs`
-        {search_dirs}         (table)           directory/directories/files to
-                                                search, mutually exclusive
-                                                with `grep_open_files`
-        {use_regex}           (boolean)         if true, special characters
-                                                won't be escaped, allows for
-                                                using regex (default: false)
-        {word_match}          (string)          can be set to `-w` to enable
-                                                exact word matches
-        {additional_args}     (function|table)  additional arguments to be
-                                                passed on. Can be fn(opts) ->
-                                                tbl
-        {disable_coordinates} (boolean)         don't show the line and row
-                                                numbers (default: false)
-        {show_line}           (boolean)         if true, shows the content of
-                                                the line in the picker
-                                                (default: true)
-        {only_sort_text}      (boolean)         only sort the text, not the
-                                                file, line or row (default:
-                                                false)
-        {file_encoding}       (string)          file encoding for the entry &
-                                                previewer
-        {hidden}              (boolean)         if true, hidden directories
-                                                and files will be searched
-                                                (default: false)
-
+      • {opts}  (`table?`)
+                • {cwd}? (`string`, default: cwd, use utils.buffer_dir() to
+                  search relative to open buffer) root dir to search from
+                • {search}? (`string`) the query to search
+                • {grep_open_files}? (`boolean`) if true, restrict search to
+                  open files only, mutually exclusive with `search_dirs`
+                • {search_dirs}? (`table`) directory/directories/files to
+                  search, mutually exclusive with `grep_open_files`
+                • {use_regex}? (`boolean`, default: `false`) if true, special
+                  characters won't be escaped, allows for using regex
+                • {word_match}? (`string`) can be set to `-w` to enable exact
+                  word matches
+                • {additional_args}? (`(fun(opts: table): string[])|table`)
+                  additional arguments to be passed on.
+                • {disable_coordinates}? (`boolean`, default: `false`) don't
+                  show the line and row numbers
+                • {only_sort_text}? (`boolean`, default: `false`) only sort
+                  the text, not the file, line or row
+                • {file_encoding}? (`string`) file encoding for the entry &
+                  previewer
 
 builtin.find_files({opts})                    *telescope.builtin.find_files()*
     Search for files (respecting .gitignore)
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+      • {opts}  (`table?`)
+                • {cwd}? (`string`, default: cwd, use utils.buffer_dir() to
+                  search relative to open buffer) root dir to search from
+                • {find_command}? (`function|table`, default: autodetect) cmd
+                  to use for the search. Can be a fn(opts) -> tbl
+                • {file_entry_encoding}? (`string`) encoding of output of
+                  `find_command`
+                • {follow}? (`boolean`, default: `false`) if true, follows
+                  symlinks (i.e. uses `-L` flag for the `find` command)
+                • {hidden}? (`boolean`, default: `false`) determines whether
+                  to show hidden files or not
+                • {no_ignore}? (`boolean`, default: `false`) show files
+                  ignored by .gitignore, .ignore, etc.
+                • {no_ignore_parent}? (`boolean`, default: `false`) show files
+                  ignored by .gitignore, .ignore, etc. in parent dirs.
+                • {search_dirs}? (`table`) directory/directories/files to
+                  search
+                • {search_file}? (`string`) specify a filename to search for
+                • {file_encoding}? (`string`) file encoding for the previewer
 
-    Options: ~
-        {cwd}                 (string)          root dir to search from
-                                                (default: cwd, use
-                                                utils.buffer_dir() to search
-                                                relative to open buffer)
-        {find_command}        (function|table)  cmd to use for the search. Can
-                                                be a fn(opts) -> tbl (default:
-                                                autodetect)
-        {file_entry_encoding} (string)          encoding of output of
-                                                `find_command`
-        {follow}              (boolean)         if true, follows symlinks
-                                                (i.e. uses `-L` flag for the
-                                                `find` command) (default:
-                                                false)
-        {hidden}              (boolean)         determines whether to show
-                                                hidden files or not (default:
-                                                false)
-        {no_ignore}           (boolean)         show files ignored by
-                                                .gitignore, .ignore, etc.
-                                                (default: false)
-        {no_ignore_parent}    (boolean)         show files ignored by
-                                                .gitignore, .ignore, etc. in
-                                                parent dirs. (default: false)
-        {search_dirs}         (table)           directory/directories/files to
-                                                search
-        {search_file}         (string)          specify a filename to search
-                                                for
-        {file_encoding}       (string)          file encoding for the
-                                                previewer
-
-
-builtin.fd()                                          *telescope.builtin.fd()*
+builtin.fd                                              *telescope.builtin.fd*
     This is an alias for the `find_files` picker
 
-
-
-builtin.treesitter()                          *telescope.builtin.treesitter()*
+builtin.treesitter({opts})                    *telescope.builtin.treesitter()*
     Lists function names, variables, and other symbols from treesitter queries
-    - Default keymaps:
-      - `<C-l>`: show autocompletion menu to prefilter your query by kind of ts
-        node you want to see (i.e. `:var:`)
 
-
-    Options: ~
-        {show_line}         (boolean)       if true, shows the row:column that
-                                            the result is found at (default:
-                                            true)
-        {bufnr}             (number)        specify the buffer number where
-                                            treesitter should run. (default:
-                                            current buffer)
-        {symbol_width}      (number)        defines the width of the symbol
-                                            section (default: 25)
-        {symbols}           (string|table)  filter results by symbol kind(s)
-        {ignore_symbols}    (string|table)  list of symbols to ignore
-        {symbol_highlights} (table)         string -> string. Matches symbol
-                                            with hl_group
-        {file_encoding}     (string)        file encoding for the previewer
-
-
-builtin.current_buffer_fuzzy_find({opts}) *telescope.builtin.current_buffer_fuzzy_find()*
-    Live fuzzy search inside of the currently open buffer
-
+    Default keymaps:
+    • `<C-l>`: show autocompletion menu to prefilter your query by kind of ts
+      node you want to see (i.e. `:var:`)
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+      • {opts}  (`table?`)
+                • {show_line}? (`boolean`, default: `true`) if true, shows the
+                  row:column that the result is found at
+                • {bufnr}? (`number`, default: current buffer) specify the
+                  buffer number where treesitter should run.
+                • {symbol_width}? (`number`, default: `25`) defines the width
+                  of the symbol section
+                • {symbols}? (`string|table`) filter results by symbol kind(s)
+                • {ignore_symbols}? (`string|table`) list of symbols to ignore
+                • {symbol_highlights}? (`table`) string -> string. Matches
+                  symbol with hl_group
+                • {file_encoding}? (`string`) file encoding for the previewer
 
-    Options: ~
-        {skip_empty_lines} (boolean)  if true we don't display empty lines
-                                      (default: false)
-        {file_encoding}    (string)   file encoding for the previewer
+                               *telescope.builtin.current_buffer_fuzzy_find()*
+builtin.current_buffer_fuzzy_find({opts})
+    Live fuzzy search inside of the currently open buffer
 
+    Parameters: ~
+      • {opts}  (`table?`)
+                • {skip_empty_lines}? (`boolean`, default: `false`) if true we
+                  don't display empty lines
+                • {results_ts_highlight}? (`boolean`, default: `true`)
+                  highlight result entries with treesitter
+                • {file_encoding}? (`string`) file encoding for the previewer
 
 builtin.tags({opts})                                *telescope.builtin.tags()*
     Lists tags in current directory with tag location file preview (users are
     required to run ctags -R to generate tags or update when introducing new
     changes)
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+      • {opts}  (`table?`)
+                • {cwd}? (`string`, default: cwd, use utils.buffer_dir() to
+                  search relative to open buffer) root dir to search from
+                • {ctags_file}? (`string`) specify a particular ctags file to
+                  use
+                • {show_line}? (`boolean`, default: `true`) if true, shows the
+                  content of the line the tag is found on in the picker
+                • {show_kind}? (`boolean`, default: `true`) if true and kind
+                  info is available, show the kind of the tag
+                • {only_sort_tags}? (`boolean`, default: `false`) if true we
+                  will only sort tags
+                • {fname_width}? (`number`, default: `30`) defines the width
+                  of the filename section
 
-    Options: ~
-        {cwd}            (string)   root dir to search from (default: cwd, use
-                                    utils.buffer_dir() to search relative to
-                                    open buffer)
-        {ctags_file}     (string)   specify a particular ctags file to use
-        {show_line}      (boolean)  if true, shows the content of the line the
-                                    tag is found on in the picker (default:
-                                    true)
-        {show_kind}      (boolean)  if true and kind info is available, show
-                                    the kind of the tag (default: true)
-        {only_sort_tags} (boolean)  if true we will only sort tags (default:
-                                    false)
-        {fname_width}    (number)   defines the width of the filename section
-                                    (default: 30)
-
-
-builtin.current_buffer_tags({opts})  *telescope.builtin.current_buffer_tags()*
+                                     *telescope.builtin.current_buffer_tags()*
+builtin.current_buffer_tags({opts})
     Lists all of the tags for the currently open buffer, with a preview
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}            (string)   root dir to search from (default: cwd, use
-                                    utils.buffer_dir() to search relative to
-                                    open buffer)
-        {ctags_file}     (string)   specify a particular ctags file to use
-        {show_line}      (boolean)  if true, shows the content of the line the
-                                    tag is found on in the picker (default:
-                                    true)
-        {show_kind}      (boolean)  if true and kind info is available, show
-                                    the kind of the tag (default: true)
-        {only_sort_tags} (boolean)  if true we will only sort tags (default:
-                                    false)
-        {fname_width}    (number)   defines the width of the filename section
-                                    (default: 30)
-
+      • {opts}  (`table?`)
+                • {cwd}? (`string`, default: cwd, use utils.buffer_dir() to
+                  search relative to open buffer) root dir to search from
+                • {ctags_file}? (`string`) specify a particular ctags file to
+                  use
+                • {show_line}? (`boolean`, default: `true`) if true, shows the
+                  content of the line the tag is found on in the picker
+                • {show_kind}? (`boolean`, default: `true`) if true and kind
+                  info is available, show the kind of the tag
+                • {only_sort_tags}? (`boolean`, default: `false`) if true we
+                  will only sort tags
+                • {fname_width}? (`number`, default: `30`) defines the width
+                  of the filename section
 
 builtin.git_files({opts})                      *telescope.builtin.git_files()*
-    Fuzzy search for files tracked by Git. This command lists the output of the
-    `git ls-files` command, respects .gitignore
-    - Default keymaps:
-      - `<cr>`: opens the currently selected file
+    Fuzzy search for files tracked by Git. This command lists the output of
+    the `git ls-files` command, respects .gitignore
 
+    Default keymaps:
+    • `<cr>`: opens the currently selected file
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}                (string)   specify the path of the repo
-        {use_file_path}      (boolean)  if we should use the current buffer
-                                        git root (default: false)
-        {use_git_root}       (boolean)  if we should use git root as cwd or
-                                        the cwd (important for submodule)
-                                        (default: true)
-        {show_untracked}     (boolean)  if true, adds `--others` flag to
-                                        command and shows untracked files
-                                        (default: false)
-        {recurse_submodules} (boolean)  if true, adds the
-                                        `--recurse-submodules` flag to command
-                                        (default: false)
-        {git_command}        (table)    command that will be executed.
-                                        {"git","ls-files","--exclude-standard","--cached"}
-        {file_encoding}      (string)   file encoding for the previewer
-
+      • {opts}  (`table?`)
+                • {show_untracked}? (`boolean`, default: `false`) if true,
+                  adds `--others` flag to command and shows untracked files
+                • {recurse_submodules}? (`boolean`, default: `false`) if true,
+                  adds the `--recurse-submodules` flag to command
+                • {git_command}? (`table`, default:
+                  `{"git", "-c", "core.quotepath=false", "ls-files", "--exclude-standard", "--cached" }`)
+                  command that will be executed.
+                • {file_encoding}? (`string`) file encoding for the previewer
+                • {cwd}? (`string`) the path of the repo
+                • {use_file_path}? (`boolean`, default: `false`) if we should
+                  use the current buffer git root
+                • {use_git_root}? (`boolean`, default: `true`) if we should
+                  use git root as cwd or the cwd (important for submodule)
 
 builtin.git_commits({opts})                  *telescope.builtin.git_commits()*
     Lists commits for current directory with diff preview
-    - Default keymaps:
-      - `<cr>`: checks out the currently selected commit
-      - `<C-r>m`: resets current branch to selected commit using mixed mode
-      - `<C-r>s`: resets current branch to selected commit using soft mode
-      - `<C-r>h`: resets current branch to selected commit using hard mode
 
+    Default keymaps:
+    • `<cr>`: checks out the currently selected commit
+    • `<C-r>m`: resets current branch to selected commit using mixed mode
+    • `<C-r>s`: resets current branch to selected commit using soft mode
+    • `<C-r>h`: resets current branch to selected commit using hard mode
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}           (string)   specify the path of the repo
-        {use_file_path} (boolean)  if we should use the current buffer git
-                                   root (default: false)
-        {use_git_root}  (boolean)  if we should use git root as cwd or the cwd
-                                   (important for submodule) (default: true)
-        {git_command}   (table)    command that will be executed.
-                                   {"git","log","--pretty=oneline","--abbrev-commit","--","."}
-
+      • {opts}  (`table?`)
+                • {git_command}? (`table`, default:
+                  `{"git","log","--pretty=oneline","--abbrev-commit","--","."}`)
+                  command that will be executed.
+                • {cwd}? (`string`) the path of the repo
+                • {use_file_path}? (`boolean`, default: `false`) if we should
+                  use the current buffer git root
+                • {use_git_root}? (`boolean`, default: `true`) if we should
+                  use git root as cwd or the cwd (important for submodule)
 
 builtin.git_bcommits({opts})                *telescope.builtin.git_bcommits()*
     Lists commits for current buffer with diff preview
-    - Default keymaps or your overridden `select_` keys:
-      - `<cr>`: checks out the currently selected commit
-      - `<c-v>`: opens a diff in a vertical split
-      - `<c-x>`: opens a diff in a horizontal split
-      - `<c-t>`: opens a diff in a new tab
 
+    Default keymaps or your overridden `select_` keys:
+    • `<cr>`: checks out the currently selected commit
+    • `<c-v>`: opens a diff in a vertical split
+    • `<c-x>`: opens a diff in a horizontal split
+    • `<c-t>`: opens a diff in a new tab
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+      • {opts}  (`table?`)
+                • {current_file}? (`string`, default: current buffer) specify
+                  the current file that should be used for bcommits
+                • {git_command}? (`table`, default:
+                  `{"git","log","--pretty=oneline","--abbrev-commit"}`)
+                  command that will be executed.
+                • {cwd}? (`string`) the path of the repo
+                • {use_file_path}? (`boolean`, default: `false`) if we should
+                  use the current buffer git root
+                • {use_git_root}? (`boolean`, default: `true`) if we should
+                  use git root as cwd or the cwd (important for submodule)
 
-    Options: ~
-        {cwd}           (string)   specify the path of the repo
-        {use_file_path} (boolean)  if we should use the current buffer git
-                                   root (default: false)
-        {use_git_root}  (boolean)  if we should use git root as cwd or the cwd
-                                   (important for submodule) (default: true)
-        {current_file}  (string)   specify the current file that should be
-                                   used for bcommits (default: current buffer)
-        {git_command}   (table)    command that will be executed.
-                                   {"git","log","--pretty=oneline","--abbrev-commit"}
-
-
-builtin.git_bcommits_range({opts})    *telescope.builtin.git_bcommits_range()*
+                                      *telescope.builtin.git_bcommits_range()*
+builtin.git_bcommits_range({opts})
     Lists commits for a range of lines in the current buffer with diff preview
     In visual mode, lists commits for the selected lines With operator mode
     enabled, lists commits inside the text object/motion
-    - Default keymaps or your overridden `select_` keys:
-      - `<cr>`: checks out the currently selected commit
-      - `<c-v>`: opens a diff in a vertical split
-      - `<c-x>`: opens a diff in a horizontal split
-      - `<c-t>`: opens a diff in a new tab
 
+    Default keymaps or your overridden `select_` keys:
+    • `<cr>`: checks out the currently selected commit
+    • `<c-v>`: opens a diff in a vertical split
+    • `<c-x>`: opens a diff in a horizontal split
+    • `<c-t>`: opens a diff in a new tab
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}          (string)   specify the path of the repo
-        {use_git_root} (boolean)  if we should use git root as cwd or the cwd
-                                  (important for submodule) (default: true)
-        {current_file} (string)   specify the current file that should be used
-                                  for bcommits (default: current buffer)
-        {git_command}  (table)    command that will be executed. the last
-                                  element must be "-L".
-                                  {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
-        {from}         (number)   the first line number in the range (default:
-                                  current line)
-        {to}           (number)   the last line number in the range (default:
-                                  the value of `from`)
-        {operator}     (boolean)  select lines in operator-pending mode
-                                  (default: false)
-
+      • {opts}  (`table?`)
+                • {from}? (`number`, default: current line) the first line
+                  number in the range
+                • {to}? (`number`, default: the value of `from`) the last line
+                  number in the range
+                • {operator}? (`boolean`, default: `false`) select lines in
+                  operator-pending mode
+                • {current_file}? (`string`, default: current buffer) specify
+                  the current file that should be used for bcommits
+                • {git_command}? (`table`, default:
+                  `{"git","log","--pretty=oneline","--abbrev-commit"}`)
+                  command that will be executed.
+                • {cwd}? (`string`) the path of the repo
+                • {use_file_path}? (`boolean`, default: `false`) if we should
+                  use the current buffer git root
+                • {use_git_root}? (`boolean`, default: `true`) if we should
+                  use git root as cwd or the cwd (important for submodule)
 
 builtin.git_branches({opts})                *telescope.builtin.git_branches()*
     List branches for current directory, with output from `git log --oneline`
     shown in the preview window
-    - Default keymaps:
-      - `<cr>`: checks out the currently selected branch
-      - `<C-t>`: tracks currently selected branch
-      - `<C-r>`: rebases currently selected branch
-      - `<C-a>`: creates a new branch, with confirmation prompt before creation
-      - `<C-d>`: deletes the currently selected branch, with confirmation
-        prompt before deletion
-      - `<C-y>`: merges the currently selected branch, with confirmation prompt
-        before deletion
 
+    Default keymaps:
+    • `<cr>`: checks out the currently selected branch
+    • `<C-t>`: tracks currently selected branch
+    • `<C-r>`: rebases currently selected branch
+    • `<C-a>`: creates a new branch, with confirmation prompt before creation
+    • `<C-d>`: deletes the currently selected branch, with confirmation prompt
+      before deletion
+    • `<C-y>`: merges the currently selected branch, with confirmation prompt
+      before deletion
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}                           (string)   specify the path of the
-                                                   repo
-        {use_file_path}                 (boolean)  if we should use the
-                                                   current buffer git root
-                                                   (default: false)
-        {use_git_root}                  (boolean)  if we should use git root
-                                                   as cwd or the cwd
-                                                   (important for submodule)
-                                                   (default: true)
-        {show_remote_tracking_branches} (boolean)  show remote tracking
-                                                   branches like origin/main
-                                                   (default: true)
-        {pattern}                       (string)   specify the pattern to
-                                                   match all refs
-
+      • {opts}  (`table?`)
+                • {show_remote_tracking_branches}? (`boolean`, default:
+                  `true`) show remote tracking branches like origin/main
+                • {pattern}? (`string`) specify the pattern to match all refs
+                • {cwd}? (`string`) the path of the repo
+                • {use_file_path}? (`boolean`, default: `false`) if we should
+                  use the current buffer git root
+                • {use_git_root}? (`boolean`, default: `true`) if we should
+                  use git root as cwd or the cwd (important for submodule)
 
 builtin.git_status({opts})                    *telescope.builtin.git_status()*
     Lists git status for current directory
-    - Default keymaps:
-      - `<Tab>`: stages or unstages the currently selected file
-      - `<cr>`: opens the currently selected file
 
+    Default keymaps:
+    • `<Tab>`: stages or unstages the currently selected file
+    • `<cr>`: opens the currently selected file
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}           (string)   specify the path of the repo
-        {use_file_path} (boolean)  if we should use the current buffer git
-                                   root (default: false)
-        {use_git_root}  (boolean)  if we should use git root as cwd or the cwd
-                                   (important for submodule) (default: true)
-        {git_icons}     (table)    string -> string. Matches name with icon
-                                   (see source code, make_entry.lua
-                                   git_icon_defaults)
-        {expand_dir}    (boolean)  pass flag `-uall` to show files in
-                                   untracked directories (default: true)
-
+      • {opts}  (`table?`)
+                • {git_icons}? (`table`) string -> string. Matches name with
+                  icon (see source code, make_entry.lua git_icon_defaults)
+                • {expand_dir}? (`boolean`, default: `true`) pass flag `-uall`
+                  to show files in untracked directories
+                • {cwd}? (`string`) the path of the repo
+                • {use_file_path}? (`boolean`, default: `false`) if we should
+                  use the current buffer git root
+                • {use_git_root}? (`boolean`, default: `true`) if we should
+                  use git root as cwd or the cwd (important for submodule)
 
 builtin.git_stash({opts})                      *telescope.builtin.git_stash()*
     Lists stash items in current repository
-    - Default keymaps:
-      - `<cr>`: runs `git apply` for currently selected stash
 
+    Default keymaps:
+    • `<cr>`: runs `git apply` for currently selected stash
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}           (string)   specify the path of the repo
-        {use_file_path} (boolean)  if we should use the current buffer git
-                                   root (default: false)
-        {use_git_root}  (boolean)  if we should use git root as cwd or the cwd
-                                   (important for submodule) (default: true)
-        {show_branch}   (boolean)  if we should display the branch name for
-                                   git stash entries (default: true)
-
+      • {opts}  (`table?`) options to pass to the picker
 
 builtin.builtin({opts})                          *telescope.builtin.builtin()*
     Lists all of the community maintained pickers built into Telescope
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {include_extensions} (boolean)  if true will show the pickers of the
-                                        installed extensions (default: false)
-        {use_default_opts}   (boolean)  if the selected picker should use its
-                                        default options (default: false)
-
+      • {opts}  (`table?`)
+                • {include_extensions}? (`boolean`, default: `false`) if true
+                  will show the pickers of the installed extensions
+                • {use_default_opts}? (`boolean`, default: `false`) if the
+                  selected picker should use its default options
 
 builtin.resume({opts})                            *telescope.builtin.resume()*
     Opens the previous picker in the identical state (incl. multi selections)
-    - Notes:
-      - Requires `cache_picker` in setup or when having invoked pickers, see
+
+    Note: ~
+      • Requires `cache_picker` in setup or when having invoked pickers, see
         |telescope.defaults.cache_picker|
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cache_index} (number)  what picker to resume, where 1 denotes most
-                                recent (default: 1)
-
+      • {opts}  (`table?`)
+                • {cache_index}? (`number`, default: `1`) what picker to
+                  resume, where 1 denotes most recent
 
 builtin.pickers({opts})                          *telescope.builtin.pickers()*
     Opens a picker over previously cached pickers in their preserved states
     (incl. multi selections)
-    - Default keymaps:
-      - `<C-x>`: delete the selected cached picker
-    - Notes:
-      - Requires `cache_picker` in setup or when having invoked pickers, see
+
+    Default keymaps:
+    • `<C-x>`: delete the selected cached picker
+
+    Note: ~
+      • Requires `cache_picker` in setup or when having invoked pickers, see
         |telescope.defaults.cache_picker|
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
+      • {opts}  (`table?`)
 
 builtin.planets({opts})                          *telescope.builtin.planets()*
     Use the telescope...
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {show_pluto} (boolean)  we love Pluto (default: false, because its a
-                                hidden feature)
-        {show_moon}  (boolean)  we love the Moon (default: false, because its
-                                a hidden feature)
-
+      • {opts}  (`table?`)
+                • {show_pluto}? (`boolean`, default: `false`, because its a
+                  hidden feature) we love Pluto
+                • {show_moon}? (`boolean`, default: `false`, because its a
+                  hidden feature) we love the Moon
 
 builtin.symbols({opts})                          *telescope.builtin.symbols()*
     Lists symbols inside of `data/telescope-sources/*.json` found in your
     runtime path or found in `stdpath("data")/telescope/symbols/*.json`. The
-    second path can be customized. We provide a couple of default symbols which
-    can be found in https://github.com/nvim-telescope/telescope-symbols.nvim.
-    This repos README also provides more information about the format in which
-    the symbols have to be.
-
+    second path can be customized. We provide a couple of default symbols
+    which can be found in
+    https://github.com/nvim-telescope/telescope-symbols.nvim. This repos
+    README also provides more information about the format in which the
+    symbols have to be.
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {symbol_path} (string)  specify the second path. Default:
-                                `stdpath("data")/telescope/symbols/*.json`
-        {sources}     (table)   specify a table of sources you want to load
-                                this time
-
+      • {opts}  (`table?`)
+                • {symbol_path}? (`string`) specify the second path. Default:
+                  `stdpath("data")/telescope/symbols/*.json`
+                • {sources}? (`table`) specify a table of sources you want to
+                  load this time
 
 builtin.commands({opts})                        *telescope.builtin.commands()*
     Lists available plugin/user commands and runs them on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {show_buf_command} (boolean)  show buf local command (Default: true)
-
+      • {opts}  (`table?`)
+                • {show_buf_command}? (`boolean`, default: `true`) show buf
+                  local command
 
 builtin.quickfix({opts})                        *telescope.builtin.quickfix()*
-    Lists items in the current quickfix list, jumps to location on `<cr>`
-
+    Lists items in the quickfix list, jumps to location on `<cr>`
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {show_line} (boolean)  show results text (default: true)
-        {trim_text} (boolean)  trim results text (default: false)
-        {nr}        (number)   specify the quickfix list number
-
+      • {opts}  (`table?`)
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {trim_text}? (`boolean`, default: `false`) trim results text
+                • {nr}? (`number`) specify the quickfix list number
 
 builtin.quickfixhistory({opts})          *telescope.builtin.quickfixhistory()*
     Lists all quickfix lists in your history and open them with
-    `builtin.quickfix`. It seems that neovim only keeps the full history for 10
-    lists
-
+    `builtin.quickfix`. It seems that neovim only keeps the full history for
+    10 lists
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
+      • {opts}  (`table?`)
 
 builtin.loclist({opts})                          *telescope.builtin.loclist()*
     Lists items from the current window's location list, jumps to location on
     `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {show_line} (boolean)  show results text (default: true)
-        {trim_text} (boolean)  trim results text (default: false)
-
+      • {opts}  (`table?`)
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {trim_text}? (`boolean`, default: `false`) trim results text
 
 builtin.oldfiles({opts})                        *telescope.builtin.oldfiles()*
     Lists previously open files, opens on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}           (string)   specify a working directory to filter
-                                   oldfiles by
-        {only_cwd}      (boolean)  show only files in the cwd (default: false)
-        {cwd_only}      (boolean)  alias for only_cwd
-        {file_encoding} (string)   file encoding for the previewer
-
+      • {opts}  (`table?`)
+                • {cwd}? (`string`) specify a working directory to filter
+                  oldfiles by
+                • {only_cwd}? (`boolean`, default: `false`) show only files in
+                  the cwd
+                • {cwd_only}? (`boolean`) alias for only_cwd
+                • {file_encoding}? (`string`) file encoding for the previewer
 
 builtin.command_history({opts})          *telescope.builtin.command_history()*
     Lists commands that were executed recently, and reruns them on `<cr>`
-    - Default keymaps:
-      - `<C-e>`: open the command line with the text of the currently selected
-        result populated in it
 
+    Default keymaps:
+    • `<C-e>`: open the command line with the text of the currently selected
+      result populated in it
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {filter_fn} (function)  filter fn(cmd:string). true if the history
-                                command should be presented.
-
+      • {opts}  (`table?`)
+                • {filter_fn}? (`fun(cmd: string): boolean`) returns true if
+                  the history command should be presented.
 
 builtin.search_history({opts})            *telescope.builtin.search_history()*
     Lists searches that were executed recently, and reruns them on `<cr>`
-    - Default keymaps:
-      - `<C-e>`: open a search window with the text of the currently selected
-        search result populated in it
 
+    Default keymaps:
+    • `<C-e>`: open a search window with the text of the currently selected
+      search result populated in it
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
+      • {opts}  (`table?`)
 
 builtin.vim_options({opts})                  *telescope.builtin.vim_options()*
     Lists vim options, allows you to edit the current value on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
+      • {opts}  (`table?`)
 
 builtin.help_tags({opts})                      *telescope.builtin.help_tags()*
     Lists available help tags and opens a new window with the relevant help
     info on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {lang}     (string)   specify language (default: vim.o.helplang)
-        {fallback} (boolean)  fallback to en if language isn't installed
-                              (default: true)
-
+      • {opts}  (`table?`)
+                • {lang}? (`string`, default: `vim.o.helplang`) specify
+                  language
+                • {fallback}? (`boolean`, default: `true`) fallback to en if
+                  language isn't installed
 
 builtin.man_pages({opts})                      *telescope.builtin.man_pages()*
     Lists manpage entries, opens them in a help window on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {sections} (table)     a list of sections to search, use `{ "ALL" }`
-                               to search in all sections (default: { "1" })
-        {man_cmd}  (function)  that returns the man command. (Default:
-                               `apropos ""` on linux, `apropos " "` on macos)
-
+      • {opts}  (`table?`)
+                • {sections}? (`string[]`, default: `{ "1" }`) a list of
+                  sections to search, use `{ "ALL" }` to search in all
+                  sections
+                • {man_cmd}? (`function`, default: `apropos ""` on linux,
+                  `apropos " "` on macos) that returns the man command.
 
 builtin.reloader({opts})                        *telescope.builtin.reloader()*
     Lists lua modules and reloads them on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {column_len} (number)  define the max column len for the module name
-                               (default: dynamic, longest module name)
-
+      • {opts}  (`table?`)
+                • {column_len}? (`number`, default: dynamic, longest module
+                  name) define the max column len for the module name
 
 builtin.buffers({opts})                          *telescope.builtin.buffers()*
     Lists open buffers in current neovim instance, opens selected buffer on
     `<cr>`
-    - Default keymaps:
-      - `<M-d>`: delete the currently selected buffer
 
+    Default keymaps:
+    • `<M-d>`: delete the currently selected buffer
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {cwd}                   (string)    specify a working directory to
-                                            filter buffers list by
-        {show_all_buffers}      (boolean)   if true, show all buffers,
-                                            including unloaded buffers
-                                            (default: true)
-        {ignore_current_buffer} (boolean)   if true, don't show the current
-                                            buffer in the list (default:
-                                            false)
-        {only_cwd}              (boolean)   if true, only show buffers in the
-                                            current working directory
-                                            (default: false)
-        {cwd_only}              (boolean)   alias for only_cwd
-        {sort_lastused}         (boolean)   Sorts current and last buffer to
-                                            the top and selects the lastused
-                                            (default: false)
-        {sort_mru}              (boolean)   Sorts all buffers after most
-                                            recent used. Not just the current
-                                            and last one (default: false)
-        {bufnr_width}           (number)    Defines the width of the buffer
-                                            numbers in front of the filenames 
-                                            (default: dynamic)
-        {file_encoding}         (string)    file encoding for the previewer
-        {sort_buffers}          (function)  sort fn(bufnr_a, bufnr_b). true if
-                                            bufnr_a should go first. Runs
-                                            after sorting by most recent (if
-                                            specified)
-        {select_current}        (boolean)   select current buffer (default:
-                                            false)
-        {disable_coordinates}   (boolean)   don't show line number (default:
-                                            false)
-
+      • {opts}  (`table?`)
+                • {cwd}? (`string`) specify a working directory to filter
+                  buffers list by
+                • {show_all_buffers}? (`boolean`, default: `true`) if true,
+                  show all buffers, including unloaded buffers
+                • {ignore_current_buffer}? (`boolean`, default: `false`) if
+                  true, don't show the current buffer in the list
+                • {only_cwd}? (`boolean`, default: `false`) if true, only show
+                  buffers in the current working directory
+                • {cwd_only}? (`boolean`) alias for only_cwd
+                • {sort_lastused}? (`boolean`, default: `false`) Sorts current
+                  and last buffer to the top and selects the lastused
+                • {sort_mru}? (`boolean`, default: `false`) Sorts all buffers
+                  after most recent used. Not just the current and last one
+                • {bufnr_width}? (`number`, default: dynamic) Defines the
+                  width of the buffer numbers in front of the filenames
+                • {file_encoding}? (`string`) file encoding for the previewer
+                • {sort_buffers}? (`(fun(buf_a: number, buf_b: number):
+                  boolean)?`) sort fn(bufnr_a, bufnr_b). true if bufnr_a
+                  should go first. Runs after sorting by most recent (if
+                  specified)
+                • {select_current}? (`boolean`, default: `false`) select
+                  current buffer
 
 builtin.colorscheme({opts})                  *telescope.builtin.colorscheme()*
     Lists available colorschemes and applies them on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {colors}          (table)    a list of additional colorschemes to
-                                     explicitly make available to telescope
-                                     (default: {})
-        {enable_preview}  (boolean)  if true, will preview the selected color
-        {ignore_builtins} (boolean)  if true, builtin colorschemes are not
-                                     listed
-
+      • {opts}  (`table?`)
+                • {colors}? (`table`, default: `{}`) a list of additional
+                  colorschemes to explicitly make available to telescope
+                • {enable_preview}? (`boolean`) if true, will preview the
+                  selected color
+                • {ignore_builtins}? (`boolean`) if true, builtin colorschemes
+                  are not listed
 
 builtin.marks({opts})                              *telescope.builtin.marks()*
     Lists vim marks and their value, jumps to the mark on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {file_encoding} (string)  file encoding for the previewer
-        {mark_type}     (string)  filter marks by type (default: "all",
-                                  options: "all"|"global"|"local")
-
+      • {opts}  (`table?`)
+                • {file_encoding}? (`string`) file encoding for the previewer
+                • {mark_type}? (`"all"|"global"|"local"`, default: `"all"`)
+                  filter marks by type
 
 builtin.registers({opts})                      *telescope.builtin.registers()*
     Lists vim registers, pastes the contents of the register on `<cr>`
-    - Default keymaps:
-      - `<C-e>`: edit the contents of the currently selected register
 
+    Default keymaps:
+    • `<C-e>`: edit the contents of the currently selected register
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
+      • {opts}  (`table?`)
 
 builtin.keymaps({opts})                          *telescope.builtin.keymaps()*
     Lists normal mode keymappings, runs the selected keymap on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {modes}      (table)     a list of short-named keymap modes to search
-                                 (default: { "n", "i", "c", "x" })
-        {show_plug}  (boolean)   if true, the keymaps for which the lhs
-                                 contains "<Plug>" are also shown (default:
-                                 true)
-        {only_buf}   (boolean)   if true, only show the buffer-local keymaps
-                                 (default: false)
-        {lhs_filter} (function)  filter(lhs:string) -> boolean. true for
-                                 keymap.lhs if the keymap should be shown
-                                 (optional)
-        {filter}     (function)  filter(km:keymap) -> boolean. true for the
-                                 keymap if it should be shown (optional)
-
+      • {opts}  (`table?`)
+                • {modes}? (`table`, default: `{ "n", "i", "c", "x" }`) a list
+                  of short-named keymap modes to search
+                • {show_plug}? (`boolean`, default: `true`) if true, the
+                  keymaps for which the lhs contains `<Plug>` are also shown
+                • {only_buf}? (`boolean`, default: `false`) if true, only show
+                  the buffer-local keymaps
+                • {lhs_filter}? (`fun(lhs:string): boolean`) return true for
+                  keymap.lhs if the keymap should be shown
+                • {filter}? (`fun(keymap: table): boolean`) return true for
+                  the keymap if it should be shown
 
 builtin.filetypes({opts})                      *telescope.builtin.filetypes()*
     Lists all available filetypes, sets currently open buffer's filetype to
     selected filetype in Telescope on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
+      • {opts}  (`table?`)
 
 builtin.highlights({opts})                    *telescope.builtin.highlights()*
     Lists all available highlights
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
+      • {opts}  (`table?`)
 
 builtin.autocommands({opts})                *telescope.builtin.autocommands()*
     Lists vim autocommands and goes to their declaration on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
+      • {opts}  (`table?`)
 
 builtin.spell_suggest({opts})              *telescope.builtin.spell_suggest()*
     Lists spelling suggestions for the current word under the cursor, replaces
     word with selected suggestion on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
+      • {opts}  (`table?`)
 
 builtin.tagstack({opts})                        *telescope.builtin.tagstack()*
     Lists the tag stack for the current window, jumps to tag on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {show_line} (boolean)  show results text (default: true)
-        {trim_text} (boolean)  trim results text (default: false)
-
+      • {opts}  (`table?`)
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {trim_text}? (`boolean`, default: `false`) trim results text
 
 builtin.jumplist({opts})                        *telescope.builtin.jumplist()*
     Lists items from Vim's jumplist, jumps to location on `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {show_line} (boolean)  show results text (default: true)
-        {trim_text} (boolean)  trim results text (default: false)
-
+      • {opts}  (`table?`)
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {trim_text}? (`boolean`, default: `false`) trim results text
 
 builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
     Lists LSP references for word under the cursor, jumps to reference on
     `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+      • {opts}  (`table?`, default: `false`)
+                • {include_declaration}? (`boolean`, default: `true`) include
+                  symbol declaration in the lsp references
+                • {include_current_line}? (`boolean`, default: `false`)
+                  include current line
+                • {jump_type}? (`string`) how to goto reference if there is
+                  only one and the definition file is different from the
+                  current file, values: "tab", "tab drop", "split", "vsplit",
+                  "never"
+                • {reuse_win}? (`boolean`) jump to existing window if buffer
+                  is already oplescope.builtin.lsp_opts
+                • {trim_text}? (`boolean`, default: `false`) trim results text
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {file_encoding}? (`string`) file encoding for the previewer
 
-    Options: ~
-        {include_declaration}  (boolean)  include symbol declaration in the
-                                          lsp references (default: true)
-        {include_current_line} (boolean)  include current line (default:
-                                          false)
-        {jump_type}            (string)   how to goto reference if there is
-                                          only one and the definition file is
-                                          different from the current file,
-                                          values: "tab", "tab drop", "split",
-                                          "vsplit", "never"
-        {show_line}            (boolean)  show results text (default: true)
-        {trim_text}            (boolean)  trim results text (default: false)
-        {reuse_win}            (boolean)  jump to existing window if buffer is
-                                          already opened (default: false)
-        {file_encoding}        (string)   file encoding for the previewer
-
-
-builtin.lsp_incoming_calls({opts})    *telescope.builtin.lsp_incoming_calls()*
+                                      *telescope.builtin.lsp_incoming_calls()*
+builtin.lsp_incoming_calls({opts})
     Lists LSP incoming calls for word under the cursor, jumps to reference on
     `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+      • {opts}  (`table?`)
+                • {trim_text}? (`boolean`, default: `false`) trim results text
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {file_encoding}? (`string`) file encoding for the previewer
 
-    Options: ~
-        {show_line}     (boolean)  show results text (default: true)
-        {trim_text}     (boolean)  trim results text (default: false)
-        {file_encoding} (string)   file encoding for the previewer
-
-
-builtin.lsp_outgoing_calls({opts})    *telescope.builtin.lsp_outgoing_calls()*
+                                      *telescope.builtin.lsp_outgoing_calls()*
+builtin.lsp_outgoing_calls({opts})
     Lists LSP outgoing calls for word under the cursor, jumps to reference on
     `<cr>`
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {show_line}     (boolean)  show results text (default: true)
-        {trim_text}     (boolean)  trim results text (default: false)
-        {file_encoding} (string)   file encoding for the previewer
-
+      • {opts}  (`table?`)
+                • {trim_text}? (`boolean`, default: `false`) trim results text
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {file_encoding}? (`string`) file encoding for the previewer
 
 builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
     Goto the definition of the word under the cursor, if there's only one,
     otherwise show all options in Telescope
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+      • {opts}  (`table?`)
+                • {jump_type}? (`string`) how to goto reference if there is
+                  only one and the definition file is different from the
+                  current file, values: "tab", "tab drop", "split", "vsplit",
+                  "never"
+                • {reuse_win}? (`boolean`) jump to existing window if buffer
+                  is already oplescope.builtin.lsp_opts
+                • {trim_text}? (`boolean`, default: `false`) trim results text
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {file_encoding}? (`string`) file encoding for the previewer
 
-    Options: ~
-        {jump_type}     (string)   how to goto definition if there is only one
-                                   and the definition file is different from
-                                   the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never"
-        {show_line}     (boolean)  show results text (default: true)
-        {trim_text}     (boolean)  trim results text (default: false)
-        {reuse_win}     (boolean)  jump to existing window if buffer is
-                                   already opened (default: false)
-        {file_encoding} (string)   file encoding for the previewer
-
-
-builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
+                                    *telescope.builtin.lsp_type_definitions()*
+builtin.lsp_type_definitions({opts})
     Goto the definition of the type of the word under the cursor, if there's
     only one, otherwise show all options in Telescope
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+      • {opts}  (`table?`)
+                • {jump_type}? (`string`) how to goto reference if there is
+                  only one and the definition file is different from the
+                  current file, values: "tab", "tab drop", "split", "vsplit",
+                  "never"
+                • {reuse_win}? (`boolean`) jump to existing window if buffer
+                  is already oplescope.builtin.lsp_opts
+                • {trim_text}? (`boolean`, default: `false`) trim results text
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {file_encoding}? (`string`) file encoding for the previewer
 
-    Options: ~
-        {jump_type}     (string)   how to goto definition if there is only one
-                                   and the definition file is different from
-                                   the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never"
-        {show_line}     (boolean)  show results text (default: true)
-        {trim_text}     (boolean)  trim results text (default: false)
-        {reuse_win}     (boolean)  jump to existing window if buffer is
-                                   already opened (default: false)
-        {file_encoding} (string)   file encoding for the previewer
-
-
-builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
+                                     *telescope.builtin.lsp_implementations()*
+builtin.lsp_implementations({opts})
     Goto the implementation of the word under the cursor if there's only one,
     otherwise show all options in Telescope
 
-
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+      • {opts}  (`table?`)
+                • {jump_type}? (`string`) how to goto reference if there is
+                  only one and the definition file is different from the
+                  current file, values: "tab", "tab drop", "split", "vsplit",
+                  "never"
+                • {reuse_win}? (`boolean`) jump to existing window if buffer
+                  is already oplescope.builtin.lsp_opts
+                • {trim_text}? (`boolean`, default: `false`) trim results text
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {file_encoding}? (`string`) file encoding for the previewer
 
-    Options: ~
-        {jump_type}     (string)   how to goto implementation if there is only
-                                   one and the definition file is different
-                                   from the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never"
-        {show_line}     (boolean)  show results text (default: true)
-        {trim_text}     (boolean)  trim results text (default: false)
-        {reuse_win}     (boolean)  jump to existing window if buffer is
-                                   already opened (default: false)
-        {file_encoding} (string)   file encoding for the previewer
-
-
-builtin.lsp_document_symbols({opts}) *telescope.builtin.lsp_document_symbols()*
+                                    *telescope.builtin.lsp_document_symbols()*
+builtin.lsp_document_symbols({opts})
     Lists LSP document symbols in the current buffer
-    - Default keymaps:
-      - `<C-l>`: show autocompletion menu to prefilter your query by type of
-        symbol you want to see (i.e. `:variable:`)
 
+    Default keymaps:
+    • `<C-l>`: show autocompletion menu to prefilter your query by type of
+      symbol you want to see (i.e. `:variable:`)
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+      • {opts}  (`table?`)
+                • {fname_width}? (`number`, default: `30`) defines the width
+                  of the filename section
+                • {symbol_width}? (`number`, default: `25`) defines the width
+                  of the symbol section
+                • {symbol_type_width}? (`number`, default: `8`) defines the
+                  width of the symbol type section
+                • {symbols}? (`string|table`) filter results by symbol kind(s)
+                • {ignore_symbols}? (`string|table`) list of symbols to ignore
+                • {symbol_highlights}? (`table`) string -> string. Matches
+                  symbol with hl_group
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {file_encoding}? (`string`) file encoding for the previewer
 
-    Options: ~
-        {fname_width}       (number)        defines the width of the filename
-                                            section (default: 30)
-        {symbol_width}      (number)        defines the width of the symbol
-                                            section (default: 25)
-        {symbol_type_width} (number)        defines the width of the symbol
-                                            type section (default: 8)
-        {show_line}         (boolean)       if true, shows the content of the
-                                            line the tag is found on (default:
-                                            false)
-        {symbols}           (string|table)  filter results by symbol kind(s)
-        {ignore_symbols}    (string|table)  list of symbols to ignore
-        {symbol_highlights} (table)         string -> string. Matches symbol
-                                            with hl_group
-        {file_encoding}     (string)        file encoding for the previewer
-
-
-builtin.lsp_workspace_symbols({opts}) *telescope.builtin.lsp_workspace_symbols()*
+                                   *telescope.builtin.lsp_workspace_symbols()*
+builtin.lsp_workspace_symbols({opts})
     Lists LSP document symbols in the current workspace
-    - Default keymaps:
-      - `<C-l>`: show autocompletion menu to prefilter your query by type of
-        symbol you want to see (i.e. `:variable:`)
 
+    Default keymaps:
+    • `<C-l>`: show autocompletion menu to prefilter your query by type of
+      symbol you want to see (i.e. `:variable:`)
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
+      • {opts}  (`table?`)
+                • {query}? (`string`, default: `""`) for what to query the
+                  workspace
+                • {fname_width}? (`number`, default: `30`) defines the width
+                  of the filename section
+                • {symbol_width}? (`number`, default: `25`) defines the width
+                  of the symbol section
+                • {symbol_type_width}? (`number`, default: `8`) defines the
+                  width of the symbol type section
+                • {symbols}? (`string|table`) filter results by symbol kind(s)
+                • {ignore_symbols}? (`string|table`) list of symbols to ignore
+                • {symbol_highlights}? (`table`) string -> string. Matches
+                  symbol with hl_group
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {file_encoding}? (`string`) file encoding for the previewer
 
-    Options: ~
-        {query}             (string)        for what to query the workspace
-                                            (default: "")
-        {fname_width}       (number)        defines the width of the filename
-                                            section (default: 30)
-        {symbol_width}      (number)        defines the width of the symbol
-                                            section (default: 25)
-        {symbol_type_width} (number)        defines the width of the symbol
-                                            type section (default: 8)
-        {show_line}         (boolean)       if true, shows the content of the
-                                            line the tag is found on (default:
-                                            false)
-        {symbols}           (string|table)  filter results by symbol kind(s)
-        {ignore_symbols}    (string|table)  list of symbols to ignore
-        {symbol_highlights} (table)         string -> string. Matches symbol
-                                            with hl_group
-        {file_encoding}     (string)        file encoding for the previewer
-
-
-builtin.lsp_dynamic_workspace_symbols({opts}) *telescope.builtin.lsp_dynamic_workspace_symbols()*
+                           *telescope.builtin.lsp_dynamic_workspace_symbols()*
+builtin.lsp_dynamic_workspace_symbols({opts})
     Dynamically lists LSP for all workspace symbols
-    - Default keymaps:
-      - `<C-l>`: show autocompletion menu to prefilter your query by type of
-        symbol you want to see (i.e. `:variable:`), only works after refining
-        to fuzzy search using <C-space>
 
+    Default keymaps:
+    • `<C-l>`: show autocompletion menu to prefilter your query by type of
+      symbol you want to see (i.e. `:variable:`), only works after refining to
+      fuzzy search using `<C-space>`
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {fname_width}       (number)        defines the width of the filename
-                                            section (default: 30)
-        {show_line}         (boolean)       if true, shows the content of the
-                                            line the symbol is found on
-                                            (default: false)
-        {symbols}           (string|table)  filter results by symbol kind(s)
-        {ignore_symbols}    (string|table)  list of symbols to ignore
-        {symbol_highlights} (table)         string -> string. Matches symbol
-                                            with hl_group
-        {file_encoding}     (string)        file encoding for the previewer
-
+      • {opts}  (`table?`)
+                • {fname_width}? (`number`, default: `30`) defines the width
+                  of the filename section
+                • {symbols}? (`string|table`) filter results by symbol kind(s)
+                • {ignore_symbols}? (`string|table`) list of symbols to ignore
+                • {symbol_highlights}? (`table`) string -> string. Matches
+                  symbol with hl_group
+                • {show_line}? (`boolean`, default: `true`) show results text
+                • {file_encoding}? (`string`) file encoding for the previewer
 
 builtin.diagnostics({opts})                  *telescope.builtin.diagnostics()*
     Lists diagnostics
-    - Fields:
-      - `All severity flags can be passed as `string` or `number` as per
-        `:vim.diagnostic.severity:`
-    - Default keymaps:
-      - `<C-l>`: show autocompletion menu to prefilter your query with the
-        diagnostic you want to see (i.e. `:warning:`)
-    - sort_by option:
-      - "buffer": order by bufnr (prioritizing current bufnr), severity, lnum
-      - "severity": order by severity, bufnr (prioritizing current bufnr), lnum
 
+    All severity flags can be passed as `string` or `number` as per
+    `vim.diagnostic.severity`.
+
+    Default keymaps:
+    • `<C-l>`: show autocompletion menu to prefilter your query with the
+      diagnostic you want to see (i.e. `warning`)
 
     Parameters: ~
-        {opts} (table)  options to pass to the picker
-
-    Options: ~
-        {bufnr}               (number|nil)      Buffer number to get
-                                                diagnostics from. Use 0 for
-                                                current buffer or nil for all
-                                                buffers
-        {severity}            (string|number)   filter diagnostics by severity
-                                                name (string) or id (number)
-        {severity_limit}      (string|number)   keep diagnostics equal or more
-                                                severe wrt severity name
-                                                (string) or id (number)
-        {severity_bound}      (string|number)   keep diagnostics equal or less
-                                                severe wrt severity name
-                                                (string) or id (number)
-        {root_dir}            (string|boolean)  if set to string, get
-                                                diagnostics only for buffers
-                                                under this dir otherwise cwd
-        {no_unlisted}         (boolean)         if true, get diagnostics only
-                                                for listed buffers
-        {no_sign}             (boolean)         hide DiagnosticSigns from
-                                                Results (default: false)
-        {line_width}          (string|number)   set length of diagnostic entry
-                                                text in Results. Use 'full'
-                                                for full untruncated text
-        {namespace}           (number)          limit your diagnostics to a
-                                                specific namespace
-        {disable_coordinates} (boolean)         don't show the line & row
-                                                numbers (default: false)
-        {sort_by}             (string)          sort order of the diagnostics
-                                                results; see above notes
-                                                (default: "buffer")
+      • {opts}  (`table?`)
+                • {bufnr}? (`number`) Buffer number to get diagnostics from.
+                  Use 0 for current buffer or nil for all buffers
+                • {severity}? (`string|number`) filter diagnostics by severity
+                  name (string) or id (number)
+                • {severity_limit}? (`string|number`) keep diagnostics equal
+                  or more severe wrt severity name (string) or id (number)
+                • {severity_bound}? (`string|number`) keep diagnostics equal
+                  or less severe wrt severity name (string) or id (number)
+                • {root_dir}? (`string|boolean`) if set to string, get
+                  diagnostics only for buffers under this dir otherwise cwd
+                • {no_unlisted}? (`boolean`) if true, get diagnostics only for
+                  listed buffers
+                • {no_sign}? (`boolean`, default: `false`) hide
+                  DiagnosticSigns from Results
+                • {line_width}? (`string|number`) set length of diagnostic
+                  entry text in Results. Use 'full' for full untruncated text
+                • {namespace}? (`number`) limit your diagnostics to a specific
+                  namespace
+                • {disable_coordinates}? (`boolean`, default: `false`) don't
+                  show the line & row numbers
+                • {sort_by}? (`"buffer"|"severity"`, default: `"buffer"`) sort
+                  order of the diagnostics results
+                  • "buffer": order by bufnr (prioritizing current bufnr),
+                    severity, lnum
+                  • "severity": order by severity, bufnr (prioritizing current
+                    bufnr), lnum
 
 
-
-================================================================================
-THEMES                                                        *telescope.themes*
+==============================================================================
+THEMES                                                      *telescope.themes*
 
 Themes are ways to combine several elements of styling together.
 
 They are helpful for managing the several different UI aspects for telescope
-and provide a simple interface for users to get a particular "style" of picker.
+and provide a simple interface for users to get a particular "style" of
+picker.
 
 themes.get_dropdown()                        *telescope.themes.get_dropdown()*
     Dropdown style theme.
 
-    Usage:
-    >
-        local opts = {...} -- picker options
-        local builtin = require('telescope.builtin')
-        local themes = require('telescope.themes')
-        builtin.find_files(themes.get_dropdown(opts))
+    Usage: >lua
+    local opts = {...} -- picker options
+    local builtin = require('telescope.builtin')
+    local themes = require('telescope.themes')
+    builtin.find_files(themes.get_dropdown(opts))
 <
-
-
 
 themes.get_cursor()                            *telescope.themes.get_cursor()*
     Cursor style theme.
 
-    Usage:
-    >
-        local opts = {...} -- picker options
-        local builtin = require('telescope.builtin')
-        local themes = require('telescope.themes')
-        builtin.find_files(themes.get_cursor(opts))
+    Usage: >lua
+    local opts = {...} -- picker options
+    local builtin = require('telescope.builtin')
+    local themes = require('telescope.themes')
+    builtin.find_files(themes.get_cursor(opts))
 <
-
-
 
 themes.get_ivy()                                  *telescope.themes.get_ivy()*
     Ivy style theme.
 
-    Usage:
-    >
-        local opts = {...} -- picker options
-        local builtin = require('telescope.builtin')
-        local themes = require('telescope.themes')
-        builtin.find_files(themes.get_ivy(opts))
+    Usage: >lua
+    local opts = {...} -- picker options
+    local builtin = require('telescope.builtin')
+    local themes = require('telescope.themes')
+    builtin.find_files(themes.get_ivy(opts))
 <
 
 
-
-
-================================================================================
-MAPPINGS                                                    *telescope.mappings*
+==============================================================================
+MAPPINGS                                                  *telescope.mappings*
 
 |telescope.mappings| is used to configure the keybindings within a telescope
-picker. These key binds are only local to the picker window and will be cleared
-once you exit the picker.
+picker. These key binds are only local to the picker window and will be
+cleared once you exit the picker.
 
 We provide multiple configuration options to make it easy for you to adjust
 telescope's default key bindings and create your own custom key binds.
@@ -1911,321 +1669,296 @@ telescope's default key bindings and create your own custom key binds.
 To see many of the builtin actions that you can use as values for this table,
 see |telescope.actions|
 
-Format is:
->
-  {
-    mode = { ..keys }
-  }
+Format is: >lua
+    {
+      mode = { ..keys }
+    }
 <
-
 where {mode} is the one character letter for a mode ('i' for insert, 'n' for
 normal).
 
-For example:
->
-  mappings = {
-    i = {
-      ["<esc>"] = require('telescope.actions').close,
-    },
-  }
+For example: >lua
+    mappings = {
+      i = {
+        ["<esc>"] = require('telescope.actions').close,
+      },
+    }
 <
-
 To disable a keymap, put `[map] = false`
-For example:
->
-  {
-    ...,
-    ["<C-n>"] = false,
-    ...,
-  }
+For example: >lua
+    {
+      ...,
+      ["<C-n>"] = false,
+      ...,
+    }
 <
-
-To override behavior of a key, simply set the value to be a function (either by
-requiring an action or by writing your own function)
->
-  {
-    ...,
-    ["<C-i>"] = require('telescope.actions').select_default,
-    ...,
-  }
+To override behavior of a key, simply set the value to be a function (either
+by requiring an action or by writing your own function) >lua
+    {
+      ...,
+      ["<C-i>"] = require('telescope.actions').select_default,
+      ...,
+    }
 <
-
 If the function you want is part of `telescope.actions`, then you can simply
 supply the function name as a string. For example, the previous option is
-equivalent to:
->
-  {
-    ...,
-    ["<C-i>"] = "select_default",
-    ...,
-  }
+equivalent to: >lua
+    {
+      ...,
+      ["<C-i>"] = "select_default",
+      ...,
+    }
 <
-
 You can also add other mappings using tables with `type = "command"`. For
-example:
->
-  {
-    ...,
-    ["jj"] = { "<esc>", type = "command" },
-    ["kk"] = { "<cmd>echo \"Hello, World!\"<cr>", type = "command" },)
-    ...,
-  }
+example: >lua
+    {
+      ...,
+      ["jj"] = { "<esc>", type = "command" },
+      ["kk"] = { "<cmd>echo \"Hello, World!\"<cr>", type = "command" },
+      ...,
+    }
 <
-
 You can also add additional options for mappings of any type ("action" and
-"command"). For example:
->
-  {
-    ...,
-    ["<C-j>"] = {
-      actions.move_selection_next, type = "action",
-      opts = { nowait = true, silent = true }
-    },
-    ...,
-  }
+"command"). For example: >lua
+    {
+      ...,
+      ["<C-j>"] = {
+        actions.move_selection_next, type = "action",
+        opts = { nowait = true, silent = true }
+      },
+      ...,
+    }
 <
-
 There are three main places you can configure |telescope.mappings|. These are
 ordered from the lowest priority to the highest priority.
-
 1. |telescope.defaults.mappings|
-2. In the |telescope.setup()| table, inside a picker with a given name, use the
-   `mappings` key
->
-  require("telescope").setup {
-    pickers = {
-      find_files = {
-        mappings = {
-          n = {
-            ["kj"] = "close",
-          },
-        },
-      },
-    },
-  }
-<
-3. `attach_mappings` function for a particular picker.
->
-  require("telescope.builtin").find_files {
-    attach_mappings = function(_, map)
-      map("i", "asdf", function(_prompt_bufnr)
-        print "You typed asdf"
-      end)
 
-      map({"i", "n"}, "<C-r>", function(_prompt_bufnr)
-        print "You typed <C-r>"
-      end, { desc = "desc for which key"})
-
-      -- needs to return true if you want to map default_mappings and
-      -- false if not
-      return true
-    end,
-  }
+2. In the |telescope.setup()| table, inside a picker with a given name, use
+   the `mappings` key >lua
+   require("telescope").setup {
+     pickers = {
+       find_files = {
+         mappings = {
+           n = {
+             ["kj"] = "close",
+           },
+         },
+       },
+     },
+   }
 <
 
+3. `attach_mappings` function for a particular picker. >lua
+   require("telescope.builtin").find_files {
+     attach_mappings = function(_, map)
+       map("i", "asdf", function(_prompt_bufnr)
+         print "You typed asdf"
+       end)
 
-================================================================================
-LAYOUT                                                *telescope.pickers.layout*
+       map({"i", "n"}, "<C-r>", function(_prompt_bufnr)
+         print "You typed <C-r>"
+       end, { desc = "desc for which key"})
+
+       -- needs to return true if you want to map default_mappings and
+       -- false if not
+       return true
+     end,
+   }
+<
+
+==============================================================================
+LAYOUT                                                      *telescope.layout*
 
 The telescope pickers layout can be configured using the
 |telescope.defaults.create_layout| option.
-
 Parameters: ~
-  - picker : A Picker object.
+  • picker : A Picker object.
 
 Return: ~
-  - layout : instance of `TelescopeLayout` class.
+  • layout : instance of `TelescopeLayout` class.
 
 Example: ~
->
-local Layout = require "telescope.pickers.layout"
 
-require("telescope").setup {
-  create_layout = function(picker)
-    local function create_window(enter, width, height, row, col, title)
-      local bufnr = vim.api.nvim_create_buf(false, true)
-      local winid = vim.api.nvim_open_win(bufnr, enter, {
-        style = "minimal",
-        relative = "editor",
-        width = width,
-        height = height,
-        row = row,
-        col = col,
-        border = "single",
-        title = title,
-      })
+>lua
+    local Layout = require "telescope.pickers.layout"
 
-      vim.wo[winid].winhighlight = "Normal:Normal"
+    require("telescope").setup {
+      create_layout = function(picker)
+        local function create_window(enter, width, height, row, col, title)
+          local bufnr = vim.api.nvim_create_buf(false, true)
+          local winid = vim.api.nvim_open_win(bufnr, enter, {
+            style = "minimal",
+            relative = "editor",
+            width = width,
+            height = height,
+            row = row,
+            col = col,
+            border = "single",
+            title = title,
+          })
 
-      return Layout.Window {
-        bufnr = bufnr,
-        winid = winid,
-      }
-    end
+          vim.wo[winid].winhighlight = "Normal:Normal"
 
-    local function destory_window(window)
-      if window then
-        if vim.api.nvim_win_is_valid(window.winid) then
-          vim.api.nvim_win_close(window.winid, true)
+          return Layout.Window {
+            bufnr = bufnr,
+            winid = winid,
+          }
         end
-        if vim.api.nvim_buf_is_valid(window.bufnr) then
-          vim.api.nvim_buf_delete(window.bufnr, { force = true })
-        end
-      end
-    end
 
-    local layout = Layout {
-      picker = picker,
-      mount = function(self)
-        self.results = create_window(false, 40, 20, 0, 0, "Results")
-        self.preview = create_window(false, 40, 23, 0, 42, "Preview")
-        self.prompt = create_window(true, 40, 1, 22, 0, "Prompt")
+        local function destory_window(window)
+          if window then
+            if vim.api.nvim_win_is_valid(window.winid) then
+              vim.api.nvim_win_close(window.winid, true)
+            end
+            if vim.api.nvim_buf_is_valid(window.bufnr) then
+              vim.api.nvim_buf_delete(window.bufnr, { force = true })
+            end
+          end
+        end
+
+        local layout = Layout {
+          picker = picker,
+          mount = function(self)
+            self.results = create_window(false, 40, 20, 0, 0, "Results")
+            self.preview = create_window(false, 40, 23, 0, 42, "Preview")
+            self.prompt = create_window(true, 40, 1, 22, 0, "Prompt")
+          end,
+          unmount = function(self)
+            destory_window(self.results)
+            destory_window(self.preview)
+            destory_window(self.prompt)
+          end,
+          update = function(self) end,
+        }
+
+        return layout
       end,
-      unmount = function(self)
-        destory_window(self.results)
-        destory_window(self.preview)
-        destory_window(self.prompt)
-      end,
-      update = function(self) end,
     }
-
-    return layout
-  end,
-}
 <
 
-TelescopeWindowBorder.config                    *TelescopeWindowBorder.config*
-
-
-    Fields: ~
-        {bufnr}        (integer)
-        {winid}        (integer|nil)
-        {change_title} (nil|function)  (self: TelescopeWindowBorder, title:
-                                       string, pos?:
-                                       "NW"|"N"|"NE"|"SW"|"S"|"SE"):nil
-
-
-TelescopeWindowBorder                                  *TelescopeWindowBorder*
-
+*TelescopeLayout*
 
     Fields: ~
-        {bufnr} (integer|nil)
-        {winid} (integer|nil)
+      • {prompt}   (`TelescopeWindow`) See |TelescopeWindow|
+      • {results}  (`TelescopeWindow`) See |TelescopeWindow|
+      • {preview}  (`TelescopeWindow?`) See |TelescopeWindow|
+      • {mount}    (`fun(self: TelescopeLayout)`) Create the layout. This
+                   needs to ensure the required properties are populated.
+      • {unmount}  (`fun(self: TelescopeLayout)`) Destroy the layout. This is
+                   responsible for performing clean-up, for example:
+                   • deleting buffers
+                   • closing windows
+                   • clearing autocmds
+      • {update}   (`fun(self: TelescopeLayout)`) Refresh the layout. This is
+                   called when, for example, vim is resized.
 
-
-TelescopeWindow.config                                *TelescopeWindow.config*
-
-
-    Fields: ~
-        {bufnr}  (integer)
-        {winid}  (integer|nil)
-        {border} (TelescopeWindowBorder.config|nil)
-
-
-TelescopeWindow                                              *TelescopeWindow*
-
-
-    Fields: ~
-        {border} (TelescopeWindowBorder)
-        {bufnr}  (integer)
-        {winid}  (integer)
-
-
-TelescopeLayout.config                                *TelescopeLayout.config*
-
+*TelescopeLayout.config*
 
     Fields: ~
-        {mount}   (function)             (self: TelescopeLayout):nil
-        {unmount} (function)             (self: TelescopeLayout):nil
-        {update}  (function)             (self: TelescopeLayout):nil
-        {prompt}  (TelescopeWindow|nil)
-        {results} (TelescopeWindow|nil)
-        {preview} (TelescopeWindow|nil)
+      • {mount}    (`function`) (self: TelescopeLayout):nil
+      • {unmount}  (`function`) (self: TelescopeLayout):nil
+      • {update}   (`function`) (self: TelescopeLayout):nil
+      • {prompt}   (`TelescopeWindow?`) See |TelescopeWindow|
+      • {results}  (`TelescopeWindow?`) See |TelescopeWindow|
+      • {preview}  (`TelescopeWindow?`) See |TelescopeWindow|
 
-
-TelescopeLayout                                              *TelescopeLayout*
-
+*TelescopeWindow*
 
     Fields: ~
-        {prompt}  (TelescopeWindow)
-        {results} (TelescopeWindow)
-        {preview} (TelescopeWindow|nil)
+      • {border}  (`TelescopeWindowBorder`) See |TelescopeWindowBorder|
+      • {bufnr}   (`integer`)
+      • {winid}   (`integer`)
+
+*TelescopeWindow.config*
+
+    Fields: ~
+      • {bufnr}   (`integer`)
+      • {winid}   (`integer?`)
+      • {border}  (`TelescopeWindowBorder.config?`) See
+                  |TelescopeWindowBorder.config|
+
+*TelescopeWindowBorder*
+
+    Fields: ~
+      • {bufnr}         (`integer?`)
+      • {winid}         (`integer?`)
+      • {change_title}  (`fun(self: TelescopeWindowBordertitle: stringpos: "NW"|"N"|"NE"|"SW"|"S"|"SE"?)`)
 
 
-Layout:mount()                              *telescope.pickers.layout:mount()*
+*TelescopeWindowBorder.config*
+
+    Fields: ~
+      • {bufnr}         (`integer`)
+      • {winid}         (`integer?`)
+      • {change_title}  (`function?`) (self: TelescopeWindowBorder, title:
+                        string, pos?: "NW"|"N"|"NE"|"SW"|"S"|"SE"):nil
+
+
+Border:change_title({title}, {pos})                    *Border:change_title()*
+    Parameters: ~
+      • {title}  (`string`)
+      • {pos}    (`"NW"|"N"|"NE"|"SW"|"S"|"SE"?`)
+
+Layout:mount()                                                *Layout:mount()*
     Create the layout. This needs to ensure the required properties are
     populated.
 
-
-
-Layout:unmount()                          *telescope.pickers.layout:unmount()*
+Layout:unmount()                                            *Layout:unmount()*
     Destroy the layout. This is responsible for performing clean-up, for
     example:
-     - deleting buffers
-     - closing windows
-     - clearing autocmds
+    • deleting buffers
+    • closing windows
+    • clearing autocmds
 
-
-
-Layout:update()                            *telescope.pickers.layout:update()*
+Layout:update()                                              *Layout:update()*
     Refresh the layout. This is called when, for example, vim is resized.
 
 
-
-
-================================================================================
-LAYOUT                                                        *telescope.layout*
+==============================================================================
+LAYOUT_STRATEGIES                                *telescope.layout_strategies*
 
 The layout of telescope pickers can be adjusted using the
 |telescope.defaults.layout_strategy| and |telescope.defaults.layout_config|
 options. For example, the following configuration changes the default layout
-strategy and the default size of the picker:
->
-  require('telescope').setup{
-    defaults = {
-      layout_strategy = 'vertical',
-      layout_config = { height = 0.95 },
-    },
-  }
+strategy and the default size of the picker: >lua
+    require('telescope').setup{
+      defaults = {
+        layout_strategy = 'vertical',
+        layout_config = { height = 0.95 },
+      },
+    }
 <
-
-
 ────────────────────────────────────────────────────────────────────────────────
 
 Layout strategies are different functions to position telescope.
 
-All layout strategies are functions with the following signature:
-
->
-  function(picker, columns, lines, layout_config)
-    -- Do some calculations here...
-    return {
-      preview = preview_configuration,
-      results = results_configuration,
-      prompt = prompt_configuration,
-    }
-  end
+All layout strategies are functions with the following signature: >lua
+    function(picker, columns, lines, layout_config)
+      -- Do some calculations here...
+      return {
+        preview = preview_configuration
+        results = results_configuration,
+        prompt = prompt_configuration,
+      }
+    end
 <
-
   Parameters: ~
-    - picker        : A Picker object. (docs coming soon)
-    - columns       : (number) Columns in the vim window
-    - lines         : (number) Lines in the vim window
-    - layout_config : (table) The configuration values specific to the picker.
+    • picker        : A Picker object. (docs coming soon)
+    • columns       : (number) Columns in the vim window
+    • lines         : (number) Lines in the vim window
+    • layout_config : (table) The configuration values specific to the picker.
 
 This means you can create your own layout strategy if you want! Just be aware
 for now that we may change some APIs or interfaces, so they may break if you
 create your own.
 
-A good method for creating your own would be to copy one of the strategies that
-most resembles what you want from
+A good method for creating your own would be to copy one of the strategies
+that most resembles what you want from
 "./lua/telescope/pickers/layout_strategies.lua" in the telescope repo.
 
-
-layout_strategies.horizontal()                 *telescope.layout.horizontal()*
+layout_strategies.horizontal          *telescope.layout_strategies.horizontal*
     Horizontal layout has two columns, one for the preview and one for the
     prompt and results.
-
     ┌──────────────────────────────────────────────────┐
     │                                                  │
     │    ┌───────────────────┐┌───────────────────┐    │
@@ -2244,44 +1977,43 @@ layout_strategies.horizontal()                 *telescope.layout.horizontal()*
     └──────────────────────────────────────────────────┘
 
     `picker.layout_config` shared options:
-      - anchor:
-        - Which edge/corner to pin the picker to
-        - See |resolver.resolve_anchor_pos()|
-      - anchor_padding:
-        - Specifies an amount of additional padding around the anchor
-        - Values should be a positive integer
-      - height:
-        - How tall to make Telescope's entire layout
-        - See |resolver.resolve_height()|
-      - mirror: Flip the location of the results/prompt and preview windows
-      - prompt_position:
-        - Where to place prompt window.
-        - Available Values: 'bottom', 'top'
-      - scroll_speed: The number of lines to scroll through the previewer
-      - width:
-        - How wide to make Telescope's entire layout
-        - See |resolver.resolve_width()|
+      • anchor:
+        • Which edge/corner to pin the picker to
+        • See |resolver.resolve_anchor_pos()|
+      • anchor_padding:
+        • Specifies an amount of additional padding around the anchor
+        • Values should be a positive integer
+      • height:
+        • How tall to make Telescope's entire layout
+        • See |resolver.resolve_height()|
+      • mirror: Flip the location of the results/prompt and preview windows
+      • prompt_position:
+        • Where to place prompt window.
+        • Available Values: 'bottom', 'top'
+      • scroll_speed: The number of lines to scroll through the previewer
+      • width:
+        • How wide to make Telescope's entire layout
+        • See |resolver.resolve_width()|
 
     `picker.layout_config` unique options:
-      - preview_cutoff: When columns are less than this value, the preview will be disabled
-      - preview_width:
-        - Change the width of Telescope's preview window
-        - See |resolver.resolve_width()|
+      • preview_cutoff: When columns are less than this value, the preview will be disabled
+      • preview_width:
+        • Change the width of Telescope's preview window
+        • See |resolver.resolve_width()|
 
-
-layout_strategies.center()                         *telescope.layout.center()*
+layout_strategies.center                  *telescope.layout_strategies.center*
     Centered layout with a combined block of the prompt and results aligned to
     the middle of the screen. The preview window is then placed in the
     remaining space above or below, according to `anchor` or `mirror`.
-    Particularly useful for creating dropdown menus (see |telescope.themes| and
-    |themes.get_dropdown()|).
+    Particularly useful for creating dropdown menus (see |telescope.themes|
+    and |themes.get_dropdown()|).
 
-    Note that vertical anchoring, i.e. `anchor` containing `"N"` or `"S"`, will
-    override `mirror` config. For `"N"` anchoring preview will be placed below
-    prompt/result block. For `"S"` anchoring preview will be placed above
-    prompt/result block. For horizontal only anchoring preview will be placed
-    according to `mirror` config, default is above the prompt/result block.
-
+    Note that vertical anchoring, i.e. `anchor` containing `"N"` or `"S"`,
+    will override `mirror` config. For `"N"` anchoring preview will be placed
+    below prompt/result block. For `"S"` anchoring preview will be placed
+    above prompt/result block. For horizontal only anchoring preview will be
+    placed according to `mirror` config, default is above the prompt/result
+    block.
     ┌──────────────────────────────────────────────────┐
     │    ┌────────────────────────────────────────┐    │
     │    │                 Preview                │    │
@@ -2300,32 +2032,30 @@ layout_strategies.center()                         *telescope.layout.center()*
     └──────────────────────────────────────────────────┘
 
     `picker.layout_config` shared options:
-      - anchor:
-        - Which edge/corner to pin the picker to
-        - See |resolver.resolve_anchor_pos()|
-      - anchor_padding:
-        - Specifies an amount of additional padding around the anchor
-        - Values should be a positive integer
-      - height:
-        - How tall to make Telescope's entire layout
-        - See |resolver.resolve_height()|
-      - mirror: Flip the location of the results/prompt and preview windows
-      - prompt_position:
-        - Where to place prompt window.
-        - Available Values: 'bottom', 'top'
-      - scroll_speed: The number of lines to scroll through the previewer
-      - width:
-        - How wide to make Telescope's entire layout
-        - See |resolver.resolve_width()|
+      • anchor:
+        • Which edge/corner to pin the picker to
+        • See |resolver.resolve_anchor_pos()|
+      • anchor_padding:
+        • Specifies an amount of additional padding around the anchor
+        • Values should be a positive integer
+      • height:
+        • How tall to make Telescope's entire layout
+        • See |resolver.resolve_height()|
+      • mirror: Flip the location of the results/prompt and preview windows
+      • prompt_position:
+        • Where to place prompt window.
+        • Available Values: 'bottom', 'top'
+      • scroll_speed: The number of lines to scroll through the previewer
+      • width:
+        • How wide to make Telescope's entire layout
+        • See |resolver.resolve_width()|
 
     `picker.layout_config` unique options:
-      - preview_cutoff: When lines are less than this value, the preview will be disabled
+      • preview_cutoff: When lines are less than this value, the preview will be disabled
 
-
-layout_strategies.cursor()                         *telescope.layout.cursor()*
-    Cursor layout dynamically positioned below the cursor if possible. If there
-    is no place below the cursor it will be placed above.
-
+layout_strategies.cursor                  *telescope.layout_strategies.cursor*
+    Cursor layout dynamically positioned below the cursor if possible. If
+    there is no place below the cursor it will be placed above.
     ┌──────────────────────────────────────────────────┐
     │                                                  │
     │   █                                              │
@@ -2344,25 +2074,23 @@ layout_strategies.cursor()                         *telescope.layout.cursor()*
     └──────────────────────────────────────────────────┘
 
     `picker.layout_config` shared options:
-      - height:
-        - How tall to make Telescope's entire layout
-        - See |resolver.resolve_height()|
-      - scroll_speed: The number of lines to scroll through the previewer
-      - width:
-        - How wide to make Telescope's entire layout
-        - See |resolver.resolve_width()|
+      • height:
+        • How tall to make Telescope's entire layout
+        • See |resolver.resolve_height()|
+      • scroll_speed: The number of lines to scroll through the previewer
+      • width:
+        • How wide to make Telescope's entire layout
+        • See |resolver.resolve_width()|
 
     `picker.layout_config` unique options:
-      - preview_cutoff: When columns are less than this value, the preview will be disabled
-      - preview_width:
-        - Change the width of Telescope's preview window
-        - See |resolver.resolve_width()|
+      • preview_cutoff: When columns are less than this value, the preview will be disabled
+      • preview_width:
+        • Change the width of Telescope's preview window
+        • See |resolver.resolve_width()|
 
-
-layout_strategies.vertical()                     *telescope.layout.vertical()*
+layout_strategies.vertical              *telescope.layout_strategies.vertical*
     Vertical layout stacks the items on top of each other. Particularly useful
     with thinner windows.
-
     ┌──────────────────────────────────────────────────┐
     │                                                  │
     │    ┌────────────────────────────────────────┐    │
@@ -2381,78 +2109,73 @@ layout_strategies.vertical()                     *telescope.layout.vertical()*
     └──────────────────────────────────────────────────┘
 
     `picker.layout_config` shared options:
-      - anchor:
-        - Which edge/corner to pin the picker to
-        - See |resolver.resolve_anchor_pos()|
-      - anchor_padding:
-        - Specifies an amount of additional padding around the anchor
-        - Values should be a positive integer
-      - height:
-        - How tall to make Telescope's entire layout
-        - See |resolver.resolve_height()|
-      - mirror: Flip the location of the results/prompt and preview windows
-      - prompt_position:
-        - Where to place prompt window.
-        - Available Values: 'bottom', 'top'
-      - scroll_speed: The number of lines to scroll through the previewer
-      - width:
-        - How wide to make Telescope's entire layout
-        - See |resolver.resolve_width()|
+      • anchor:
+        • Which edge/corner to pin the picker to
+        • See |resolver.resolve_anchor_pos()|
+      • anchor_padding:
+        • Specifies an amount of additional padding around the anchor
+        • Values should be a positive integer
+      • height:
+        • How tall to make Telescope's entire layout
+        • See |resolver.resolve_height()|
+      • mirror: Flip the location of the results/prompt and preview windows
+      • prompt_position:
+        • Where to place prompt window.
+        • Available Values: 'bottom', 'top'
+      • scroll_speed: The number of lines to scroll through the previewer
+      • width:
+        • How wide to make Telescope's entire layout
+        • See |resolver.resolve_width()|
 
     `picker.layout_config` unique options:
-      - preview_cutoff: When lines are less than this value, the preview will be disabled
-      - preview_height:
-        - Change the height of Telescope's preview window
-        - See |resolver.resolve_height()|
+      • preview_cutoff: When lines are less than this value, the preview will be disabled
+      • preview_height:
+        • Change the height of Telescope's preview window
+        • See |resolver.resolve_height()|
 
-
-layout_strategies.flex()                             *telescope.layout.flex()*
+layout_strategies.flex                      *telescope.layout_strategies.flex*
     Flex layout swaps between `horizontal` and `vertical` strategies based on
     the window width
-     - Supports |layout_strategies.vertical| or |layout_strategies.horizontal|
-       features
-
+    • Supports |layout_strategies.vertical| or |layout_strategies.horizontal|
+      features
 
     `picker.layout_config` shared options:
-      - anchor:
-        - Which edge/corner to pin the picker to
-        - See |resolver.resolve_anchor_pos()|
-      - anchor_padding:
-        - Specifies an amount of additional padding around the anchor
-        - Values should be a positive integer
-      - height:
-        - How tall to make Telescope's entire layout
-        - See |resolver.resolve_height()|
-      - mirror: Flip the location of the results/prompt and preview windows
-      - prompt_position:
-        - Where to place prompt window.
-        - Available Values: 'bottom', 'top'
-      - scroll_speed: The number of lines to scroll through the previewer
-      - width:
-        - How wide to make Telescope's entire layout
-        - See |resolver.resolve_width()|
+      • anchor:
+        • Which edge/corner to pin the picker to
+        • See |resolver.resolve_anchor_pos()|
+      • anchor_padding:
+        • Specifies an amount of additional padding around the anchor
+        • Values should be a positive integer
+      • height:
+        • How tall to make Telescope's entire layout
+        • See |resolver.resolve_height()|
+      • mirror: Flip the location of the results/prompt and preview windows
+      • prompt_position:
+        • Where to place prompt window.
+        • Available Values: 'bottom', 'top'
+      • scroll_speed: The number of lines to scroll through the previewer
+      • width:
+        • How wide to make Telescope's entire layout
+        • See |resolver.resolve_width()|
 
     `picker.layout_config` unique options:
-      - flip_columns: The number of columns required to move to horizontal mode
-      - flip_lines: The number of lines required to move to horizontal mode
-      - horizontal: Options to pass when switching to horizontal layout
-      - vertical: Options to pass when switching to vertical layout
+      • flip_columns: The number of columns required to move to horizontal mode
+      • flip_lines: The number of lines required to move to horizontal mode
+      • horizontal: Options to pass when switching to horizontal layout
+      • vertical: Options to pass when switching to vertical layout
 
-
-layout_strategies.bottom_pane()               *telescope.layout.bottom_pane()*
+layout_strategies.bottom_pane        *telescope.layout_strategies.bottom_pane*
     Bottom pane can be used to create layouts similar to "ivy".
 
     For an easy ivy configuration, see |themes.get_ivy()|
 
 
-
-
-================================================================================
-RESOLVE                                                      *telescope.resolve*
+==============================================================================
+RESOLVE                                                    *telescope.resolve*
 
 Provides "resolver functions" to allow more customisable inputs for options.
 
-resolver.resolve_height()                 *telescope.resolve.resolve_height()*
+resolver.resolve_height({val})            *telescope.resolve.resolve_height()*
     Converts input to a function that returns the height. The input must take
     one of five forms:
     1. 0 <= number < 1
@@ -2462,20 +2185,24 @@ resolver.resolve_height()                 *telescope.resolve.resolve_height()*
     3. function
        Must have signature: function(self, max_columns, max_lines): number
     4. table of the form: { val, max = ..., min = ... }
-       val has to be in the first form 0 <= val < 1 and only one is given, 
+       val has to be in the first form 0 <= val < 1 and only one is given,
        `min` or `max` as fixed number
     5. table of the form: {padding = `foo`}
        where `foo` has one of the previous three forms.
        The height is then set to be the remaining space after padding. For
-       example, if the window has height 50, and the input is {padding = 5}, 
+       example, if the window has height 50, and the input is {padding = 5},
        the height returned will be `40 = 50 - 2*5`
 
     The returned function will have signature: function(self, max_columns,
     max_lines): number
 
+    Parameters: ~
+      • {val}  (`any`) see description above
 
+    Return: ~
+        (`fun(self, max_columns: number, max_lines: number): number`)
 
-resolver.resolve_width()                   *telescope.resolve.resolve_width()*
+resolver.resolve_width({val})              *telescope.resolve.resolve_width()*
     Converts input to a function that returns the width. The input must take
     one of five forms:
     1. 0 <= number < 1
@@ -2485,62 +2212,76 @@ resolver.resolve_width()                   *telescope.resolve.resolve_width()*
     3. function
        Must have signature: function(self, max_columns, max_lines): number
     4. table of the form: { val, max = ..., min = ... }
-       val has to be in the first form 0 <= val < 1 and only one is given, 
+       val has to be in the first form 0 <= val < 1 and only one is given,
        `min` or `max` as fixed number
     5. table of the form: {padding = `foo`}
        where `foo` has one of the previous three forms.
        The width is then set to be the remaining space after padding. For
-       example, if the window has width 100, and the input is {padding = 5}, 
+       example, if the window has width 100, and the input is {padding = 5},
        the width returned will be `90 = 100 - 2*5`
 
     The returned function will have signature: function(self, max_columns,
     max_lines): number
 
+    Parameters: ~
+      • {val}  (`any`) see description above
 
+    Return: ~
+        (`fun(self, max_columns: number, max_lines: number): number`)
 
-resolver.resolve_anchor_pos()         *telescope.resolve.resolve_anchor_pos()*
+                                      *telescope.resolve.resolve_anchor_pos()*
+resolver.resolve_anchor_pos({anchor}, {p_width}, {p_height}, {max_columns}, {max_lines}, {anchor_padding})
     Calculates the adjustment required to move the picker from the middle of
     the screen to an edge or corner.
     The `anchor` can be any of the following strings:
-      - "", "CENTER", "NW", "N", "NE", "E", "SE", "S", "SW", "W" The anchors
-        have the following meanings:
-      - "" or "CENTER":
-        the picker will remain in the middle of the screen.
-      - Compass directions:
-        the picker will move to the corresponding edge/corner e.g. "NW" -> "top
-        left corner", "E" -> "right edge", "S" -> "bottom edge"
+    • "", "CENTER", "NW", "N", "NE", "E", "SE", "S", "SW", "W" The anchors
+      have the following meanings:
+    • "" or "CENTER":
+      the picker will remain in the middle of the screen.
+    • Compass directions:
+      the picker will move to the corresponding edge/corner e.g. "NW" -> "top
+      left corner", "E" -> "right edge", "S" -> "bottom edge"
+
+    Parameters: ~
+      • {anchor}          (`""|"CENTER"|"NW"|"N"|"NE"|"E"|"SE"|"S"|"SW"`)
+      • {p_width}         (`number`) window width
+      • {p_height}        (`number`) window height
+      • {max_columns}     (`number`) max number of columns
+      • {max_lines}       (`number`) max number of lines
+      • {anchor_padding}  (`number`) padding to add to the anchor
+
+    Return: ~
+        (`number[]`) row and col
 
 
-
-
-================================================================================
-MAKE_ENTRY                                                *telescope.make_entry*
+==============================================================================
+MAKE_ENTRY                                              *telescope.make_entry*
 
 Each picker has a finder made up of two parts, the results which are the data
-to be displayed, and the entry_maker. These entry_makers are functions returned
-from make_entry functions. These will be referred to as entry_makers in the
-following documentation.
+to be displayed, and the entry_maker. These entry_makers are functions
+returned from make_entry functions. These will be referred to as entry_makers
+in the following documentation.
 
 Every entry maker returns a function that accepts the data to be used for an
 entry. This function will return an entry table (or nil, meaning skip this
 entry) which contains the following important keys:
-- value any: value key can be anything but still required
-- valid bool (optional): is an optional key because it defaults to true but if
+• value any: value key can be anything but still required
+• valid bool (optional): is an optional key because it defaults to true but if
   the key is set to false it will not be displayed by the picker
-- ordinal string: is the text that is used for filtering
-- display string|function: is either a string of the text that is being 
-  displayed or a function receiving the entry at a later stage, when the entry 
-  is actually being displayed. A function can be useful here if a complex 
+• ordinal string: is the text that is used for filtering
+• display string|function: is either a string of the text that is being
+  displayed or a function receiving the entry at a later stage, when the entry
+  is actually being displayed. A function can be useful here if a complex
   calculation has to be done. `make_entry` can also return a second value - a
   highlight array which will then apply to the line. Highlight entry in this
   array has the following signature `{ { start_col, end_col }, hl_group }`
-- filename string (optional): will be interpreted by the default `<cr>` action
+• filename string (optional): will be interpreted by the default `<cr>` action
   as open this file
-- bufnr number (optional): will be interpreted by the default `<cr>` action as
+• bufnr number (optional): will be interpreted by the default `<cr>` action as
   open this buffer
-- lnum number (optional): lnum value which will be interpreted by the default
+• lnum number (optional): lnum value which will be interpreted by the default
   `<cr>` action as a jump to this line
-- col number (optional): col value which will be interpreted by the default
+• col number (optional): col value which will be interpreted by the default
   `<cr>` action as a jump to this column
 
 For more information on easier displaying, see
@@ -2548,9 +2289,8 @@ For more information on easier displaying, see
 
 TODO: Document something we call `entry_index`
 
-
-================================================================================
-ENTRY_DISPLAY                                  *telescope.pickers.entry_display*
+==============================================================================
+PICKERS_ENTRY_DISPLAY                        *telescope.pickers_entry_display*
 
 Entry Display is used to format each entry shown in the result panel.
 
@@ -2559,27 +2299,25 @@ column widths we pass into it. We then can use this function n times to return
 a string based on structured input.
 
 Note that if you call `create()` inside `make_display` it will be called for
-every single entry. So it is suggested to do this outside of `make_display` for
-the best performance.
+every single entry. So it is suggested to do this outside of `make_display`
+for the best performance.
 
 The create function will use the column widths passed to it in
-configuration.items. Each item in that table is the number of characters in the
-column. It's also possible for the final column to not have a fixed width, this
-will be shown in the configuration as 'remaining = true'.
+configuration.items. Each item in that table is the number of characters in
+the column. It's also possible for the final column to not have a fixed width,
+this will be shown in the configuration as 'remaining = true'.
 
-An example of this configuration is shown for the buffers picker:
->
-local displayer = entry_display.create {
-  separator = " ",
-  items = {
-    { width = opts.bufnr_width },
-    { width = 4 },
-    { width = icon_width },
-    { remaining = true },
-  },
-}
+An example of this configuration is shown for the buffers picker: >lua
+    local displayer = entry_display.create {
+      separator = " ",
+      items = {
+        { width = opts.bufnr_width },
+        { width = 4 },
+        { width = icon_width },
+        { remaining = true },
+      },
+    }
 <
-
 This shows 4 columns, the first is defined in the opts as the width we'll use
 when display_string is the number of the buffer. The second has a fixed width
 of 4 and the third column's width will be decided by the width of the icons we
@@ -2587,18 +2325,16 @@ use. The fourth column will use the remaining space. Finally, we have also
 defined the separator between each column will be the space " ".
 
 An example of how the display reference will be used is shown, again for the
-buffers picker:
->
-return displayer {
-  { entry.bufnr, "TelescopeResultsNumber" },
-  { entry.indicator, "TelescopeResultsComment" },
-  { icon, hl_group },
-  display_bufname .. ":" .. entry.lnum,
-}
+buffers picker: >lua
+    return displayer {
+      { entry.bufnr, "TelescopeResultsNumber" },
+      { entry.indicator, "TelescopeResultsComment" },
+      { icon, hl_group },
+      display_bufname .. ":" .. entry.lnum,
+    }
 <
-
-There are two types of values each column can have. Either a simple String or a
-table containing the String as well as the hl_group.
+There are two types of values each column can have. Either a simple String or
+a table containing the String as well as the hl_group.
 
 The displayer can return values, string and an optional highlights. The string
 is all the text to be displayed for this entry as a single string. If parts of
@@ -2608,18 +2344,17 @@ table.
 For a better understanding of how create() and displayer are used it's best to
 look at the code in make_entry.lua.
 
-
-================================================================================
-UTILS                                                          *telescope.utils*
+==============================================================================
+UTILS                                                        *telescope.utils*
 
 Utilities for writing telescope pickers
 
-utils.flatten()                                    *telescope.utils.flatten()*
-
+utils.flatten({t})                                 *telescope.utils.flatten()*
+    Parameters: ~
+      • {t}  (`table`)
 
     Return: ~
-        table
-
+        (`table`)
 
 utils.path_expand({path})                      *telescope.utils.path_expand()*
     Hybrid of `vim.fn.expand()` and custom `vim.fs.normalize()`
@@ -2631,52 +2366,47 @@ utils.path_expand({path})                      *telescope.utils.path_expand()*
 
     Other paths will have '~' and environment variables expanded. Unlike
     `vim.fs.normalize()`, backslashes are preserved. This has better
-    compatibility with `plenary.path` and also avoids mangling valid Unix paths
-    with literal backslashes.
+    compatibility with `plenary.path` and also avoids mangling valid Unix
+    paths with literal backslashes.
 
     Trailing slashes are trimmed. With the exception of root paths. eg. `/` on
     Unix or `C:\` on Windows
 
-
-
     Parameters: ~
-        {path} (string)
+      • {path}  (`string`)
 
     Return: ~
-        string
-
+        (`string`)
 
 utils.transform_path({opts}, {path})        *telescope.utils.transform_path()*
-    Transform path is a util function that formats a path based on path_display
-    found in `opts` or the default value from config. It is meant to be used in
-    make_entry to have a uniform interface for builtins as well as extensions
-    utilizing the same user configuration Note: It is only supported inside
-    `make_entry`/`make_display` the use of this function outside of telescope
-    might yield to undefined behavior and will not be addressed by us
-
+    Transform path is a util function that formats a path based on
+    path_display found in `opts` or the default value from config. It is meant
+    to be used in make_entry to have a uniform interface for builtins as well
+    as extensions utilizing the same user configuration Note: It is only
+    supported inside `make_entry`/`make_display` the use of this function
+    outside of telescope might yield to undefined behavior and will not be
+    addressed by us
 
     Parameters: ~
-        {opts} (table)       The opts the users passed into the picker. Might
-                             contains a path_display key
-        {path} (string|nil)  The path that should be formatted
+      • {opts}  (`table`) The opts the users passed into the picker. Might
+                contains a path_display key
+      • {path}  (`string?`) The path that should be formatted
 
-    Return: ~
-        string: path to be displayed
-        table: The transformed path ready to be displayed with the styling
-
+    Return (multiple): ~
+        (`string`) path to be displayed
+        (`table`) The transformed path ready to be displayed with the styling
 
 utils.notify({funname}, {opts})                     *telescope.utils.notify()*
     Telescope Wrapper around vim.notify
 
-
     Parameters: ~
-        {funname} (string)  name of the function that will be
-        {opts}    (table)   opts.level string, opts.msg string, opts.once bool
+      • {funname}  (`string`) name of the function that will be
+      • {opts}     (`table`) opts.level string, opts.msg string, opts.once
+                   bool
 
 
-
-================================================================================
-ACTIONS                                                      *telescope.actions*
+==============================================================================
+ACTIONS                                                    *telescope.actions*
 
 These functions are useful for people creating their own mappings.
 
@@ -2685,260 +2415,229 @@ argument (1) or they can be a custom telescope type called "action" (2).
 
 (1) The `prompt_bufnr` of a normal function denotes the identifier of your
 picker which can be used to access the picker state. In practice, users most
-commonly access from both picker and global state via the following:
->
-  -- for utility functions
-  local action_state = require "telescope.actions.state"
+commonly access from both picker and global state via the following: >lua
+    -- for utility functions
+    local action_state = require "telescope.actions.state"
 
-  local actions = {}
-  actions.do_stuff = function(prompt_bufnr)
-    local current_picker = action_state.get_current_picker(prompt_bufnr) -- picker state
-    local entry = action_state.get_selected_entry()
-  end
+    local actions = {}
+    actions.do_stuff = function(prompt_bufnr)
+      local current_picker = action_state.get_current_picker(prompt_bufnr) -- picker state
+      local entry = action_state.get_selected_entry()
+    end
 <
-
 See |telescope.actions.state| for more information.
 
 (2) To transform a module of functions into a module of "action"s, you need to
-do the following:
->
-  local transform_mod = require("telescope.actions.mt").transform_mod
+do the following: >lua
+    local transform_mod = require("telescope.actions.mt").transform_mod
 
-  local mod = {}
-  mod.a1 = function(prompt_bufnr)
-    -- your code goes here
-    -- You can access the picker/global state as described above in (1).
-  end
+    local mod = {}
+    mod.a1 = function(prompt_bufnr)
+      -- your code goes here
+      -- You can access the picker/global state as described above in (1).
+    end
 
-  mod.a2 = function(prompt_bufnr)
-    -- your code goes here
-  end
-  mod = transform_mod(mod)
+    mod.a2 = function(prompt_bufnr)
+      -- your code goes here
+    end
+    mod = transform_mod(mod)
 
-  -- Now the following is possible. This means that actions a2 will be executed
-  -- after action a1. You can chain as many actions as you want.
-  local action = mod.a1 + mod.a2
-  action(bufnr)
+    -- Now the following is possible. This means that actions a2 will be executed
+    -- after action a1. You can chain as many actions as you want.
+    local action = mod.a1 + mod.a2
+    action(bufnr)
 <
-
 Another interesting thing to do is that these actions now have functions you
 can call. These functions include `:replace(f)`, `:replace_if(f, c)`,
 `replace_map(tbl)` and `enhance(tbl)`. More information on these functions can
-be found in the `developers.md` and `lua/tests/automated/action_spec.lua` file.
+be found in the `developers.md` and `lua/tests/automated/action_spec.lua`
+file.
 
-actions.move_selection_next({prompt_bufnr}) *telescope.actions.move_selection_next()*
+                                     *telescope.actions.move_selection_next()*
+actions.move_selection_next({prompt_bufnr})
     Move the selection to the next entry
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.move_selection_previous({prompt_bufnr}) *telescope.actions.move_selection_previous()*
+                                 *telescope.actions.move_selection_previous()*
+actions.move_selection_previous({prompt_bufnr})
     Move the selection to the previous entry
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.move_selection_worse({prompt_bufnr}) *telescope.actions.move_selection_worse()*
+                                    *telescope.actions.move_selection_worse()*
+actions.move_selection_worse({prompt_bufnr})
     Move the selection to the entry that has a worse score
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.move_selection_better({prompt_bufnr}) *telescope.actions.move_selection_better()*
+                                   *telescope.actions.move_selection_better()*
+actions.move_selection_better({prompt_bufnr})
     Move the selection to the entry that has a better score
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.move_to_top({prompt_bufnr})          *telescope.actions.move_to_top()*
     Move to the top of the picker
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.move_to_middle({prompt_bufnr})    *telescope.actions.move_to_middle()*
+                                          *telescope.actions.move_to_middle()*
+actions.move_to_middle({prompt_bufnr})
     Move to the middle of the picker
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.move_to_bottom({prompt_bufnr})    *telescope.actions.move_to_bottom()*
+                                          *telescope.actions.move_to_bottom()*
+actions.move_to_bottom({prompt_bufnr})
     Move to the bottom of the picker
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.add_selection({prompt_bufnr})      *telescope.actions.add_selection()*
+                                           *telescope.actions.add_selection()*
+actions.add_selection({prompt_bufnr})
     Add current entry to multi select
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.remove_selection({prompt_bufnr}) *telescope.actions.remove_selection()*
+                                        *telescope.actions.remove_selection()*
+actions.remove_selection({prompt_bufnr})
     Remove current entry from multi select
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.toggle_selection({prompt_bufnr}) *telescope.actions.toggle_selection()*
+                                        *telescope.actions.toggle_selection()*
+actions.toggle_selection({prompt_bufnr})
     Toggle current entry status for multi select
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.select_all({prompt_bufnr})            *telescope.actions.select_all()*
     Multi select all entries.
-    - Note: selected entries may include results not visible in the results pop
-      up.
 
+    Note: ~
+      • selected entries may include results not visible in the results pop up.
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.drop_all({prompt_bufnr})                *telescope.actions.drop_all()*
     Drop all entries from the current multi selection.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.toggle_all({prompt_bufnr})            *telescope.actions.toggle_all()*
     Toggle multi selection for all entries.
-    - Note: toggled entries may include results not visible in the results pop
-      up.
 
+    Note: ~
+      • toggled entries may include results not visible in the results pop up.
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.preview_scrolling_up({prompt_bufnr}) *telescope.actions.preview_scrolling_up()*
+                                    *telescope.actions.preview_scrolling_up()*
+actions.preview_scrolling_up({prompt_bufnr})
     Scroll the preview window up
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.preview_scrolling_down({prompt_bufnr}) *telescope.actions.preview_scrolling_down()*
+                                  *telescope.actions.preview_scrolling_down()*
+actions.preview_scrolling_down({prompt_bufnr})
     Scroll the preview window down
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.preview_scrolling_left({prompt_bufnr}) *telescope.actions.preview_scrolling_left()*
+                                  *telescope.actions.preview_scrolling_left()*
+actions.preview_scrolling_left({prompt_bufnr})
     Scroll the preview window to the left
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.preview_scrolling_right({prompt_bufnr}) *telescope.actions.preview_scrolling_right()*
+                                 *telescope.actions.preview_scrolling_right()*
+actions.preview_scrolling_right({prompt_bufnr})
     Scroll the preview window to the right
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.results_scrolling_up({prompt_bufnr}) *telescope.actions.results_scrolling_up()*
+                                    *telescope.actions.results_scrolling_up()*
+actions.results_scrolling_up({prompt_bufnr})
     Scroll the results window up
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.results_scrolling_down({prompt_bufnr}) *telescope.actions.results_scrolling_down()*
+                                  *telescope.actions.results_scrolling_down()*
+actions.results_scrolling_down({prompt_bufnr})
     Scroll the results window down
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.results_scrolling_left({prompt_bufnr}) *telescope.actions.results_scrolling_left()*
+                                  *telescope.actions.results_scrolling_left()*
+actions.results_scrolling_left({prompt_bufnr})
     Scroll the results window to the left
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.results_scrolling_right({prompt_bufnr}) *telescope.actions.results_scrolling_right()*
+                                 *telescope.actions.results_scrolling_right()*
+actions.results_scrolling_right({prompt_bufnr})
     Scroll the results window to the right
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.center({prompt_bufnr})                    *telescope.actions.center()*
-    Center the cursor in the window, can be used after selecting a file to edit
-    You can just map `actions.select_default + actions.center`
-
+    Center the cursor in the window, can be used after selecting a file to
+    edit You can just map `actions.select_default + actions.center`
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.select_default({prompt_bufnr})    *telescope.actions.select_default()*
+                                          *telescope.actions.select_default()*
+actions.select_default({prompt_bufnr})
     Perform default action on selection, usually something like
     `:edit <selection>`
 
     i.e. open the selection in the current buffer
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.select_horizontal({prompt_bufnr}) *telescope.actions.select_horizontal()*
+                                       *telescope.actions.select_horizontal()*
+actions.select_horizontal({prompt_bufnr})
     Perform 'horizontal' action on selection, usually something like
     `:new <selection>`
 
     i.e. open the selection in a new horizontal split
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.select_vertical({prompt_bufnr})  *telescope.actions.select_vertical()*
+                                         *telescope.actions.select_vertical()*
+actions.select_vertical({prompt_bufnr})
     Perform 'vertical' action on selection, usually something like
     `:vnew <selection>`
 
     i.e. open the selection in a new vertical split
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.select_tab({prompt_bufnr})            *telescope.actions.select_tab()*
     Perform 'tab' action on selection, usually something like
@@ -2946,10 +2645,8 @@ actions.select_tab({prompt_bufnr})            *telescope.actions.select_tab()*
 
     i.e. open the selection in a new tab
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.select_drop({prompt_bufnr})          *telescope.actions.select_drop()*
     Perform 'drop' action on selection, usually something like
@@ -2957,529 +2654,460 @@ actions.select_drop({prompt_bufnr})          *telescope.actions.select_drop()*
 
     i.e. open the selection in a window
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.select_tab_drop({prompt_bufnr})  *telescope.actions.select_tab_drop()*
+                                         *telescope.actions.select_tab_drop()*
+actions.select_tab_drop({prompt_bufnr})
     Perform 'tab drop' action on selection, usually something like
     `:tab drop <selection>`
 
     i.e. open the selection in a new tab
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.file_edit({prompt_bufnr})              *telescope.actions.file_edit()*
     Perform file edit on selection, usually something like
     `:edit <selection>`
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.file_split({prompt_bufnr})            *telescope.actions.file_split()*
     Perform file split on selection, usually something like
     `:new <selection>`
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.file_vsplit({prompt_bufnr})          *telescope.actions.file_vsplit()*
     Perform file vsplit on selection, usually something like
     `:vnew <selection>`
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.file_tab({prompt_bufnr})                *telescope.actions.file_tab()*
     Perform file tab on selection, usually something like
     `:tabedit <selection>`
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.close({prompt_bufnr})                      *telescope.actions.close()*
     Close the Telescope window, usually used within an action
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions._close({prompt_bufnr})                    *telescope.actions._close()*
-    Close the Telescope window, usually used within an action
-    Deprecated and no longer needed, does the same as
-    |telescope.actions.close|. Might be removed in the future
-
-
-    Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
-
-actions.edit_command_line({prompt_bufnr}) *telescope.actions.edit_command_line()*
+                                       *telescope.actions.edit_command_line()*
+actions.edit_command_line({prompt_bufnr})
     Set a value in the command line and don't run it, making it editable.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.set_command_line({prompt_bufnr}) *telescope.actions.set_command_line()*
+                                        *telescope.actions.set_command_line()*
+actions.set_command_line({prompt_bufnr})
     Set a value in the command line and run it
 
+    Parameters: ~
+      • {prompt_bufnr}  (`number`) The prompt bufnr
+
+                                        *telescope.actions.edit_search_line()*
+actions.edit_search_line({prompt_bufnr})
+    Set a value in the search line and don't search for it, making it
+    editable.
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.edit_search_line({prompt_bufnr}) *telescope.actions.edit_search_line()*
-    Set a value in the search line and don't search for it, making it editable.
-
-
-    Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
-
-actions.set_search_line({prompt_bufnr})  *telescope.actions.set_search_line()*
+                                         *telescope.actions.set_search_line()*
+actions.set_search_line({prompt_bufnr})
     Set a value in the search line and search for it
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.edit_register({prompt_bufnr})      *telescope.actions.edit_register()*
+                                           *telescope.actions.edit_register()*
+actions.edit_register({prompt_bufnr})
     Edit a register
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.paste_register({prompt_bufnr})    *telescope.actions.paste_register()*
+                                          *telescope.actions.paste_register()*
+actions.paste_register({prompt_bufnr})
     Paste the selected register into the buffer
 
     Note: only meant to be used inside builtin.registers
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.insert_symbol({prompt_bufnr})      *telescope.actions.insert_symbol()*
+                                           *telescope.actions.insert_symbol()*
+actions.insert_symbol({prompt_bufnr})
     Insert a symbol into the current buffer (while switching to normal mode)
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.insert_symbol_i({prompt_bufnr})  *telescope.actions.insert_symbol_i()*
+                                         *telescope.actions.insert_symbol_i()*
+actions.insert_symbol_i({prompt_bufnr})
     Insert a symbol into the current buffer and keeping the insert mode.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_create_branch({prompt_bufnr}) *telescope.actions.git_create_branch()*
+                                       *telescope.actions.git_create_branch()*
+actions.git_create_branch({prompt_bufnr})
     Create and checkout a new git branch if it doesn't already exist
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_apply_stash({prompt_bufnr})  *telescope.actions.git_apply_stash()*
+                                         *telescope.actions.git_apply_stash()*
+actions.git_apply_stash({prompt_bufnr})
     Applies an existing git stash
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.git_checkout({prompt_bufnr})        *telescope.actions.git_checkout()*
     Checkout an existing git branch
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_switch_branch({prompt_bufnr}) *telescope.actions.git_switch_branch()*
+                                       *telescope.actions.git_switch_branch()*
+actions.git_switch_branch({prompt_bufnr})
     Switch to git branch.
     If the branch already exists in local, switch to that. If the branch is
     only in remote, create new branch tracking remote and switch to new one.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_rename_branch()            *telescope.actions.git_rename_branch()*
+                                       *telescope.actions.git_rename_branch()*
+actions.git_rename_branch({prompt_bufnr})
     Action to rename selected git branch
 
+    Parameters: ~
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_track_branch({prompt_bufnr}) *telescope.actions.git_track_branch()*
+                                        *telescope.actions.git_track_branch()*
+actions.git_track_branch({prompt_bufnr})
     Tell git to track the currently selected remote branch in Telescope
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_delete_branch({prompt_bufnr}) *telescope.actions.git_delete_branch()*
+                                       *telescope.actions.git_delete_branch()*
+actions.git_delete_branch({prompt_bufnr})
     Delete all currently selected branches
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_merge_branch({prompt_bufnr}) *telescope.actions.git_merge_branch()*
+                                        *telescope.actions.git_merge_branch()*
+actions.git_merge_branch({prompt_bufnr})
     Merge the currently selected branch
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_rebase_branch({prompt_bufnr}) *telescope.actions.git_rebase_branch()*
+                                       *telescope.actions.git_rebase_branch()*
+actions.git_rebase_branch({prompt_bufnr})
     Rebase to selected git branch
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_reset_mixed({prompt_bufnr})  *telescope.actions.git_reset_mixed()*
+                                         *telescope.actions.git_reset_mixed()*
+actions.git_reset_mixed({prompt_bufnr})
     Reset to selected git commit using mixed mode
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_reset_soft({prompt_bufnr})    *telescope.actions.git_reset_soft()*
+                                          *telescope.actions.git_reset_soft()*
+actions.git_reset_soft({prompt_bufnr})
     Reset to selected git commit using soft mode
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_reset_hard({prompt_bufnr})    *telescope.actions.git_reset_hard()*
+                                          *telescope.actions.git_reset_hard()*
+actions.git_reset_hard({prompt_bufnr})
     Reset to selected git commit using hard mode
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_checkout_current_buffer({prompt_bufnr}) *telescope.actions.git_checkout_current_buffer()*
+                             *telescope.actions.git_checkout_current_buffer()*
+actions.git_checkout_current_buffer({prompt_bufnr})
     Checkout a specific file for a given sha
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.git_staging_toggle({prompt_bufnr}) *telescope.actions.git_staging_toggle()*
+                                      *telescope.actions.git_staging_toggle()*
+actions.git_staging_toggle({prompt_bufnr})
     Stage/unstage selected file
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.send_selected_to_qflist({prompt_bufnr}) *telescope.actions.send_selected_to_qflist()*
+                                 *telescope.actions.send_selected_to_qflist()*
+actions.send_selected_to_qflist({prompt_bufnr})
     Sends the selected entries to the quickfix list, replacing the previous
     entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.add_selected_to_qflist({prompt_bufnr}) *telescope.actions.add_selected_to_qflist()*
+                                  *telescope.actions.add_selected_to_qflist()*
+actions.add_selected_to_qflist({prompt_bufnr})
     Adds the selected entries to the quickfix list, keeping the previous
     entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.send_to_qflist({prompt_bufnr})    *telescope.actions.send_to_qflist()*
+                                          *telescope.actions.send_to_qflist()*
+actions.send_to_qflist({prompt_bufnr})
     Sends all entries to the quickfix list, replacing the previous entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.add_to_qflist({prompt_bufnr})      *telescope.actions.add_to_qflist()*
+                                           *telescope.actions.add_to_qflist()*
+actions.add_to_qflist({prompt_bufnr})
     Adds all entries to the quickfix list, keeping the previous entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.send_selected_to_loclist({prompt_bufnr}) *telescope.actions.send_selected_to_loclist()*
+                                *telescope.actions.send_selected_to_loclist()*
+actions.send_selected_to_loclist({prompt_bufnr})
     Sends the selected entries to the location list, replacing the previous
     entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.add_selected_to_loclist({prompt_bufnr}) *telescope.actions.add_selected_to_loclist()*
+                                 *telescope.actions.add_selected_to_loclist()*
+actions.add_selected_to_loclist({prompt_bufnr})
     Adds the selected entries to the location list, keeping the previous
     entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.send_to_loclist({prompt_bufnr})  *telescope.actions.send_to_loclist()*
+                                         *telescope.actions.send_to_loclist()*
+actions.send_to_loclist({prompt_bufnr})
     Sends all entries to the location list, replacing the previous entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.add_to_loclist({prompt_bufnr})    *telescope.actions.add_to_loclist()*
+                                          *telescope.actions.add_to_loclist()*
+actions.add_to_loclist({prompt_bufnr})
     Adds all entries to the location list, keeping the previous entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.smart_send_to_qflist({prompt_bufnr}) *telescope.actions.smart_send_to_qflist()*
+                                    *telescope.actions.smart_send_to_qflist()*
+actions.smart_send_to_qflist({prompt_bufnr})
     Sends the selected entries to the quickfix list, replacing the previous
     entries. If no entry was selected, sends all entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.smart_add_to_qflist({prompt_bufnr}) *telescope.actions.smart_add_to_qflist()*
+                                     *telescope.actions.smart_add_to_qflist()*
+actions.smart_add_to_qflist({prompt_bufnr})
     Adds the selected entries to the quickfix list, keeping the previous
     entries. If no entry was selected, adds all entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.smart_send_to_loclist({prompt_bufnr}) *telescope.actions.smart_send_to_loclist()*
+                                   *telescope.actions.smart_send_to_loclist()*
+actions.smart_send_to_loclist({prompt_bufnr})
     Sends the selected entries to the location list, replacing the previous
     entries. If no entry was selected, sends all entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.smart_add_to_loclist({prompt_bufnr}) *telescope.actions.smart_add_to_loclist()*
+                                    *telescope.actions.smart_add_to_loclist()*
+actions.smart_add_to_loclist({prompt_bufnr})
     Adds the selected entries to the location list, keeping the previous
     entries. If no entry was selected, adds all entries.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.complete_tag({prompt_bufnr})        *telescope.actions.complete_tag()*
     Open completion menu containing the tags which can be used to filter the
     results in a faster way
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.cycle_history_next({prompt_bufnr}) *telescope.actions.cycle_history_next()*
+                                      *telescope.actions.cycle_history_next()*
+actions.cycle_history_next({prompt_bufnr})
     Cycle to the next search prompt in the history
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.cycle_history_prev({prompt_bufnr}) *telescope.actions.cycle_history_prev()*
+                                      *telescope.actions.cycle_history_prev()*
+actions.cycle_history_prev({prompt_bufnr})
     Cycle to the previous search prompt in the history
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.open_qflist({prompt_bufnr})          *telescope.actions.open_qflist()*
     Open the quickfix list. It makes sense to use this in combination with one
-    of the send_to_qflist actions `actions.smart_send_to_qflist +
-    actions.open_qflist`
-
+    of the send_to_qflist actions
+    `actions.smart_send_to_qflist + actions.open_qflist`
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.open_loclist({prompt_bufnr})        *telescope.actions.open_loclist()*
     Open the location list. It makes sense to use this in combination with one
-    of the send_to_loclist actions `actions.smart_send_to_qflist +
-    actions.open_qflist`
-
+    of the send_to_loclist actions
+    `actions.smart_send_to_qflist + actions.open_qflist`
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.delete_buffer({prompt_bufnr})      *telescope.actions.delete_buffer()*
+                                           *telescope.actions.delete_buffer()*
+actions.delete_buffer({prompt_bufnr})
     Delete the selected buffer or all the buffers selected using multi
     selection.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.cycle_previewers_next({prompt_bufnr}) *telescope.actions.cycle_previewers_next()*
+                                   *telescope.actions.cycle_previewers_next()*
+actions.cycle_previewers_next({prompt_bufnr})
     Cycle to the next previewer if there is one available.
     This action is not mapped on default.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.cycle_previewers_prev({prompt_bufnr}) *telescope.actions.cycle_previewers_prev()*
+                                   *telescope.actions.cycle_previewers_prev()*
+actions.cycle_previewers_prev({prompt_bufnr})
     Cycle to the previous previewer if there is one available.
     This action is not mapped on default.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.remove_selected_picker({prompt_bufnr}) *telescope.actions.remove_selected_picker()*
+                                  *telescope.actions.remove_selected_picker()*
+actions.remove_selected_picker({prompt_bufnr})
     Removes the selected picker in |builtin.pickers|.
     This action is not mapped by default and only intended for
     |builtin.pickers|.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.which_key({prompt_bufnr})              *telescope.actions.which_key()*
     Display the keymaps of registered actions similar to which-key.nvim.
 
-    - Notes:
-      - The defaults can be overridden via |action_generate.which_key|.
-
+    Note: ~
+      • The defaults can be overridden via |action_generate.which_key|.
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.to_fuzzy_refine({prompt_bufnr})  *telescope.actions.to_fuzzy_refine()*
+                                         *telescope.actions.to_fuzzy_refine()*
+actions.to_fuzzy_refine({prompt_bufnr})
     Move from a non-fuzzy search to a fuzzy one.
     This action is meant to be used in live_grep and
     lsp_dynamic_workspace_symbols
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 actions.delete_mark({prompt_bufnr})          *telescope.actions.delete_mark()*
     Delete the selected mark or all the marks selected using multi selection.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.insert_original_cword({prompt_bufnr}) *telescope.actions.insert_original_cword()*
+                                   *telescope.actions.insert_original_cword()*
+actions.insert_original_cword({prompt_bufnr})
     Insert the word under the cursor of the original (pre-Telescope) window
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.insert_original_cWORD({prompt_bufnr}) *telescope.actions.insert_original_cWORD()*
+                                   *telescope.actions.insert_original_cWORD()*
+actions.insert_original_cWORD({prompt_bufnr})
     Insert the WORD under the cursor of the original (pre-Telescope) window
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.insert_original_cfile({prompt_bufnr}) *telescope.actions.insert_original_cfile()*
+                                   *telescope.actions.insert_original_cfile()*
+actions.insert_original_cfile({prompt_bufnr})
     Insert the file under the cursor of the original (pre-Telescope) window
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-actions.insert_original_cline({prompt_bufnr}) *telescope.actions.insert_original_cline()*
+                                   *telescope.actions.insert_original_cline()*
+actions.insert_original_cline({prompt_bufnr})
     Insert the line under the cursor of the original (pre-Telescope) window
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 
-
-================================================================================
-ACTIONS_STATE                                          *telescope.actions.state*
+==============================================================================
+ACTIONS_STATE                                        *telescope.actions_state*
 
 Functions to be used to determine the current state of telescope.
 
 Generally used from within other |telescope.actions|
 
-action_state.get_selected_entry() *telescope.actions.state.get_selected_entry()*
+                                *telescope.actions_state.get_selected_entry()*
+actions_state.get_selected_entry()
     Get the current entry
 
+    Return: ~
+        (`table`) the selected entry
 
-
-action_state.get_current_line()   *telescope.actions.state.get_current_line()*
+                                  *telescope.actions_state.get_current_line()*
+actions_state.get_current_line()
     Gets the current line in the search prompt
 
+    Return: ~
+        (`string`) the current line in the search prompt
 
-
-action_state.get_current_picker({prompt_bufnr}) *telescope.actions.state.get_current_picker()*
+                                *telescope.actions_state.get_current_picker()*
+actions_state.get_current_picker({prompt_bufnr})
     Gets the current picker
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
+
+    Return: ~
+        (`table`) the current picker
 
 
-
-================================================================================
-ACTIONS_SET                                              *telescope.actions.set*
+==============================================================================
+ACTIONS_SET                                            *telescope.actions_set*
 
 Telescope action sets are used to provide an interface for managing actions
 that all primarily do the same thing, but with slight tweaks.
@@ -3489,390 +3117,318 @@ vertical split, etc. Instead of making users have to overwrite EACH of those
 every time they want to change this behavior, they can instead replace the
 `set` itself and then it will work great and they're done.
 
-action_set.shift_selection({prompt_bufnr}, {change}) *telescope.actions.set.shift_selection()*
+                                     *telescope.actions_set.shift_selection()*
+actions_set.shift_selection({prompt_bufnr}, {change})
     Move the current selection of a picker {change} rows. Handles not
     overflowing / underflowing the list.
 
-
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-        {change}       (number)  The amount to shift the selection by
+      • {prompt_bufnr}  (`number`) The prompt bufnr
+      • {change}        (`number`) The amount to shift the selection by
 
 
-action_set.select({prompt_bufnr}, {type})     *telescope.actions.set.select()*
-    Select the current entry. This is the action set to overwrite common
-    actions by the user.
-
-    By default maps to editing a file.
-
-
-    Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-        {type}         (string)  The type of selection to make
-
-
-action_set.edit({prompt_bufnr}, {command})      *telescope.actions.set.edit()*
-    Edit a file based on the current selection.
-
-
-    Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-        {command}      (string)  The command to use to open the file.
-
-
-action_set.scroll_previewer({prompt_bufnr}, {direction}) *telescope.actions.set.scroll_previewer()*
-    Scrolls the previewer up or down. Defaults to a half page scroll, but can
-    be overridden using the `scroll_speed` option in `layout_config`. See
-    |telescope.layout| for more details.
-
-
-    Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-        {direction}    (number)  The direction of the scrolling
-
-
-action_set.scroll_horizontal_previewer({prompt_bufnr}, {direction}) *telescope.actions.set.scroll_horizontal_previewer()*
-    Scrolls the previewer to the left or right. Defaults to a half page scroll,
-    but can be overridden using the `scroll_speed` option in `layout_config`.
-    See |telescope.layout| for more details.
-
-
-    Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-        {direction}    (number)  The direction of the scrolling
-
-
-action_set.scroll_results({prompt_bufnr}, {direction}) *telescope.actions.set.scroll_results()*
-    Scrolls the results up or down. Defaults to a half page scroll, but can be
-    overridden using the `scroll_speed` option in `layout_config`. See
-    |telescope.layout| for more details.
-
-
-    Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-        {direction}    (number)  The direction of the scrolling
-
-
-action_set.scroll_horizontal_results({prompt_bufnr}, {direction}) *telescope.actions.set.scroll_horizontal_results()*
-    Scrolls the results to the left or right. Defaults to a half page scroll,
-    but can be overridden using the `scroll_speed` option in `layout_config`.
-    See |telescope.layout| for more details.
-
-
-    Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-        {direction}    (number)  The direction of the scrolling
-
-
-
-================================================================================
-ACTIONS_LAYOUT                                        *telescope.actions.layout*
+==============================================================================
+ACTIONS_LAYOUT                                      *telescope.actions_layout*
 
 The layout actions are actions to be used to change the layout of a picker.
 
-action_layout.toggle_preview({prompt_bufnr}) *telescope.actions.layout.toggle_preview()*
+                                   *telescope.actions_layout.toggle_preview()*
+actions_layout.toggle_preview({prompt_bufnr})
     Toggle preview window.
-    - Note: preview window can be toggled even if preview is set to false.
 
-    This action is not mapped by default.
-
+    Note: ~
+      • preview window can be toggled even if preview is set to false.
+      • this action is not mapped by default.
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-action_layout.toggle_prompt_position({prompt_bufnr}) *telescope.actions.layout.toggle_prompt_position()*
+                           *telescope.actions_layout.toggle_prompt_position()*
+actions_layout.toggle_prompt_position({prompt_bufnr})
     Toggles the `prompt_position` option between "top" and "bottom". Checks if
     `prompt_position` is an option for the current layout.
 
-    This action is not mapped by default.
-
+    Note: ~
+      • this action is not mapped by default.
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-action_layout.toggle_mirror({prompt_bufnr}) *telescope.actions.layout.toggle_mirror()*
+                                    *telescope.actions_layout.toggle_mirror()*
+actions_layout.toggle_mirror({prompt_bufnr})
     Toggles the `mirror` option between `true` and `false`. Checks if `mirror`
     is an option for the current layout.
 
-    This action is not mapped by default.
-
+    Note: ~
+      • this action is not mapped by default.
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-action_layout.cycle_layout_next({prompt_bufnr}) *telescope.actions.layout.cycle_layout_next()*
+                                *telescope.actions_layout.cycle_layout_next()*
+actions_layout.cycle_layout_next({prompt_bufnr})
     Cycles to the next layout in `cycle_layout_list`.
 
-    This action is not mapped by default.
-
+    Note: ~
+      • this action is not mapped by default.
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
-
-action_layout.cycle_layout_prev({prompt_bufnr}) *telescope.actions.layout.cycle_layout_prev()*
+                                *telescope.actions_layout.cycle_layout_prev()*
+actions_layout.cycle_layout_prev({prompt_bufnr})
     Cycles to the previous layout in `cycle_layout_list`.
 
-    This action is not mapped by default.
-
+    Note: ~
+      • this action is not mapped by default.
 
     Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 
-
-================================================================================
-ACTIONS_UTILS                                          *telescope.actions.utils*
+==============================================================================
+ACTIONS_UTILS                                        *telescope.actions_utils*
 
 Utilities to wrap functions around picker selections and entries.
 
 Generally used from within other |telescope.actions|
 
-utils.map_entries({prompt_bufnr}, {f}) *telescope.actions.utils.map_entries()*
+                                       *telescope.actions_utils.map_entries()*
+actions_utils.map_entries({prompt_bufnr}, {f})
     Apply `f` to the entries of the current picker.
-    - Notes:
-      - Mapped entries include all currently filtered results, not just the
+    • Notes:
+      • Mapped entries include all currently filtered results, not just the
         visible ones.
-      - Indices are 1-indexed, whereas rows are 0-indexed.
-    - Warning: `map_entries` has no return value.
-      - The below example showcases how to collect results
+      • Indices are 1-indexed, whereas rows are 0-indexed.
+    • Warning: `map_entries` has no return value.
+      • The below example showcases how to collect results
 
-    Usage:
-    >
-      local action_state = require "telescope.actions.state"
-      local action_utils = require "telescope.actions.utils"
-      function entry_value_by_row()
-        local prompt_bufnr = vim.api.nvim_get_current_buf()
-        local current_picker = action_state.get_current_picker(prompt_bufnr)
-        local results = {}
-        action_utils.map_entries(prompt_bufnr, function(entry, index, row)
-          results[row] = entry.value
-        end)
-        return results
-      end
+    Usage: >lua
+    local action_state = require "telescope.actions.state"
+    local action_utils = require "telescope.actions.utils"
+    function entry_value_by_row()
+      local prompt_bufnr = vim.api.nvim_get_current_buf()
+      local current_picker = action_state.get_current_picker(prompt_bufnr)
+      local results = {}
+      action_utils.map_entries(prompt_bufnr, function(entry, index, row)
+        results[row] = entry.value
+      end)
+      return results
+    end
 <
 
-
     Parameters: ~
-        {prompt_bufnr} (number)    The prompt bufnr
-        {f}            (function)  Function to map onto entries of picker that
-                                   takes (entry, index, row) as viable
-                                   arguments
+      • {prompt_bufnr}  (`number`) The prompt bufnr
+      • {f}             (`function`) Function to map onto entries of picker
+                        that takes (entry, index, row) as viable arguments
 
-
-utils.map_selections({prompt_bufnr}, {f}) *telescope.actions.utils.map_selections()*
+                                    *telescope.actions_utils.map_selections()*
+actions_utils.map_selections({prompt_bufnr}, {f})
     Apply `f` to the multi selections of the current picker and return a table
     of mapped selections.
-    - Notes:
-      - Mapped selections may include results not visible in the results pop
+    • Notes:
+      • Mapped selections may include results not visible in the results pop
         up.
-      - Selected entries are returned in order of their selection.
-    - Warning: `map_selections` has no return value.
-      - The below example showcases how to collect results
+      • Selected entries are returned in order of their selection.
+    • Warning: `map_selections` has no return value.
+      • The below example showcases how to collect results
 
-    Usage:
-    >
-      local action_state = require "telescope.actions.state"
-      local action_utils = require "telescope.actions.utils"
-      function selection_by_index()
-        local prompt_bufnr = vim.api.nvim_get_current_buf()
-        local current_picker = action_state.get_current_picker(prompt_bufnr)
-        local results = {}
-        action_utils.map_selections(prompt_bufnr, function(entry, index)
-          results[index] = entry.value
-        end)
-        return results
-      end
+    Usage: >lua
+    local action_state = require "telescope.actions.state"
+    local action_utils = require "telescope.actions.utils"
+    function selection_by_index()
+      local prompt_bufnr = vim.api.nvim_get_current_buf()
+      local current_picker = action_state.get_current_picker(prompt_bufnr)
+      local results = {}
+      action_utils.map_selections(prompt_bufnr, function(entry, index)
+        results[index] = entry.value
+      end)
+      return results
+    end
 <
 
+    Parameters: ~
+      • {prompt_bufnr}  (`number`) The prompt bufnr
+      • {f}             (`function`) Function to map onto selection of picker
+                        that takes (selection) as a viable argument
+
+                           *telescope.actions_utils.get_registered_mappings()*
+actions_utils.get_registered_mappings({prompt_bufnr})
+    Utility to collect mappings of prompt buffer in array of
+    `{mode, keybind, name}`.
 
     Parameters: ~
-        {prompt_bufnr} (number)    The prompt bufnr
-        {f}            (function)  Function to map onto selection of picker
-                                   that takes (selection) as a viable argument
+      • {prompt_bufnr}  (`number`) The prompt bufnr
 
 
-utils.get_registered_mappings({prompt_bufnr}) *telescope.actions.utils.get_registered_mappings()*
-    Utility to collect mappings of prompt buffer in array of `{mode, keybind,
-    name}`.
-
-
-    Parameters: ~
-        {prompt_bufnr} (number)  The prompt bufnr
-
-
-
-================================================================================
-ACTIONS_GENERATE                                    *telescope.actions.generate*
+==============================================================================
+ACTIONS_GENERATE                                  *telescope.actions_generate*
 
 Module for convenience to override defaults of corresponding
 |telescope.actions| at |telescope.setup()|.
 
-General usage:
->
-  require("telescope").setup {
-    defaults = {
-      mappings = {
-        n = {
-          ["?"] = action_generate.which_key {
-            name_width = 20, -- typically leads to smaller floats
-            max_height = 0.5, -- increase potential maximum height
-            separator = " > ", -- change sep between mode, keybind, and name
-            close_with_action = false, -- do not close float on action
+General usage: >lua
+    require("telescope").setup {
+      defaults = {
+        mappings = {
+          n = {
+            ["?"] = action_generate.which_key {
+              name_width = 20, -- typically leads to smaller floats
+              max_height = 0.5, -- increase potential maximum height
+              separator = " > ", -- change sep between mode, keybind, and name
+              close_with_action = false, -- do not close float on action
+            },
           },
         },
       },
-    },
-  }
+    }
 <
 
-action_generate.which_key({opts})     *telescope.actions.generate.which_key()*
+                                      *telescope.actions_generate.which_key()*
+actions_generate.which_key({opts})
     Display the keymaps of registered actions similar to which-key.nvim.
-
-    - Floating window:
-      - Appears on the opposite side of the prompt.
-      - Resolves to minimum required number of lines to show hints with `opts`
+    • Floating window:
+      • Appears on the opposite side of the prompt.
+      • Resolves to minimum required number of lines to show hints with `opts`
         or truncates entries at `max_height`.
-      - Closes automatically on action call and can be disabled with by setting
-        `close_with_action` to false.
-
+      • Closes automatically on action call and can be disabled with by
+        setting `close_with_action` to false.
 
     Parameters: ~
-        {opts} (table)  options to pass to toggling registered actions
+      • {opts}  (`table`) options to pass to toggling registered actions
+
+
+==============================================================================
+ACTIONS_HISTORY                                    *telescope.actions_history*
+
+A base implementation of a prompt history that provides a simple history and
+can be replaced with a custom implementation.
+
+For example: We provide an extension for a smart history that uses sql.nvim to
+map histories to metadata, like the calling picker or cwd.
+
+So you have a history for:
+• find_files project_1
+• grep_string project_1
+• live_grep project_1
+• find_files project_2
+• grep_string project_2
+• live_grep project_2
+• etc
+
+See https://github.com/nvim-telescope/telescope-smart-history.nvim
+
+*History*
+    Manages prompt history
 
     Fields: ~
-        {max_height}             (number)   % of max. height or no. of rows
-                                            for hints (default: 0.4), see
-                                            |resolver.resolve_height()|
-        {only_show_current_mode} (boolean)  only show keymaps for the current
-                                            mode (default: true)
-        {mode_width}             (number)   fixed width of mode to be shown
-                                            (default: 1)
-        {keybind_width}          (number)   fixed width of keybind to be shown
-                                            (default: 7)
-        {name_width}             (number)   fixed width of action name to be
-                                            shown (default: 30)
-        {column_padding}         (string)   string to split; can be used for
-                                            vertical separator (default: " ")
-        {mode_hl}                (string)   hl group of mode (default:
-                                            TelescopeResultsConstant)
-        {keybind_hl}             (string)   hl group of keybind (default:
-                                            TelescopeResultsVariable)
-        {name_hl}                (string)   hl group of action name (default:
-                                            TelescopeResultsFunction)
-        {column_indent}          (number)   number of left-most spaces before
-                                            keybinds are shown (default: 4)
-        {line_padding}           (number)   row padding in top and bottom of
-                                            float (default: 1)
-        {separator}              (string)   separator string between mode, key
-                                            bindings, and action (default: "
-                                            -> ")
-        {close_with_action}      (boolean)  registered action will close
-                                            keymap float (default: true)
-        {normal_hl}              (string)   winhl of "Normal" for keymap hints
-                                            floating window (default:
-                                            "TelescopePrompt")
-        {border_hl}              (string)   winhl of "Normal" for keymap
-                                            borders (default:
-                                            "TelescopePromptBorder")
-        {winblend}               (number)   pseudo-transparency of keymap
-                                            hints floating window
-        {zindex}                 (number)   z-index of keymap hints floating
-                                            window (default: 100)
+      • {enabled}     (`boolean`) Will indicate if History is enabled or
+                      disabled
+      • {path}        (`string`) Will point to the location of the history
+                      file
+      • {limit}       (`string`) Will have the limit of the history. Can be
+                      nil, if limit is disabled.
+      • {content}     (`table`) History table. Needs to be filled by your own
+                      History implementation
+      • {index}       (`number`) Used to keep track of the next or previous
+                      index. Default is #content + 1
+      • {cycle_wrap}  (`boolean`) Controls if history will wrap on reaching
+                      beginning or end
 
 
+histories.new()                              *telescope.actions_history.new()*
+    Shorthand to create a new history
 
-================================================================================
-PREVIEWERS                                                *telescope.previewers*
+                              *telescope.actions_history.get_simple_history()*
+histories.get_simple_history()
+    A simple implementation of history.
+
+    It will keep one unified history across all pickers.
+
+
+==============================================================================
+PREVIEWERS                                              *telescope.previewers*
 
 Provides a Previewer table that has to be implemented by each previewer. To
 achieve this, this module also provides two wrappers that abstract most of the
 work and make it really easy to create new previewers.
-  - `previewers.new_termopen_previewer`
-  - `previewers.new_buffer_previewer`
+• `previewers.new_termopen_previewer`
+• `previewers.new_buffer_previewer`
 
 Furthermore, there are a collection of previewers already defined which can be
 used for every picker, as long as the entries of the picker provide the
 necessary fields. The more important ones are
-  - `previewers.cat`
-  - `previewers.vimgrep`
-  - `previewers.qflist`
-  - `previewers.vim_buffer_cat`
-  - `previewers.vim_buffer_vimgrep`
-  - `previewers.vim_buffer_qflist`
+• `previewers.cat`
+• `previewers.vimgrep`
+• `previewers.qflist`
+• `previewers.vim_buffer_cat`
+• `previewers.vim_buffer_vimgrep`
+• `previewers.vim_buffer_qflist`
 
-Previewers can be disabled for any builtin or custom picker by doing :Telescope
-find_files previewer=false
+Previewers can be disabled for any builtin or custom picker by doing
+`:Telescope find_files previewer=false`
 
-previewers.Previewer()                      *telescope.previewers.Previewer()*
+previewers.Previewer                          *telescope.previewers.Previewer*
     This is the base table all previewers have to implement. It's possible to
-    write a wrapper for this because most previewers need to have the same keys
-    set. Examples of wrappers are:
-      - `new_buffer_previewer`
-      - `new_termopen_previewer`
+    write a wrapper for this because most previewers need to have the same
+    keys set. Examples of wrappers are:
+    • `new_buffer_previewer`
+    • `new_termopen_previewer`
 
     To create a new table do following:
-      - `local new_previewer = Previewer:new(opts)`
+    • `local new_previewer = Previewer:new(opts)`
 
     What `:new` expects is listed below
 
-    The interface provides the following set of functions. All of them, besides
-    `new`, will be handled by telescope pickers.
-    - `:new(opts)`
-    - `:preview(entry, status)`
-    - `:teardown()`
-    - `:send_input(input)`
-    - `:scroll_fn(direction)`
-    - `:scroll_horizontal_fn(direction)`
+    The interface provides the following set of functions. All of them,
+    besides `new`, will be handled by telescope pickers.
+    • `:new(opts)`
+    • `:preview(entry, status)`
+    • `:teardown()`
+    • `:send_input(input)`
+    • `:scroll_fn(direction)`
+    • `:scroll_horizontal_fn(direction)`
 
     `Previewer:new()` expects a table as input with following keys:
-      - `setup` function(self): Will be called the first time preview will be 
-        called.
-      - `teardown` function(self): Will be called on clean up.
-      - `preview_fn` function(self, entry, status): Will be called each time a
-        new entry was selected.
-      - `title` function(self): Will return the static title of the previewer.
-      - `dynamic_title` function(self, entry): Will return the dynamic title of
-        the previewer. Will only be called when config value
-        dynamic_preview_title is true.
-      - `send_input` function(self, input): This is meant for 
-        `termopen_previewer` and it can be used to send input to the terminal 
-        application, like less.
-      - `scroll_fn` function(self, direction): Used to make scrolling work.
-      - `scroll_horizontal_fn` function(self, direction): Used to make 
-        horizontal scrolling work.
-
-
+    • `setup` function(self): Will be called the first time preview will be
+      called.
+    • `teardown` function(self): Will be called on clean up.
+    • `preview_fn` function(self, entry, status): Will be called each time a
+      new entry was selected.
+    • `title` function(self): Will return the static title of the previewer.
+    • `dynamic_title` function(self, entry): Will return the dynamic title of
+      the previewer. Will only be called when config value
+      dynamic_preview_title is true.
+    • `send_input` function(self, input): This is meant for
+      `termopen_previewer` and it can be used to send input to the terminal
+      application, like less.
+    • `scroll_fn` function(self, direction): Used to make scrolling work.
+    • `scroll_horizontal_fn` function(self, direction): Used to make
+      horizontal scrolling work.
 
 previewers.new()                                  *telescope.previewers.new()*
     A shorthand for creating a new Previewer. The provided table will be
     forwarded to `Previewer:new(...)`
 
-
-
-previewers.new_termopen_previewer() *telescope.previewers.new_termopen_previewer()*
+                               *telescope.previewers.new_termopen_previewer()*
+previewers.new_termopen_previewer({opts})
     Is a wrapper around Previewer and helps with creating a new
     `termopen_previewer`.
 
     It requires you to specify one table entry `get_command(entry, status)`.
-    This `get_command` function has to return the terminal command that will be
-    executed for each entry. Example:
-    >
-      get_command = function(entry, status)
-        return { 'bat', entry.path }
-      end
+    This `get_command` function has to return the terminal command that will
+    be executed for each entry. Example: >lua
+    get_command = function(entry, status)
+      return { 'bat', entry.path }
+    end
 <
-
     Additionally you can define:
-    - `title` a static title for example "File Preview"
-    - `dyn_title(self, entry)` a dynamic title function which gets called when
+    • `title` a static title for example "File Preview"
+    • `dyn_title(self, entry)` a dynamic title function which gets called when
       config value `dynamic_preview_title = true`
-    - `env` table: define environment variables to forward to the terminal 
+    • `env` table: define environment variables to forward to the terminal
       process. Example:
-      - `{ ['PAGER'] = '', ['MANWIDTH'] = 50 }`
+      • `{ ['PAGER'] = '', ['MANWIDTH'] = 50 }`
 
     It's an easy way to get your first previewer going and it integrates well
     with `bat` and `less`. Providing out of the box scrolling if the command
@@ -3881,22 +3437,24 @@ previewers.new_termopen_previewer() *telescope.previewers.new_termopen_previewer
     Furthermore, if `env` is not set, it will forward all `config.set_env`
     environment variables to that terminal process.
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.cat()                                  *telescope.previewers.cat()*
+previewers.cat({opts})                            *telescope.previewers.cat()*
     Provides a `termopen_previewer` which has the ability to display files. It
-    will always show the top of the file and has support for `bat`(prioritized)
-    and `cat`. Each entry has to provide either the field `path` or `filename`
-    in order to make this previewer work.
+    will always show the top of the file and has support for
+    `bat`(prioritized) and `cat`. Each entry has to provide either the field
+    `path` or `filename` in order to make this previewer work.
 
     The preferred way of using this previewer is like this
     `require('telescope.config').values.cat_previewer` This will respect user
-    configuration and will use `buffer_previewers` in case it's configured that
-    way.
+    configuration and will use `buffer_previewers` in case it's configured
+    that way.
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.vimgrep()                          *telescope.previewers.vimgrep()*
+previewers.vimgrep({opts})                    *telescope.previewers.vimgrep()*
     Provides a `termopen_previewer` which has the ability to display files at
     the provided line. It has support for `bat`(prioritized) and `cat`. Each
     entry has to provide either the field `path` or `filename` and a `lnum`
@@ -3904,12 +3462,13 @@ previewers.vimgrep()                          *telescope.previewers.vimgrep()*
 
     The preferred way of using this previewer is like this
     `require('telescope.config').values.grep_previewer` This will respect user
-    configuration and will use `buffer_previewers` in case it's configured that
-    way.
+    configuration and will use `buffer_previewers` in case it's configured
+    that way.
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.qflist()                            *telescope.previewers.qflist()*
+previewers.qflist({opts})                      *telescope.previewers.qflist()*
     Provides a `termopen_previewer` which has the ability to display files at
     the provided line or range. It has support for `bat`(prioritized) and
     `cat`. Each entry has to provide either the field `path` or `filename`,
@@ -3921,13 +3480,15 @@ previewers.qflist()                            *telescope.previewers.qflist()*
     user configuration and will use buffer previewers in case it's configured
     that way.
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.new_buffer_previewer() *telescope.previewers.new_buffer_previewer()*
+                                 *telescope.previewers.new_buffer_previewer()*
+previewers.new_buffer_previewer({opts})
     An interface to instantiate a new `buffer_previewer`. That means that the
     content actually lives inside a vim buffer which enables us more control
-    over the actual content. For example, we can use `vim.fn.search` to jump to
-    a specific line or reuse buffers/already opened files more easily. This
+    over the actual content. For example, we can use `vim.fn.search` to jump
+    to a specific line or reuse buffers/already opened files more easily. This
     interface is more complex than `termopen_previewer` but offers more
     flexibility over your content. It was designed to display files but was
     extended to also display the output of terminal commands.
@@ -3935,111 +3496,112 @@ previewers.new_buffer_previewer() *telescope.previewers.new_buffer_previewer()*
     In the following options, state table and general tips are mentioned to
     make your experience with this previewer more seamless.
 
-
     options:
-      - `define_preview = function(self, entry, status)` (required) Is called
-        for each selected entry, after each selection_move (up or down) and is
-        meant to handle things like reading file, jump to line or attach a
-        highlighter.
-      - `setup = function(self)` (optional) Is called once at the beginning,
-        before the preview for the first entry is displayed. You can return a
-        table of vars that will be available in `self.state` in each
-        `define_preview` call.
-      - `teardown = function(self)` (optional) Will be called at the end, when
-        the picker is being closed and is meant to clean up everything that was
-        allocated by the previewer. The `buffer_previewer` will automatically
-        clean up all created buffers. So you only need to handle things that
-        were introduced by you.
-      - `keep_last_buf = true` (optional) Will not delete the last selected
-        buffer. This would allow you to reuse that buffer in the select action.
-        For example, that buffer can be opened in a new split, rather than
-        recreating that buffer in an action. To access the last buffer number: 
-        `require('telescope.state').get_global_key("last_preview_bufnr")`
-      - `get_buffer_by_name = function(self, entry)` Allows you to set a unique
-        name for each buffer. This is used for caching purposes.
-        `self.state.bufname` will be nil if the entry was never loaded or the
-        unique name when it was loaded once. For example, useful if you have
-        one file but multiple entries. This happens for grep and lsp builtins.
-        So to make the cache work only load content if `self.state.bufname ~=
-        entry.your_unique_key`
-      - `title` a static title for example "File Preview"
-      - `dyn_title(self, entry)` a dynamic title function which gets called 
-        when config value `dynamic_preview_title = true`
+    • `define_preview = function(self, entry, status)` (required) Is called
+      for each selected entry, after each selection_move (up or down) and is
+      meant to handle things like reading file, jump to line or attach a
+      highlighter.
+    • `setup = function(self)` (optional) Is called once at the beginning,
+      before the preview for the first entry is displayed. You can return a
+      table of vars that will be available in `self.state` in each
+      `define_preview` call.
+    • `teardown = function(self)` (optional) Will be called at the end, when
+      the picker is being closed and is meant to clean up everything that was
+      allocated by the previewer. The `buffer_previewer` will automatically
+      clean up all created buffers. So you only need to handle things that
+      were introduced by you.
+    • `keep_last_buf = true` (optional) Will not delete the last selected
+      buffer. This would allow you to reuse that buffer in the select action.
+      For example, that buffer can be opened in a new split, rather than
+      recreating that buffer in an action. To access the last buffer number:
+      `require('telescope.state').get_global_key("last_preview_bufnr")`
+    • `get_buffer_by_name = function(self, entry)` Allows you to set a unique
+      name for each buffer. This is used for caching purposes.
+      `self.state.bufname` will be nil if the entry was never loaded or the
+      unique name when it was loaded once. For example, useful if you have one
+      file but multiple entries. This happens for grep and lsp builtins. So to
+      make the cache work only load content if
+      `self.state.bufname ~= entry.your_unique_key`
+    • `title` a static title for example "File Preview"
+    • `dyn_title(self, entry)` a dynamic title function which gets called when
+      config value `dynamic_preview_title = true`
 
     `self.state` table:
-      - `self.state.bufnr` Is the current buffer number, in which you have to
-        write the loaded content. Don't create a buffer yourself, otherwise
-        it's not managed by the buffer_previewer interface and you will
-        probably be better off writing your own interface.
-      - self.state.winid Current window id. Useful if you want to set the
-        cursor to a provided line number.
-      - self.state.bufname Will return the current buffer name, if
-        `get_buffer_by_name` is defined. nil will be returned if the entry was
-        never loaded or when `get_buffer_by_name` is not set.
+    • `self.state.bufnr` Is the current buffer number, in which you have to
+      write the loaded content. Don't create a buffer yourself, otherwise it's
+      not managed by the buffer_previewer interface and you will probably be
+      better off writing your own interface.
+    • self.state.winid Current window id. Useful if you want to set the cursor
+      to a provided line number.
+    • self.state.bufname Will return the current buffer name, if
+      `get_buffer_by_name` is defined. nil will be returned if the entry was
+      never loaded or when `get_buffer_by_name` is not set.
 
     Tips:
-      - If you want to display content of a terminal job, use: 
-        `require('telescope.previewers.utils').job_maker(cmd, bufnr, opts)`
-          - `cmd` table: for example { 'git', 'diff', entry.value }
-          - `bufnr` number: in which the content will be written
-          - `opts` table: with following keys
-            - `bufname` string: used for cache
-            - `value` string: used for cache
-            - `mode` string: either "insert" or "append". "insert" is default
-            - `env` table: define environment variables. Example:
-              - `{ ['PAGER'] = '', ['MANWIDTH'] = 50 }`
-            - `cwd` string: define current working directory for job
-            - `callback` function(bufnr, content): will be called when job is
-              done. Content will be nil if job is already loaded. So you can do
-              highlighting only the first time the previewer is created for
-              that entry. Use the returned `bufnr` and not `self.state.bufnr`
-              in callback, because state can already be changed at this point
-              in time.
-      - If you want to attach a highlighter use:
-        - `require('telescope.previewers.utils').highlighter(bufnr, ft)`
-          - This will prioritize tree sitter highlighting if available for 
-            environment and language.
-        - `require('telescope.previewers.utils').regex_highlighter(bufnr, ft)`
-        - `require('telescope.previewers.utils').ts_highlighter(bufnr, ft)`
-      - If you want to use `vim.fn.search` or similar you need to run it in 
-        that specific buffer context. Do
-    >
-          vim.api.nvim_buf_call(bufnr, function()
-            -- for example `search` and `matchadd`
-          end)
+    • If you want to display content of a terminal job, use:
+      `require('telescope.previewers.utils').job_maker(cmd, bufnr, opts)`
+      • `cmd` table: for example { 'git', 'diff', entry.value }
+      • `bufnr` number: in which the content will be written
+      • `opts` table: with following keys
+        • `bufname` string: used for cache
+        • `value` string: used for cache
+        • `mode` string: either "insert" or "append". "insert" is default
+        • `env` table: define environment variables. Example:
+          • `{ ['PAGER'] = '', ['MANWIDTH'] = 50 }`
+        • `cwd` string: define current working directory for job
+        • `callback` function(bufnr, content): will be called when job is
+          done. Content will be nil if job is already loaded. So you can do
+          highlighting only the first time the previewer is created for that
+          entry. Use the returned `bufnr` and not `self.state.bufnr` in
+          callback, because state can already be changed at this point in
+          time.
+    • If you want to attach a highlighter use:
+      • `require('telescope.previewers.utils').highlighter(bufnr, ft)`
+        • This will prioritize tree sitter highlighting if available for
+          environment and language.
+      • `require('telescope.previewers.utils').regex_highlighter(bufnr, ft)`
+      • `require('telescope.previewers.utils').ts_highlighter(bufnr, ft)`
+    • If you want to use `vim.fn.search` or similar you need to run it in that
+      specific buffer context. Do >lua
+      vim.api.nvim_buf_call(bufnr, function()
+        -- for example `search` and `matchadd`
+      end)
 <
-    to achieve that.
-      - If you want to read a file into the buffer it's best to use 
-        `buffer_previewer_maker`. But access this function with 
+      to achieve that.
+      • If you want to read a file into the buffer it's best to use
+        `buffer_previewer_maker`. But access this function with
         `require('telescope.config').values.buffer_previewer_maker` because it
         can be redefined by users.
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.buffer_previewer_maker({filepath}, {bufnr}, {opts}) *telescope.previewers.buffer_previewer_maker()*
-    A universal way of reading a file into a buffer previewer. It handles async
-    reading, cache, highlighting, displaying directories and provides a
+                               *telescope.previewers.buffer_previewer_maker()*
+previewers.buffer_previewer_maker({filepath}, {bufnr}, {opts})
+    A universal way of reading a file into a buffer previewer. It handles
+    async reading, cache, highlighting, displaying directories and provides a
     callback which can be used, to jump to a line in the buffer.
 
-
     Parameters: ~
-        {filepath} (string)  String to the filepath, will be expanded
-        {bufnr}    (number)  Where the content will be written
-        {opts}     (table)   keys: `use_ft_detect`, `bufname` and `callback`
+      • {filepath}  (`string`) String to the filepath, will be expanded
+      • {bufnr}     (`number`) Where the content will be written
+      • {opts}      (`table`) keys: `use_ft_detect`, `bufname` and `callback`
 
-
-previewers.vim_buffer_cat()            *telescope.previewers.vim_buffer_cat()*
+                                       *telescope.previewers.vim_buffer_cat()*
+previewers.vim_buffer_cat({opts})
     A previewer that is used to display a file. It uses the `buffer_previewer`
     interface and won't jump to the line. To integrate this one into your own
-    picker make sure that the field `path` or `filename` is set for each entry.
-    The preferred way of using this previewer is like this
+    picker make sure that the field `path` or `filename` is set for each
+    entry. The preferred way of using this previewer is like this
     `require('telescope.config').values.file_previewer` This will respect user
     configuration and will use `termopen_previewer` in case it's configured
     that way.
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.vim_buffer_vimgrep()    *telescope.previewers.vim_buffer_vimgrep()*
+                                   *telescope.previewers.vim_buffer_vimgrep()*
+previewers.vim_buffer_vimgrep({opts})
     A previewer that is used to display a file and jump to the provided line.
     It uses the `buffer_previewer` interface. To integrate this one into your
     own picker make sure that the field `path` or `filename` and `lnum` is set
@@ -4051,9 +3613,11 @@ previewers.vim_buffer_vimgrep()    *telescope.previewers.vim_buffer_vimgrep()*
     configuration and will use `termopen_previewer` in case it's configured
     that way.
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.vim_buffer_qflist()      *telescope.previewers.vim_buffer_qflist()*
+                                    *telescope.previewers.vim_buffer_qflist()*
+previewers.vim_buffer_qflist({opts})
     Is the same as `vim_buffer_vimgrep` and only exists for consistency with
     `term_previewers`.
 
@@ -4062,171 +3626,66 @@ previewers.vim_buffer_qflist()      *telescope.previewers.vim_buffer_qflist()*
     user configuration and will use `termopen_previewer` in case it's
     configured that way.
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.git_branch_log()            *telescope.previewers.git_branch_log()*
+                                       *telescope.previewers.git_branch_log()*
+previewers.git_branch_log({opts})
     A previewer that shows a log of a branch as graph
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.git_stash_diff()            *telescope.previewers.git_stash_diff()*
+                                       *telescope.previewers.git_stash_diff()*
+previewers.git_stash_diff({opts})
     A previewer that shows a diff of a stash
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.git_commit_diff_to_parent() *telescope.previewers.git_commit_diff_to_parent()*
+                            *telescope.previewers.git_commit_diff_to_parent()*
+previewers.git_commit_diff_to_parent({opts})
     A previewer that shows a diff of a commit to a parent commit.
     The run command is `git --no-pager diff SHA^! -- $CURRENT_FILE`
 
     The current file part is optional. So is only uses it with bcommits.
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.git_commit_diff_to_head() *telescope.previewers.git_commit_diff_to_head()*
+                              *telescope.previewers.git_commit_diff_to_head()*
+previewers.git_commit_diff_to_head({opts})
     A previewer that shows a diff of a commit to head.
     The run command is `git --no-pager diff --cached $SHA -- $CURRENT_FILE`
 
     The current file part is optional. So is only uses it with bcommits.
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.git_commit_diff_as_was() *telescope.previewers.git_commit_diff_as_was()*
+                               *telescope.previewers.git_commit_diff_as_was()*
+previewers.git_commit_diff_as_was({opts})
     A previewer that shows a diff of a commit as it was.
-    The run command is `git --no-pager show $SHA:$CURRENT_FILE` or `git
-    --no-pager show $SHA`
+    The run command is `git --no-pager show $SHA:$CURRENT_FILE` or
+    `git --no-pager show $SHA`
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.git_commit_message()    *telescope.previewers.git_commit_message()*
+                                   *telescope.previewers.git_commit_message()*
+previewers.git_commit_message({opts})
     A previewer that shows the commit message of a diff.
     The run command is `git --no-pager log -n 1 $SHA`
 
+    Parameters: ~
+      • {opts}  (`table`) options
 
-
-previewers.git_file_diff()              *telescope.previewers.git_file_diff()*
+previewers.git_file_diff({opts})        *telescope.previewers.git_file_diff()*
     A previewer that shows the current diff of a file. Used in git_status.
     The run command is `git --no-pager diff $FILE`
 
-
-
-previewers.display_content()          *telescope.previewers.display_content()*
-    A deprecated way of displaying content more easily. Was written at a time,
-    where the buffer_previewer interface wasn't present. Nowadays it's easier
-    to just use this. We will keep it around for backwards compatibility
-    because some extensions use it. It doesn't use cache or some other clever
-    tricks.
-
-
-
-
-================================================================================
-HISTORY                                              *telescope.actions.history*
-
-A base implementation of a prompt history that provides a simple history and
-can be replaced with a custom implementation.
-
-For example: We provide an extension for a smart history that uses sql.nvim to
-map histories to metadata, like the calling picker or cwd.
-
-So you have a history for:
-- find_files project_1
-- grep_string project_1
-- live_grep project_1
-- find_files project_2
-- grep_string project_2
-- live_grep project_2
-- etc
-
-See https://github.com/nvim-telescope/telescope-smart-history.nvim
-
-histories.History()                      *telescope.actions.history.History()*
-    Manages prompt history
-
-
-    Fields: ~
-        {enabled}    (boolean)  Will indicate if History is enabled or
-                                disabled
-        {path}       (string)   Will point to the location of the history file
-        {limit}      (string)   Will have the limit of the history. Can be
-                                nil, if limit is disabled.
-        {content}    (table)    History table. Needs to be filled by your own
-                                History implementation
-        {index}      (number)   Used to keep track of the next or previous
-                                index. Default is #content + 1
-        {cycle_wrap} (boolean)  Controls if history will wrap on reaching
-                                beginning or end
-
-
-histories.History:new({opts})        *telescope.actions.history.History:new()*
-    Create a new History
-
-
     Parameters: ~
-        {opts} (table)  Defines the behavior of History
-
-    Fields: ~
-        {init}    (function)  Will be called after handling configuration
-                              (required)
-        {append}  (function)  How to append a new prompt item (required)
-        {reset}   (function)  What happens on reset. Will be called when
-                              telescope closes (required)
-        {pre_get} (function)  Will be called before a next or previous item
-                              will be returned (optional)
+      • {opts}  (`table`) options
 
 
-histories.new()                              *telescope.actions.history.new()*
-    Shorthand to create a new history
-
-
-
-histories.History:reset()          *telescope.actions.history.History:reset()*
-    Will reset the history index to the default initial state. Will happen
-    after the picker closed
-
-
-
-histories.History:append({line}, {picker}, {no_reset}) *telescope.actions.history.History:append()*
-    Append a new line to the history
-
-
-    Parameters: ~
-        {line}     (string)   current line that will be appended
-        {picker}   (table)    the current picker object
-        {no_reset} (boolean)  On default it will reset the state at the end.
-                              If you don't want to do this set to true
-
-
-histories.History:get_next({line}, {picker}) *telescope.actions.history.History:get_next()*
-    Will return the next history item. Can be nil if there are no next items
-
-
-    Parameters: ~
-        {line}   (string)  the current line
-        {picker} (table)   the current picker object
-
-    Return: ~
-        string: the next history item
-
-
-histories.History:get_prev({line}, {picker}) *telescope.actions.history.History:get_prev()*
-    Will return the previous history item. Can be nil if there are no previous
-    items
-
-
-    Parameters: ~
-        {line}   (string)  the current line
-        {picker} (table)   the current picker object
-
-    Return: ~
-        string: the previous history item
-
-
-histories.get_simple_history() *telescope.actions.history.get_simple_history()*
-    A simple implementation of history.
-
-    It will keep one unified history across all pickers.
-
-
-
-
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1,3 +1,5 @@
+*telescope.txt*            Find, Filter, Preview, Pick. All lua, all the time.
+
 ==============================================================================
 INTRODUCTION                                                  *telescope.nvim*
 
@@ -1882,7 +1884,7 @@ Example: ~
     Fields: ~
       • {bufnr}         (`integer?`)
       • {winid}         (`integer?`)
-      • {change_title}  (`fun(self: TelescopeWindowBordertitle: stringpos: "NW"|"N"|"NE"|"SW"|"S"|"SE"?)`)
+      • {change_title}  (`fun(self: TelescopeWindowBorder, title: string, pos: "NW"|"N"|"NE"|"SW"|"S"|"SE"?)`)
 
 
 *TelescopeWindowBorder.config*

--- a/lua/telescope/actions/generate.lua
+++ b/lua/telescope/actions/generate.lua
@@ -1,27 +1,23 @@
----@tag telescope.actions.generate
----@config { ["module"] = "telescope.actions.generate", ["name"] = "ACTIONS_GENERATE" }
-
----@brief [[
+---@brief
 --- Module for convenience to override defaults of corresponding |telescope.actions| at |telescope.setup()|.
 ---
 --- General usage:
---- <code>
----   require("telescope").setup {
----     defaults = {
----       mappings = {
----         n = {
----           ["?"] = action_generate.which_key {
----             name_width = 20, -- typically leads to smaller floats
----             max_height = 0.5, -- increase potential maximum height
----             separator = " > ", -- change sep between mode, keybind, and name
----             close_with_action = false, -- do not close float on action
----           },
+--- ```lua
+--- require("telescope").setup {
+---   defaults = {
+---     mappings = {
+---       n = {
+---         ["?"] = action_generate.which_key {
+---           name_width = 20, -- typically leads to smaller floats
+---           max_height = 0.5, -- increase potential maximum height
+---           separator = " > ", -- change sep between mode, keybind, and name
+---           close_with_action = false, -- do not close float on action
 ---         },
 ---       },
 ---     },
----   }
---- </code>
----@brief ]]
+---   },
+--- }
+--- ```
 
 local actions = require "telescope.actions"
 local config = require "telescope.config"
@@ -30,12 +26,8 @@ local finders = require "telescope.finders"
 
 local action_generate = {}
 
---- Display the keymaps of registered actions similar to which-key.nvim.<br>
---- - Floating window:
----   - Appears on the opposite side of the prompt.
----   - Resolves to minimum required number of lines to show hints with `opts` or truncates entries at `max_height`.
----   - Closes automatically on action call and can be disabled with by setting `close_with_action` to false.
----@param opts table: options to pass to toggling registered actions
+---@inlinedoc
+---@class telescope.actions.generate.which_key.opts
 ---@field max_height number: % of max. height or no. of rows for hints (default: 0.4), see |resolver.resolve_height()|
 ---@field only_show_current_mode boolean: only show keymaps for the current mode (default: true)
 ---@field mode_width number: fixed width of mode to be shown (default: 1)
@@ -53,6 +45,13 @@ local action_generate = {}
 ---@field border_hl string: winhl of "Normal" for keymap borders (default: "TelescopePromptBorder")
 ---@field winblend number: pseudo-transparency of keymap hints floating window
 ---@field zindex number: z-index of keymap hints floating window (default: 100)
+
+--- Display the keymaps of registered actions similar to which-key.nvim.
+--- - Floating window:
+---   - Appears on the opposite side of the prompt.
+---   - Resolves to minimum required number of lines to show hints with `opts` or truncates entries at `max_height`.
+---   - Closes automatically on action call and can be disabled with by setting `close_with_action` to false.
+---@param opts table: options to pass to toggling registered actions
 action_generate.which_key = function(opts)
   local which_key = function(prompt_bufnr)
     actions.which_key(prompt_bufnr, opts)

--- a/lua/telescope/actions/history.lua
+++ b/lua/telescope/actions/history.lua
@@ -4,10 +4,7 @@ local utils = require "telescope.utils"
 
 local uv = vim.uv
 
----@tag telescope.actions.history
----@config { ["module"] = "telescope.actions.history" }
-
----@brief [[
+---@brief
 --- A base implementation of a prompt history that provides a simple history
 --- and can be replaced with a custom implementation.
 ---
@@ -24,7 +21,6 @@ local uv = vim.uv
 --- - etc
 ---
 --- See https://github.com/nvim-telescope/telescope-smart-history.nvim
----@brief ]]
 
 -- TODO(conni2461): currently not present in plenary path only sync.
 -- But sync is just unnecessary here
@@ -57,12 +53,15 @@ local histories = {}
 histories.History = {}
 histories.History.__index = histories.History
 
---- Create a new History
----@param opts table: Defines the behavior of History
+---@inlinedoc
+---@class telescope.actions.history.opts
 ---@field init function: Will be called after handling configuration (required)
 ---@field append function: How to append a new prompt item (required)
 ---@field reset function: What happens on reset. Will be called when telescope closes (required)
 ---@field pre_get function: Will be called before a next or previous item will be returned (optional)
+
+--- Create a new History
+---@param opts table: Defines the behavior of History
 function histories.History:new(opts)
   local obj = {}
   if conf.history == false or type(conf.history) ~= "table" then

--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1,7 +1,4 @@
----@tag telescope.actions
----@config { ["module"] = "telescope.actions" }
-
----@brief [[
+---@brief
 --- These functions are useful for people creating their own mappings.
 ---
 --- Actions can be either normal functions that expect the `prompt_bufnr` as
@@ -10,47 +7,46 @@
 --- (1) The `prompt_bufnr` of a normal function denotes the identifier of your
 --- picker which can be used to access the picker state. In practice, users
 --- most commonly access from both picker and global state via the following:
---- <code>
----   -- for utility functions
----   local action_state = require "telescope.actions.state"
+--- ```lua
+--- -- for utility functions
+--- local action_state = require "telescope.actions.state"
 ---
----   local actions = {}
----   actions.do_stuff = function(prompt_bufnr)
----     local current_picker = action_state.get_current_picker(prompt_bufnr) -- picker state
----     local entry = action_state.get_selected_entry()
----   end
---- </code>
+--- local actions = {}
+--- actions.do_stuff = function(prompt_bufnr)
+---   local current_picker = action_state.get_current_picker(prompt_bufnr) -- picker state
+---   local entry = action_state.get_selected_entry()
+--- end
+--- ```
 ---
 --- See |telescope.actions.state| for more information.
 ---
 --- (2) To transform a module of functions into a module of "action"s, you need
 --- to do the following:
---- <code>
----   local transform_mod = require("telescope.actions.mt").transform_mod
+--- ```lua
+--- local transform_mod = require("telescope.actions.mt").transform_mod
 ---
----   local mod = {}
----   mod.a1 = function(prompt_bufnr)
----     -- your code goes here
----     -- You can access the picker/global state as described above in (1).
----   end
+--- local mod = {}
+--- mod.a1 = function(prompt_bufnr)
+---   -- your code goes here
+---   -- You can access the picker/global state as described above in (1).
+--- end
 ---
----   mod.a2 = function(prompt_bufnr)
----     -- your code goes here
----   end
----   mod = transform_mod(mod)
+--- mod.a2 = function(prompt_bufnr)
+---   -- your code goes here
+--- end
+--- mod = transform_mod(mod)
 ---
----   -- Now the following is possible. This means that actions a2 will be executed
----   -- after action a1. You can chain as many actions as you want.
----   local action = mod.a1 + mod.a2
----   action(bufnr)
---- </code>
+--- -- Now the following is possible. This means that actions a2 will be executed
+--- -- after action a1. You can chain as many actions as you want.
+--- local action = mod.a1 + mod.a2
+--- action(bufnr)
+--- ```
 ---
 --- Another interesting thing to do is that these actions now have functions you
 --- can call. These functions include `:replace(f)`, `:replace_if(f, c)`,
 --- `replace_map(tbl)` and `enhance(tbl)`. More information on these functions
 --- can be found in the `developers.md` and `lua/tests/automated/action_spec.lua`
 --- file.
----@brief ]]
 
 local api = vim.api
 
@@ -156,7 +152,7 @@ actions.toggle_selection = function(prompt_bufnr)
 end
 
 --- Multi select all entries.
---- - Note: selected entries may include results not visible in the results pop up.
+---@note selected entries may include results not visible in the results pop up.
 ---@param prompt_bufnr number: The prompt bufnr
 actions.select_all = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
@@ -193,7 +189,7 @@ actions.drop_all = function(prompt_bufnr)
 end
 
 --- Toggle multi selection for all entries.
---- - Note: toggled entries may include results not visible in the results pop up.
+---@note toggled entries may include results not visible in the results pop up.
 ---@param prompt_bufnr number: The prompt bufnr
 actions.toggle_all = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
@@ -1255,8 +1251,7 @@ actions.remove_selected_picker = function(prompt_bufnr)
 end
 
 --- Display the keymaps of registered actions similar to which-key.nvim.<br>
---- - Notes:
----   - The defaults can be overridden via |action_generate.which_key|.
+---@note The defaults can be overridden via |action_generate.which_key|.
 ---@param prompt_bufnr number: The prompt bufnr
 actions.which_key = function(prompt_bufnr, opts)
   opts = opts or {}

--- a/lua/telescope/actions/layout.lua
+++ b/lua/telescope/actions/layout.lua
@@ -1,9 +1,5 @@
----@tag telescope.actions.layout
----@config { ["module"] = "telescope.actions.layout", ["name"] = "ACTIONS_LAYOUT" }
-
----@brief [[
+---@brief
 --- The layout actions are actions to be used to change the layout of a picker.
----@brief ]]
 
 local action_state = require "telescope.actions.state"
 local state = require "telescope.state"
@@ -18,9 +14,8 @@ local action_layout = setmetatable({}, {
 })
 
 --- Toggle preview window.
---- - Note: preview window can be toggled even if preview is set to false.
----
---- This action is not mapped by default.
+---@note preview window can be toggled even if preview is set to false.
+---@note this action is not mapped by default.
 ---@param prompt_bufnr number: The prompt bufnr
 action_layout.toggle_preview = function(prompt_bufnr)
   local picker = action_state.get_current_picker(prompt_bufnr)
@@ -54,7 +49,7 @@ end
 --- Toggles the `prompt_position` option between "top" and "bottom".
 --- Checks if `prompt_position` is an option for the current layout.
 ---
---- This action is not mapped by default.
+---@note this action is not mapped by default.
 ---@param prompt_bufnr number: The prompt bufnr
 action_layout.toggle_prompt_position = function(prompt_bufnr)
   local picker = action_state.get_current_picker(prompt_bufnr)
@@ -87,7 +82,7 @@ end
 --- Toggles the `mirror` option between `true` and `false`.
 --- Checks if `mirror` is an option for the current layout.
 ---
---- This action is not mapped by default.
+---@note this action is not mapped by default.
 ---@param prompt_bufnr number: The prompt bufnr
 action_layout.toggle_mirror = function(prompt_bufnr)
   local picker = action_state.get_current_picker(prompt_bufnr)
@@ -138,13 +133,13 @@ end
 
 --- Cycles to the next layout in `cycle_layout_list`.
 ---
---- This action is not mapped by default.
+---@note this action is not mapped by default.
 ---@param prompt_bufnr number: The prompt bufnr
 action_layout.cycle_layout_next = get_cycle_layout(1)
 
 --- Cycles to the previous layout in `cycle_layout_list`.
 ---
---- This action is not mapped by default.
+---@note this action is not mapped by default.
 ---@param prompt_bufnr number: The prompt bufnr
 action_layout.cycle_layout_prev = get_cycle_layout(-1)
 

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -1,7 +1,4 @@
----@tag telescope.actions.set
----@config { ["module"] = "telescope.actions.set", ["name"] = "ACTIONS_SET" }
-
----@brief [[
+---@brief
 --- Telescope action sets are used to provide an interface for managing
 --- actions that all primarily do the same thing, but with slight tweaks.
 ---
@@ -9,7 +6,6 @@
 --- a vertical split, etc. Instead of making users have to overwrite EACH
 --- of those every time they want to change this behavior, they can instead
 --- replace the `set` itself and then it will work great and they're done.
----@brief ]]
 
 local api = vim.api
 

--- a/lua/telescope/actions/state.lua
+++ b/lua/telescope/actions/state.lua
@@ -1,11 +1,7 @@
----@tag telescope.actions.state
----@config { ["module"] = "telescope.actions.state", ["name"] = "ACTIONS_STATE" }
-
----@brief [[
+---@brief
 --- Functions to be used to determine the current state of telescope.
 ---
 --- Generally used from within other |telescope.actions|
----@brief ]]
 
 local global_state = require "telescope.state"
 local conf = require("telescope.config").values
@@ -13,17 +9,20 @@ local conf = require("telescope.config").values
 local action_state = {}
 
 --- Get the current entry
+---@return table # the selected entry
 function action_state.get_selected_entry()
   return global_state.get_global_key "selected_entry"
 end
 
 --- Gets the current line in the search prompt
+---@return string # the current line in the search prompt
 function action_state.get_current_line()
   return global_state.get_global_key "current_line" or ""
 end
 
 --- Gets the current picker
 ---@param prompt_bufnr number: The prompt bufnr
+---@return table # the current picker
 function action_state.get_current_picker(prompt_bufnr)
   return global_state.get_status(prompt_bufnr).picker
 end

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -1,11 +1,7 @@
----@tag telescope.actions.utils
----@config { ["module"] = "telescope.actions.utils", ["name"] = "ACTIONS_UTILS" }
-
----@brief [[
+---@brief
 --- Utilities to wrap functions around picker selections and entries.
 ---
 --- Generally used from within other |telescope.actions|
----@brief ]]
 
 local action_state = require "telescope.actions.state"
 
@@ -19,19 +15,19 @@ local utils = {}
 ---   - The below example showcases how to collect results
 ---
 --- Usage:
---- <code>
----   local action_state = require "telescope.actions.state"
----   local action_utils = require "telescope.actions.utils"
----   function entry_value_by_row()
----     local prompt_bufnr = vim.api.nvim_get_current_buf()
----     local current_picker = action_state.get_current_picker(prompt_bufnr)
----     local results = {}
----     action_utils.map_entries(prompt_bufnr, function(entry, index, row)
----       results[row] = entry.value
----     end)
----     return results
----   end
---- </code>
+--- ```lua
+--- local action_state = require "telescope.actions.state"
+--- local action_utils = require "telescope.actions.utils"
+--- function entry_value_by_row()
+---   local prompt_bufnr = vim.api.nvim_get_current_buf()
+---   local current_picker = action_state.get_current_picker(prompt_bufnr)
+---   local results = {}
+---   action_utils.map_entries(prompt_bufnr, function(entry, index, row)
+---     results[row] = entry.value
+---   end)
+---   return results
+--- end
+--- ```
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto entries of picker that takes (entry, index, row) as viable arguments
 function utils.map_entries(prompt_bufnr, f)
@@ -55,19 +51,19 @@ end
 ---   - The below example showcases how to collect results
 ---
 --- Usage:
---- <code>
----   local action_state = require "telescope.actions.state"
----   local action_utils = require "telescope.actions.utils"
----   function selection_by_index()
----     local prompt_bufnr = vim.api.nvim_get_current_buf()
----     local current_picker = action_state.get_current_picker(prompt_bufnr)
----     local results = {}
----     action_utils.map_selections(prompt_bufnr, function(entry, index)
----       results[index] = entry.value
----     end)
----     return results
----   end
---- </code>
+--- ```lua
+--- local action_state = require "telescope.actions.state"
+--- local action_utils = require "telescope.actions.utils"
+--- function selection_by_index()
+---   local prompt_bufnr = vim.api.nvim_get_current_buf()
+---   local current_picker = action_state.get_current_picker(prompt_bufnr)
+---   local results = {}
+---   action_utils.map_selections(prompt_bufnr, function(entry, index)
+---     results[index] = entry.value
+---   end)
+---   return results
+--- end
+--- ```
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto selection of picker that takes (selection) as a viable argument
 function utils.map_selections(prompt_bufnr, f)

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -114,6 +114,7 @@ end
 -- Special keys:
 --  opts.search_dirs -- list of directory to search in
 --  opts.grep_open_files -- boolean to restrict search to open files
+---@param opts telescope.builtin.live_grep.opts
 files.live_grep = function(opts)
   local vimgrep_arguments = opts.vimgrep_arguments or conf.vimgrep_arguments
   if not has_rg_program("live_grep", vimgrep_arguments[1]) then
@@ -176,7 +177,7 @@ files.live_grep = function(opts)
     end
 
     return flatten { args, "--", prompt, search_list }
-  end, opts.entry_maker or make_entry.gen_from_vimgrep(opts), opts.max_results, opts.cwd)
+  end, opts.entry_maker or make_entry.gen_from_vimgrep(opts), nil, opts.cwd)
 
   pickers
     .new(opts, {
@@ -195,6 +196,7 @@ files.live_grep = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.grep_string.opts
 files.grep_string = function(opts)
   local vimgrep_arguments = vim.F.if_nil(opts.vimgrep_arguments, conf.vimgrep_arguments)
   if not has_rg_program("grep_string", vimgrep_arguments[1]) then
@@ -274,6 +276,7 @@ files.grep_string = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.find_files.opts
 files.find_files = function(opts)
   local find_command = (function()
     if opts.find_command then
@@ -405,7 +408,7 @@ files.find_files = function(opts)
     :find()
 end
 
---  TODO: finish docs for opts.show_line
+---@param opts telescope.builtin.treesitter.opts
 files.treesitter = function(opts)
   opts.show_line = vim.F.if_nil(opts.show_line, true)
   local ts = vim.treesitter
@@ -468,6 +471,7 @@ files.treesitter = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.current_buffer_fuzzy_find.opts
 files.current_buffer_fuzzy_find = function(opts)
   -- All actions are on the current buffer
   local filename = api.nvim_buf_get_name(opts.bufnr)
@@ -580,6 +584,7 @@ files.current_buffer_fuzzy_find = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.tags.opts
 files.tags = function(opts)
   local tagfiles = opts.ctags_file and { opts.ctags_file } or vim.fn.tagfiles()
   for i, ctags_file in ipairs(tagfiles) do
@@ -630,6 +635,7 @@ files.tags = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.current_buffer_tags.opts
 files.current_buffer_tags = function(opts)
   return files.tags(vim.tbl_extend("force", {
     prompt_title = "Current Buffer Tags",

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -21,8 +21,9 @@ local get_git_command_output = function(args, opts)
   return utils.get_os_command_output(git_command(args, opts), opts.cwd)
 end
 
+---@param opts telescope.builtin.git_files.opts
 git.files = function(opts)
-  if opts.is_bare then
+  if opts._is_bare then
     utils.notify("builtin.git_files", {
       msg = "This operation must be run in a work tree",
       level = "ERROR",
@@ -66,6 +67,7 @@ git.files = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.git_commits.opts
 git.commits = function(opts)
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
   opts.git_command =
@@ -186,6 +188,7 @@ local bcommits_picker = function(opts, title, finder)
   })
 end
 
+---@param opts telescope.builtin.git_bcommits.opts
 git.bcommits = function(opts)
   opts.current_line = (opts.current_file == nil) and get_current_buf_line(opts.winnr) or nil
   opts.current_file = vim.F.if_nil(opts.current_file, api.nvim_buf_get_name(opts.bufnr))
@@ -204,6 +207,7 @@ git.bcommits = function(opts)
   bcommits_picker(opts, title, finder):find()
 end
 
+---@param opts telescope.builtin.git_bcommits_range.opts
 git.bcommits_range = function(opts)
   opts.current_line = (opts.current_file == nil) and get_current_buf_line(opts.winnr) or nil
   opts.current_file = vim.F.if_nil(opts.current_file, api.nvim_buf_get_name(opts.bufnr))
@@ -245,6 +249,7 @@ git.bcommits_range = function(opts)
   bcommits_picker(opts, title, finder):find()
 end
 
+---@param opts telescope.builtin.git_branches.opts
 git.branches = function(opts)
   local format = "%(HEAD)"
     .. "%(refname)"
@@ -362,8 +367,9 @@ git.branches = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.git_status.opts
 git.status = function(opts)
-  if opts.is_bare then
+  if opts._is_bare then
     utils.notify("builtin.git_status", {
       msg = "This operation must be run in a work tree",
       level = "ERROR",
@@ -491,7 +497,7 @@ local set_opts_cwd = function(opts)
     if in_worktree[1] ~= "true" and in_bare[1] ~= "true" then
       try_worktrees(opts)
     elseif in_worktree[1] ~= "true" and in_bare[1] == "true" then
-      opts.is_bare = true
+      opts._is_bare = true
     end
   else
     if opts.use_git_root then

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -39,6 +39,7 @@ end
 
 local internal = {}
 
+---@param opts telescope.builtin.builtin.opts
 internal.builtin = function(opts)
   opts.include_extensions = vim.F.if_nil(opts.include_extensions, false)
   opts.use_default_opts = vim.F.if_nil(opts.use_default_opts, false)
@@ -130,6 +131,7 @@ internal.builtin = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.resume.opts: options to pass to the picker
 internal.resume = function(opts)
   opts = opts or {}
   opts.cache_index = vim.F.if_nil(opts.cache_index, 1)
@@ -176,6 +178,7 @@ internal.resume = function(opts)
   pickers.new(opts, picker):find()
 end
 
+---@param opts telescope.builtin.pickers.opts: options to pass to the picker
 internal.pickers = function(opts)
   local cached_pickers = state.get_global_key "cached_pickers"
   if cached_pickers == nil or vim.tbl_isempty(cached_pickers) then
@@ -233,6 +236,7 @@ internal.pickers = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.planets.opts: options to pass to the picker
 internal.planets = function(opts)
   local show_pluto = opts.show_pluto or false
   local show_moon = opts.show_moon or false
@@ -281,6 +285,7 @@ internal.planets = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.symbol.opts: options to pass to the picker
 internal.symbols = function(opts)
   local initial_mode = vim.fn.mode()
   local files = api.nvim_get_runtime_file("data/telescope-sources/*.json", true)
@@ -357,6 +362,7 @@ internal.symbols = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.commands.opts: options to pass to the picker
 internal.commands = function(opts)
   pickers
     .new(opts, {
@@ -411,6 +417,7 @@ internal.commands = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.quickfix.opts: options to pass to the picker
 internal.quickfix = function(opts)
   local qf_identifier = opts.id or vim.F.if_nil(opts.nr, 0)
   local locations = vim.fn.getqflist({ [opts.id and "id" or "nr"] = qf_identifier, items = true }).items
@@ -433,6 +440,7 @@ internal.quickfix = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.quickfixhistory.opts: options to pass to the picker
 internal.quickfixhistory = function(opts)
   local qflists = {}
   for i = 1, 10 do -- (n)vim keeps at most 10 quickfix lists in full
@@ -501,6 +509,7 @@ internal.quickfixhistory = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.loclist.opts: options to pass to the picker
 internal.loclist = function(opts)
   local locations = vim.fn.getloclist(0)
   local filenames = {}
@@ -530,6 +539,7 @@ internal.loclist = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.oldfiles.opts: options to pass to the picker
 internal.oldfiles = function(opts)
   opts = apply_cwd_only_aliases(opts)
   opts.include_current_session = vim.F.if_nil(opts.include_current_session, true)
@@ -589,6 +599,7 @@ internal.oldfiles = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.commands_history.opts: options to pass to the picker
 internal.command_history = function(opts)
   local history_string = vim.fn.execute "history cmd"
   local history_list = utils.split_lines(history_string)
@@ -629,6 +640,7 @@ internal.command_history = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.search_history.opts: options to pass to the picker
 internal.search_history = function(opts)
   local search_string = vim.fn.execute "history search"
   local search_list = utils.split_lines(search_string)
@@ -659,6 +671,7 @@ internal.search_history = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.vim_options.opts: options to pass to the picker
 internal.vim_options = function(opts)
   local res = {}
   for _, v in pairs(api.nvim_get_all_options_info()) do
@@ -707,6 +720,7 @@ internal.vim_options = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.help_tags.opts: options to pass to the picker
 internal.help_tags = function(opts)
   opts.lang = vim.F.if_nil(opts.lang, vim.o.helplang)
   opts.fallback = vim.F.if_nil(opts.fallback, true)
@@ -823,6 +837,7 @@ internal.help_tags = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.man_pages.opts: options to pass to the picker
 internal.man_pages = function(opts)
   opts.sections = vim.F.if_nil(opts.sections, { "1" })
   assert(vim.islist(opts.sections), "sections should be a list")
@@ -872,6 +887,7 @@ internal.man_pages = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.reload.opts: options to pass to the picker
 internal.reloader = function(opts)
   local package_list = vim.tbl_keys(package.loaded)
 
@@ -922,6 +938,7 @@ internal.reloader = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.buffers.opts: options to pass to the picker
 internal.buffers = function(opts)
   opts = apply_cwd_only_aliases(opts)
 
@@ -1012,6 +1029,7 @@ internal.buffers = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.colorscheme.opts: options to pass to the picker
 internal.colorscheme = function(opts)
   local before_background = vim.o.background
   local before_color = api.nvim_exec2("colorscheme", { output = true }).output
@@ -1142,6 +1160,7 @@ internal.colorscheme = function(opts)
   picker:find()
 end
 
+---@param opts telescope.builtin.marks.opts: options to pass to the picker
 internal.marks = function(opts)
   local local_marks = {
     items = vim.fn.getmarklist(opts.bufnr),
@@ -1208,6 +1227,7 @@ internal.marks = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.registers.opts: options to pass to the picker
 internal.registers = function(opts)
   local registers_table = { '"', "-", "#", "=", "/", "*", "+", ":", ".", "%" }
 
@@ -1239,6 +1259,7 @@ internal.registers = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.keymaps.opts: options to pass to the picker
 internal.keymaps = function(opts)
   opts.modes = vim.F.if_nil(opts.modes, { "n", "i", "c", "x" })
   opts.show_plug = vim.F.if_nil(opts.show_plug, true)
@@ -1301,6 +1322,7 @@ internal.keymaps = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.filetypes.opts: options to pass to the picker
 internal.filetypes = function(opts)
   local filetypes = vim.fn.getcompletion("", "filetype")
 
@@ -1328,6 +1350,7 @@ internal.filetypes = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.highlights.opts: options to pass to the picker
 internal.highlights = function(opts)
   local highlights = vim.fn.getcompletion("", "highlight")
 
@@ -1357,6 +1380,7 @@ internal.highlights = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.autocommands.opts: options to pass to the picker
 internal.autocommands = function(opts)
   local autocmds = api.nvim_get_autocmds {}
   table.sort(autocmds, function(lhs, rhs)
@@ -1417,6 +1441,7 @@ internal.autocommands = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.spell_suggest.opts: options to pass to the picker
 internal.spell_suggest = function(opts)
   local cursor_word = vim.fn.expand "<cword>"
   local suggestions = vim.fn.spellsuggest(cursor_word)
@@ -1447,6 +1472,7 @@ internal.spell_suggest = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.tagstack.opts: options to pass to the picker
 internal.tagstack = function(opts)
   opts = opts or {}
   local tagstack = vim.fn.gettagstack().items
@@ -1486,6 +1512,7 @@ internal.tagstack = function(opts)
     :find()
 end
 
+---@param opts telescope.builtin.jumplist.opts: options to pass to the picker
 internal.jumplist = function(opts)
   opts = opts or {}
   local jumplist = vim.fn.getjumplist()[1]

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -108,10 +108,12 @@ local function calls(opts, direction)
   end)
 end
 
+---@param opts telescope.builtin.lsp_in_out_calls.opts: options to pass to the picker
 M.incoming_calls = function(opts)
   calls(opts, "from")
 end
 
+---@param opts telescope.builtin.lsp_in_out_calls.opts: options to pass to the picker
 M.outgoing_calls = function(opts)
   calls(opts, "to")
 end
@@ -249,6 +251,7 @@ local function list_or_jump(action, title, funname, params, opts)
   end)
 end
 
+---@param opts telescope.builtin.lsp_references.opts: options to pass to the picker (default: false)
 M.references = function(opts)
   opts.include_current_line = vim.F.if_nil(opts.include_current_line, false)
   local params = client_position_params(opts.winnr, {
@@ -257,11 +260,13 @@ M.references = function(opts)
   return list_or_jump("textDocument/references", "LSP References", "builtin.lsp_references", params, opts)
 end
 
+---@param opts telescope.builtin.list_or_jump.opts: options to pass to the picker
 M.definitions = function(opts)
   local params = client_position_params(opts.winnr)
   return list_or_jump("textDocument/definition", "LSP Definitions", "builtin.lsp_definitions", params, opts)
 end
 
+---@param opts telescope.builtin.list_or_jump.opts: options to pass to the picker
 M.type_definitions = function(opts)
   local params = client_position_params(opts.winnr)
   return list_or_jump(
@@ -273,6 +278,7 @@ M.type_definitions = function(opts)
   )
 end
 
+---@param opts telescope.builtin.list_or_jump.opts: options to pass to the picker
 M.implementations = function(opts)
   local params = client_position_params(opts.winnr)
   return list_or_jump("textDocument/implementation", "LSP Implementations", "builtin.lsp_implementations", params, opts)
@@ -310,6 +316,7 @@ local symbols_sorter = function(symbols)
   return symbols
 end
 
+---@param opts telescope.builtin.lsp_document_symbols.opts: options to pass to the picker
 M.document_symbols = function(opts)
   local params = client_position_params(opts.winnr)
   lsp.buf_request(opts.bufnr, "textDocument/documentSymbol", params, function(err, result, ctx, _)
@@ -364,6 +371,7 @@ M.document_symbols = function(opts)
   end)
 end
 
+---@param opts telescope.builtin.lsp_workspace_symbols.opts: options to pass to the picker
 M.workspace_symbols = function(opts)
   local params = { query = opts.query or "" }
   lsp.buf_request(opts.bufnr, "workspace/symbol", params, function(err, server_result, ctx, _)
@@ -437,6 +445,7 @@ local function get_workspace_symbols_requester(bufnr, opts)
   end
 end
 
+---@param opts telescope.builtin.lsp_dynamic_workspace_symbols.opts: options to pass to the picker
 M.dynamic_workspace_symbols = function(opts)
   pickers
     .new(opts, {

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -1,30 +1,27 @@
----@tag telescope.builtin
+---@diagnostic disable: undefined-doc-param
 
----@config { ['field_heading'] = "Options", ["module"] = "telescope.builtin" }
-
----@brief [[
+---@brief
 --- Telescope Builtins is a collection of community maintained pickers to support common workflows. It can be used as
 --- reference when writing PRs, Telescope extensions, your own custom pickers, or just as a discovery tool for all of
 --- the amazing pickers already shipped with Telescope!
 ---
 --- Any of these functions can just be called directly by doing:
----
+--- ```vim
 --- :lua require('telescope.builtin').$NAME_OF_PICKER()
+--- ```
 ---
 --- To use any of Telescope's default options or any picker-specific options, call your desired picker by passing a lua
 --- table to the picker with all of the options you want to use. Here's an example with the live_grep picker:
----
---- <code>
----   :lua require('telescope.builtin').live_grep({
----     prompt_title = 'find string in open buffers...',
----     grep_open_files = true
----   })
----   -- or with dropdown theme
----   :lua require('telescope.builtin').find_files(require('telescope.themes').get_dropdown{
----     previewer = false
----   })
---- </code>
----@brief ]]
+--- ```lua
+--- require('telescope.builtin').live_grep({
+---   prompt_title = 'find string in open buffers...',
+---   grep_open_files = true
+--- })
+--- -- or with dropdown theme
+--- require("telescope.builtin").find_files(
+---   require("telescope.themes").get_dropdown { previewer = false }
+--- )
+--- ```
 
 local builtin = {}
 
@@ -45,91 +42,110 @@ end
 --
 --
 
+---@inlinedocdoc
+---@class telescope.builtin.live_grep.opts : telescope.builtin.base_opts
+---@field cwd? string root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
+---@field grep_open_files? boolean if true, restrict search to open files only, mutually exclusive with `search_dirs`
+---@field search_dirs? table directory/directories/files to search, mutually exclusive with `grep_open_files`
+---@field glob_pattern? (string|string[]) argument to be used with `--glob`, e.g. `*.toml`, can use the opposite `!*.toml`
+---@field type_filter? string argument to be used with `--type`, e.g. "rust", see `rg --type-list`
+---@field additional_args? (fun(opts: table): string[])|table: additional arguments to be passed on.
+---@field disable_coordinates? boolean don't show the line & row numbers (default: `false`)
+---@field file_encoding? string file encoding for the entry & previewer
+
 --- Search for a string and get results live as you type, respects .gitignore
----@param opts table: options to pass to the picker
----@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
----@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
----@field search_dirs table: directory/directories/files to search, mutually exclusive with `grep_open_files`
----@field glob_pattern string|table: argument to be used with `--glob`, e.g. "*.toml", can use the opposite "!*.toml"
----@field type_filter string: argument to be used with `--type`, e.g. "rust", see `rg --type-list`
----@field additional_args function|table: additional arguments to be passed on. Can be fn(opts) -> tbl
----@field max_results number: define a upper result value
----@field disable_coordinates boolean: don't show the line & row numbers (default: false)
----@field show_line boolean: if true, shows the content of the line in the picker (default: true)
----@field file_encoding string: file encoding for the entry & previewer
----@field hidden boolean: if true, hidden directories and files will be searched (default: false)
+---@param opts? telescope.builtin.live_grep.opts table: options to pass to the picker
 builtin.live_grep = require_on_exported_call("telescope.builtin.__files").live_grep
 
+---@inlinedocdoc
+---@class telescope.builtin.grep_string.opts : telescope.builtin.base_opts
+---@field cwd? string root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
+---@field search? string the query to search
+---@field grep_open_files? boolean if true, restrict search to open files only, mutually exclusive with `search_dirs`
+---@field search_dirs? table directory/directories/files to search, mutually exclusive with `grep_open_files`
+---@field use_regex? boolean if true, special characters won't be escaped, allows for using regex (default: `false`)
+---@field word_match? string can be set to `-w` to enable exact word matches
+---@field additional_args? (fun(opts: table): string[])|table: additional arguments to be passed on.
+---@field disable_coordinates? boolean don't show the line and row numbers (default: `false`)
+---@field only_sort_text? boolean only sort the text, not the file, line or row (default: `false`)
+---@field file_encoding? string file encoding for the entry & previewer
+
 --- Searches for the string under your cursor or the visual selection in your current working directory
----@param opts table: options to pass to the picker
----@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
----@field search string: the query to search
----@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
----@field search_dirs table: directory/directories/files to search, mutually exclusive with `grep_open_files`
----@field use_regex boolean: if true, special characters won't be escaped, allows for using regex (default: false)
----@field word_match string: can be set to `-w` to enable exact word matches
----@field additional_args function|table: additional arguments to be passed on. Can be fn(opts) -> tbl
----@field disable_coordinates boolean: don't show the line and row numbers (default: false)
----@field show_line boolean: if true, shows the content of the line in the picker (default: true)
----@field only_sort_text boolean: only sort the text, not the file, line or row (default: false)
----@field file_encoding string: file encoding for the entry & previewer
----@field hidden boolean: if true, hidden directories and files will be searched (default: false)
+---@param opts? telescope.builtin.grep_string.opts: options to pass to the picker
 builtin.grep_string = require_on_exported_call("telescope.builtin.__files").grep_string
 
+---@inlinedoc
+---@class telescope.builtin.find_files.opts : telescope.builtin.base_opts
+---@field cwd? string root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
+---@field find_command? (function|table) cmd to use for the search. Can be a fn(opts) -> tbl (default: autodetect)
+---@field file_entry_encoding? string encoding of output of `find_command`
+---@field follow? boolean if true, follows symlinks (i.e. uses `-L` flag for the `find` command) (default: `false`)
+---@field hidden? boolean determines whether to show hidden files or not (default: `false`)
+---@field no_ignore? boolean show files ignored by .gitignore, .ignore, etc. (default: `false`)
+---@field no_ignore_parent? boolean show files ignored by .gitignore, .ignore, etc. in parent dirs. (default: `false`)
+---@field search_dirs? table directory/directories/files to search
+---@field search_file? string specify a filename to search for
+---@field file_encoding? string file encoding for the previewer
+
 --- Search for files (respecting .gitignore)
----@param opts table: options to pass to the picker
----@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
----@field find_command function|table: cmd to use for the search. Can be a fn(opts) -> tbl (default: autodetect)
----@field file_entry_encoding string: encoding of output of `find_command`
----@field follow boolean: if true, follows symlinks (i.e. uses `-L` flag for the `find` command) (default: false)
----@field hidden boolean: determines whether to show hidden files or not (default: false)
----@field no_ignore boolean: show files ignored by .gitignore, .ignore, etc. (default: false)
----@field no_ignore_parent boolean: show files ignored by .gitignore, .ignore, etc. in parent dirs. (default: false)
----@field search_dirs table: directory/directories/files to search
----@field search_file string: specify a filename to search for
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.find_files.opts: options to pass to the picker
 builtin.find_files = require_on_exported_call("telescope.builtin.__files").find_files
 
 --- This is an alias for the `find_files` picker
 builtin.fd = builtin.find_files
 
+---@inlinedoc
+---@class telescope.builtin.treesitter.opts : telescope.builtin.base_opts
+---@field show_line? boolean if true, shows the row:column that the result is found at (default: `true`)
+---@field bufnr? number specify the buffer number where treesitter should run. (default: current buffer)
+---@field symbol_width? number defines the width of the symbol section (default: `25`)
+---@field symbols? (string|table) filter results by symbol kind(s)
+---@field ignore_symbols? (string|table) list of symbols to ignore
+---@field symbol_highlights? table string -> string. Matches symbol with hl_group
+---@field file_encoding? string file encoding for the previewer
+
 --- Lists function names, variables, and other symbols from treesitter queries
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by kind of ts node you want to see (i.e. `:var:`)
----@field show_line boolean: if true, shows the row:column that the result is found at (default: true)
----@field bufnr number: specify the buffer number where treesitter should run. (default: current buffer)
----@field symbol_width number: defines the width of the symbol section (default: 25)
----@field symbols string|table: filter results by symbol kind(s)
----@field ignore_symbols string|table: list of symbols to ignore
----@field symbol_highlights table: string -> string. Matches symbol with hl_group
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.treesitter.opts: options to pass to the picker
 builtin.treesitter = require_on_exported_call("telescope.builtin.__files").treesitter
 
+---@inlinedoc
+---@class telescope.builtin.current_buffer_fuzzy_find.opts : telescope.builtin.base_opts
+---@field skip_empty_lines? boolean if true we don't display empty lines (default: `false`)
+---@field results_ts_highlight? boolean highlight result entries with treesitter (default: `true`)
+---@field file_encoding? string file encoding for the previewer
+
 --- Live fuzzy search inside of the currently open buffer
----@param opts table: options to pass to the picker
----@field skip_empty_lines boolean: if true we don't display empty lines (default: false)
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.current_buffer_fuzzy_find.opts: options to pass to the picker
 builtin.current_buffer_fuzzy_find = require_on_exported_call("telescope.builtin.__files").current_buffer_fuzzy_find
+
+---@inlinedoc
+---@class telescope.builtin.tags.opts : telescope.builtin.base_opts
+---@field cwd? string root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
+---@field ctags_file? string specify a particular ctags file to use
+---@field show_line? boolean if true, shows the content of the line the tag is found on in the picker (default: `true`)
+---@field show_kind? boolean if true and kind info is available, show the kind of the tag (default: `true`)
+---@field only_sort_tags? boolean if true we will only sort tags (default: `false`)
+---@field fname_width? number defines the width of the filename section (default: `30`)
 
 --- Lists tags in current directory with tag location file preview (users are required to run ctags -R to generate tags
 --- or update when introducing new changes)
----@param opts table: options to pass to the picker
----@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
----@field ctags_file string: specify a particular ctags file to use
----@field show_line boolean: if true, shows the content of the line the tag is found on in the picker (default: true)
----@field show_kind boolean: if true and kind info is available, show the kind of the tag (default: true)
----@field only_sort_tags boolean: if true we will only sort tags (default: false)
----@field fname_width number: defines the width of the filename section (default: 30)
+---@param opts? telescope.builtin.tags.opts: options to pass to the picker
 builtin.tags = require_on_exported_call("telescope.builtin.__files").tags
 
+---@inlinedoc
+---@class telescope.builtin.current_buffer_tags.opts : telescope.builtin.base_opts
+---@field cwd? string root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
+---@field ctags_file? string specify a particular ctags file to use
+---@field show_line? boolean if true, shows the content of the line the tag is found on in the picker (default: `true`)
+---@field show_kind? boolean if true and kind info is available, show the kind of the tag (default: `true`)
+---@field only_sort_tags? boolean if true we will only sort tags (default: `false`)
+---@field fname_width? number defines the width of the filename section (default: `30`)
+
 --- Lists all of the tags for the currently open buffer, with a preview
----@param opts table: options to pass to the picker
----@field cwd string: root dir to search from (default: cwd, use utils.buffer_dir() to search relative to open buffer)
----@field ctags_file string: specify a particular ctags file to use
----@field show_line boolean: if true, shows the content of the line the tag is found on in the picker (default: true)
----@field show_kind boolean: if true and kind info is available, show the kind of the tag (default: true)
----@field only_sort_tags boolean: if true we will only sort tags (default: false)
----@field fname_width number: defines the width of the filename section (default: 30)
+---@param opts? telescope.builtin.current_buffer_tags.opts: options to pass to the picker
 builtin.current_buffer_tags = require_on_exported_call("telescope.builtin.__files").current_buffer_tags
 
 --
@@ -138,101 +154,114 @@ builtin.current_buffer_tags = require_on_exported_call("telescope.builtin.__file
 --
 --
 
+---@inlinedoc
+---@class telescope.builtin.git_opts : telescope.builtin.base_opts
+---@field _is_bare boolean: if the repo is a bare repo
+---@field cwd? string the path of the repo
+---@field use_file_path? boolean if we should use the current buffer git root (default: `false`)
+---@field use_git_root? boolean if we should use git root as cwd or the cwd (important for submodule) (default: `true`)
+
+---@inlinedoc
+---@class telescope.builtin.git_files.opts : telescope.builtin.git_opts
+---@field show_untracked? boolean if true, adds `--others` flag to command and shows untracked files (default: `false`)
+---@field recurse_submodules? boolean if true, adds the `--recurse-submodules` flag to command (default: `false`)
+---@field git_command? table command that will be executed. (default: `{"git", "-c", "core.quotepath=false", "ls-files", "--exclude-standard", "--cached" }`)
+---@field file_encoding? string file encoding for the previewer
+
 --- Fuzzy search for files tracked by Git. This command lists the output of the `git ls-files` command,
 --- respects .gitignore
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<cr>`: opens the currently selected file
----@param opts table: options to pass to the picker
----@field cwd string: specify the path of the repo
----@field use_file_path boolean: if we should use the current buffer git root (default: false)
----@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
----@field show_untracked boolean: if true, adds `--others` flag to command and shows untracked files (default: false)
----@field recurse_submodules boolean: if true, adds the `--recurse-submodules` flag to command (default: false)
----@field git_command table: command that will be executed. {"git","ls-files","--exclude-standard","--cached"}
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.git_files.opts: options to pass to the picker
 builtin.git_files = require_on_exported_call("telescope.builtin.__git").files
 
+---@inlinedoc
+---@class telescope.builtin.git_commits.opts : telescope.builtin.git_opts
+---@field git_command? table command that will be executed. (default: `{"git","log","--pretty=oneline","--abbrev-commit","--","."}`)
+
 --- Lists commits for current directory with diff preview
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<cr>`: checks out the currently selected commit
 ---   - `<C-r>m`: resets current branch to selected commit using mixed mode
 ---   - `<C-r>s`: resets current branch to selected commit using soft mode
 ---   - `<C-r>h`: resets current branch to selected commit using hard mode
----@param opts table: options to pass to the picker
----@field cwd string: specify the path of the repo
----@field use_file_path boolean: if we should use the current buffer git root (default: false)
----@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
----@field git_command table: command that will be executed. {"git","log","--pretty=oneline","--abbrev-commit","--","."}
+---@param opts? telescope.builtin.git_commits.opts: options to pass to the picker
 builtin.git_commits = require_on_exported_call("telescope.builtin.__git").commits
 
+---@inlinedoc
+---@class telescope.builtin.git_bcommits.opts : telescope.builtin.git_opts
+---@field current_file? string specify the current file that should be used for bcommits (default: current buffer)
+---@field git_command? table command that will be executed. (default: `{"git","log","--pretty=oneline","--abbrev-commit"}`)
+
 --- Lists commits for current buffer with diff preview
---- - Default keymaps or your overridden `select_` keys:
+---
+--- Default keymaps or your overridden `select_` keys:
 ---   - `<cr>`: checks out the currently selected commit
 ---   - `<c-v>`: opens a diff in a vertical split
 ---   - `<c-x>`: opens a diff in a horizontal split
 ---   - `<c-t>`: opens a diff in a new tab
----@param opts table: options to pass to the picker
----@field cwd string: specify the path of the repo
----@field use_file_path boolean: if we should use the current buffer git root (default: false)
----@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
----@field current_file string: specify the current file that should be used for bcommits (default: current buffer)
----@field git_command table: command that will be executed. {"git","log","--pretty=oneline","--abbrev-commit"}
+---@param opts? telescope.builtin.git_bcommits.opts: options to pass to the picker
 builtin.git_bcommits = require_on_exported_call("telescope.builtin.__git").bcommits
+
+---@inlinedoc
+---@class telescope.builtin.git_bcommits_range.opts : telescope.builtin.git_bcommits.opts
+---@field from? number the first line number in the range (default: current line)
+---@field to? number the last line number in the range (default: the value of `from`)
+---@field operator? boolean select lines in operator-pending mode (default: `false`)
 
 --- Lists commits for a range of lines in the current buffer with diff preview
 --- In visual mode, lists commits for the selected lines
 --- With operator mode enabled, lists commits inside the text object/motion
---- - Default keymaps or your overridden `select_` keys:
+---
+--- Default keymaps or your overridden `select_` keys:
 ---   - `<cr>`: checks out the currently selected commit
 ---   - `<c-v>`: opens a diff in a vertical split
 ---   - `<c-x>`: opens a diff in a horizontal split
 ---   - `<c-t>`: opens a diff in a new tab
----@param opts table: options to pass to the picker
----@field cwd string: specify the path of the repo
----@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
----@field current_file string: specify the current file that should be used for bcommits (default: current buffer)
----@field git_command table: command that will be executed. the last element must be "-L". {"git","log","--pretty=oneline","--abbrev-commit","--no-patch","-L"}
----@field from number: the first line number in the range (default: current line)
----@field to number: the last line number in the range (default: the value of `from`)
----@field operator boolean: select lines in operator-pending mode (default: false)
+---@param opts? telescope.builtin.git_bcommits_range.opts: options to pass to the picker
 builtin.git_bcommits_range = require_on_exported_call("telescope.builtin.__git").bcommits_range
 
+---@inlinedoc
+---@class telescope.builtin.git_branches.opts : telescope.builtin.git_opts
+---@field show_remote_tracking_branches? boolean show remote tracking branches like origin/main (default: `true`)
+---@field pattern? string specify the pattern to match all refs
+
 --- List branches for current directory, with output from `git log --oneline` shown in the preview window
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<cr>`: checks out the currently selected branch
 ---   - `<C-t>`: tracks currently selected branch
 ---   - `<C-r>`: rebases currently selected branch
 ---   - `<C-a>`: creates a new branch, with confirmation prompt before creation
 ---   - `<C-d>`: deletes the currently selected branch, with confirmation prompt before deletion
 ---   - `<C-y>`: merges the currently selected branch, with confirmation prompt before deletion
----@param opts table: options to pass to the picker
----@field cwd string: specify the path of the repo
----@field use_file_path boolean: if we should use the current buffer git root (default: false)
----@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
----@field show_remote_tracking_branches boolean: show remote tracking branches like origin/main (default: true)
----@field pattern string: specify the pattern to match all refs
+---@param opts? telescope.builtin.git_branches.opts: options to pass to the picker
 builtin.git_branches = require_on_exported_call("telescope.builtin.__git").branches
 
+---@inlinedoc
+---@class telescope.builtin.git_status.opts : telescope.builtin.git_opts
+---@field git_icons? table string -> string. Matches name with icon (see source code, make_entry.lua git_icon_defaults)
+---@field expand_dir? boolean pass flag `-uall` to show files in untracked directories (default: `true`)
+
 --- Lists git status for current directory
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<Tab>`: stages or unstages the currently selected file
 ---   - `<cr>`: opens the currently selected file
----@param opts table: options to pass to the picker
----@field cwd string: specify the path of the repo
----@field use_file_path boolean: if we should use the current buffer git root (default: false)
----@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
----@field git_icons table: string -> string. Matches name with icon (see source code, make_entry.lua git_icon_defaults)
----@field expand_dir boolean: pass flag `-uall` to show files in untracked directories (default: true)
+---@param opts? telescope.builtin.git_status.opts: options to pass to the picker
 builtin.git_status = require_on_exported_call("telescope.builtin.__git").status
 
+---@inlinedoc
+---@class telescope.builtin.git_stash.opts : telescope.builtin.git_opts
+---@field show_branch? boolean if we should display the branch name for git stash entries (default: `true`)
+
 --- Lists stash items in current repository
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<cr>`: runs `git apply` for currently selected stash
----@param opts table: options to pass to the picker
----@field cwd string: specify the path of the repo
----@field use_file_path boolean: if we should use the current buffer git root (default: false)
----@field use_git_root boolean: if we should use git root as cwd or the cwd (important for submodule) (default: true)
----@field show_branch boolean: if we should display the branch name for git stash entries (default: true)
+---@param opts? table: options to pass to the picker
 builtin.git_stash = require_on_exported_call("telescope.builtin.__git").stash
 
 --
@@ -241,180 +270,265 @@ builtin.git_stash = require_on_exported_call("telescope.builtin.__git").stash
 --
 --
 
+---@inlinedoc
+---@class telescope.builtin.builtin.opts : telescope.builtin.base_opts
+---@field include_extensions? boolean if true will show the pickers of the installed extensions (default: `false`)
+---@field use_default_opts? boolean if the selected picker should use its default options (default: `false`)
+
 --- Lists all of the community maintained pickers built into Telescope
----@param opts table: options to pass to the picker
----@field include_extensions boolean: if true will show the pickers of the installed extensions (default: false)
----@field use_default_opts boolean: if the selected picker should use its default options (default: false)
+---@param opts? telescope.builtin.builtin.opts: options to pass to the picker
 builtin.builtin = require_on_exported_call("telescope.builtin.__internal").builtin
 
+---@inlinedoc
+---@class telescope.builtin.resume.opts : telescope.builtin.base_opts
+---@field cache_index? number what picker to resume, where 1 denotes most recent (default: `1`)
+
 --- Opens the previous picker in the identical state (incl. multi selections)
---- - Notes:
----   - Requires `cache_picker` in setup or when having invoked pickers, see |telescope.defaults.cache_picker|
----@param opts table: options to pass to the picker
----@field cache_index number: what picker to resume, where 1 denotes most recent (default: 1)
+---@note Requires `cache_picker` in setup or when having invoked pickers, see |telescope.defaults.cache_picker|
+---@param opts? telescope.builtin.resume.opts: options to pass to the picker
 builtin.resume = require_on_exported_call("telescope.builtin.__internal").resume
 
+---@inlinedoc
+---@class telescope.builtin.pickers.opts : telescope.builtin.base_opts
+
 --- Opens a picker over previously cached pickers in their preserved states (incl. multi selections)
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<C-x>`: delete the selected cached picker
---- - Notes:
----   - Requires `cache_picker` in setup or when having invoked pickers, see |telescope.defaults.cache_picker|
----@param opts table: options to pass to the picker
+---@note Requires `cache_picker` in setup or when having invoked pickers, see |telescope.defaults.cache_picker|
+---@param opts? telescope.builtin.pickers.opts: options to pass to the picker
 builtin.pickers = require_on_exported_call("telescope.builtin.__internal").pickers
 
+---@inlinedoc
+---@class telescope.builtin.planets.opts : telescope.builtin.base_opts
+---@field show_pluto? boolean we love Pluto (default: `false`, because its a hidden feature)
+---@field show_moon? boolean we love the Moon (default: `false`, because its a hidden feature)
+
 --- Use the telescope...
----@param opts table: options to pass to the picker
----@field show_pluto boolean: we love Pluto (default: false, because its a hidden feature)
----@field show_moon boolean: we love the Moon (default: false, because its a hidden feature)
+---@param opts? telescope.builtin.planets.opts: options to pass to the picker
 builtin.planets = require_on_exported_call("telescope.builtin.__internal").planets
+
+---@inlinedoc
+---@class telescope.builtin.symbol.opts : telescope.builtin.base_opts
+---@field symbol_path? string specify the second path. Default: `stdpath("data")/telescope/symbols/*.json`
+---@field sources? table specify a table of sources you want to load this time
 
 --- Lists symbols inside of `data/telescope-sources/*.json` found in your runtime path
 --- or found in `stdpath("data")/telescope/symbols/*.json`. The second path can be customized.
 --- We provide a couple of default symbols which can be found in
 --- https://github.com/nvim-telescope/telescope-symbols.nvim. This repos README also provides more
 --- information about the format in which the symbols have to be.
----@param opts table: options to pass to the picker
----@field symbol_path string: specify the second path. Default: `stdpath("data")/telescope/symbols/*.json`
----@field sources table: specify a table of sources you want to load this time
+---@param opts? telescope.builtin.symbol.opts: options to pass to the picker
 builtin.symbols = require_on_exported_call("telescope.builtin.__internal").symbols
 
+---@inlinedoc
+---@class telescope.builtin.commands.opts : telescope.builtin.base_opts
+---@field show_buf_command? boolean show buf local command (default: `true`)
+
 --- Lists available plugin/user commands and runs them on `<cr>`
----@param opts table: options to pass to the picker
----@field show_buf_command boolean: show buf local command (Default: true)
+---@param opts? telescope.builtin.commands.opts: options to pass to the picker
 builtin.commands = require_on_exported_call("telescope.builtin.__internal").commands
 
---- Lists items in the current quickfix list, jumps to location on `<cr>`
----@param opts table: options to pass to the picker
----@field show_line boolean: show results text (default: true)
----@field trim_text boolean: trim results text (default: false)
----@field nr number: specify the quickfix list number
+---@inlinedoc
+---@class telescope.builtin.quickfix.opts : telescope.builtin.base_opts
+---@field show_line? boolean show results text (default: `true`)
+---@field trim_text? boolean trim results text (default: `false`)
+---@field nr? number specify the quickfix list number
+
+--- Lists items in the quickfix list, jumps to location on `<cr>`
+---@param opts? telescope.builtin.quickfix.opts: options to pass to the picker
 builtin.quickfix = require_on_exported_call("telescope.builtin.__internal").quickfix
+
+---@inlinedoc
+---@class telescope.builtin.quickfixhistory.opts : telescope.builtin.base_opts
 
 --- Lists all quickfix lists in your history and open them with `builtin.quickfix`. It seems that neovim
 --- only keeps the full history for 10 lists
----@param opts table: options to pass to the picker
+---@param opts? telescope.builtin.quickfixhistory.opts: options to pass to the picker
 builtin.quickfixhistory = require_on_exported_call("telescope.builtin.__internal").quickfixhistory
 
+---@inlinedoc
+---@class telescope.builtin.loclist.opts : telescope.builtin.base_opts
+---@field show_line? boolean show results text (default: `true`)
+---@field trim_text? boolean trim results text (default: `false`)
+
 --- Lists items from the current window's location list, jumps to location on `<cr>`
----@param opts table: options to pass to the picker
----@field show_line boolean: show results text (default: true)
----@field trim_text boolean: trim results text (default: false)
+---@param opts? telescope.builtin.loclist.opts: options to pass to the picker
 builtin.loclist = require_on_exported_call("telescope.builtin.__internal").loclist
 
+---@inlinedoc
+---@class telescope.builtin.oldfiles.opts : telescope.builtin.base_opts
+---@field cwd? string specify a working directory to filter oldfiles by
+---@field only_cwd? boolean show only files in the cwd (default: `false`)
+---@field cwd_only? boolean alias for only_cwd
+---@field file_encoding? string file encoding for the previewer
+
 --- Lists previously open files, opens on `<cr>`
----@param opts table: options to pass to the picker
----@field cwd string: specify a working directory to filter oldfiles by
----@field only_cwd boolean: show only files in the cwd (default: false)
----@field cwd_only boolean: alias for only_cwd
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.oldfiles.opts: options to pass to the picker
 builtin.oldfiles = require_on_exported_call("telescope.builtin.__internal").oldfiles
 
+---@inlinedoc
+---@class telescope.builtin.commands_history.opts : telescope.builtin.base_opts
+---@field filter_fn? (fun(cmd: string): boolean) returns true if the history command should be presented.
+
 --- Lists commands that were executed recently, and reruns them on `<cr>`
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<C-e>`: open the command line with the text of the currently selected result populated in it
----@param opts table: options to pass to the picker
----@field filter_fn function: filter fn(cmd:string). true if the history command should be presented.
+---@param opts? telescope.builtin.commands_history.opts: options to pass to the picker
 builtin.command_history = require_on_exported_call("telescope.builtin.__internal").command_history
 
+---@inlinedoc
+---@class telescope.builtin.search_history.opts : telescope.builtin.base_opts
+
 --- Lists searches that were executed recently, and reruns them on `<cr>`
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<C-e>`: open a search window with the text of the currently selected search result populated in it
----@param opts table: options to pass to the picker
+---@param opts? telescope.builtin.search_history.opts: options to pass to the picker
 builtin.search_history = require_on_exported_call("telescope.builtin.__internal").search_history
 
+---@inlinedoc
+---@class telescope.builtin.vim_options.opts : telescope.builtin.base_opts
+
 --- Lists vim options, allows you to edit the current value on `<cr>`
----@param opts table: options to pass to the picker
+---@param opts? telescope.builtin.vim_options.opts: options to pass to the picker
 builtin.vim_options = require_on_exported_call("telescope.builtin.__internal").vim_options
 
+---@inlinedoc
+---@class telescope.builtin.help_tags.opts : telescope.builtin.base_opts
+---@field lang? string specify language (default: `vim.o.helplang`)
+---@field fallback? boolean fallback to en if language isn't installed (default: `true`)
+
 --- Lists available help tags and opens a new window with the relevant help info on `<cr>`
----@param opts table: options to pass to the picker
----@field lang string: specify language (default: vim.o.helplang)
----@field fallback boolean: fallback to en if language isn't installed (default: true)
+---@param opts? telescope.builtin.help_tags.opts: options to pass to the picker
 builtin.help_tags = require_on_exported_call("telescope.builtin.__internal").help_tags
 
+---@inlinedoc
+---@class telescope.builtin.man_pages.opts : telescope.builtin.base_opts
+---@field sections? string[] a list of sections to search, use `{ "ALL" }` to search in all sections (default: `{ "1" }`)
+---@field man_cmd? function that returns the man command. (Default: `apropos ""` on linux, `apropos " "` on macos)
+
 --- Lists manpage entries, opens them in a help window on `<cr>`
----@param opts table: options to pass to the picker
----@field sections table: a list of sections to search, use `{ "ALL" }` to search in all sections (default: { "1" })
----@field man_cmd function: that returns the man command. (Default: `apropos ""` on linux, `apropos " "` on macos)
+---@param opts? telescope.builtin.man_pages.opts: options to pass to the picker
 builtin.man_pages = require_on_exported_call("telescope.builtin.__internal").man_pages
 
+---@inlinedoc
+---@class telescope.builtin.reload.opts : telescope.builtin.base_opts
+---@field column_len? number define the max column len for the module name (default: dynamic, longest module name)
+
 --- Lists lua modules and reloads them on `<cr>`
----@param opts table: options to pass to the picker
----@field column_len number: define the max column len for the module name (default: dynamic, longest module name)
+---@param opts? telescope.builtin.reload.opts: options to pass to the picker
 builtin.reloader = require_on_exported_call("telescope.builtin.__internal").reloader
 
+---@inlinedoc
+---@class telescope.builtin.buffers.opts : telescope.builtin.base_opts
+---@field cwd? string specify a working directory to filter buffers list by
+---@field show_all_buffers? boolean if true, show all buffers, including unloaded buffers (default: `true`)
+---@field ignore_current_buffer? boolean if true, don't show the current buffer in the list (default: `false`)
+---@field only_cwd? boolean if true, only show buffers in the current working directory (default: `false`)
+---@field cwd_only? boolean alias for only_cwd
+---@field sort_lastused? boolean Sorts current and last buffer to the top and selects the lastused (default: `false`)
+---@field sort_mru? boolean Sorts all buffers after most recent used. Not just the current and last one (default: `false`)
+---@field bufnr_width? number Defines the width of the buffer numbers in front of the filenames  (default: dynamic)
+---@field file_encoding? string file encoding for the previewer
+---
+---  sort fn(bufnr_a, bufnr_b). true if bufnr_a should go first. Runs after sorting by most recent (if specified)
+---@field sort_buffers? (fun(buf_a: number, buf_b: number): boolean)?
+---@field select_current? boolean select current buffer (default: `false`)
+
 --- Lists open buffers in current neovim instance, opens selected buffer on `<cr>`
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<M-d>`: delete the currently selected buffer
----@param opts table: options to pass to the picker
----@field cwd string: specify a working directory to filter buffers list by
----@field show_all_buffers boolean: if true, show all buffers, including unloaded buffers (default: true)
----@field ignore_current_buffer boolean: if true, don't show the current buffer in the list (default: false)
----@field only_cwd boolean: if true, only show buffers in the current working directory (default: false)
----@field cwd_only boolean: alias for only_cwd
----@field sort_lastused boolean: Sorts current and last buffer to the top and selects the lastused (default: false)
----@field sort_mru boolean: Sorts all buffers after most recent used. Not just the current and last one (default: false)
----@field bufnr_width number: Defines the width of the buffer numbers in front of the filenames  (default: dynamic)
----@field file_encoding string: file encoding for the previewer
----@field sort_buffers function: sort fn(bufnr_a, bufnr_b). true if bufnr_a should go first. Runs after sorting by most recent (if specified)
----@field select_current boolean: select current buffer (default: false)
----@field disable_coordinates boolean: don't show line number (default: false)
+---@param opts? telescope.builtin.buffers.opts: options to pass to the picker
 builtin.buffers = require_on_exported_call("telescope.builtin.__internal").buffers
 
+---@inlinedoc
+---@class telescope.builtin.colorscheme.opts : telescope.builtin.base_opts
+---@field colors? table a list of additional colorschemes to explicitly make available to telescope (default: `{}`)
+---@field enable_preview? boolean if true, will preview the selected color
+---@field ignore_builtins? boolean if true, builtin colorschemes are not listed
+
 --- Lists available colorschemes and applies them on `<cr>`
----@param opts table: options to pass to the picker
----@field colors table: a list of additional colorschemes to explicitly make available to telescope (default: {})
----@field enable_preview boolean: if true, will preview the selected color
----@field ignore_builtins boolean: if true, builtin colorschemes are not listed
+---@param opts? telescope.builtin.colorscheme.opts: options to pass to the picker
 builtin.colorscheme = require_on_exported_call("telescope.builtin.__internal").colorscheme
 
+---@inlinedoc
+---@class telescope.builtin.marks.opts : telescope.builtin.base_opts
+---@field file_encoding? string file encoding for the previewer
+---@field mark_type? "all"|"global"|"local": filter marks by type (default: `"all"`)
+
 --- Lists vim marks and their value, jumps to the mark on `<cr>`
----@param opts table: options to pass to the picker
----@field file_encoding string: file encoding for the previewer
----@field mark_type string: filter marks by type (default: "all", options: "all"|"global"|"local")
+---@param opts? telescope.builtin.marks.opts: options to pass to the picker
 builtin.marks = require_on_exported_call("telescope.builtin.__internal").marks
 
+---@inlinedoc
+---@class telescope.builtin.registers.opts : telescope.builtin.base_opts
+
 --- Lists vim registers, pastes the contents of the register on `<cr>`
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<C-e>`: edit the contents of the currently selected register
----@param opts table: options to pass to the picker
+---@param opts? telescope.builtin.registers.opts: options to pass to the picker
 builtin.registers = require_on_exported_call("telescope.builtin.__internal").registers
 
+---@inlinedoc
+---@class telescope.builtin.keymaps.opts : telescope.builtin.base_opts
+---@field modes? table a list of short-named keymap modes to search (default: `{ "n", "i", "c", "x" }`)
+---@field show_plug? boolean if true, the keymaps for which the lhs contains `<Plug>` are also shown (default: `true`)
+---@field only_buf? boolean if true, only show the buffer-local keymaps (default: `false`)
+---@field lhs_filter? (fun(lhs:string): boolean) return true for keymap.lhs if the keymap should be shown
+---@field filter? (fun(keymap: table): boolean) return true for the keymap if it should be shown
+
 --- Lists normal mode keymappings, runs the selected keymap on `<cr>`
----@param opts table: options to pass to the picker
----@field modes table: a list of short-named keymap modes to search (default: { "n", "i", "c", "x" })
----@field show_plug boolean: if true, the keymaps for which the lhs contains "<Plug>" are also shown (default: true)
----@field only_buf boolean: if true, only show the buffer-local keymaps (default: false)
----@field lhs_filter function: filter(lhs:string) -> boolean. true for keymap.lhs if the keymap should be shown (optional)
----@field filter function: filter(km:keymap) -> boolean. true for the keymap if it should be shown (optional)
+---@param opts? telescope.builtin.keymaps.opts: options to pass to the picker
 builtin.keymaps = require_on_exported_call("telescope.builtin.__internal").keymaps
 
+---@inlinedoc
+---@class telescope.builtin.filetypes.opts : telescope.builtin.base_opts
+
 --- Lists all available filetypes, sets currently open buffer's filetype to selected filetype in Telescope on `<cr>`
----@param opts table: options to pass to the picker
+---@param opts? telescope.builtin.filetypes.opts: options to pass to the picker
 builtin.filetypes = require_on_exported_call("telescope.builtin.__internal").filetypes
 
+---@inlinedoc
+---@class telescope.builtin.highlights.opts : telescope.builtin.base_opts
+
 --- Lists all available highlights
----@param opts table: options to pass to the picker
+---@param opts? telescope.builtin.highlights.opts: options to pass to the picker
 builtin.highlights = require_on_exported_call("telescope.builtin.__internal").highlights
 
+---@inlinedoc
+---@class telescope.builtin.autocommands.opts : telescope.builtin.base_opts
+
 --- Lists vim autocommands and goes to their declaration on `<cr>`
----@param opts table: options to pass to the picker
+---@param opts? telescope.builtin.autocommands.opts: options to pass to the picker
 builtin.autocommands = require_on_exported_call("telescope.builtin.__internal").autocommands
 
+---@inlinedoc
+---@class telescope.builtin.spell_suggest.opts : telescope.builtin.base_opts
+
 --- Lists spelling suggestions for the current word under the cursor, replaces word with selected suggestion on `<cr>`
----@param opts table: options to pass to the picker
+---@param opts? telescope.builtin.spell_suggest.opts: options to pass to the picker
 builtin.spell_suggest = require_on_exported_call("telescope.builtin.__internal").spell_suggest
 
+---@inlinedoc
+---@class telescope.builtin.tagstack.opts : telescope.builtin.base_opts
+---@field show_line? boolean show results text (default: `true`)
+---@field trim_text? boolean trim results text (default: `false`)
+
 --- Lists the tag stack for the current window, jumps to tag on `<cr>`
----@param opts table: options to pass to the picker
----@field show_line boolean: show results text (default: true)
----@field trim_text boolean: trim results text (default: false)
+---@param opts? telescope.builtin.tagstack.opts: options to pass to the picker
 builtin.tagstack = require_on_exported_call("telescope.builtin.__internal").tagstack
 
+---@inlinedoc
+---@class telescope.builtin.jumplist.opts : telescope.builtin.base_opts
+---@field show_line? boolean show results text (default: `true`)
+---@field trim_text? boolean trim results text (default: `false`)
+
 --- Lists items from Vim's jumplist, jumps to location on `<cr>`
----@param opts table: options to pass to the picker
----@field show_line boolean: show results text (default: true)
----@field trim_text boolean: trim results text (default: false)
+---@param opts? telescope.builtin.jumplist.opts: options to pass to the picker
 builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jumplist
 
 --
@@ -423,98 +537,98 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 --
 --
 
+---@inlinedoc
+---@class telescope.builtin.lsp_opts : telescope.builtin.base_opts
+---@field show_line? boolean show results text (default: `true`)
+---@field file_encoding? string file encoding for the previewer
+
+---@inlinedoc
+---@class telescope.builtin.list_or_jump.opts : telescope.builtin.lsp_opts
+---@field jump_type? string how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
+---@field reuse_win? boolean jump to existing window if buffer is already oplescope.builtin.lsp_opts
+---@field trim_text? boolean trim results text (default: `false`)
+
+---@inlinedoc
+---@class telescope.builtin.lsp_references.opts : telescope.builtin.list_or_jump.opts
+---@field include_declaration? boolean include symbol declaration in the lsp references (default: `true`)
+---@field include_current_line? boolean include current line (default: `false`)
+
 --- Lists LSP references for word under the cursor, jumps to reference on `<cr>`
----@param opts table: options to pass to the picker
----@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
----@field include_current_line boolean: include current line (default: false)
----@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
----@field show_line boolean: show results text (default: true)
----@field trim_text boolean: trim results text (default: false)
----@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.lsp_references.opts: options to pass to the picker (default: `false`)
 builtin.lsp_references = require_on_exported_call("telescope.builtin.__lsp").references
 
+---@inlinedoc
+---@class telescope.builtin.lsp_in_out_calls.opts : telescope.builtin.lsp_opts
+---@field trim_text? boolean trim results text (default: `false`)
+
 --- Lists LSP incoming calls for word under the cursor, jumps to reference on `<cr>`
----@param opts table: options to pass to the picker
----@field show_line boolean: show results text (default: true)
----@field trim_text boolean: trim results text (default: false)
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.lsp_in_out_calls.opts: options to pass to the picker
 builtin.lsp_incoming_calls = require_on_exported_call("telescope.builtin.__lsp").incoming_calls
 
 --- Lists LSP outgoing calls for word under the cursor, jumps to reference on `<cr>`
----@param opts table: options to pass to the picker
----@field show_line boolean: show results text (default: true)
----@field trim_text boolean: trim results text (default: false)
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.lsp_in_out_calls.opts: options to pass to the picker
 builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp").outgoing_calls
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
----@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
----@field show_line boolean: show results text (default: true)
----@field trim_text boolean: trim results text (default: false)
----@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.list_or_jump.opts: options to pass to the picker
 builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").definitions
 
 --- Goto the definition of the type of the word under the cursor, if there's only one,
 --- otherwise show all options in Telescope
----@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
----@field show_line boolean: show results text (default: true)
----@field trim_text boolean: trim results text (default: false)
----@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.list_or_jump.opts: options to pass to the picker
 builtin.lsp_type_definitions = require_on_exported_call("telescope.builtin.__lsp").type_definitions
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
----@param opts table: options to pass to the picker
----@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
----@field show_line boolean: show results text (default: true)
----@field trim_text boolean: trim results text (default: false)
----@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.list_or_jump.opts: options to pass to the picker
 builtin.lsp_implementations = require_on_exported_call("telescope.builtin.__lsp").implementations
 
+---@inlinedoc
+---@class telescope.builtin.lsp_document_symbols.opts : telescope.builtin.lsp_opts
+---@field fname_width? number defines the width of the filename section (default: `30`)
+---@field symbol_width? number defines the width of the symbol section (default: `25`)
+---@field symbol_type_width? number defines the width of the symbol type section (default: `8`)
+---@field symbols? (string|table) filter results by symbol kind(s)
+---@field ignore_symbols? (string|table) list of symbols to ignore
+---@field symbol_highlights? table string -> string. Matches symbol with hl_group
+
 --- Lists LSP document symbols in the current buffer
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
----@param opts table: options to pass to the picker
----@field fname_width number: defines the width of the filename section (default: 30)
----@field symbol_width number: defines the width of the symbol section (default: 25)
----@field symbol_type_width number: defines the width of the symbol type section (default: 8)
----@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
----@field symbols string|table: filter results by symbol kind(s)
----@field ignore_symbols string|table: list of symbols to ignore
----@field symbol_highlights table: string -> string. Matches symbol with hl_group
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.lsp_document_symbols.opts: options to pass to the picker
 builtin.lsp_document_symbols = require_on_exported_call("telescope.builtin.__lsp").document_symbols
 
+---@inlinedoc
+---@class telescope.builtin.lsp_workspace_symbols.opts : telescope.builtin.lsp_opts
+---@field query? string for what to query the workspace (default: `""`)
+---@field fname_width? number defines the width of the filename section (default: `30`)
+---@field symbol_width? number defines the width of the symbol section (default: `25`)
+---@field symbol_type_width? number defines the width of the symbol type section (default: `8`)
+---@field symbols? (string|table) filter results by symbol kind(s)
+---@field ignore_symbols? (string|table) list of symbols to ignore
+---@field symbol_highlights? table string -> string. Matches symbol with hl_group
+
 --- Lists LSP document symbols in the current workspace
---- - Default keymaps:
+---
+--- Default keymaps:
 ---   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`)
----@param opts table: options to pass to the picker
----@field query string: for what to query the workspace (default: "")
----@field fname_width number: defines the width of the filename section (default: 30)
----@field symbol_width number: defines the width of the symbol section (default: 25)
----@field symbol_type_width number: defines the width of the symbol type section (default: 8)
----@field show_line boolean: if true, shows the content of the line the tag is found on (default: false)
----@field symbols string|table: filter results by symbol kind(s)
----@field ignore_symbols string|table: list of symbols to ignore
----@field symbol_highlights table: string -> string. Matches symbol with hl_group
----@field file_encoding string: file encoding for the previewer
+---@param opts? telescope.builtin.lsp_workspace_symbols.opts: options to pass to the picker
 builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.__lsp").workspace_symbols
 
+---@inlinedoc
+---@class telescope.builtin.lsp_dynamic_workspace_symbols.opts : telescope.builtin.lsp_opts
+---@field fname_width? number defines the width of the filename section (default: `30`)
+---@field symbols? (string|table) filter results by symbol kind(s)
+---@field ignore_symbols? (string|table) list of symbols to ignore
+---@field symbol_highlights? table string -> string. Matches symbol with hl_group
+
 --- Dynamically lists LSP for all workspace symbols
---- - Default keymaps:
----   - `<C-l>`: show autocompletion menu to prefilter your query by type of symbol you want to see (i.e. `:variable:`), only works after refining to fuzzy search using <C-space>
----@param opts table: options to pass to the picker
----@field fname_width number: defines the width of the filename section (default: 30)
----@field show_line boolean: if true, shows the content of the line the symbol is found on (default: false)
----@field symbols string|table: filter results by symbol kind(s)
----@field ignore_symbols string|table: list of symbols to ignore
----@field symbol_highlights table: string -> string. Matches symbol with hl_group
----@field file_encoding string: file encoding for the previewer
+---
+--- Default keymaps:
+---   - `<C-l>`: show autocompletion menu to prefilter your query by type of
+---   symbol you want to see (i.e. `:variable:`), only works after refining to
+---   fuzzy search using `<C-space>`
+---@param opts? telescope.builtin.lsp_dynamic_workspace_symbols.opts: options to pass to the picker
 builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.builtin.__lsp").dynamic_workspace_symbols
 
 --
@@ -523,27 +637,36 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 --
 --
 
---- Lists diagnostics
---- - Fields:
----   - `All severity flags can be passed as `string` or `number` as per `:vim.diagnostic.severity:`
---- - Default keymaps:
----   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `:warning:`)
---- - sort_by option:
+---@inlinedoc
+---@class telescope.builtin.diagnostics.opts : telescope.builtin.base_opts
+---@field bufnr? number Buffer number to get diagnostics from. Use 0 for current buffer or nil for all buffers
+---@field severity? (string|number) filter diagnostics by severity name (string) or id (number)
+---@field severity_limit? (string|number) keep diagnostics equal or more severe wrt severity name (string) or id (number)
+---@field severity_bound? (string|number) keep diagnostics equal or less severe wrt severity name (string) or id (number)
+---@field root_dir? (string|boolean) if set to string, get diagnostics only for buffers under this dir otherwise cwd
+---@field no_unlisted? boolean if true, get diagnostics only for listed buffers
+---@field no_sign? boolean hide DiagnosticSigns from Results (default: `false`)
+---@field line_width? (string|number) set length of diagnostic entry text in Results. Use 'full' for full untruncated text
+---@field namespace? number limit your diagnostics to a specific namespace
+---@field disable_coordinates? boolean don't show the line & row numbers (default: `false`)
+--- sort order of the diagnostics results (default: `"buffer"`)
 ---   - "buffer": order by bufnr (prioritizing current bufnr), severity, lnum
 ---   - "severity": order by severity, bufnr (prioritizing current bufnr), lnum
----@param opts table: options to pass to the picker
----@field bufnr number|nil: Buffer number to get diagnostics from. Use 0 for current buffer or nil for all buffers
----@field severity string|number: filter diagnostics by severity name (string) or id (number)
----@field severity_limit string|number: keep diagnostics equal or more severe wrt severity name (string) or id (number)
----@field severity_bound string|number: keep diagnostics equal or less severe wrt severity name (string) or id (number)
----@field root_dir string|boolean: if set to string, get diagnostics only for buffers under this dir otherwise cwd
----@field no_unlisted boolean: if true, get diagnostics only for listed buffers
----@field no_sign boolean: hide DiagnosticSigns from Results (default: false)
----@field line_width string|number: set length of diagnostic entry text in Results. Use 'full' for full untruncated text
----@field namespace number: limit your diagnostics to a specific namespace
----@field disable_coordinates boolean: don't show the line & row numbers (default: false)
----@field sort_by string: sort order of the diagnostics results; see above notes (default: "buffer")
+---@field sort_by? "buffer"|"severity"
+
+--- Lists diagnostics
+---
+--- All severity flags can be passed as `string` or `number` as per `vim.diagnostic.severity`.
+---
+--- Default keymaps:
+---   - `<C-l>`: show autocompletion menu to prefilter your query with the diagnostic you want to see (i.e. `warning`)
+---@param opts? telescope.builtin.diagnostics.opts: options to pass to the picker
 builtin.diagnostics = require_on_exported_call("telescope.builtin.__diagnostics").get
+
+---@nodoc
+---@class telescope.builtin.base_opts
+---@field bufnr number: buffer number to use for the picker (default: current buffer)
+---@field winnr number: window number to use for the picker (default: current window)
 
 local apply_config = function(mod)
   for k, v in pairs(mod) do
@@ -595,6 +718,6 @@ local apply_config = function(mod)
   return mod
 end
 
--- We can't do this in one statement because tree-sitter-lua docgen gets confused if we do
+-- We can't do this in one statement because docgen gets confused if we do
 builtin = apply_config(builtin)
 return builtin

--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -1,7 +1,4 @@
----@tag telescope.command
----@config { ["module"] = "telescope.command" }
-
----@brief [[
+---@brief
 ---
 --- Telescope commands can be called through two apis,
 --- the lua api and the viml api.
@@ -9,25 +6,25 @@
 --- The lua api is the more direct way to interact with Telescope, as you directly call the
 --- lua functions that Telescope defines.
 --- It can be called in a lua file using commands like:
---- <pre>
---- `require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
---- </pre>
+--- ```lua
+--- require("telescope.builtin").find_files { hidden = true, layout_config = { prompt_position = "top" } }
+--- ```
 --- If you want to use this api from a vim file you should prepend `lua` to the command, as below:
---- <pre>
---- `lua require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
---- </pre>
+--- ```vim
+--- lua require("telescope.builtin").find_files { hidden = true, layout_config = { prompt_position = "top" } }
+--- ```
 --- If you want to use this api from a neovim command line you should prepend `:lua` to
 --- the command, as below:
---- <pre>
---- `:lua require("telescope.builtin").find_files({hidden=true, layout_config={prompt_position="top"}})`
---- </pre>
+--- ```vim
+--- :lua require("telescope.builtin").find_files { hidden = true, layout_config = { prompt_position = "top" } }
+--- ```
 ---
 --- The viml api is more indirect, as first the command must be parsed to the relevant lua
 --- equivalent, which brings some limitations.
 --- The viml api can be called using commands like:
---- <pre>
---- `:Telescope find_files hidden=true layout_config={"prompt_position":"top"}`
---- </pre>
+--- ```vim
+--- :Telescope find_files hidden=true layout_config={"prompt_position":"top"}
+--- ```
 --- This involves setting options using an `=` and using viml syntax for lists and
 --- dictionaries when the corresponding lua function requires a table.
 ---
@@ -36,12 +33,11 @@
 --- only want to search within the folder `/foo bar/subfolder/` you could not do that using the
 --- viml api, as the path name contains a space.
 --- Similarly, you could NOT set the `prompt_position` to `"top"` using the following command:
---- <pre>
---- `:Telescope find_files layout_config={ "prompt_position" : "top" }`
---- </pre>
+--- ```vim
+--- :Telescope find_files layout_config={ "prompt_position" : "top" }
+--- ```
 --- as there are spaces in the option.
----
----@brief ]]
+
 local themes = require "telescope.themes"
 local builtin = require "telescope.builtin"
 local extensions = require("telescope._extensions").manager

--- a/lua/telescope/config/resolve.lua
+++ b/lua/telescope/config/resolve.lua
@@ -1,12 +1,7 @@
----@tag telescope.resolve
----@config { ["module"] = "telescope.resolve" }
-
----@brief [[
+---@brief
 --- Provides "resolver functions" to allow more customisable inputs for options.
----@brief ]]
 
 --[[
-
 Ultimately boils down to getting `height` and `width` for:
 - prompt
 - preview
@@ -86,10 +81,7 @@ That's the next step to scrolling.
     height = ...
     width = ...
 }
-
-
-
---]]
+]]
 
 local resolver = {}
 local _resolve_map = {}
@@ -202,6 +194,8 @@ end
 ---
 --- The returned function will have signature:
 ---     function(self, max_columns, max_lines): number
+---@param val any see description above
+---@return fun(self, max_columns: number, max_lines: number): number
 resolver.resolve_height = function(val)
   for k, v in pairs(_resolve_map) do
     if k(val) then
@@ -231,6 +225,8 @@ end
 ---
 --- The returned function will have signature:
 ---     function(self, max_columns, max_lines): number
+---@param val any see description above
+---@return fun(self, max_columns: number, max_lines: number): number
 resolver.resolve_width = function(val)
   for k, v in pairs(_resolve_map) do
     if k(val) then
@@ -244,13 +240,20 @@ end
 --- Calculates the adjustment required to move the picker from the middle of the screen to
 --- an edge or corner. <br>
 --- The `anchor` can be any of the following strings:
----   - "", "CENTER", "NW", "N", "NE", "E", "SE", "S", "SW", "W"
+--- - "", "CENTER", "NW", "N", "NE", "E", "SE", "S", "SW", "W"
 --- The anchors have the following meanings:
----   - "" or "CENTER":<br>
----     the picker will remain in the middle of the screen.
----   - Compass directions:<br>
----     the picker will move to the corresponding edge/corner
----     e.g. "NW" -> "top left corner", "E" -> "right edge", "S" -> "bottom edge"
+--- - "" or "CENTER":<br>
+---   the picker will remain in the middle of the screen.
+--- - Compass directions:<br>
+---   the picker will move to the corresponding edge/corner
+---   e.g. "NW" -> "top left corner", "E" -> "right edge", "S" -> "bottom edge"
+---@param anchor ""|"CENTER"|"NW"|"N"|"NE"|"E"|"SE"|"S"|"SW"|"W
+---@param p_width number window width
+---@param p_height number window height
+---@param max_columns number max number of columns
+---@param max_lines number max number of lines
+---@param anchor_padding number padding to add to the anchor
+---@return number[] # row and col
 resolver.resolve_anchor_pos = function(anchor, p_width, p_height, max_columns, max_lines, anchor_padding)
   anchor = anchor:upper()
   local pos = { 0, 0 }

--- a/lua/telescope/init.lua
+++ b/lua/telescope/init.lua
@@ -2,24 +2,23 @@ local _extensions = require "telescope._extensions"
 
 local telescope = {}
 
--- TODO(conni2461): also table of contents for tree-sitter-lua
 -- TODO: Add pre to the works
 -- ---@pre [[
 -- ---@pre ]]
 
----@brief [[
+---@brief
 --- Telescope.nvim is a plugin for fuzzy finding and neovim. It helps you search,
 --- filter, find and pick things in Lua.
 ---
 --- Getting started with telescope:
----   1. Run `:checkhealth telescope` to make sure everything is installed.
----   2. Evaluate it is working with
----      `:Telescope find_files` or
----      `:lua require("telescope.builtin").find_files()`
----   3. Put a `require("telescope").setup()` call somewhere in your neovim config.
----   4. Read |telescope.setup| to check what config keys are available and what you can put inside the setup call
----   5. Read |telescope.builtin| to check which builtin pickers are offered and what options these implement
----   6. Profit
+--- 1. Run `:checkhealth telescope` to make sure everything is installed.
+--- 2. Evaluate it is working with
+---    `:Telescope find_files` or
+---    `:lua require("telescope.builtin").find_files()`
+--- 3. Put a `require("telescope").setup()` call somewhere in your neovim config.
+--- 4. Read |telescope.setup| to check what config keys are available and what you can put inside the setup call
+--- 5. Read |telescope.builtin| to check which builtin pickers are offered and what options these implement
+--- 6. Profit
 ---
 ---  The below flow chart illustrates a simplified telescope architecture:
 --- <pre>
@@ -87,16 +86,12 @@ local telescope = {}
 ---   :h telescope.actions.history
 ---   :h telescope.previewers
 --- </pre>
----@brief ]]
-
----@tag telescope.nvim
----@config { ["name"] = "INTRODUCTION" }
 
 --- Setup function to be run by user. Configures the defaults, pickers and
 --- extensions of telescope.
 ---
 --- Usage:
---- <code>
+--- ```lua
 --- require('telescope').setup{
 ---   defaults = {
 ---     -- Default configuration for telescope goes here:
@@ -120,9 +115,10 @@ local telescope = {}
 ---     -- please take a look at the readme of the extension you want to configure
 ---   }
 --- }
---- </code>
+--- ```
+---
+---@eval return require('telescope').__format_setup_keys()
 ---@param opts table: Configuration opts. Keys: defaults, pickers, extensions
----@eval { ["description"] = require('telescope').__format_setup_keys() }
 function telescope.setup(opts)
   opts = opts or {}
 
@@ -136,8 +132,7 @@ function telescope.setup(opts)
 end
 
 --- Load an extension.
---- - Notes:
----   - Loading triggers ext setup via the config passed in |telescope.setup|
+---@note Loading triggers ext setup via the config passed in |telescope.setup|
 ---@param name string: Name of the extension
 function telescope.load_extension(name)
   return _extensions.load(name)
@@ -170,7 +165,7 @@ telescope.__format_setup_keys = function()
   end
 
   table.insert(result, "</pre>")
-  return result
+  return table.concat(result, "\n")
 end
 
 return telescope

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1,6 +1,4 @@
----@tag telescope.make_entry
-
----@brief [[
+---@brief
 ---
 --- Each picker has a finder made up of two parts, the results which are the
 --- data to be displayed, and the entry_maker. These entry_makers are functions
@@ -32,7 +30,6 @@
 --- For more information on easier displaying, see |telescope.pickers.entry_display|
 ---
 --- TODO: Document something we call `entry_index`
----@brief ]]
 
 local api = vim.api
 

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -1,6 +1,4 @@
----@tag telescope.mappings
-
----@brief [[
+---@brief
 --- |telescope.mappings| is used to configure the keybindings within
 --- a telescope picker. These key binds are only local to the picker window
 --- and will be cleared once you exit the picker.
@@ -12,116 +10,115 @@
 --- table, see |telescope.actions|
 ---
 --- Format is:
---- <code>
----   {
----     mode = { ..keys }
----   }
---- </code>
+--- ```lua
+--- {
+---   mode = { ..keys }
+--- }
+--- ```
 ---
 ---  where {mode} is the one character letter for a mode ('i' for insert, 'n' for normal).
 ---
 ---  For example:
---- <code>
----   mappings = {
----     i = {
----       ["<esc>"] = require('telescope.actions').close,
----     },
----   }
---- </code>
+--- ```lua
+--- mappings = {
+---   i = {
+---     ["<esc>"] = require('telescope.actions').close,
+---   },
+--- }
+--- ```
 ---
 --- To disable a keymap, put `[map] = false`<br>
 --- For example:
---- <code>
----   {
----     ...,
----     ["<C-n>"] = false,
----     ...,
----   }
---- </code>
+--- ```lua
+--- {
+---   ...,
+---   ["<C-n>"] = false,
+---   ...,
+--- }
+--- ```
 ---
 --- To override behavior of a key, simply set the value
 --- to be a function (either by requiring an action or by writing
 --- your own function)
---- <code>
----   {
----     ...,
----     ["<C-i>"] = require('telescope.actions').select_default,
----     ...,
----   }
---- </code>
+--- ```lua
+--- {
+---   ...,
+---   ["<C-i>"] = require('telescope.actions').select_default,
+---   ...,
+--- }
+--- ```
 ---
----  If the function you want is part of `telescope.actions`, then you can
----  simply supply the function name as a string.
----    For example, the previous option is equivalent to:
---- <code>
----   {
----     ...,
----     ["<C-i>"] = "select_default",
----     ...,
----   }
---- </code>
+--- If the function you want is part of `telescope.actions`, then you can
+--- simply supply the function name as a string.
+--- For example, the previous option is equivalent to:
+--- ```lua
+--- {
+---   ...,
+---   ["<C-i>"] = "select_default",
+---   ...,
+--- }
+--- ```
 ---
----  You can also add other mappings using tables with `type = "command"`.
----    For example:
---- <code>
----   {
----     ...,
----     ["jj"] = { "<esc>", type = "command" },
----     ["kk"] = { "<cmd>echo \"Hello, World!\"<cr>", type = "command" },)
----     ...,
----   }
---- </code>
+--- You can also add other mappings using tables with `type = "command"`.
+--- For example:
+--- ```lua
+--- {
+---   ...,
+---   ["jj"] = { "<esc>", type = "command" },
+---   ["kk"] = { "<cmd>echo \"Hello, World!\"<cr>", type = "command" },
+---   ...,
+--- }
+--- ```
 ---
 --- You can also add additional options for mappings of any type ("action" and "command").
----   For example:
---- <code>
----   {
----     ...,
----     ["<C-j>"] = {
----       actions.move_selection_next, type = "action",
----       opts = { nowait = true, silent = true }
----     },
----     ...,
----   }
---- </code>
+--- For example:
+--- ```lua
+--- {
+---   ...,
+---   ["<C-j>"] = {
+---     actions.move_selection_next, type = "action",
+---     opts = { nowait = true, silent = true }
+---   },
+---   ...,
+--- }
+--- ```
 ---
 --- There are three main places you can configure |telescope.mappings|. These are
 --- ordered from the lowest priority to the highest priority.
 ---
 --- 1. |telescope.defaults.mappings|
 --- 2. In the |telescope.setup()| table, inside a picker with a given name, use the `mappings` key
---- <code>
----   require("telescope").setup {
----     pickers = {
----       find_files = {
----         mappings = {
----           n = {
----             ["kj"] = "close",
+---     ```lua
+---     require("telescope").setup {
+---       pickers = {
+---         find_files = {
+---           mappings = {
+---             n = {
+---               ["kj"] = "close",
+---             },
 ---           },
 ---         },
 ---       },
----     },
----   }
---- </code>
+---     }
+---     ```
 --- 3. `attach_mappings` function for a particular picker.
---- <code>
----   require("telescope.builtin").find_files {
----     attach_mappings = function(_, map)
----       map("i", "asdf", function(_prompt_bufnr)
----         print "You typed asdf"
----       end)
+---     ```lua
+---     require("telescope.builtin").find_files {
+---       attach_mappings = function(_, map)
+---         map("i", "asdf", function(_prompt_bufnr)
+---           print "You typed asdf"
+---         end)
 ---
----       map({"i", "n"}, "<C-r>", function(_prompt_bufnr)
----         print "You typed <C-r>"
----       end, { desc = "desc for which key"})
+---         map({"i", "n"}, "<C-r>", function(_prompt_bufnr)
+---           print "You typed <C-r>"
+---         end, { desc = "desc for which key"})
 ---
----       -- needs to return true if you want to map default_mappings and
----       -- false if not
----       return true
----     end,
----   }
---- </code>
----@brief ]]
+---         -- needs to return true if you want to map default_mappings and
+---         -- false if not
+---         return true
+---       end,
+---     }
+---     ```
 
 local api = vim.api
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -800,14 +800,14 @@ end
 --- such as deleting buffers or files.
 ---
 --- Example usage:
---- <code>
+--- ```lua
 --- actions.delete_something = function(prompt_bufnr)
 ---    local current_picker = action_state.get_current_picker(prompt_bufnr)
 ---    current_picker:delete_selection(function(selection)
 ---      -- delete the selection outside of telescope
 ---    end)
 --- end
---- </code>
+--- ```
 ---
 --- Example usage in telescope:
 ---   - `actions.delete_buffer()`

--- a/lua/telescope/pickers/entry_display.lua
+++ b/lua/telescope/pickers/entry_display.lua
@@ -1,6 +1,4 @@
----@tag telescope.pickers.entry_display
-
----@brief [[
+---@brief
 --- Entry Display is used to format each entry shown in the result panel.
 ---
 --- Entry Display create() will give us a function based on the configuration
@@ -17,7 +15,7 @@
 --- width, this will be shown in the configuration as 'remaining = true'.
 ---
 --- An example of this configuration is shown for the buffers picker:
---- <code>
+--- ```lua
 --- local displayer = entry_display.create {
 ---   separator = " ",
 ---   items = {
@@ -27,7 +25,7 @@
 ---     { remaining = true },
 ---   },
 --- }
---- </code>
+--- ```
 ---
 --- This shows 4 columns, the first is defined in the opts as the width we'll
 --- use when display_string is the number of the buffer. The second has a fixed
@@ -37,14 +35,14 @@
 ---
 --- An example of how the display reference will be used is shown, again for
 --- the buffers picker:
---- <code>
+--- ```lua
 --- return displayer {
 ---   { entry.bufnr, "TelescopeResultsNumber" },
 ---   { entry.indicator, "TelescopeResultsComment" },
 ---   { icon, hl_group },
 ---   display_bufname .. ":" .. entry.lnum,
 --- }
---- </code>
+--- ```
 ---
 --- There are two types of values each column can have. Either a simple String
 --- or a table containing the String as well as the hl_group.
@@ -56,7 +54,6 @@
 ---
 --- For a better understanding of how create() and displayer are used it's best to look
 --- at the code in make_entry.lua.
----@brief ]]
 
 local strings = require "plenary.strings"
 local state = require "telescope.state"

--- a/lua/telescope/pickers/layout.lua
+++ b/lua/telescope/pickers/layout.lua
@@ -1,18 +1,17 @@
----@tag telescope.pickers.layout
----@config { ["module"] = "telescope.pickers.layout" }
-
----@brief [[
+---@brief
 --- The telescope pickers layout can be configured using the
 --- |telescope.defaults.create_layout| option.
 ---
+--- <pre>
 --- Parameters: ~
----   - picker : A Picker object.
+---   • picker : A Picker object.
 ---
 --- Return: ~
----   - layout : instance of `TelescopeLayout` class.
+---   • layout : instance of `TelescopeLayout` class.
 ---
 --- Example: ~
---- <code>
+--- </pre>
+--- ```lua
 --- local Layout = require "telescope.pickers.layout"
 ---
 --- require("telescope").setup {
@@ -67,8 +66,7 @@
 ---     return layout
 ---   end,
 --- }
---- </code>
----@brief ]]
+--- ```
 
 local function wrap_instance(class, instance)
   local self = instance

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -1,19 +1,16 @@
----@tag telescope.layout
----@config { ["module"] = "telescope.layout" }
-
----@brief [[
+---@brief
 --- The layout of telescope pickers can be adjusted using the
 --- |telescope.defaults.layout_strategy| and |telescope.defaults.layout_config| options.
 --- For example, the following configuration changes the default layout strategy and the
 --- default size of the picker:
---- <code>
----   require('telescope').setup{
----     defaults = {
----       layout_strategy = 'vertical',
----       layout_config = { height = 0.95 },
----     },
----   }
---- </code>
+--- ```lua
+--- require('telescope').setup{
+---   defaults = {
+---     layout_strategy = 'vertical',
+---     layout_config = { height = 0.95 },
+---   },
+--- }
+--- ```
 ---
 --- ────────────────────────────────────────────────────────────────────────────────
 ---
@@ -21,23 +18,23 @@
 ---
 --- All layout strategies are functions with the following signature:
 ---
---- <code>
----   function(picker, columns, lines, layout_config)
----     -- Do some calculations here...
----     return {
----       preview = preview_configuration,
----       results = results_configuration,
----       prompt = prompt_configuration,
----     }
----   end
---- </code>
+--- ```lua
+--- function(picker, columns, lines, layout_config)
+---   -- Do some calculations here...
+---   return {
+---     preview = preview_configuration
+---     results = results_configuration,
+---     prompt = prompt_configuration,
+---   }
+--- end
+--- ```
 ---
 --- <pre>
 ---   Parameters: ~
----     - picker        : A Picker object. (docs coming soon)
----     - columns       : (number) Columns in the vim window
----     - lines         : (number) Lines in the vim window
----     - layout_config : (table) The configuration values specific to the picker.
+---     • picker        : A Picker object. (docs coming soon)
+---     • columns       : (number) Columns in the vim window
+---     • lines         : (number) Lines in the vim window
+---     • layout_config : (table) The configuration values specific to the picker.
 --- </pre>
 ---
 --- This means you can create your own layout strategy if you want! Just be aware
@@ -48,7 +45,6 @@
 --- resembles what you want from "./lua/telescope/pickers/layout_strategies.lua" in the
 --- telescope repo.
 ---
----@brief ]]
 
 local api = vim.api
 
@@ -72,12 +68,12 @@ local calc_tabline = function(max_lines)
 end
 
 -- Helper function for capping over/undersized width/height, and calculating spacing
---@param cur_size number: size to be capped
---@param max_size any: the maximum size, e.g. max_lines or max_columns
---@param bs number: the size of the border
---@param w_num number: the maximum number of windows of the picker in the given direction
---@param b_num number: the number of border rows/column in the given direction (when border enabled)
---@param s_num number: the number of gaps in the given direction (when border disabled)
+---@param cur_size number: size to be capped
+---@param max_size any: the maximum size, e.g. max_lines or max_columns
+---@param bs number: the size of the border
+---@param w_num number: the maximum number of windows of the picker in the given direction
+---@param b_num number: the number of border rows/column in the given direction (when border enabled)
+---@param s_num number: the number of gaps in the given direction (when border disabled)
 local calc_size_and_spacing = function(cur_size, max_size, bs, w_num, b_num, s_num)
   local spacing = s_num * (1 - bs) + b_num * bs
   cur_size = math.min(cur_size, max_size)
@@ -115,11 +111,11 @@ local adjust_pos = function(pos, ...)
   end
 end
 
---@param strategy_name string: the name of the layout_strategy we are validating for
---@param configuration table: table with keys for each option available
---@param values table: table containing all of the non-default options we want to set
---@param default_layout_config table: table with the default values to configure layouts
---@return table: table containing the combined options (defaults and non-defaults)
+---@param strategy_name string: the name of the layout_strategy we are validating for
+---@param configuration table: table with keys for each option available
+---@param values table: table containing all of the non-default options we want to set
+---@param default_layout_config table?: table with the default values to configure layouts
+---@return table: table containing the combined options (defaults and non-defaults)
 local function validate_layout_config(strategy_name, configuration, values, default_layout_config)
   assert(strategy_name, "It is required to have a strategy name for validation.")
   local valid_configuration_keys = get_valid_configuration_keys(configuration)
@@ -216,11 +212,11 @@ layout_strategies._format = function(name)
 
   local add_value = function(k, val)
     if type(val) == "string" then
-      table.insert(results, string.format("  - %s: %s", k, val))
+      table.insert(results, string.format("  • %s: %s", k, val))
     elseif type(val) == "table" then
-      table.insert(results, string.format("  - %s:", k))
+      table.insert(results, string.format("  • %s:", k))
       for _, line in ipairs(val) do
-        table.insert(results, string.format("    - %s", line))
+        table.insert(results, string.format("    • %s", line))
       end
     else
       error(string.format("expected string or table but found '%s'", type(val)))
@@ -243,15 +239,15 @@ layout_strategies._format = function(name)
   end
 
   table.insert(results, "</pre>")
-  return results
+  return table.concat(results, "\n")
 end
 
---@param name string: the name to be assigned to the layout
---@param layout_config table: table where keys are the available options for the layout
---@param layout function: function with signature
---          function(self, max_columns, max_lines, layout_config): table
---        the returned table is the sizing and location information for the parts of the picker
---@retun function: wrapped function that inputs a validated layout_config into the `layout` function
+---@param name string: the name to be assigned to the layout
+---@param layout_config table: table where keys are the available options for the layout
+---@param layout function: function with signature
+---          function(self, max_columns, max_lines, layout_config): table
+---        the returned table is the sizing and location information for the parts of the picker
+---@retun function: wrapped function that inputs a validated layout_config into the `layout` function
 local function make_documented_layout(name, layout_config, layout)
   -- Save configuration data to be used by documentation
   layout_strategies._configurations[name] = layout_config
@@ -292,7 +288,7 @@ end
 --- │                                                  │
 --- └──────────────────────────────────────────────────┘
 --- </pre>
----@eval { ["description"] = require('telescope.pickers.layout_strategies')._format("horizontal") }
+---@eval return require('telescope.pickers.layout_strategies')._format("horizontal")
 ---
 layout_strategies.horizontal = make_documented_layout(
   "horizontal",
@@ -432,7 +428,7 @@ layout_strategies.horizontal = make_documented_layout(
 --- │                                                  │
 --- └──────────────────────────────────────────────────┘
 --- </pre>
----@eval { ["description"] = require("telescope.pickers.layout_strategies")._format("center") }
+---@eval return require("telescope.pickers.layout_strategies")._format("center")
 ---
 layout_strategies.center = make_documented_layout(
   "center",
@@ -558,7 +554,7 @@ layout_strategies.center = make_documented_layout(
 --- │                                                  │
 --- └──────────────────────────────────────────────────┘
 --- </pre>
----@eval { ["description"] = require("telescope.pickers.layout_strategies")._format("cursor") }
+---@eval return require("telescope.pickers.layout_strategies")._format("cursor")
 layout_strategies.cursor = make_documented_layout(
   "cursor",
   vim.tbl_extend("error", {
@@ -671,7 +667,7 @@ layout_strategies.cursor = make_documented_layout(
 --- │                                                  │
 --- └──────────────────────────────────────────────────┘
 --- </pre>
----@eval { ["description"] = require("telescope.pickers.layout_strategies")._format("vertical") }
+---@eval return require("telescope.pickers.layout_strategies")._format("vertical")
 ---
 layout_strategies.vertical = make_documented_layout(
   "vertical",
@@ -772,7 +768,7 @@ layout_strategies.vertical = make_documented_layout(
 --- Flex layout swaps between `horizontal` and `vertical` strategies based on the window width
 ---  -  Supports |layout_strategies.vertical| or |layout_strategies.horizontal| features
 ---
----@eval { ["description"] = require("telescope.pickers.layout_strategies")._format("flex") }
+---@eval return require("telescope.pickers.layout_strategies")._format("flex")
 ---
 layout_strategies.flex = make_documented_layout(
   "flex",

--- a/lua/telescope/previewers/init.lua
+++ b/lua/telescope/previewers/init.lua
@@ -1,26 +1,23 @@
----@tag telescope.previewers
----@config { ["module"] = "telescope.previewers" }
-
----@brief [[
+---@brief
 --- Provides a Previewer table that has to be implemented by each previewer.
 --- To achieve this, this module also provides two wrappers that abstract most
 --- of the work and make it really easy to create new previewers.
----   - `previewers.new_termopen_previewer`
----   - `previewers.new_buffer_previewer`
+--- - `previewers.new_termopen_previewer`
+--- - `previewers.new_buffer_previewer`
 ---
 --- Furthermore, there are a collection of previewers already defined which
 --- can be used for every picker, as long as the entries of the picker provide
 --- the necessary fields. The more important ones are
----   - `previewers.cat`
----   - `previewers.vimgrep`
----   - `previewers.qflist`
----   - `previewers.vim_buffer_cat`
----   - `previewers.vim_buffer_vimgrep`
----   - `previewers.vim_buffer_qflist`
+--- - `previewers.cat`
+--- - `previewers.vimgrep`
+--- - `previewers.qflist`
+--- - `previewers.vim_buffer_cat`
+--- - `previewers.vim_buffer_vimgrep`
+--- - `previewers.vim_buffer_qflist`
 ---
 --- Previewers can be disabled for any builtin or custom picker by doing
----   :Telescope find_files previewer=false
----@brief ]]
+--- <br>
+--- `:Telescope find_files previewer=false`
 
 local Previewer = require "telescope.previewers.previewer"
 local term_previewer = require "telescope.previewers.term_previewer"
@@ -32,11 +29,11 @@ local previewers = {}
 --- write a wrapper for this because most previewers need to have the same
 --- keys set.
 --- Examples of wrappers are:
----   - `new_buffer_previewer`
----   - `new_termopen_previewer`
+--- - `new_buffer_previewer`
+--- - `new_termopen_previewer`
 ---
 --- To create a new table do following:
----   - `local new_previewer = Previewer:new(opts)`
+--- - `local new_previewer = Previewer:new(opts)`
 ---
 --- What `:new` expects is listed below
 ---
@@ -50,22 +47,21 @@ local previewers = {}
 --- - `:scroll_horizontal_fn(direction)`
 ---
 --- `Previewer:new()` expects a table as input with following keys:
----   - `setup` function(self): Will be called the first time preview will be
----                           called.
----   - `teardown` function(self): Will be called on clean up.
----   - `preview_fn` function(self, entry, status): Will be called each time
----                                                 a new entry was selected.
----   - `title` function(self): Will return the static title of the previewer.
----   - `dynamic_title` function(self, entry): Will return the dynamic title of
----                                            the previewer. Will only be called
----                                            when config value dynamic_preview_title
----                                            is true.
----   - `send_input` function(self, input): This is meant for
----                                         `termopen_previewer` and it can be
----                                         used to send input to the terminal
----                                         application, like less.
----   - `scroll_fn` function(self, direction): Used to make scrolling work.
----   - `scroll_horizontal_fn` function(self, direction): Used to make
+--- - `setup` function(self): Will be called the first time preview will be called.
+--- - `teardown` function(self): Will be called on clean up.
+--- - `preview_fn` function(self, entry, status): Will be called each time
+---                                               a new entry was selected.
+--- - `title` function(self): Will return the static title of the previewer.
+--- - `dynamic_title` function(self, entry): Will return the dynamic title of
+---                                          the previewer. Will only be called
+---                                          when config value dynamic_preview_title
+---                                          is true.
+--- - `send_input` function(self, input): This is meant for
+---                                       `termopen_previewer` and it can be
+---                                       used to send input to the terminal
+---                                       application, like less.
+--- - `scroll_fn` function(self, direction): Used to make scrolling work.
+--- - `scroll_horizontal_fn` function(self, direction): Used to make
 ---                                                       horizontal scrolling work.
 previewers.Previewer = Previewer
 
@@ -81,11 +77,11 @@ end
 --- It requires you to specify one table entry `get_command(entry, status)`.
 --- This `get_command` function has to return the terminal command that will be
 --- executed for each entry. Example:
---- <code>
----   get_command = function(entry, status)
----     return { 'bat', entry.path }
----   end
---- </code>
+--- ```lua
+--- get_command = function(entry, status)
+---   return { 'bat', entry.path }
+--- end
+--- ```
 ---
 --- Additionally you can define:
 --- - `title` a static title for example "File Preview"
@@ -101,6 +97,7 @@ end
 ---
 --- Furthermore, if `env` is not set, it will forward all `config.set_env` environment variables to
 --- that terminal process.
+---@param opts table options
 previewers.new_termopen_previewer = term_previewer.new_termopen_previewer
 
 --- Provides a `termopen_previewer` which has the ability to display files.
@@ -112,6 +109,7 @@ previewers.new_termopen_previewer = term_previewer.new_termopen_previewer
 --- `require('telescope.config').values.cat_previewer`
 --- This will respect user configuration and will use `buffer_previewers` in
 --- case it's configured that way.
+---@param opts table options
 previewers.cat = term_previewer.cat
 
 --- Provides a `termopen_previewer` which has the ability to display files at
@@ -123,6 +121,7 @@ previewers.cat = term_previewer.cat
 --- `require('telescope.config').values.grep_previewer`
 --- This will respect user configuration and will use `buffer_previewers` in
 --- case it's configured that way.
+---@param opts table options
 previewers.vimgrep = term_previewer.vimgrep
 
 --- Provides a `termopen_previewer` which has the ability to display files at
@@ -135,6 +134,7 @@ previewers.vimgrep = term_previewer.vimgrep
 --- `require('telescope.config').values.qflist_previewer`
 --- This will respect user configuration and will use buffer previewers in
 --- case it's configured that way.
+---@param opts table options
 previewers.qflist = term_previewer.qflist
 
 --- An interface to instantiate a new `buffer_previewer`.
@@ -152,87 +152,88 @@ previewers.qflist = term_previewer.qflist
 ---
 ---
 --- options:
----   - `define_preview = function(self, entry, status)` (required)
----     Is called for each selected entry, after each selection_move
----     (up or down) and is meant to handle things like reading file,
----     jump to line or attach a highlighter.
----   - `setup = function(self)` (optional)
----     Is called once at the beginning, before the preview for the first
----     entry is displayed. You can return a table of vars that will be
----     available in `self.state` in each `define_preview` call.
----   - `teardown = function(self)` (optional)
----     Will be called at the end, when the picker is being closed and is
----     meant to clean up everything that was allocated by the previewer.
----     The `buffer_previewer` will automatically clean up all created buffers.
----     So you only need to handle things that were introduced by you.
----   - `keep_last_buf = true` (optional)
----     Will not delete the last selected buffer. This would allow you to
----     reuse that buffer in the select action. For example, that buffer can
----     be opened in a new split, rather than recreating that buffer in
----     an action. To access the last buffer number:
----     `require('telescope.state').get_global_key("last_preview_bufnr")`
----   - `get_buffer_by_name = function(self, entry)`
----     Allows you to set a unique name for each buffer. This is used for
----     caching purposes. `self.state.bufname` will be nil if the entry was
----     never loaded or the unique name when it was loaded once. For example,
----     useful if you have one file but multiple entries. This happens for grep
----     and lsp builtins. So to make the cache work only load content if
----     `self.state.bufname ~= entry.your_unique_key`
----   - `title` a static title for example "File Preview"
----   - `dyn_title(self, entry)` a dynamic title function which gets called
----     when config value `dynamic_preview_title = true`
+--- - `define_preview = function(self, entry, status)` (required)
+---   Is called for each selected entry, after each selection_move
+---   (up or down) and is meant to handle things like reading file,
+---   jump to line or attach a highlighter.
+--- - `setup = function(self)` (optional)
+---   Is called once at the beginning, before the preview for the first
+---   entry is displayed. You can return a table of vars that will be
+---   available in `self.state` in each `define_preview` call.
+--- - `teardown = function(self)` (optional)
+---   Will be called at the end, when the picker is being closed and is
+---   meant to clean up everything that was allocated by the previewer.
+---   The `buffer_previewer` will automatically clean up all created buffers.
+---   So you only need to handle things that were introduced by you.
+--- - `keep_last_buf = true` (optional)
+---   Will not delete the last selected buffer. This would allow you to
+---   reuse that buffer in the select action. For example, that buffer can
+---   be opened in a new split, rather than recreating that buffer in
+---   an action. To access the last buffer number:
+---   `require('telescope.state').get_global_key("last_preview_bufnr")`
+--- - `get_buffer_by_name = function(self, entry)`
+---   Allows you to set a unique name for each buffer. This is used for
+---   caching purposes. `self.state.bufname` will be nil if the entry was
+---   never loaded or the unique name when it was loaded once. For example,
+---   useful if you have one file but multiple entries. This happens for grep
+---   and lsp builtins. So to make the cache work only load content if
+---   `self.state.bufname ~= entry.your_unique_key`
+--- - `title` a static title for example "File Preview"
+--- - `dyn_title(self, entry)` a dynamic title function which gets called
+---   when config value `dynamic_preview_title = true`
 ---
 --- `self.state` table:
----   - `self.state.bufnr`
----     Is the current buffer number, in which you have to write the loaded
----     content.
----     Don't create a buffer yourself, otherwise it's not managed by the
----     buffer_previewer interface and you will probably be better off
----     writing your own interface.
----   - self.state.winid
----     Current window id. Useful if you want to set the cursor to a provided
----     line number.
----   - self.state.bufname
----     Will return the current buffer name, if `get_buffer_by_name` is
----     defined. nil will be returned if the entry was never loaded or when
----     `get_buffer_by_name` is not set.
+--- - `self.state.bufnr`
+---   Is the current buffer number, in which you have to write the loaded
+---   content.
+---   Don't create a buffer yourself, otherwise it's not managed by the
+---   buffer_previewer interface and you will probably be better off
+---   writing your own interface.
+--- - self.state.winid
+---   Current window id. Useful if you want to set the cursor to a provided
+---   line number.
+--- - self.state.bufname
+---   Will return the current buffer name, if `get_buffer_by_name` is
+---   defined. nil will be returned if the entry was never loaded or when
+---   `get_buffer_by_name` is not set.
 ---
 --- Tips:
----   - If you want to display content of a terminal job, use:
----     `require('telescope.previewers.utils').job_maker(cmd, bufnr, opts)`
----       - `cmd` table: for example { 'git', 'diff', entry.value }
----       - `bufnr` number: in which the content will be written
----       - `opts` table: with following keys
----         - `bufname` string: used for cache
----         - `value` string: used for cache
----         - `mode` string: either "insert" or "append". "insert" is default
----         - `env` table: define environment variables. Example:
----           - `{ ['PAGER'] = '', ['MANWIDTH'] = 50 }`
----         - `cwd` string: define current working directory for job
----         - `callback` function(bufnr, content): will be called when job
----           is done. Content will be nil if job is already loaded.
----           So you can do highlighting only the first time the previewer
----           is created for that entry.
----           Use the returned `bufnr` and not `self.state.bufnr` in callback,
----           because state can already be changed at this point in time.
----   - If you want to attach a highlighter use:
----     - `require('telescope.previewers.utils').highlighter(bufnr, ft)`
+--- - If you want to display content of a terminal job, use:
+---   `require('telescope.previewers.utils').job_maker(cmd, bufnr, opts)`
+---   - `cmd` table: for example { 'git', 'diff', entry.value }
+---   - `bufnr` number: in which the content will be written
+---   - `opts` table: with following keys
+---     - `bufname` string: used for cache
+---     - `value` string: used for cache
+---     - `mode` string: either "insert" or "append". "insert" is default
+---     - `env` table: define environment variables. Example:
+---       - `{ ['PAGER'] = '', ['MANWIDTH'] = 50 }`
+---     - `cwd` string: define current working directory for job
+---     - `callback` function(bufnr, content): will be called when job
+---       is done. Content will be nil if job is already loaded.
+---       So you can do highlighting only the first time the previewer
+---       is created for that entry.
+---       Use the returned `bufnr` and not `self.state.bufnr` in callback,
+---       because state can already be changed at this point in time.
+--- - If you want to attach a highlighter use:
+---   - `require('telescope.previewers.utils').highlighter(bufnr, ft)`
 ---       - This will prioritize tree sitter highlighting if available for
----         environment and language.
----     - `require('telescope.previewers.utils').regex_highlighter(bufnr, ft)`
----     - `require('telescope.previewers.utils').ts_highlighter(bufnr, ft)`
----   - If you want to use `vim.fn.search` or similar you need to run it in
----     that specific buffer context. Do
---- <code>
----       vim.api.nvim_buf_call(bufnr, function()
----         -- for example `search` and `matchadd`
----       end)
---- </code>
+---       environment and language.
+---   - `require('telescope.previewers.utils').regex_highlighter(bufnr, ft)`
+---   - `require('telescope.previewers.utils').ts_highlighter(bufnr, ft)`
+--- - If you want to use `vim.fn.search` or similar you need to run it in
+---   that specific buffer context. Do
+---     ```lua
+---     vim.api.nvim_buf_call(bufnr, function()
+---       -- for example `search` and `matchadd`
+---     end)
+---     ```
 ---     to achieve that.
 ---   - If you want to read a file into the buffer it's best to use
 ---     `buffer_previewer_maker`. But access this function with
 ---     `require('telescope.config').values.buffer_previewer_maker`
 ---     because it can be redefined by users.
+---@param opts table options
 previewers.new_buffer_previewer = buffer_previewer.new_buffer_previewer
 
 --- A universal way of reading a file into a buffer previewer.
@@ -251,6 +252,7 @@ previewers.buffer_previewer_maker = buffer_previewer.file_maker
 --- `require('telescope.config').values.file_previewer`
 --- This will respect user configuration and will use `termopen_previewer` in
 --- case it's configured that way.
+---@param opts table options
 previewers.vim_buffer_cat = buffer_previewer.cat
 
 --- A previewer that is used to display a file and jump to the provided line.
@@ -263,6 +265,7 @@ previewers.vim_buffer_cat = buffer_previewer.cat
 --- `require('telescope.config').values.grep_previewer`
 --- This will respect user configuration and will use `termopen_previewer` in
 --- case it's configured that way.
+---@param opts table options
 previewers.vim_buffer_vimgrep = buffer_previewer.vimgrep
 
 --- Is the same as `vim_buffer_vimgrep` and only exists for consistency with
@@ -272,36 +275,44 @@ previewers.vim_buffer_vimgrep = buffer_previewer.vimgrep
 --- `require('telescope.config').values.qflist_previewer`
 --- This will respect user configuration and will use `termopen_previewer` in
 --- case it's configured that way.
+---@param opts table options
 previewers.vim_buffer_qflist = buffer_previewer.qflist
 
 --- A previewer that shows a log of a branch as graph
+---@param opts table options
 previewers.git_branch_log = buffer_previewer.git_branch_log
 
 --- A previewer that shows a diff of a stash
+---@param opts table options
 previewers.git_stash_diff = buffer_previewer.git_stash_diff
 
 --- A previewer that shows a diff of a commit to a parent commit.<br>
 --- The run command is `git --no-pager diff SHA^! -- $CURRENT_FILE`
 ---
 --- The current file part is optional. So is only uses it with bcommits.
+---@param opts table options
 previewers.git_commit_diff_to_parent = buffer_previewer.git_commit_diff_to_parent
 
 --- A previewer that shows a diff of a commit to head.<br>
 --- The run command is `git --no-pager diff --cached $SHA -- $CURRENT_FILE`
 ---
 --- The current file part is optional. So is only uses it with bcommits.
+---@param opts table options
 previewers.git_commit_diff_to_head = buffer_previewer.git_commit_diff_to_head
 
 --- A previewer that shows a diff of a commit as it was.<br>
 --- The run command is `git --no-pager show $SHA:$CURRENT_FILE` or `git --no-pager show $SHA`
+---@param opts table options
 previewers.git_commit_diff_as_was = buffer_previewer.git_commit_diff_as_was
 
 --- A previewer that shows the commit message of a diff.<br>
 --- The run command is `git --no-pager log -n 1 $SHA`
+---@param opts table options
 previewers.git_commit_message = buffer_previewer.git_commit_message
 
 --- A previewer that shows the current diff of a file. Used in git_status.<br>
 --- The run command is `git --no-pager diff $FILE`
+---@param opts table options
 previewers.git_file_diff = buffer_previewer.git_file_diff
 
 previewers.ctags = buffer_previewer.ctags
@@ -317,6 +328,7 @@ previewers.pickers = buffer_previewer.pickers
 --- to just use this. We will keep it around for backwards compatibility
 --- because some extensions use it.
 --- It doesn't use cache or some other clever tricks.
+---@nodoc
 previewers.display_content = buffer_previewer.display_content
 
 return previewers

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -3,27 +3,23 @@
 --
 -- local opts = themes.get_dropdown { winblend = 3 }
 
----@tag telescope.themes
----@config { ["module"] = "telescope.themes" }
-
----@brief [[
+---@brief
 --- Themes are ways to combine several elements of styling together.
 ---
 --- They are helpful for managing the several different UI aspects for telescope and provide
 --- a simple interface for users to get a particular "style" of picker.
----@brief ]]
 
 local themes = {}
 
 --- Dropdown style theme.
 ---
 --- Usage:
---- <code>
----     local opts = {...} -- picker options
----     local builtin = require('telescope.builtin')
----     local themes = require('telescope.themes')
----     builtin.find_files(themes.get_dropdown(opts))
---- </code>
+--- ```lua
+--- local opts = {...} -- picker options
+--- local builtin = require('telescope.builtin')
+--- local themes = require('telescope.themes')
+--- builtin.find_files(themes.get_dropdown(opts))
+--- ```
 function themes.get_dropdown(opts)
   opts = opts or {}
 
@@ -67,12 +63,12 @@ end
 --- Cursor style theme.
 ---
 --- Usage:
---- <code>
----     local opts = {...} -- picker options
----     local builtin = require('telescope.builtin')
----     local themes = require('telescope.themes')
----     builtin.find_files(themes.get_cursor(opts))
---- </code>
+--- ```lua
+--- local opts = {...} -- picker options
+--- local builtin = require('telescope.builtin')
+--- local themes = require('telescope.themes')
+--- builtin.find_files(themes.get_cursor(opts))
+--- ```
 function themes.get_cursor(opts)
   opts = opts or {}
 
@@ -99,12 +95,12 @@ end
 --- Ivy style theme.
 ---
 --- Usage:
---- <code>
----     local opts = {...} -- picker options
----     local builtin = require('telescope.builtin')
----     local themes = require('telescope.themes')
----     builtin.find_files(themes.get_ivy(opts))
---- </code>
+--- ```lua
+--- local opts = {...} -- picker options
+--- local builtin = require('telescope.builtin')
+--- local themes = require('telescope.themes')
+--- builtin.find_files(themes.get_ivy(opts))
+--- ```
 function themes.get_ivy(opts)
   opts = opts or {}
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -1,9 +1,5 @@
----@tag telescope.utils
----@config { ["module"] = "telescope.utils" }
-
----@brief [[
+---@brief
 --- Utilities for writing telescope pickers
----@brief ]]
 
 local api = vim.api
 

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -1,24 +1,33 @@
--- Setup telescope with defaults
-if RELOAD then
-  RELOAD "telescope"
-end
-require("telescope").setup()
+vim.opt.rtp:prepend "."
+vim.opt.rtp:prepend "../plenary.nvim/"
 
-local docgen = require "docgen"
+vim.env.DOCGEN_PATH = vim.env.DOCGEN_PATH or "build/docgen.nvim"
 
-local docs = {}
+load(vim.fn.system "curl -s https://raw.githubusercontent.com/jamestrew/docgen.nvim/master/scripts/bootstrap.lua")()
 
-docs.test = function()
-  -- TODO: Fix the other files so that we can add them here.
-  local input_files = {
-    "./lua/telescope/init.lua",
+require("docgen").run {
+  name = "telescope",
+  files = {
+    {
+      "./lua/telescope/init.lua",
+      title = "INTRODUCTION",
+      tag = "telescope.nvim",
+      fn_prefix = "telescope",
+      fn_tag_prefix = "telescope",
+    },
+    -- "./lua/telescope/pickers.lua"
     "./lua/telescope/command.lua",
     "./lua/telescope/builtin/init.lua",
     "./lua/telescope/themes.lua",
     "./lua/telescope/mappings.lua",
-    "./lua/telescope/pickers/layout.lua",
-    "./lua/telescope/pickers/layout_strategies.lua",
-    "./lua/telescope/config/resolve.lua",
+    { "./lua/telescope/pickers/layout.lua", title = "LAYOUT", tag = "telescope.layout", fn_prefix = "layout" },
+    {
+      "./lua/telescope/pickers/layout_strategies.lua",
+      title = "LAYOUT_STRATEGIES",
+      tag = "telescope.layout_strategies",
+      fn_prefix = "layout_strategies",
+    },
+    { "./lua/telescope/config/resolve.lua", title = "RESOLVE", tag = "telescope.resolve", fn_prefix = "resolver" },
     "./lua/telescope/make_entry.lua",
     "./lua/telescope/pickers/entry_display.lua",
     "./lua/telescope/utils.lua",
@@ -28,22 +37,7 @@ docs.test = function()
     "./lua/telescope/actions/layout.lua",
     "./lua/telescope/actions/utils.lua",
     "./lua/telescope/actions/generate.lua",
+    { "./lua/telescope/actions/history.lua", fn_prefix = "histories" },
     "./lua/telescope/previewers/init.lua",
-    "./lua/telescope/actions/history.lua",
-  }
-
-  local output_file = "./doc/telescope.txt"
-  local output_file_handle = io.open(output_file, "w")
-
-  for _, input_file in ipairs(input_files) do
-    docgen.write(input_file, output_file_handle)
-  end
-
-  output_file_handle:write " vim:tw=78:ts=8:ft=help:norl:\n"
-  output_file_handle:close()
-  vim.cmd [[checktime]]
-end
-
-docs.test()
-
-return docs
+  },
+}

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -1,23 +1,10 @@
 vim.opt.rtp:prepend "../plenary.nvim"
 vim.opt.rtp:prepend "."
-
-local docgenpath = ".test-deps/docgen.nvim"
-if not vim.uv.fs_stat(docgenpath) then
-  vim
-    .system({
-      "git",
-      "clone",
-      "--filter=blob:none",
-      "--single-branch",
-      "https://github.com/jamestrew/docgen.nvim",
-      docgenpath,
-    })
-    :wait()
-end
-vim.opt.rtp:prepend(docgenpath)
+vim.opt.rtp:prepend ".deps/docgen.nvim"
 
 require("docgen").run {
   name = "telescope",
+  description = "Find, Filter, Preview, Pick. All lua, all the time.",
   files = {
     {
       "./lua/telescope/init.lua",
@@ -31,7 +18,7 @@ require("docgen").run {
     "./lua/telescope/builtin/init.lua",
     "./lua/telescope/themes.lua",
     "./lua/telescope/mappings.lua",
-    { "./lua/telescope/pickers/layout.lua", title = "LAYOUT", tag = "telescope.layout", fn_prefix = "layout" },
+    { "./lua/telescope/pickers/layout.lua", title = "LAYOUT",  tag = "telescope.layout",  fn_prefix = "layout" },
     {
       "./lua/telescope/pickers/layout_strategies.lua",
       title = "LAYOUT_STRATEGIES",

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -1,9 +1,20 @@
+vim.opt.rtp:prepend "../plenary.nvim"
 vim.opt.rtp:prepend "."
-vim.opt.rtp:prepend "../plenary.nvim/"
 
-vim.env.DOCGEN_PATH = vim.env.DOCGEN_PATH or "build/docgen.nvim"
-
-load(vim.fn.system "curl -s https://raw.githubusercontent.com/jamestrew/docgen.nvim/master/scripts/bootstrap.lua")()
+local docgenpath = ".test-deps/docgen.nvim"
+if not vim.uv.fs_stat(docgenpath) then
+  vim
+    .system({
+      "git",
+      "clone",
+      "--filter=blob:none",
+      "--single-branch",
+      "https://github.com/jamestrew/docgen.nvim",
+      docgenpath,
+    })
+    :wait()
+end
+vim.opt.rtp:prepend(docgenpath)
 
 require("docgen").run {
   name = "telescope",

--- a/scripts/minimal_init.vim
+++ b/scripts/minimal_init.vim
@@ -1,6 +1,5 @@
 set rtp+=.
 set rtp+=../plenary.nvim/
-set rtp+=../tree-sitter-lua/
 
 runtime! plugin/plenary.vim
 runtime! plugin/telescope.lua


### PR DESCRIPTION
Initial conversion of gendoc to https://github.com/jamestrew/docgen.nvim

main differences from tree-sitter-lua's doc gen:
- uses luacats annotations instead of emmylua allowing for tighter integration between lua_ls type checking and documentation annotations
- all descriptions are parsed as markdown using tree-sitter-markdown so improved parsing
- vimdoc rendering is heavily based off of the code used by neovim core so things will look very similar to neovim core docs
