### PR TITLE
Add kind to builtin.tags picker

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1016,8 +1016,6 @@ builtin.tags({opts})                                *telescope.builtin.tags()*
                                     false)
         {fname_width}    (number)   defines the width of the filename section
                                     (default: 30)
-        {show_kind}      (boolean)  if true, show the tag kind on the picker
-                                    (default: true)
 
 
 builtin.current_buffer_tags({opts})  *telescope.builtin.current_buffer_tags()*
@@ -1039,8 +1037,6 @@ builtin.current_buffer_tags({opts})  *telescope.builtin.current_buffer_tags()*
                                     false)
         {fname_width}    (number)   defines the width of the filename section
                                     (default: 30)
-        {show_kind}      (boolean)  if true, show the tag kind on the picker
-                                    (default: true)
 
 
 builtin.git_files({opts})                      *telescope.builtin.git_files()*

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1016,6 +1016,8 @@ builtin.tags({opts})                                *telescope.builtin.tags()*
                                     false)
         {fname_width}    (number)   defines the width of the filename section
                                     (default: 30)
+        {show_kind}      (boolean)  if true, show the tag kind on the picker
+                                    (default: true)
 
 
 builtin.current_buffer_tags({opts})  *telescope.builtin.current_buffer_tags()*
@@ -1037,6 +1039,8 @@ builtin.current_buffer_tags({opts})  *telescope.builtin.current_buffer_tags()*
                                     false)
         {fname_width}    (number)   defines the width of the filename section
                                     (default: 30)
+        {show_kind}      (boolean)  if true, show the tag kind on the picker
+                                    (default: true)
 
 
 builtin.git_files({opts})                      *telescope.builtin.git_files()*

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1137,7 +1137,7 @@ function make_entry.gen_from_ctags(opts)
     tag_entry.col = 1
     tag_entry.lnum = lnum and tonumber(lnum) or 1
     if show_kind then
-       tag_entry.kind = kind
+      tag_entry.kind = kind
     end
 
     return setmetatable(tag_entry, mt)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1025,6 +1025,7 @@ end
 function make_entry.gen_from_ctags(opts)
   opts = opts or {}
 
+  local show_kind = vim.F.if_nil(opts.show_kind, true)
   local cwd = utils.path_expand(opts.cwd or vim.loop.cwd())
   local current_file = Path:new(vim.api.nvim_buf_get_name(opts.bufnr)):normalize(cwd)
 
@@ -1135,7 +1136,7 @@ function make_entry.gen_from_ctags(opts)
     tag_entry.filename = file
     tag_entry.col = 1
     tag_entry.lnum = lnum and tonumber(lnum) or 1
-    if opts.show_kind then
+    if show_kind then
        tag_entry.kind = kind
     end
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1029,6 +1029,7 @@ function make_entry.gen_from_ctags(opts)
   local current_file = Path:new(vim.api.nvim_buf_get_name(opts.bufnr)):normalize(cwd)
 
   local display_items = {
+    { width = 16 },
     { remaining = true },
   }
 
@@ -1070,6 +1071,7 @@ function make_entry.gen_from_ctags(opts)
           end,
         },
         entry.tag,
+        entry.kind,
         scode,
       }
     end
@@ -1097,13 +1099,14 @@ function make_entry.gen_from_ctags(opts)
       return nil
     end
 
-    local tag, file, scode, lnum
-    -- ctags gives us: 'tags\tfile\tsource'
-    tag, file, scode = string.match(line, '([^\t]+)\t([^\t]+)\t/^?\t?(.*)/;"\t+.*')
+    local tag, file, scode, lnum, extension_fields
+    -- ctags gives us: 'tags\tfile\tsource;"extension_fields'
+    tag, file, scode, extension_fields = string.match(line, '([^\t]+)\t([^\t]+)\t/^?\t?(.*)/;"\t+(.*)')
     if not tag then
       -- hasktags gives us: 'tags\tfile\tlnum'
       tag, file, lnum = string.match(line, "([^\t]+)\t([^\t]+)\t(%d+).*")
     end
+    local kind = string.match(extension_fields or "", "kind:(%S+)") or "unknownkind"
 
     if Path.path.sep == "\\" then
       file = string.gsub(file, "/", "\\")
@@ -1132,6 +1135,7 @@ function make_entry.gen_from_ctags(opts)
     tag_entry.filename = file
     tag_entry.col = 1
     tag_entry.lnum = lnum and tonumber(lnum) or 1
+    tag_entry.kind = kind
 
     return setmetatable(tag_entry, mt)
   end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1106,7 +1106,7 @@ function make_entry.gen_from_ctags(opts)
       -- hasktags gives us: 'tags\tfile\tlnum'
       tag, file, lnum = string.match(line, "([^\t]+)\t([^\t]+)\t(%d+).*")
     end
-    local kind = string.match(extension_fields or "", "kind:(%S+)") or "unknownkind"
+    local kind = string.match(extension_fields or "", "kind:(%S+)")
 
     if Path.path.sep == "\\" then
       file = string.gsub(file, "/", "\\")
@@ -1135,7 +1135,9 @@ function make_entry.gen_from_ctags(opts)
     tag_entry.filename = file
     tag_entry.col = 1
     tag_entry.lnum = lnum and tonumber(lnum) or 1
-    tag_entry.kind = kind
+    if opts.show_kind then
+       tag_entry.kind = kind
+    end
 
     return setmetatable(tag_entry, mt)
   end


### PR DESCRIPTION
# Description

The current tags picker will not show the kind

Current tags picker: 
![image](https://github.com/user-attachments/assets/d1b77457-db88-452a-9ef6-fde05b0e92d8)

With this changes the picker will show the kind (`method`, `field`, `package`, `class` , etc): 

![image](https://github.com/user-attachments/assets/fc0816ca-af49-4fe0-a296-656fa1e02ae1)


It augments the regex match in the existing picker to get the `extensions_fields` that may be present on each line of the `tags` file (see [TAG FILE FORMAT](https://docs.ctags.io/en/latest/man/ctags.1.html#tag-file-format)).

That `extension_fields` may contain a `kind:xxx` field, if it does it will be picked up and added to the entry otherwise the `unknownkind` will be used.
 
To generate a `tags` file that includes kinds use 

```
git ls-files .  |  $(brew --prefix universal-ctags)/bin/ctags --fields=+zK -L - -f tags
```

where the `--fields=+zK` is the part that adds the kinds. 


Fixes #3233

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] manual test, using a `tags` file generated with `git ls-files .  |  $(brew --prefix universal-ctags)/bin/ctags --fields=+zK -L - -f tags`

Tested the with the following keymap to trigger telescope

```
vim.keymap.set("n", ";c", function()
	require("telescope.builtin").tags({ only_sort_tags = true, show_line = false, path_display = {"filename_first"} })
end, opts)
```

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.11.0-dev-492+g0cdeb06db
Build type: RelWithDebInfo
LuaJIT 2.1.1720049189
```
* Operating system and version: macOS Sonoma 14.5

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)


