### PR TITLE
Fix some issues with builtin.colorscheme

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -985,7 +985,7 @@ end
 internal.colorscheme = function(opts)
   local before_background = vim.o.background
   local before_color = vim.api.nvim_exec2("colorscheme", { output = true }).output
-  local need_restore = true
+  local need_restore = not not opts.enable_preview
 
   local colors = opts.colors or { before_color }
   if not vim.tbl_contains(colors, before_color) then
@@ -1049,8 +1049,8 @@ internal.colorscheme = function(opts)
           return
         end
 
-        actions.close(prompt_bufnr)
         need_restore = false
+        actions.close(prompt_bufnr)
         vim.cmd.colorscheme(selection.value)
       end)
       action_set.shift_selection:enhance {
@@ -1060,16 +1060,8 @@ internal.colorscheme = function(opts)
             utils.__warn_no_selection "builtin.colorscheme"
             return
           end
-          need_restore = true
           if opts.enable_preview then
             vim.cmd.colorscheme(selection.value)
-          end
-        end,
-      }
-      actions.close:enhance {
-        post = function()
-          if need_restore then
-            vim.cmd.colorscheme(before_color)
           end
         end,
       }
@@ -1082,8 +1074,9 @@ internal.colorscheme = function(opts)
           utils.__warn_no_selection "builtin.colorscheme"
           return
         end
-        need_restore = true
-        vim.cmd.colorscheme(selection.value)
+        if opts.enable_preview then
+          vim.cmd.colorscheme(selection.value)
+        end
       end,
     },
   })

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1053,18 +1053,6 @@ internal.colorscheme = function(opts)
         actions.close(prompt_bufnr)
         vim.cmd.colorscheme(selection.value)
       end)
-      action_set.shift_selection:enhance {
-        post = function()
-          local selection = action_state.get_selected_entry()
-          if selection == nil then
-            utils.__warn_no_selection "builtin.colorscheme"
-            return
-          end
-          if opts.enable_preview then
-            vim.cmd.colorscheme(selection.value)
-          end
-        end,
-      }
       return true
     end,
     on_complete = {
@@ -1089,6 +1077,21 @@ internal.colorscheme = function(opts)
       if need_restore then
         vim.o.background = before_background
         vim.cmd.colorscheme(before_color)
+      end
+    end
+
+    -- rewrite picker.set_selection so that color schemes can be previewed when the current
+    -- selection is shifted using the keyboard or if an item is clicked with the mouse
+    local set_selection = picker.set_selection
+    picker.set_selection = function(self, row)
+      set_selection(self, row)
+      local selection = action_state.get_selected_entry()
+      if selection == nil then
+        utils.__warn_no_selection "builtin.colorscheme"
+        return
+      end
+      if opts.enable_preview then
+        vim.cmd.colorscheme(selection.value)
       end
     end
   end


### PR DESCRIPTION
# Description

This PR fixes a couple of issues I found with the current implementation of `builtin.colorscheme`. Currently two problems can be observed:
- The color scheme changes when searching, even when `enable_preview` is false. Shifting the selection behaves as expected however.
- Color schemes cannot be previewed by clicking with the mouse when `enable_preview` is set to true.

The code is modified to fix these issues.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Test A:
      1. Run `:Telescope colorscheme enable_preview=false`
      2. Start searching for something
      3. Note that the color scheme is not changed until the enter key is pressed
- [ ] Test B
      1. Run `:Telescope colorscheme enable_preview=true`
      2. Use the mouse to click on one of the options
      3. Observe that the color scheme is changed
      4. Exit Telescope and the original color scheme should be restored

**Configuration**:
* Neovim version (nvim --version): v0.10.1
* Operating system and version: Linux 6.9.3

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
