### PR TITLE
fix!(lsp): use generic_sorter for `dynamic_workspace_symbols`

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -839,6 +839,9 @@ options you want to use. Here's an example with the live_grep picker: >lua
 builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
     Search for a string and get results live as you type, respects .gitignore
 
+    Default keymaps:
+    • `<C-space>`: refine current results with a fuzzy search
+
     Parameters: ~
       • {opts}  (`table?`)
                 • {cwd}? (`string`, default: cwd, use utils.buffer_dir() to
@@ -1563,9 +1566,7 @@ builtin.lsp_dynamic_workspace_symbols({opts})
     Dynamically lists LSP for all workspace symbols
 
     Default keymaps:
-    • `<C-l>`: show autocompletion menu to prefilter your query by type of
-      symbol you want to see (i.e. `:variable:`), only works after refining to
-      fuzzy search using `<C-space>`
+    • `<C-space>`: refine current results with a fuzzy search
 
     Parameters: ~
       • {opts}  (`table?`)

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -5,7 +5,6 @@ local lsp = vim.lsp
 
 local channel = require("plenary.async.control").channel
 local actions = require "telescope.actions"
-local sorters = require "telescope.sorters"
 local conf = require("telescope.config").values
 local finders = require "telescope.finders"
 local make_entry = require "telescope.make_entry"

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -455,7 +455,7 @@ M.dynamic_workspace_symbols = function(opts)
         fn = get_workspace_symbols_requester(opts.bufnr, opts),
       },
       previewer = conf.qflist_previewer(opts),
-      sorter = sorters.highlighter_only(opts),
+      sorter = conf.generic_sorter(opts),
       attach_mappings = function(_, map)
         map("i", "<c-space>", actions.to_fuzzy_refine)
         return true

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -54,6 +54,9 @@ end
 ---@field file_encoding? string file encoding for the entry & previewer
 
 --- Search for a string and get results live as you type, respects .gitignore
+---
+--- Default keymaps:
+---   - `<C-space>`: refine current results with a fuzzy search
 ---@param opts? telescope.builtin.live_grep.opts table: options to pass to the picker
 builtin.live_grep = require_on_exported_call("telescope.builtin.__files").live_grep
 
@@ -625,9 +628,7 @@ builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.__ls
 --- Dynamically lists LSP for all workspace symbols
 ---
 --- Default keymaps:
----   - `<C-l>`: show autocompletion menu to prefilter your query by type of
----   symbol you want to see (i.e. `:variable:`), only works after refining to
----   fuzzy search using `<C-space>`
+---   - `<C-space>`: refine current results with a fuzzy search
 ---@param opts? telescope.builtin.lsp_dynamic_workspace_symbols.opts: options to pass to the picker
 builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.builtin.__lsp").dynamic_workspace_symbols
 


### PR DESCRIPTION
The `highlighter_only` sorter should be reserved for pickers that have finders that already return results in an some good order (ie. like `live_grep`). But this isn't something that language server reliably do and some return results in frankly useless orders.

So swapping out the sorter for `conf.generic_sorter`.

This is somewhat of a breaking change.
closes https://github.com/nvim-telescope/telescope.nvim/issues/2104