### PR TITLE
fix(buffer_previewer): save state from `opt.setup` call

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -380,7 +380,7 @@ previewers.new_buffer_previewer = function(opts)
   function opts.setup(self)
     local state = {}
     if opt_setup then
-      vim.tbl_deep_extend("force", state, opt_setup(self))
+      state = vim.tbl_deep_extend("force", state, opt_setup(self))
     end
     return state
   end


### PR DESCRIPTION
The merged table returned from `vim.tbl_deep_extend` was not being utilized/assigned.
