### PR TITLE
fix(term_previewer): save state from `opt.setup` call

### DIFF
--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -161,7 +161,7 @@ previewers.new_termopen_previewer = function(opts)
   function opts.setup(self)
     local state = {}
     if opt_setup then
-      vim.tbl_deep_extend("force", state, opt_setup(self))
+      state = vim.tbl_deep_extend("force", state, opt_setup(self))
     end
     return state
   end


### PR DESCRIPTION
The merged table return from `vim.tbl_deep_extend` was not being utilized/assigned.

Related: https://github.com/nvim-telescope/telescope.nvim/pull/3253