### PR TITLE
fix(builtin.vim_options): fix getting current option values

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -647,7 +647,11 @@ end
 internal.vim_options = function(opts)
   local res = {}
   for _, v in pairs(vim.api.nvim_get_all_options_info()) do
-    table.insert(res, v)
+    local ok, value = pcall(vim.api.nvim_get_option_value, v.name, {})
+    if ok then
+      v.value = value
+      table.insert(res, v)
+    end
   end
   table.sort(res, function(left, right)
     return left.name < right.name

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -679,7 +679,9 @@ internal.vim_options = function(opts)
           end
 
           vim.api.nvim_feedkeys(
-            string.format("%s:set %s=%s", esc, selection.value.name, selection.value.value),
+            selection.value.type == "boolean"
+            and string.format("%s:set %s!", esc, selection.value.name)
+            or string.format("%s:set %s=%s", esc, selection.value.name, selection.value.value),
             "m",
             true
           )

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -679,9 +679,8 @@ internal.vim_options = function(opts)
           end
 
           vim.api.nvim_feedkeys(
-            selection.value.type == "boolean"
-            and string.format("%s:set %s!", esc, selection.value.name)
-            or string.format("%s:set %s=%s", esc, selection.value.name, selection.value.value),
+            selection.value.type == "boolean" and string.format("%s:set %s!", esc, selection.value.name)
+              or string.format("%s:set %s=%s", esc, selection.value.name, selection.value.value),
             "m",
             true
           )

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1003,19 +1003,14 @@ function make_entry.gen_from_vimoptions(opts)
       display = make_display,
       value = {
         name = o.name,
-        value = o.default,
+        value = o.value,
         type = o.type,
         scope = o.scope,
       },
-      ordinal = string.format("%s %s %s", o.name, o.type, o.scope),
+      ordinal = string.format("%s %s %s %s", o.name, o.type, o.scope, utils.display_termcodes(tostring(o.value))),
     }
 
-    local ok, value = pcall(vim.api.nvim_get_option_value, o.name, {})
-    if ok then
-      entry.value.value = value
-      entry.ordinal = entry.ordinal .. " " .. utils.display_termcodes(tostring(value))
-      return make_entry.set_default_entry_mt(entry, opts)
-    end
+    return make_entry.set_default_entry_mt(entry, opts)
   end
 end
 

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1010,7 +1010,7 @@ function make_entry.gen_from_vimoptions(opts)
       ordinal = string.format("%s %s %s", o.name, o.type, o.scope),
     }
 
-    local ok, value = pcall(vim.api.nvim_get_option, o.name)
+    local ok, value = pcall(vim.api.nvim_get_option_value, o.name, { buf = opts.bufnr })
     if ok then
       entry.value.value = value
       entry.ordinal = entry.ordinal .. " " .. utils.display_termcodes(tostring(value))

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1010,15 +1010,12 @@ function make_entry.gen_from_vimoptions(opts)
       ordinal = string.format("%s %s %s", o.name, o.type, o.scope),
     }
 
-    local ok, value = pcall(vim.api.nvim_get_option_value, o.name, { buf = opts.bufnr })
+    local ok, value = pcall(vim.api.nvim_get_option_value, o.name, {})
     if ok then
       entry.value.value = value
       entry.ordinal = entry.ordinal .. " " .. utils.display_termcodes(tostring(value))
-    else
-      entry.ordinal = entry.ordinal .. " " .. utils.display_termcodes(tostring(o.default))
+      return make_entry.set_default_entry_mt(entry, opts)
     end
-
-    return make_entry.set_default_entry_mt(entry, opts)
   end
 end
 


### PR DESCRIPTION
# Description

The current builtin picker `vim_options` did not correctly get the current value of all options. This PR fixes that.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. `nvim test.lua`
2. `:Telescope vim_options`
3. Search for `'filetype`

Result before change: 

![image](https://github.com/user-attachments/assets/a9f20211-78fd-48e4-a848-0f8ba171645c)

Result after change:

![image](https://github.com/user-attachments/assets/6b2298eb-e0be-41b3-886a-59dc04707fc0)

**Configuration**:
* Neovim version (nvim --version): NVIM v0.11.0-dev-611+g615f7bbff
* Operating system and version: Windows 11

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
