### PR TITLE
fix(__internal) : fix slash problem in oldfiles

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -542,7 +542,7 @@ internal.oldfiles = function(opts)
       local open_by_lsp = string.match(buffer, "line 0$")
       if match and not open_by_lsp then
         local file = vim.api.nvim_buf_get_name(match)
-        if utils.iswin then -- for slash problem in windows
+        if utils.iswin then
           file = file:gsub("/", "\\")
         end
         if vim.loop.fs_stat(file) and match ~= current_buffer then
@@ -553,7 +553,7 @@ internal.oldfiles = function(opts)
   end
 
   for _, file in ipairs(vim.v.oldfiles) do
-    if utils.iswin then -- for slash problem in windows
+    if utils.iswin then
       file = file:gsub("/", "\\")
     end
     local file_stat = vim.loop.fs_stat(file)

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -532,12 +532,19 @@ internal.oldfiles = function(opts)
   local current_file = vim.api.nvim_buf_get_name(current_buffer)
   local results = {}
 
+  if utils.iswin then -- for slash problem in windows
+    current_file = current_file:gsub("/", "\\")
+  end
+
   if opts.include_current_session then
     for _, buffer in ipairs(utils.split_lines(vim.fn.execute ":buffers! t")) do
       local match = tonumber(string.match(buffer, "%s*(%d+)"))
       local open_by_lsp = string.match(buffer, "line 0$")
       if match and not open_by_lsp then
         local file = vim.api.nvim_buf_get_name(match)
+        if utils.iswin then -- for slash problem in windows
+          file = file:gsub("/", "\\")
+        end
         if vim.loop.fs_stat(file) and match ~= current_buffer then
           table.insert(results, file)
         end
@@ -546,6 +553,9 @@ internal.oldfiles = function(opts)
   end
 
   for _, file in ipairs(vim.v.oldfiles) do
+    if utils.iswin then -- for slash problem in windows
+      file = file:gsub("/", "\\")
+    end
     local file_stat = vim.loop.fs_stat(file)
     if file_stat and file_stat.type == "file" and not vim.tbl_contains(results, file) and file ~= current_file then
       table.insert(results, file)


### PR DESCRIPTION
# Description

- Problems

Problem with slash and backslash being mixed up is chronic issue of neovim in Windows. it makes telescope prompt perceive same path differently when it execute to oldfiles picker.

some function like `nvim_buf_get_name()` or `vim.v.oldfiles` give paths which are mixed up with slash and backslash.

- What it did For windows, 

it always needs to change slash(/) to backslash(\) when function which deal with path because entry_maker works properly only the case that path string has \ not /.

- Effect

1) oldfiles picker doesn't show duplicated list
2) `defaults.path_display` configuration feature will works well at oldfiles pikcer

Fixes #1683
It is related with PR #3103 what i submitted but opened 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ v ] Test A
1) open oldfiles picker 
2) path_display feature will works all entry of oldfiles. 
   (before the issue is fixed, the path which has slash and backslash being mixed up cannot be applied by path_display
   even though `vim.opt.shellslash` is `true`
![image](https://github.com/user-attachments/assets/2b7bee3e-44fe-4a68-a59d-cd9b39d74626)

I checked with formatter stylua also and add some simple comment about it




**Configuration**:
* Neovim version (nvim --version): v0.10.0
* Operating system and version: Windows 10

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
