### PR TITLE
fix: #3265 use pairs in Pickers:delete_selection

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -833,7 +833,7 @@ function Picker:delete_selection(delete_cb)
   end
 
   local selection_index = {}
-  for result_index, result_entry in ipairs(self.finder.results) do
+  for result_index, result_entry in pairs(self.finder.results) do
     if vim.tbl_contains(delete_selections, result_entry) then
       table.insert(selection_index, result_index)
     end


### PR DESCRIPTION
ipairs won't find find all results if entry_maker happens to return nil for a line.

# Description

Fixing Pickers:delete_selection so it finds all results even if entry_maker returns nil

Fixes #3265

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] make test
- [x] fixes repro case described in the issue

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.10.1
Build type: Release
LuaJIT 2.1.1720049189

* Operating system and version:
macOS 14.6

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
