### PR TITLE
fix(builtin.oldfiles): no output when cwd is root

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -554,7 +554,6 @@ internal.oldfiles = function(opts)
 
   if opts.cwd_only or opts.cwd then
     local cwd = opts.cwd_only and vim.loop.cwd() or opts.cwd
-    cwd = cwd .. utils.get_separator()
     results = vim.tbl_filter(function(file)
       return buf_in_cwd(file, cwd)
     end, results)


### PR DESCRIPTION
# Description

When oldfiles is configured to only show files in the current working directory and the current working directory is root, no results will be displayed because a slash is appended to a path string that already ends with a slash. The line that does this is not needed because the `buf_in_cwd` function already does this (and only adds it if needed).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Test A:
      1. Launch nvim from the root directory
      2. Start the oldfiles picker
      3. Observe that nothing will be shown

**Configuration**:
* Neovim version (nvim --version): v0.10.1
* Operating system and version: Linux 6.9.3

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
