### PR TITLE
man_pages - list man pages for word under cursor

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1415,7 +1415,7 @@ builtin.man_pages({opts})                      *telescope.builtin.man_pages()*
 
     Options: ~
         {sections} (table)     a list of sections to search, use `{ "ALL" }`
-                               to search in all sections (default: { "1" })
+                               to search in all sections (default: { "ALL" })
         {cword}    (boolean)   list man pages for word under cursor (default: false)
         {man_cmd}  (function)  that returns the man command. (Default:
                                `apropos ""` on linux, `apropos " "` on macos)

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1416,6 +1416,7 @@ builtin.man_pages({opts})                      *telescope.builtin.man_pages()*
     Options: ~
         {sections} (table)     a list of sections to search, use `{ "ALL" }`
                                to search in all sections (default: { "1" })
+        {cword}    (boolean)   list man pages for word under cursor (default: false)
         {man_cmd}  (function)  that returns the man command. (Default:
                                `apropos ""` on linux, `apropos " "` on macos)
 

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -796,18 +796,27 @@ end
 internal.man_pages = function(opts)
   opts.sections = vim.F.if_nil(opts.sections, { "1" })
   assert(utils.islist(opts.sections), "sections should be a list")
-  opts.man_cmd = utils.get_lazy_default(opts.man_cmd, function()
-    local uname = vim.loop.os_uname()
-    local sysname = string.lower(uname.sysname)
-    if sysname == "darwin" then
-      local major_version = tonumber(vim.fn.matchlist(uname.release, [[^\(\d\+\)\..*]])[2]) or 0
-      return major_version >= 22 and { "apropos", "." } or { "apropos", " " }
-    elseif sysname == "freebsd" then
-      return { "apropos", "." }
-    else
-      return { "apropos", "" }
-    end
-  end)
+
+  opts.cword = vim.F.if_nil(opts.cword, false)
+  assert(opts.cword == true or opts.cword == false, "cword should be either true or false")
+
+  if opts.cword then
+    opts.man_cmd = { "whatis", vim.fn.expand "<cword>" }
+  else
+    opts.man_cmd = utils.get_lazy_default(opts.man_cmd, function()
+      local uname = vim.loop.os_uname()
+      local sysname = string.lower(uname.sysname)
+      if sysname == "darwin" then
+        local major_version = tonumber(vim.fn.matchlist(uname.release, [[^\(\d\+\)\..*]])[2]) or 0
+        return major_version >= 22 and { "apropos", "." } or { "apropos", " " }
+      elseif sysname == "freebsd" then
+        return { "apropos", "." }
+      else
+        return { "apropos", "" }
+      end
+    end)
+  end
+  -- open
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_apropos(opts)
   opts.env = { PATH = vim.env.PATH, MANPATH = vim.env.MANPATH }
 

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -794,7 +794,7 @@ internal.help_tags = function(opts)
 end
 
 internal.man_pages = function(opts)
-  opts.sections = vim.F.if_nil(opts.sections, { "1" })
+  opts.sections = vim.F.if_nil(opts.sections, { "ALL" })
   assert(utils.islist(opts.sections), "sections should be a list")
 
   opts.cword = vim.F.if_nil(opts.cword, false)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -330,6 +330,7 @@ builtin.help_tags = require_on_exported_call("telescope.builtin.__internal").hel
 --- Lists manpage entries, opens them in a help window on `<cr>`
 ---@param opts table: options to pass to the picker
 ---@field sections table: a list of sections to search, use `{ "ALL" }` to search in all sections (default: { "1" })
+---@field cword boolean: list man pages for word under cursor (default: false)
 ---@field man_cmd function: that returns the man command. (Default: `apropos ""` on linux, `apropos " "` on macos)
 builtin.man_pages = require_on_exported_call("telescope.builtin.__internal").man_pages
 


### PR DESCRIPTION
# Description

1. Add a cword boolean option to list man pages for word under cursor.
2. Change the default section from 1 to ALL

This now allows a programmer to list all relevant man pages for the API word under cursor in the source code.
For example, for open(...), the list will be:
* open (3pm)
* open (2)

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Running telescope
- [ ] Telescope man_pages cword=true
- [ ] Telescope man_pages sections={"2"} cword=true
- [ ] Telescope man_pages sections={"ALL"}
- [ ] Telescope man_pages sections={"1"} cword=false
- [ ] Telescope man_pages sections={"1"} cword=invalidstring
- [ ] Telescope man_pages sections={"1"} cword=1

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.10.0
Build type: Release
LuaJIT 2.1.1713484068
```
* Operating system and version:
Fedora 39

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)