### PR TITLE
docs(README.md): Add human readable description to keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ Using Lua:
 
 ```lua
 local builtin = require('telescope.builtin')
-vim.keymap.set('n', '<leader>ff', builtin.find_files, {})
-vim.keymap.set('n', '<leader>fg', builtin.live_grep, {})
-vim.keymap.set('n', '<leader>fb', builtin.buffers, {})
-vim.keymap.set('n', '<leader>fh', builtin.help_tags, {})
+vim.keymap.set('n', '<leader>ff', builtin.find_files, { desc = 'Telescope find files' })
+vim.keymap.set('n', '<leader>fg', builtin.live_grep, { desc = 'Telescope live grep' })
+vim.keymap.set('n', '<leader>fb', builtin.buffers, { desc = 'Telescope buffers' })
+vim.keymap.set('n', '<leader>fh', builtin.help_tags, { desc= 'Telescope help tags' })
 ```
 
 See [builtin pickers](#pickers) for a list of all builtin functions.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ local builtin = require('telescope.builtin')
 vim.keymap.set('n', '<leader>ff', builtin.find_files, { desc = 'Telescope find files' })
 vim.keymap.set('n', '<leader>fg', builtin.live_grep, { desc = 'Telescope live grep' })
 vim.keymap.set('n', '<leader>fb', builtin.buffers, { desc = 'Telescope buffers' })
-vim.keymap.set('n', '<leader>fh', builtin.help_tags, { desc= 'Telescope help tags' })
+vim.keymap.set('n', '<leader>fh', builtin.help_tags, { desc = 'Telescope help tags' })
 ```
 
 See [builtin pickers](#pickers) for a list of all builtin functions.


### PR DESCRIPTION
# Description

In the readme, I think it would be nice to add human readable descriptions to the keymaps.

See: https://neovim.io/doc/user/lua.html#vim.keymap.set()

and documentation for the `desc` parameter:
https://neovim.io/doc/user/api.html#nvim_set_keymap()

This makes the output for tools like [which-key.nvim](https://github.com/folke/which-key.nvim) look nicer.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

- use [which-key.nvim](https://github.com/folke/which-key.nvim) to look at the keymaps

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.10.1
Build type: Release
LuaJIT 2.1.1720049189
Run "nvim -V1 -v" for more info
```
* Operating system and version:
```
macOS 14.6.1
```

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)