### PR TITLE
feat: extend builtin diagnostic to allow displayed text customization

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1831,6 +1831,8 @@ builtin.diagnostics({opts})                  *telescope.builtin.diagnostics()*
         {sort_by}             (string)          sort order of the diagnostics
                                                 results; see above notes
                                                 (default: "buffer")
+        {text}                (function|nil)    allow to expand text displayed
+                                                (default: diagnostic.message)
 
 
 

--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -107,12 +107,18 @@ local diagnostics_to_tbl = function(opts)
   end
 
   local preprocess_diag = function(diagnostic)
+    local text = vim.trim(diagnostic.message:gsub("[\n]", ""))
+
+    if type(opts.text) == "function" then
+      text = opts.text(diagnostic)
+    end
+
     return {
       bufnr = diagnostic.bufnr,
       filename = bufnr_name_map[diagnostic.bufnr],
       lnum = diagnostic.lnum + 1,
       col = diagnostic.col + 1,
-      text = vim.trim(diagnostic.message:gsub("[\n]", "")),
+      text = text,
       type = severities[diagnostic.severity] or severities[1],
     }
   end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -537,6 +537,7 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 ---@field namespace number: limit your diagnostics to a specific namespace
 ---@field disable_coordinates boolean: don't show the line & row numbers (default: false)
 ---@field sort_by string: sort order of the diagnostics results; see above notes (default: "buffer")
+---@field text function|nil: allow to expand text displayed (default: diagnostic.message)
 builtin.diagnostics = require_on_exported_call("telescope.builtin.__diagnostics").get
 
 local apply_config = function(mod)


### PR DESCRIPTION
This extends `builtin.diagnostic` opts, allowing to use a custom function. Solves #2544 