### PR TITLE
fix(picker): check nil before calling get_entry

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -957,7 +957,7 @@ end
 --- Also updates the highlighting for the given entry
 ---@param row number: the number of the chosen row
 function Picker:toggle_selection(row)
-  local entry = self.manager:get_entry(self:get_index(row))
+  local entry = self.manager and self.manager:get_entry(self:get_index(row))
   if entry == nil then
     return
   end


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

When typing fast at neovim startup on Windows, error message

```txt
E5108: Error executing lua: .../nvim-data/lazy/telescope.nvim/lua/telescope/pickers.lua:960: attempt to index field 'manager' (a boolean value)
stack traceback:
  .../nvim-data/lazy/telescope.nvim/lua/telescope/pickers.lua:960: in function 'toggle_selection'
  ...-data/lazy/telescope.nvim/lua/telescope/actions/init.lua:155: in function 'run_replace_or_original'
  ...im-data/lazy/telescope.nvim/lua/telescope/actions/mt.lua:65: in function 'key_func'
  ...nvim-data/lazy/telescope.nvim/lua/telescope/mappings.lua:293: in function <...nvim-data/lazy/telescope.nvim/lua/telescope/mappings.lua:292>
```

may occur if accidentally pressed `<Tab>` or `<C-i>`

Related: #866, #236

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- manually tested, as the bug is obvious and the fix is simple

**Configuration**:

- Neovim version (nvim --version): 0.10.1
- Operating system and version: Windows 10

# Checklist

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
