### PR TITLE
fix(previewers): limit git log entries to prevent fork bomb

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -802,6 +802,7 @@ previewers.git_branch_log = defaulter(function(opts)
         "--no-pager",
         "log",
         "--graph",
+        "--max-count=1000", -- prevent fork bombing with large repos
         "--pretty=format:%h -%d %s (%cr)",
         "--abbrev-commit",
         "--date=relative",


### PR DESCRIPTION
Adds `--max-count=1000` flag to the `git log` command in the `git_branch_log` previewer. This prevents potential fork bombing issues with large repositories.

closes https://github.com/nvim-telescope/telescope.nvim/issues/2933