### PR TITLE
fix(buffers): bad `sort_lastused` result selection

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -938,10 +938,6 @@ internal.buffers = function(opts)
   for i, bufnr in ipairs(bufnrs) do
     local flag = bufnr == vim.fn.bufnr "" and "%" or (bufnr == vim.fn.bufnr "#" and "#" or " ")
 
-    if opts.sort_lastused and not opts.ignore_current_buffer and flag == "#" then
-      default_selection_idx = 2
-    end
-
     local element = {
       bufnr = bufnr,
       flag = flag,


### PR DESCRIPTION
Bad condition led to the selection being stuck at idx = 2 until only one result is left, despite idx = 1 result being a better match.

Neither `sort_lastused` or `ignore_current_buffer` should affect the position of the selection.
Former is used simply to sort the buffer list. The latter is used to filter out the current buffer.

closes https://github.com/nvim-telescope/telescope.nvim/issues/3262