### PR TITLE
fix: git status quotes path with spaces

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1381,11 +1381,15 @@ function make_entry.gen_from_git_status(opts)
       return nil
     end
 
-    local mod, file = entry:match "^(..) (.+)$"
+    -- PATH is quoted when containing special characters (including space)
+    local mod, file = entry:match "^(..) \"(.+)\"$"
     -- Ignore entries that are the PATH in XY ORIG_PATH PATH
     -- (renamed or copied files)
     if not mod then
-      return nil
+      mod, file = entry:match "^(..) (.+)$"
+      if not mod then
+        return nil
+      end
     end
 
     return setmetatable({


### PR DESCRIPTION
# Description

First try to match the path with quotes, then try without.

Fixes #3284

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

```
mkdir repro
cd repro
git init
echo "test file" > 'file with space.txt'
nvim -nu ~/minimal.lua
```

Then do `:lua require("telescope.builtin").git_status()`, type `file` and `<CR>`.

**Configuration**:
* Neovim version (nvim --version): 
* Operating system and version: Arch

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
