### PR TITLE
Revert "fix(buffers): bad `sort_lastused` result selection"

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -938,6 +938,10 @@ internal.buffers = function(opts)
   for i, bufnr in ipairs(bufnrs) do
     local flag = bufnr == vim.fn.bufnr "" and "%" or (bufnr == vim.fn.bufnr "#" and "#" or " ")
 
+    if opts.sort_lastused and not opts.ignore_current_buffer and flag == "#" then
+      default_selection_idx = 2
+    end
+
     local element = {
       bufnr = bufnr,
       flag = flag,


### PR DESCRIPTION
Reverts nvim-telescope/telescope.nvim#3289

`sort_lastused` and `ignore_current_buffer` options impacting the initial selection was intended behavior based off of fzf.vim.
https://github.com/nvim-telescope/telescope.nvim/pull/3289#issuecomment-2345252200