### PR TITLE
feat(builtin): allow picking help pages and colorschemes not yet loaded by Lazy.nvim

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1008,6 +1008,19 @@ internal.colorscheme = function(opts)
     end, vim.fn.getcompletion("", "color"))
   )
 
+  -- if lazy is available, extend the colors list with unloaded colorschemes
+  local lazy = package.loaded["lazy.core.util"]
+  if lazy and lazy.get_unloaded_rtp then
+    local paths = lazy.get_unloaded_rtp ""
+    local all_files = vim.fn.globpath(table.concat(paths, ","), "colors/*", 1, 1)
+    for _, f in ipairs(all_files) do
+      local color = vim.fn.fnamemodify(f, ":t:r")
+      if not vim.tbl_contains(colors, color) then
+        table.insert(colors, color)
+      end
+    end
+  end
+
   if opts.ignore_builtins then
     -- stylua: ignore
     local builtins = {

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -712,7 +712,17 @@ internal.help_tags = function(opts)
   end
 
   local help_files = {}
-  local all_files = vim.api.nvim_get_runtime_file("doc/*", true)
+
+  local rtp = vim.o.runtimepath
+  -- extend the runtime path with all plugins not loaded by lazy.nvim
+  local lazy = package.loaded["lazy.core.util"]
+  if lazy and lazy.get_unloaded_rtp then
+    local paths = lazy.get_unloaded_rtp ""
+    if #paths > 0 then
+      rtp = rtp .. "," .. table.concat(paths, ",")
+    end
+  end
+  local all_files = vim.fn.globpath(rtp, "doc/*", 1, 1)
   for _, fullpath in ipairs(all_files) do
     local file = utils.path_tail(fullpath)
     if file == "tags" then


### PR DESCRIPTION
# Description

This extends the built in `help_tags` and `colorscheme` pickers to support selecting from plugins that are not yet loaded by the Lazy plugin manger as described by the developer (https://github.com/ibhagwan/fzf-lua/discussions/1296). I have fully tested this and it works great even if the user doesn't use `lazy.nvim` and is a non-breaking change.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Have a plugin that is lazy loaded (`lazy = true`) and not yet loaded into the editor that provides a colorscheme. Run `:Telescope colorscheme` and see that it is on the list. When selecting it, it successfully loads automatically and is displayed
- [x] Have a plugin that is lazy loaded (`lazy = true`) and not yet loaded into the editor that provides a help docs. Run `:Telescope help_tags` and search for the plugin, select one and see that you can view the help page

**Configuration**:
* Neovim version (nvim --version): Nvim 0.10.1
* Operating system and version: Arch Linux, latest

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
