### PR TITLE
fix(entry_index): prevent recursive indexing on overrides

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -77,10 +77,23 @@ local get_filename_fn = function()
 end
 
 local handle_entry_index = function(opts, t, k)
+  local overrides = rawget(t, "_overrides")
+
+  if overrides and overrides[k] then
+    return
+  end
+
   local override = ((opts or {}).entry_index or {})[k]
   if not override then
     return
   end
+
+  if overrides == nil then
+    overrides = {}
+    rawset(t, "_overrides", overrides)
+  end
+
+  overrides[k] = true
 
   local val, save = override(t, opts)
   if save then


### PR DESCRIPTION
When indexing into an entry inside of the override function, the same key you are overriding, this causes an infinitely recursive indexing.

eg.
```lua
local opts = {
  entry_index = {
    text = function(entry)
      -- accessing the same key you're overriding in the override
      -- function will lead to stack overflow

      return "foobar " .. entry.text -- bad
    end,
  }
}
```

This change will let the entries keep track of indexes that have been overridden and prevent recursive indexing.
