### PR TITLE
fix(pickers): sorting_strategy=asc stale result clearing

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -431,13 +431,8 @@ function Picker:clear_extra_rows(results_bufnr)
   local worst_line, ok, msg
   if self.sorting_strategy == "ascending" then
     local num_results = self.manager:num_results()
-    worst_line = self.max_results - num_results
-
-    if worst_line <= 0 then
-      return
-    end
-
-    ok, msg = pcall(vim.api.nvim_buf_set_lines, results_bufnr, num_results, -1, false, {})
+    worst_line = math.min(num_results, self.max_results)
+    ok, msg = pcall(vim.api.nvim_buf_set_lines, results_bufnr, worst_line, -1, false, {})
   else
     worst_line = self:get_row(self.manager:num_results())
     if worst_line <= 0 then
@@ -1452,10 +1447,10 @@ end
 
 --- Handles updating the picker after all the entries are scored/processed.
 ---@param results_bufnr number
----@param find_id number
+---@param _ number
 ---@param prompt string
 ---@param status_updater function
-function Picker:get_result_completor(results_bufnr, find_id, prompt, status_updater)
+function Picker:get_result_completor(results_bufnr, _, prompt, status_updater)
   return vim.schedule_wrap(function()
     if self.closed == true or self:is_done() then
       return

--- a/lua/tests/automated/pickers/live_grep_spec.lua
+++ b/lua/tests/automated/pickers/live_grep_spec.lua
@@ -1,0 +1,46 @@
+if vim.fn.has "mac" == 1 or require("telescope.utils").iswin then
+  return
+end
+
+local tester = require "telescope.testharness"
+
+local disp = function(val)
+  return vim.inspect(val, { newline = " ", indent = "" })
+end
+
+describe("builtin.live_grep", function()
+  for _, configuration in ipairs {
+    { sorting_strategy = "descending" },
+    { sorting_strategy = "ascending" },
+  } do
+    it("clears results correctly when " .. disp(configuration), function()
+      tester.run_string(string.format(
+        [[
+        runner.picker(
+          "live_grep",
+          "abcd<esc>G",
+          {
+            post_typed = {
+              {
+                5,
+                function()
+                  return #vim.tbl_filter(function(line)
+                    return line ~= ""
+                  end, GetResults())
+                end,
+              },
+            },
+          },
+          vim.tbl_extend("force", {
+            sorter = require("telescope.sorters").get_fzy_sorter(),
+            layout_strategy = "center",
+            cwd = "./lua/tests/fixtures/live_grep",
+            temp__scrolling_limit = 5,
+          }, vim.json.decode [==[%s]==])
+        )
+        ]],
+        vim.json.encode(configuration)
+      ))
+    end)
+  end
+end)

--- a/lua/tests/fixtures/live_grep/a.txt
+++ b/lua/tests/fixtures/live_grep/a.txt
@@ -1,0 +1,14 @@
+abc
+abc
+abc
+abc
+abc
+
+
+abcd
+abcd
+abcd
+abcd
+abcd
+
+abcde


### PR DESCRIPTION
With `sorting_strategy='ascending'`, the results buffer should never have lines beyond the `max_results` count OR the number of available results, whichever is smaller.

closes #3282
