### PR TITLE
fix(highlights): preview may (rarely) show wrong highlight

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -1116,7 +1116,7 @@ previewers.highlights = defaulter(function(_)
       vim.schedule(function()
         vim.api.nvim_buf_call(self.state.bufnr, function()
           vim.cmd "keepjumps norm! gg"
-          vim.fn.search(entry.value .. " ")
+          vim.fn.search("^" .. entry.value .. " ")
           local lnum = vim.api.nvim_win_get_cursor(self.state.winid)[1]
           -- That one is actually a match but its better to use it like that then matchadd
           pcall(vim.api.nvim_buf_clear_namespace, self.state.bufnr, ns_previewer, 0, -1)


### PR DESCRIPTION
# Description

Fixes a bug in the builtin highlights picker where the selected highlight won't be displayed in the previewer if the selected highlight is a suffix of another highlight and that other highlight occurs first in the list of highlights. For example, having `Comment` selected in the picker shows `SpecialComment` in the previewer. Another example is 'Cursor'/'TermCursor'

The fix is trivial, just match at the start of the line (in addition to requiring a space after)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] run `:Telescope highlights` and search for `Comment`. Expected: `Comment` is shown in the preview. Actual: `SpecialComment` is shown

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.10.1
Build type: Release
LuaJIT 2.1.1720049189

* Operating system and version:
Darwin astrotop.local 23.6.0 Darwin Kernel Version 23.6.0: Fri Jul  5 17:54:20 PDT 2024; root:xnu-10063.141.1~2/RELEASE_X86_64 x86_64

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
