### PR TITLE
fix(treesitter): adapt to upstream change

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -662,7 +662,11 @@ end)
 --- Checks if treesitter parser for language is installed
 ---@param lang string
 utils.has_ts_parser = function(lang)
-  return pcall(vim.treesitter.language.add, lang)
+  if vim.fn.has "nvim-0.11" == 1 then
+    return vim.treesitter.language.add(lang)
+  else
+    return pcall(vim.treesitter.language.add, lang)
+  end
 end
 
 --- Telescope Wrapper around vim.notify


### PR DESCRIPTION
In Nvim 0.11, `vim.treesitter.language.add()` returns `true` on success or `nil,errmsg` on failure instead of throwing an error. This allows using `add()` directly as a check for available treesitter parsers.

See https://github.com/neovim/neovim/pull/30379
