### PR TITLE
fix: always use pcall to check for treesitter parser

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -662,11 +662,7 @@ end)
 --- Checks if treesitter parser for language is installed
 ---@param lang string
 utils.has_ts_parser = function(lang)
-  if vim.fn.has "nvim-0.11" == 1 then
-    return vim.treesitter.language.add(lang)
-  else
-    return pcall(vim.treesitter.language.add, lang)
-  end
+  return pcall(vim.treesitter.language.add, lang)
 end
 
 --- Telescope Wrapper around vim.notify


### PR DESCRIPTION
# Description

When previewing a file, which does not have a treesitter parser, on `nvim v0.11` an error is thrown. This change always uses pcall to try to add the treesitter parser for the detected filetype. Hence, the success and a message is returned and the previewer can gracefully just display the file's contents without highlighting.

Fixes #3314

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Preview any file for which no treesitter parser exist. I have specifically called into `require"telescope.builtin".find_files{}`

**Configuration**:
* Neovim version (nvim --version):

```
NVIM v0.11.0-dev-616+gfd65422b9
Build type: RelWithDebInfo
LuaJIT 2.1.1723675123
Run "nvim -V1 -v" for more info
```

* Operating system and version:

- OS Name: Microsoft Windows 11 Enterprise
- Version: 10.0.22631 Build 22631

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
