### PR TITLE
fix(git_status): correctly count result on_complete

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -393,9 +393,18 @@ git.status = function(opts)
       sorter = conf.file_sorter(opts),
       on_complete = {
         function(self)
-          local lines = self.manager:num_results()
           local prompt = action_state.get_current_line()
-          if lines == 0 and prompt == "" then
+
+          -- HACK: self.manager:num_results() can return 0 despite having results
+          -- due to some async/event loop shenanigans (#3316)
+          local count = 0
+          for _, entry in pairs(self.finder.results) do
+            if entry and entry.valid ~= false then
+              count = count + 1
+            end
+          end
+
+          if count == 0 and prompt == "" then
             utils.notify("builtin.git_status", {
               msg = "No changes found",
               level = "ERROR",

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1387,7 +1387,7 @@ function make_entry.gen_from_git_status(opts)
       return nil
     end
 
-    return setmetatable({
+    return make_entry.set_default_entry_mt({
       value = file,
       status = mod,
       ordinal = entry,


### PR DESCRIPTION
The previous implementation of `self.manager:num_results()` could return 0 despite having results due to suspected async/event loop issues (#3316). This change counts valid entries manually to ensure accurate result count.


closes #3316

