### PR TITLE
Open wrong filepath located at network drive for Windows

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -138,7 +138,7 @@ action_set.edit = function(prompt_bufnr, command)
   local filename, row, col
 
   if entry.path or entry.filename then
-    filename = entry.path or entry.filename
+    filename = entry.filename or entry.path
 
     -- TODO: Check for off-by-one
     row = entry.row or entry.lnum


### PR DESCRIPTION
# Description

Let's say in Windows, we map a Network Drive at `Z:` to `\\share\data\`.
Then open nvim in, for example, `Z:\\code`.

Folder structure for `code` is like:
```
code/
  - test.c
  - main.c
```

Bug reproduce steps:
1. Open `test.c` in Neovim.
2. Query a tag with `Telescope tags` command
3. Select a tag located in `main.c`
4. **WRONG** filepath will be opened
something like absolute path of `\share\data\main.c` is open but actually we want `.\main.c`.

Maybe it is better to fix the path expansion for `entry.path` but I can not found where that happens, so just workaround using the relative path `entry.filename`.

## Type of change

- Bug fix

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Follow the reproduce steps and verify the bug is fixed.
- [x] Open a project located in normal disk, and follow the reproduce steps to verify it still works.

**Configuration**:
* Neovim version (nvim --version): 0.9.5
* Operating system and version: Windows 11

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
