### PR TITLE
marks picker: add support for cwd and cwd_only options

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1187,6 +1187,13 @@ internal.marks = function(opts)
   end
   marks_table = vim.fn.extend(marks_table, marks_others)
 
+  if opts.cwd_only or opts.cwd then
+    local cwd = opts.cwd_only and vim.loop.cwd() or opts.cwd
+    marks_table = vim.tbl_filter(function(row)
+      return buf_in_cwd(row.filename, cwd)
+    end, marks_table)
+  end
+
   pickers
     .new(opts, {
       prompt_title = "Marks",

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -368,6 +368,8 @@ builtin.colorscheme = require_on_exported_call("telescope.builtin.__internal").c
 ---@param opts table: options to pass to the picker
 ---@field file_encoding string: file encoding for the previewer
 ---@field mark_type string: filter marks by type (default: "all", options: "all"|"global"|"local")
+---@field cwd string: specify a working directory to filter marks list by
+---@field cwd_only boolean: if true, only show marks in the current working directory (default: false)
 builtin.marks = require_on_exported_call("telescope.builtin.__internal").marks
 
 --- Lists vim registers, pastes the contents of the register on `<cr>`


### PR DESCRIPTION
# Description

This PR allows usage of `cwd` and `cwd_only` options in `marks` picker.

Fixes #3213

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] `:lua require('telescope.builtin').marks({ cwd_only = true })`
- [ ] `:lua require('telescope.builtin').marks({ cwd = '/path/to/cwd' })`

**Configuration**:
* Neovim version (nvim --version): NVIM v0.10.1
* Operating system and version: macOS 14.7

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
