### PR TITLE
fix(previewer): `preview=false` option inheritance

### DIFF
--- a/lua/telescope/command.lua
+++ b/lua/telescope/command.lua
@@ -112,6 +112,9 @@ command.convert_user_opts = function(user_opts)
             user_opts[key] = eval
           else
             -- otherwise return nil (allows split check later)
+            -- BUG: this doesn't allow things like `preview=false`, where an
+            -- option supports other types other than the default type
+            -- (`preview` has a default type of table)
             user_opts[key] = nil
           end
         end

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -36,6 +36,9 @@ local function defaulter(f, default_opts)
   default_opts = default_opts or {}
   return {
     new = function(opts)
+      if opts.preview == false then
+        return false
+      end
       if conf.preview == false and not opts.preview then
         return false
       end


### PR DESCRIPTION
According to `:h telescope.defaults.preview`, we should be able to do `preview=false` to disable the previewer for pickers. With how picker options resolve inheritance, something like this should work.

```lua
require('telescope').setup {
  defaults = { preview = true },
  pickers = { find_files = { preview = false } }
}
```
Here, find_files should not show a previewer but it previously would.

Corrects this by checking if `opts.preview` is explicitly set to `false`. In which case, we won't show the previewer.

Closes #3325
