### PR TITLE
refactor: adapt to deprecated jump_to_location

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -442,7 +442,7 @@ files.treesitter = function(opts)
   end
 
   results = utils.filter_symbols(results, opts)
-  if results == nil then
+  if vim.tbl_isempty(results) then
     -- error message already printed in `utils.filter_symbols`
     return
   end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -121,7 +121,7 @@ utils.filter_symbols = function(results, opts, post_filter)
       msg = "Either opts.symbols or opts.ignore_symbols, can't process opposing options at the same time!",
       level = "ERROR",
     })
-    return
+    return {}
   elseif not (has_ignore or has_symbols) then
     return results
   elseif has_ignore then
@@ -133,7 +133,7 @@ utils.filter_symbols = function(results, opts, post_filter)
         msg = "Please pass ignore_symbols as either a string or a list of strings",
         level = "ERROR",
       })
-      return
+      return {}
     end
 
     opts.ignore_symbols = vim.tbl_map(string.lower, opts.ignore_symbols)
@@ -149,7 +149,7 @@ utils.filter_symbols = function(results, opts, post_filter)
         msg = "Please pass filtering symbols as either a string or a list of strings",
         level = "ERROR",
       })
-      return
+      return {}
     end
 
     opts.symbols = vim.tbl_map(string.lower, opts.symbols)


### PR DESCRIPTION
# Description

`vim.lsp.util.jump_to_location` was deprecated in https://github.com/neovim/neovim/pull/30877
This replaces it with `vim.lsp.util.show_document` which `jump_to_location` uses anyways.

The underlying function is available in 0.9

There are also some associated type annotation changes.

I also changed the return to an empty table rather than nil for some lsp complaints although functionally it remains the same

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

gd's in 0.9, 0.10 and HEAD

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
