### PR TITLE
fix: vim.str_byteindex argument order

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -23,7 +23,7 @@ utils.iswin = vim.loop.os_uname().sysname == "Windows_NT"
 ---@return integer
 utils.str_byteindex = function(s, i, encoding)
   if vim.fn.has "nvim-0.11" == 1 then
-    return vim.str_byteindex(s, encoding, i, false)
+    return vim.str_byteindex(s, i, encoding, false)
   else
     return vim.lsp.util._str_byteindex_enc(s, i, encoding)
   end


### PR DESCRIPTION
# Description


The recently added shim, didn't call vim.str_byteindex with right arguments. 
https://neovim.io/doc/user/lua.html#vim.str_byteindex()

This change fixes that.

Fixes #3346

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

LSP + Telescope work again with this change.
I just called `require('telescope.builtin').lsp_definitions`.

**Configuration**:

* Neovim version (nvim --version):

NVIM v0.11.0-dev-981+g82b02ae2f-Homebrew
Build type: Release
LuaJIT 2.1.1727870382

* Operating system and version:

MacOS 15.1

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
