### PR TITLE
fix(builtin): avoid duplicate LSP reference results

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -191,9 +191,17 @@ local function list_or_jump(action, title, funname, params, opts)
           local locations = {}
 
           if not utils.islist(result) then
-            vim.list_extend(locations, { result })
-          else
-            vim.list_extend(locations, result)
+            result = { result }
+          end
+
+          for _, value in pairs(result) do
+            if
+              not vim.tbl_contains(items, function(item)
+                return vim.deep_equal(item.user_data, value)
+              end, { predicate = true })
+            then
+              vim.list_extend(locations, { value })
+            end
           end
 
           local offset_encoding = vim.lsp.get_client_by_id(client_id).offset_encoding


### PR DESCRIPTION
# Description

In case of multiple LSP servers, making a request to each server can result in similar results.

For example:
In angular project, if both typescript & angular language server are setup and running, execution of "textDocument/references" resulting in telescope showing duplicate list of results.

Fix is to check if resulting table (`items`) contains similar item and don't add it.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Test A
- [ ] Test B

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
