### PR TITLE
feat(live_grep): Allow passing multiple file types for type_filter

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -864,9 +864,10 @@ builtin.live_grep({opts})                      *telescope.builtin.live_grep()*
         {glob_pattern}        (string|table)    argument to be used with
                                                 `--glob`, e.g. "*.toml", can
                                                 use the opposite "!*.toml"
-        {type_filter}         (string)          argument to be used with
-                                                `--type`, e.g. "rust", see `rg
-                                                --type-list`
+        {type_filter}         (string|table)    comma-separated string or
+                                                string list argument to be
+                                                used with `--type`, e.g. "rust",
+                                                see `rg --type-list`
         {additional_args}     (function|table)  additional arguments to be
                                                 passed on. Can be fn(opts) ->
                                                 tbl

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -138,7 +138,13 @@ files.live_grep = function(opts)
   end
 
   if opts.type_filter then
-    additional_args[#additional_args + 1] = "--type=" .. opts.type_filter
+    local file_types = opts.type_filter
+    if type(opts.type_filter) == "string" then
+      file_types = vim.split(opts.type_filter, ",", { trimempty = true })
+    end
+    for _, file_type in ipairs(file_types) do
+      additional_args[#additional_args + 1] = "--type=" .. file_type
+    end
   end
 
   if type(opts.glob_pattern) == "string" then

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -51,7 +51,7 @@ end
 ---@field grep_open_files boolean: if true, restrict search to open files only, mutually exclusive with `search_dirs`
 ---@field search_dirs table: directory/directories/files to search, mutually exclusive with `grep_open_files`
 ---@field glob_pattern string|table: argument to be used with `--glob`, e.g. "*.toml", can use the opposite "!*.toml"
----@field type_filter string: argument to be used with `--type`, e.g. "rust", see `rg --type-list`
+---@field type_filter string|table: comma-separated string or string list argument to be used with `--type`, e.g. "rust", see `rg --type-list`
 ---@field additional_args function|table: additional arguments to be passed on. Can be fn(opts) -> tbl
 ---@field max_results number: define a upper result value
 ---@field disable_coordinates boolean: don't show the line & row numbers (default: false)


### PR DESCRIPTION
# Description

This PR allows passing multiple file types to `type_filter` in the `live_grep` builtin. Previously, only a single file type was allowed.
This implementation accepts a comma separated string (easier when using the `:Telescope live_grep` command) or a table of strings. It splits the input and passes it as multiple `--type` args to `ripgrep`.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] `:Telescope live_grep type_filter=lua`
- [ ] `:Telescope live_grep type_filter=lua,md`
- [ ] `:lua require("telescope.builtin").live_grep({type_filter="lua"})`
- [ ] `:lua require("telescope.builtin").live_grep({type_filter={"lua","md"}})`

**Configuration**:
* Neovim version (nvim --version): `v0.10.2`
* Operating system and version: Arch Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
