### PR TITLE
feat(buffer_previewer): add Neoscroll support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ wiki.
 - [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) (finder/preview)
 - [neovim LSP](https://neovim.io/doc/user/lsp.html) (picker)
 - [devicons](https://github.com/nvim-tree/nvim-web-devicons) (icons)
+- [karb94/neoscroll.nvim](https://github.com/karb94/neoscroll.nvim) (smooth scrolling preview)
 
 ### Installation
 

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -5,6 +5,7 @@ local putils = require "telescope.previewers.utils"
 local Previewer = require "telescope.previewers.previewer"
 local conf = require("telescope.config").values
 local global_state = require "telescope.state"
+local has_neoscroll, neoscroll = pcall(require, "neoscroll")
 
 local pscan = require "plenary.scandir"
 
@@ -475,7 +476,11 @@ previewers.new_buffer_previewer = function(opts)
   end
 
   if not opts.scroll_fn then
-    opts.scroll_fn = scroll_fn
+    if has_neoscroll then
+      opts.scroll_fn = neoscroll.telescope_scroll_fn
+    else
+      opts.scroll_fn = scroll_fn
+    end
   end
 
   if not opts.scroll_horizontal_fn then


### PR DESCRIPTION
# Description

I am the author of [Neoscroll](https://github.com/karb94/neoscroll.nvim), a smooth scrolling plugin. Some of my users requested support for Telescope's buffer previews [#79](https://github.com/karb94/neoscroll.nvim/issues/79). This PR adds Neoscroll smooth scrolling support to Telescope's buffer_previewer when Neoscroll is available.


Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Install Neoscroll from `master` branch.
2. Install Telescope with this PR
3. Make sure Neoscroll is imported before Telescope on startup
4. Run any telescope command with buffer preview

**Configuration**:
* Neovim version (nvim --version): 0.10.2
* Operating system and version: NixOS unstable

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
