### PR TITLE
refactor: expose path_truncate

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -207,7 +207,7 @@ local calc_result_length = function(truncate_len)
   return type(truncate_len) == "number" and len - truncate_len or len
 end
 
-local path_truncate = function(path, truncate_len, opts)
+utils.path_truncate = function(path, truncate_len, opts)
   if opts.__length == nil then
     opts.__length = calc_result_length(truncate_len)
   end
@@ -404,7 +404,7 @@ utils.transform_path = function(opts, path)
     end
 
     if vim.tbl_contains(path_display, "truncate") or path_display.truncate then
-      transformed_path = path_truncate(transformed_path, path_display.truncate, opts)
+      transformed_path = utils.path_truncate(transformed_path, path_display.truncate, opts)
     end
 
     if vim.tbl_contains(path_display, "filename_first") or path_display["filename_first"] ~= nil then


### PR DESCRIPTION
# Description

Third parties and custom pickers would benefit from `path_truncate` being exposed in the API, specially considering it is using `calc_result_length` and it is too complicated and hacky for other developers to come to the conclusion they can achieve line length like that, I made it public for myself and now I can truncate paths in my custom picker like this:

```lua
utils.path_truncate(display_filename, 1, {})
```

I can't imagine how I could achieve this myself without investing so much time.

Fixes # (issue)

## Type of change

- This change requires a documentation update --- does it? I'm not sure if similar items in the api are documented, for example `is_path_hidden` is not documented.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

N/A as it is just exposing something already used internally and has been tested.

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [?] I have made corresponding changes to the documentation (lua annotations)
