### PR TITLE
feat(pickers/grep): add ltrim_text option

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -328,9 +328,14 @@ do
           end
         end
 
+        local entry_text = entry.text
+        if opts.ltrim_text then
+          entry_text = entry_text:gsub("^%s+", "")
+        end
+
         local display, hl_group, icon = utils.transform_devicons(
           entry.filename,
-          string.format(display_string, display_filename, coordinates, entry.text),
+          string.format(display_string, display_filename, coordinates, entry_text),
           disable_devicons
         )
 


### PR DESCRIPTION
# Description

When I grep multiple files, pickers are usually filled with leading white space. I find it easier if all entries are vertically aligned, even if that doesn't reflect the actual line in file.

I was doing this in my config:

```lua
local make_entry = require 'telescope.make_entry'
local original_entry_maker = make_entry.gen_from_vimgrep {}
local custom_entry_maker = function(line)
  local _, _, identifier, text = string.find(line, [[(..-:%d+:%d+):(.*)]])
  text = text:gsub('^%s+', '')
  local line = identifier .. ':' .. text
  return original_entry_maker(line)
end

vim.keymap.set('n', '<leader>sw', function()
  builtin.grep_string { entry_maker = custom_entry_maker }
end, { desc = '[S]earch current [W]ord' })
```

Figured it would be better if I sneak a config option in the picker, so here's my attempt to do so.

I'm not familiar with Lua, Telescope nor NVim. (I'm a cool person though)
I'm very open to change code or add docs if someone can point me in the right direction.

I've tried using `text.triml()` but that didn't work for me, so I went with the regex. Is there a more performant way to do that in Lua/NVim?

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

I see grepped lines without the leading space when I set the option. Not setting it has the same effect of setting it to false, so it defaults to the current behavior (not a breaking change).

Default behavior:

![image](https://github.com/user-attachments/assets/0ca03e18-2c51-4441-bda9-c0c7a4dab152)

With `ltrim_text = true`: 

![image](https://github.com/user-attachments/assets/b85b4431-64f6-4bc2-875e-02c0419a49f6)

**Configuration**:
* Neovim version (nvim --version): 0.10.2
* Operating system and version: Windows 11 and macOS 14.7.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
