### PR TITLE
feat(diagnosticts): add option to show the source of the entry

### DIFF
--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -107,12 +107,13 @@ local diagnostics_to_tbl = function(opts)
   end
 
   local preprocess_diag = function(diagnostic)
+    local source = opts.show_source and " (" .. diagnostic.source .. ")" or ""
     return {
       bufnr = diagnostic.bufnr,
       filename = bufnr_name_map[diagnostic.bufnr],
       lnum = diagnostic.lnum + 1,
       col = diagnostic.col + 1,
-      text = vim.trim(diagnostic.message:gsub("[\n]", "")),
+      text = vim.trim(diagnostic.message:gsub("[\n]", "")) .. source,
       type = severities[diagnostic.severity] or severities[1],
     }
   end

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -539,6 +539,7 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 ---@field namespace number: limit your diagnostics to a specific namespace
 ---@field disable_coordinates boolean: don't show the line & row numbers (default: false)
 ---@field sort_by string: sort order of the diagnostics results; see above notes (default: "buffer")
+---@field show_source boolean: show source of diagnostic entries (default: false)
 builtin.diagnostics = require_on_exported_call("telescope.builtin.__diagnostics").get
 
 local apply_config = function(mod)


### PR DESCRIPTION
# Description

Adds option to show LSP source to diagnostics picker.
It's useful when you work on a multilanguage project.

Fixes https://github.com/nvim-telescope/telescope.nvim/issues/2544
Fixes https://github.com/nvim-telescope/telescope.nvim/issues/2110

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Use `telescope.builtin.diagnostics` with `{ show_source = true }` table.
```lua
vim.keymap.set("n", "<leader>sd", function()
	builtin.diagnostics({ show_source = true })
end)
```
 In the end of every result there should be the source that created the entry

**Configuration**:
* Neovim version (nvim --version): v0.10.2
* Operating system and version: Ubuntu 24.04.1 LTS

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
