### PR TITLE
Default builtin quickfix to use current list instead of last.

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1314,7 +1314,7 @@ builtin.commands({opts})                        *telescope.builtin.commands()*
 
 
 builtin.quickfix({opts})                        *telescope.builtin.quickfix()*
-    Lists items in the quickfix list, jumps to location on `<cr>`
+    Lists items in the current quickfix list, jumps to location on `<cr>`
 
 
     Parameters: ~

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -412,7 +412,7 @@ internal.commands = function(opts)
 end
 
 internal.quickfix = function(opts)
-  local qf_identifier = opts.id or vim.F.if_nil(opts.nr, "$")
+  local qf_identifier = opts.id or vim.F.if_nil(opts.nr, 0)
   local locations = vim.fn.getqflist({ [opts.id and "id" or "nr"] = qf_identifier, items = true }).items
 
   if vim.tbl_isempty(locations) then

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -279,7 +279,7 @@ builtin.symbols = require_on_exported_call("telescope.builtin.__internal").symbo
 ---@field show_buf_command boolean: show buf local command (Default: true)
 builtin.commands = require_on_exported_call("telescope.builtin.__internal").commands
 
---- Lists items in the quickfix list, jumps to location on `<cr>`
+--- Lists items in the current quickfix list, jumps to location on `<cr>`
 ---@param opts table: options to pass to the picker
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)


### PR DESCRIPTION
# Description

This change updates Telescope quickfix command to default to opening the **current quickfix list** instead of the **last quickfix list**. The previous behavior caused confusion when navigating the quickfix stack (e.g., using `:colder` or `:cnewer`), as Telescope would always display the last quickfix list instead of the currently active one.

This update aligns Telescope's behavior with the user's expectation of viewing the active quickfix list. Users who wish to explicitly view the last quickfix list can still configure their query with appropriate parameters.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration.

- [x] Verified navigation between quickfix lists (`:colder`, `:cnewer`) works correctly with Telescope.
- [x] Tested default behavior to open the current quickfix list.
- [x] Tested explicit configuration to query the last quickfix list when needed.

**Configuration**:
* Neovim version (`nvim --version`):
  ```plaintext
  NVIM v0.11.0-dev-1410+gc51bf5a6b2
  Build type: Release
  LuaJIT 2.1.1734355927
  Run "nvim -V1 -v" for more info
* Operating system and version:
`5.15.167.4-microsoft-standard-WSL2 Ubuntu 22.04.1 LTS`
# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
