### PR TITLE
feat: `git restore` using `git_status` picker

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -896,6 +896,34 @@ actions.git_staging_toggle = function(prompt_bufnr)
   end
 end
 
+--- Restore a file from the git index
+---@param prompt_bufnr number: The prompt bufnr
+actions.git_restore_to_index = function(prompt_bufnr)
+  local cwd = action_state.get_current_picker(prompt_bufnr).cwd
+  local selection = action_state.get_selected_entry()
+  if selection == nil then
+    utils.__warn_no_selection "actions.git_restore_to_index"
+    return
+  end
+  if selection.status:sub(2) == " " then
+    utils.notify("actions.git_restore_to_index", {
+      msg = "Nothing to restore",
+      level = "WARN",
+    })
+    return
+  elseif selection.status:sub(2) == "?" then
+    utils.notify("action.git_restore_to_index", {
+      msg = "File not present at HEAD or index",
+      level = "ERROR",
+    })
+    return
+  end
+  if not ask_to_confirm("All worktree changes to the file will be lost. Proceed? [y/n] ", "y") then
+    return
+  end
+  utils.get_os_command_output({ "git", "restore", selection.value }, cwd)
+end
+
 local entry_to_qf = function(entry)
   local text = entry.text
 

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -430,8 +430,24 @@ git.status = function(opts)
             picker:refresh(gen_new_finder(), { reset_prompt = false })
           end,
         }
+        actions.git_restore_to_index:enhance {
+          post = function()
+            local picker = action_state.get_current_picker(prompt_bufnr)
+
+            -- temporarily register a callback which keeps selection on refresh
+            local selection = picker:get_selection_row()
+            local callbacks = { unpack(picker._completion_callbacks) } -- shallow copy
+            picker:register_completion_callback(function(self)
+              self:set_selection(selection)
+              self._completion_callbacks = callbacks
+            end)
+
+            picker:refresh(gen_new_finder(), { reset_prompt = false })
+          end
+        }
 
         map({ "i", "n" }, "<tab>", actions.git_staging_toggle)
+        map({ "i", "n" }, "<c-r>", actions.git_restore_to_index)
         return true
       end,
     })


### PR DESCRIPTION
# Description

Added an action to perform `git restore` on files from the git_status picker by pressing `<c-r>` when on a selection.

**Note:** Telescope takes about 1 sec to respond to `<c-r>`. This is an internal issue to telescope. I confirmed this by changing the keymap of `git_reset_soft` to `<c-r>`.  This doesn't happen if there is some other key after `<c-r>`, like `<c-r>s` for `git_reset_soft`.

Closes #3012

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Run `Telescope git_status` in a local repository with some files having some modifications that are neither staged nor committed. Move the selection to one of such files and press `Ctrl-R`. Press `Enter` when a prompt asks you for confirmation. The file will be restored to its staged version, or its `HEAD` version if there are no staged modifications.

**Configuration**:
* Neovim version (nvim --version): 0.10.1
* Operating system and version: Linux Mint 22

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
