### PR TITLE
feat(picker): allow appending original window's file name/path/dir to prompt

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -1546,6 +1546,34 @@ actions.insert_original_cline = function(prompt_bufnr)
   current_picker:set_prompt(current_picker.original_cline, false)
 end
 
+--- Insert the file path of buffer in the original (pre-Telescope) window
+---@param prompt_bufnr number: The prompt bufnr
+actions.insert_original_file_path = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  current_picker:set_prompt(current_picker.original_file_path, false)
+end
+
+--- Insert the file name of buffer in the original (pre-Telescope) window
+---@param prompt_bufnr number: The prompt bufnr
+actions.insert_original_file_name = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  current_picker:set_prompt(current_picker.original_file_name, false)
+end
+
+--- Insert the bare file name of buffer in the original (pre-Telescope) window
+---@param prompt_bufnr number: The prompt bufnr
+actions.insert_original_file_bare_name = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  current_picker:set_prompt(current_picker.original_file_bare_name, false)
+end
+
+--- Insert the directory of file in the original (pre-Telescope) window
+---@param prompt_bufnr number: The prompt bufnr
+actions.insert_original_file_dir = function(prompt_bufnr)
+  local current_picker = action_state.get_current_picker(prompt_bufnr)
+  current_picker:set_prompt(current_picker.original_file_dir, false)
+end
+
 actions.nop = function(_) end
 
 actions.mouse_click = function(prompt_bufnr)

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -179,6 +179,10 @@ mappings.default_mappings = config.values.default_mappings
       ["<C-r><C-a>"] = actions.insert_original_cWORD,
       ["<C-r><C-f>"] = actions.insert_original_cfile,
       ["<C-r><C-l>"] = actions.insert_original_cline,
+      ["<C-r><C-p>"] = actions.insert_original_file_path,
+      ["<C-r><C-n>"] = actions.insert_original_file_name,
+      ["<C-r><C-b>"] = actions.insert_original_file_bare_name,
+      ["<C-r><C-d>"] = actions.insert_original_file_dir,
 
       -- disable c-j because we dont want to allow new lines #2123
       ["<C-j>"] = actions.nop,

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -538,6 +538,10 @@ function Picker:find()
   _, self.original_cfile = pcall(vim.fn.expand, "<cfile>")
   _, self.original_cline = pcall(vim.api.nvim_get_current_line)
   _, self.original_cline = pcall(vim.trim, self.original_cline)
+  _, self.original_file_path = pcall(vim.fn.expand, "%")
+  _, self.original_file_name = pcall(vim.fn.expand, "%:t")
+  _, self.original_file_bare_name = pcall(vim.fn.expand, "%:t:r")
+  _, self.original_file_dir = pcall(vim.fn.expand, "%:h")
 
   -- User autocmd run it before create Telescope window
   vim.api.nvim_exec_autocmds("User", { pattern = "TelescopeFindPre" })


### PR DESCRIPTION
# Description

Store the `<cWORD>`, `<cfile>` and `cursor line` of the original window before showing up telescope window, and create new action to insert/append the them into the telescope prompt buffer.

Allows for similar behaviors to c_CTRL-R_CTRL-W.
follows: #3134

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
