### PR TITLE
chore(ci): use latest macOS instead of deprecated macos-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-22.04, macos-latest, windows-2022]
         rev: [nightly, v0.9.5, v0.10.0]
         include:
           - os: ubuntu-22.04
             install-rg: sudo apt-get update && sudo apt-get install -y ripgrep
-          - os: macos-12
+          - os: macos-latest
             install-rg: brew update && brew install ripgrep
           - os: windows-2022
             install-rg: choco install ripgrep


### PR DESCRIPTION
I see other PRs' tests are failed due to this deprecation.