### PR TITLE
Support `filter_items`

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -197,6 +197,9 @@ end
 local function list_or_jump(action, title, funname, params, opts)
   opts.reuse_win = vim.F.if_nil(opts.reuse_win, false)
   opts.curr_filepath = vim.api.nvim_buf_get_name(opts.bufnr)
+  opts.filter_items = opts.filter_items or function(items)
+    return items
+  end
 
   vim.lsp.buf_request_all(opts.bufnr, action, params, function(results_per_client)
     local items = {}
@@ -234,6 +237,7 @@ local function list_or_jump(action, title, funname, params, opts)
 
     items = apply_action_handler(action, items, opts)
     items = filter_file_ignore_patters(items, opts)
+    items = opts.filter_items(items)
 
     if vim.tbl_isempty(items) then
       utils.notify(funname, {

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -428,6 +428,7 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
 ---@field file_encoding string: file encoding for the previewer
+---@field filter_items FilterItemsCallback: callback to filter out quickfix entries that should be ignored
 builtin.lsp_references = require_on_exported_call("telescope.builtin.__lsp").references
 
 --- Lists LSP incoming calls for word under the cursor, jumps to reference on `<cr>`
@@ -451,6 +452,7 @@ builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp")
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
 ---@field file_encoding string: file encoding for the previewer
+---@field filter_items FilterItemsCallback: callback to filter out quickfix entries that should be ignored
 builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").definitions
 
 --- Goto the definition of the type of the word under the cursor, if there's only one,
@@ -461,6 +463,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
 ---@field file_encoding string: file encoding for the previewer
+---@field filter_items FilterItemsCallback: callback to filter out quickfix entries that should be ignored
 builtin.lsp_type_definitions = require_on_exported_call("telescope.builtin.__lsp").type_definitions
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
@@ -470,6 +473,7 @@ builtin.lsp_type_definitions = require_on_exported_call("telescope.builtin.__lsp
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
 ---@field file_encoding string: file encoding for the previewer
+---@field filter_items FilterItemsCallback: callback to filter out quickfix entries that should be ignored
 builtin.lsp_implementations = require_on_exported_call("telescope.builtin.__lsp").implementations
 
 --- Lists LSP document symbols in the current buffer
@@ -512,6 +516,8 @@ builtin.lsp_workspace_symbols = require_on_exported_call("telescope.builtin.__ls
 ---@field symbol_highlights table: string -> string. Matches symbol with hl_group
 ---@field file_encoding string: file encoding for the previewer
 builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.builtin.__lsp").dynamic_workspace_symbols
+
+---@alias FilterItemsCallback fun(items: vim.quickfix.entry[]): vim.quickfix.entry[]
 
 --
 --


### PR DESCRIPTION
# Description

This PR aims to add support for generic items filtering mechanism as described in #3401.

Resolves #3401.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

```lua
local map = function(keys, func, desc, mode)
  mode = mode or 'n'
  vim.keymap.set(mode, keys, func, { buffer = event.buf, desc = 'LSP: ' .. desc })
end

map('gd', function()
  require('telescope.builtin').lsp_definitions {
    filter_items = function(items)
      return items -- Test A: Returns all results.
      -- return {} -- Test B: Returns nothing, displaying the `No LSP Definitions found` message.
    end,
  }
end, '[G]oto [D]efinition')
```

**Configuration**:

* Neovim version (nvim --version): 
  ```
  NVIM v0.10.3
  Build type: Release
  LuaJIT 2.1.1734355927
  ```
* Operating system and version: macOS 13.4

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
