### PR TITLE
fix(from_entry): skip validation with unnamed buffer

### DIFF
--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -26,7 +26,7 @@ function from_entry.path(entry, validate, escape)
   end
 
   -- only 0 if neither filereadable nor directory
-  if validate then
+  if validate and path ~= "[No Name]" then
     -- We need to expand for filereadable and isdirectory
     -- TODO(conni2461): we are not going to return the expanded path because
     --                  this would lead to cache misses in the perviewer.


### PR DESCRIPTION
# Description

It wasn't possible to preview unnamed buffers in ":Telescope buffer".

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual testing - created a new unnamed buffer and opened ":Telescope buffers"

**Configuration**:
* Neovim version (nvim --version): v0.10.3
* Operating system and version: Arch Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
