### PR TITLE
 Check for nil where nil was giving me problems

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -545,9 +545,11 @@ previewers.vimgrep = defaulter(function(opts)
 
       local middle_ln = math.floor(lnum + (lnend - lnum) / 2)
       pcall(vim.api.nvim_win_set_cursor, self.state.winid, { middle_ln + 1, 0 })
-      vim.api.nvim_buf_call(bufnr, function()
-        vim.cmd "norm! zz"
-      end)
+      if bufnr ~= nil then
+        vim.api.nvim_buf_call(bufnr, function()
+          vim.cmd "norm! zz"
+        end)
+      end
     end
   end
 
@@ -566,7 +568,7 @@ previewers.vimgrep = defaulter(function(opts)
       local has_buftype = entry.bufnr
           and vim.api.nvim_buf_is_valid(entry.bufnr)
           and vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= ""
-        or false
+          or false
       local p
       if not has_buftype then
         p = from_entry.path(entry, true, false)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -545,7 +545,7 @@ previewers.vimgrep = defaulter(function(opts)
 
       local middle_ln = math.floor(lnum + (lnend - lnum) / 2)
       pcall(vim.api.nvim_win_set_cursor, self.state.winid, { middle_ln + 1, 0 })
-      if bufnr ~= nil then
+      if bufnr ~= nil then 
         vim.api.nvim_buf_call(bufnr, function()
           vim.cmd "norm! zz"
         end)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -568,7 +568,7 @@ previewers.vimgrep = defaulter(function(opts)
       local has_buftype = entry.bufnr
           and vim.api.nvim_buf_is_valid(entry.bufnr)
           and vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= ""
-          or false
+        or false
       local p
       if not has_buftype then
         p = from_entry.path(entry, true, false)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -546,6 +546,7 @@ previewers.vimgrep = defaulter(function(opts)
       local middle_ln = math.floor(lnum + (lnend - lnum) / 2)
       pcall(vim.api.nvim_win_set_cursor, self.state.winid, { middle_ln + 1, 0 })
       if bufnr ~= nil then
+
         vim.api.nvim_buf_call(bufnr, function()
           vim.cmd "norm! zz"
         end)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -546,7 +546,6 @@ previewers.vimgrep = defaulter(function(opts)
       local middle_ln = math.floor(lnum + (lnend - lnum) / 2)
       pcall(vim.api.nvim_win_set_cursor, self.state.winid, { middle_ln + 1, 0 })
       if bufnr ~= nil then
-
         vim.api.nvim_buf_call(bufnr, function()
           vim.cmd "norm! zz"
         end)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -545,7 +545,7 @@ previewers.vimgrep = defaulter(function(opts)
 
       local middle_ln = math.floor(lnum + (lnend - lnum) / 2)
       pcall(vim.api.nvim_win_set_cursor, self.state.winid, { middle_ln + 1, 0 })
-      if bufnr ~= nil then 
+      if bufnr ~= nil then
         vim.api.nvim_buf_call(bufnr, function()
           vim.cmd "norm! zz"
         end)


### PR DESCRIPTION
# Description

When picking buffers, when filtering, if there is one left, I have my telescope configured to pick the last remaining entry automatically:

```lua
  pickers = {
    -- Default configuration for builtin pickers goes here:
    -- picker_name = {
    --   picker_config_key = value,
    --   ...
    -- }
    -- Now the picker_config_key will be applied every time you call this
    -- builtin picker
    find_files = {
      --theme = "ivy"
      hidden = true,
    },
    buffers = {
      --theme = 'ivy',
      on_complete = {
        function(picker)
          local index = 0
          for _ in picker.manager:iter() do
            index = index + 1
            if index > 1 then
              break
            end
          end
          if index == 1 then
            local bufno = tonumber(picker.prompt_bufnr)
            local to_call = require('telescope.actions').select_default
            local _ = pcall(to_call, bufno)
          end
        end
      }
    },
  },

```

see full setup [here](https://github.com/jam1015/dotfiles/blob/master/.config/nvim/lua/plugin_configs/telescope.lua)

the problem is that I get error messages if this automatic selection gets triggered for a terminal buffer.  This small check for nil skips the code that was triggering the error.


## Type of change

checks for nil and skips line centering if the buffer number is nil

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Me just running `:Telescope  buffers` and narrowing the list down to a single terminal buffer so that it is all that is left; there are no error messages anymore.



**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:
NVIM v0.10.4
Build type: RelWithDebInfo
LuaJIT 2.1.1736781742
Run "nvim -V1 -v" for more info
# Checklist:

- [ check] My code follows the style guidelines of this project (stylua)
- [ check] I have performed a self-review of my own code
- [check] I have commented my code, particularly in hard-to-understand areas
- [check] I have made corresponding changes to the documentation (lua annotations)
