### PR TITLE
fix(git_status): keep picker open if pwd is clean

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -407,9 +407,8 @@ git.status = function(opts)
           if count == 0 and prompt == "" then
             utils.notify("builtin.git_status", {
               msg = "No changes found",
-              level = "ERROR",
+              level = "INFO",
             })
-            actions.close(self.prompt_bufnr)
           end
         end,
       },


### PR DESCRIPTION
# Description

Fixes # (https://github.com/nvim-telescope/telescope.nvim/issues/3414)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. create git repo, commit all, make pwd clean.
```sh
git init && git add --all && git commit --message=add
```
2. `nvim -nu minimal.lua`
3. use command to open git_status picker.
```vim
Telescope git_status
```

Expect behavier:
1. Send a `INFO` message.
2. Remain picker panel open.

**Configuration**:
* Neovim version (nvim --version):
```lua
local root = vim.fn.fnamemodify("./.repro", ":p")

-- set stdpaths to use .repro
for _, name in ipairs { "config", "data", "state", "cache" } do
  vim.env[("XDG_%s_HOME"):format(name:upper())] = root .. "/" .. name
end

-- bootstrap lazy
local lazypath = root .. "/plugins/lazy.nvim"
if not vim.uv.fs_stat(lazypath) then
  vim.fn.system {
    "git",
    "clone",
    "--filter=blob:none",
    "https://github.com/folke/lazy.nvim.git",
    lazypath,
  }
end
vim.opt.runtimepath:prepend(lazypath)

-- install plugins
local plugins = {
  {
    "nvim-telescope/telescope.nvim",
    dependencies = {
      "nvim-lua/plenary.nvim",
    },
    config = function()
      -- ADD INIT.LUA SETTINGS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
      require("telescope").setup {}
    end,
  },
}

require("lazy").setup(plugins, {
  root = root .. "/plugins",
})
```

* Operating system and version:
Debian 12
# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
