### PR TITLE
feat(builtin.treesitter) send user message if no symbols found.

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -444,10 +444,10 @@ files.treesitter = function(opts)
   results = utils.filter_symbols(results, opts)
   if vim.tbl_isempty(results) then
     -- error message already printed in `utils.filter_symbols`
-    return
-  end
-
-  if vim.tbl_isempty(results) then
+    utils.notify("builtin.treesitter", {
+      msg = "No symbols found",
+      level = "INFO",
+    })
     return
   end
 


### PR DESCRIPTION
# Description

- Remove redundant empty check in `builtin.treesitter`.
- Send user a `INFO` message if found no symbols, just like how other builtin pickers works.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x]  Manual testing - open a empty file and open ":Telescope treesitter"
- [x]  Manual testing - open example file `a.lua` and open ":Telescope treesitter"
a.lua 
```
var a = {}
```

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.10.4
Build type: Release
LuaJIT 2.1.171348406
* Operating system and version:
Debian 12 

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
