### PR TITLE
fix(git_status): Fix worktree not found when use_file_path=true

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -459,11 +459,7 @@ local try_worktrees = function(opts)
 end
 
 local current_path_toplevel = function()
-  local gitdir = vim.fn.finddir(".git", vim.fn.expand "%:p" .. ";")
-  if gitdir == "" then
-    return nil
-  end
-  return Path:new(gitdir):parent():absolute()
+  return vim.fs.root(0, ".git")
 end
 
 local set_opts_cwd = function(opts)


### PR DESCRIPTION
# Description

`:lua require("telescope.builtin").git_status { use_file_path = true }` fails when called from worktree.
This happens because we're looking for `.git` directory while for worktrees it's a `.git` file.
I propose a better solution which use `git rev-parse --show-toplevel` that will work regardless of git internals (similar approach already used in another part of code).

Fixes #3409

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See #3409 for minimal config that reproduces the issue.

I've tested it on non-worktree/worktree/non-git my full config.

**Configuration**:
```
NVIM v0.10.2
Build type: Release
LuaJIT 2.1.1713484068
Run "nvim -V1 -v" for more info
```
* windows 11 + fedora 47

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
