### PR TITLE
fix: swap items of tags entry

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -1063,8 +1063,8 @@ function make_entry.gen_from_ctags(opts)
             return path_style
           end,
         },
-        entry.tag,
         entry.kind,
+        entry.tag,
         scode,
       }
     end


### PR DESCRIPTION
# Description
Tags entry reserves 16 char for the tag name and the remaining place is left for the kind symbols.
This commit orders tags name *then* kind symbol as tags name can be long function name while kind is only one word.

Here is an example of what it looks like 
### Before
![image](https://github.com/user-attachments/assets/bb650bcf-5829-4c68-a4b6-0599cfab8602)

### After 
![image](https://github.com/user-attachments/assets/d7ae5aad-376a-4cf1-a4e6-cb599d1c840c)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Generate tags file with tags name longer than 16 chars. Call command `:Telescope tags`. See the tags name are not truncated.

**Configuration**:
* Neovim version (nvim --version): 0.10
* Operating system and version: LinuxMint 22

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
