### PR TITLE
fix(utils): `filter_symbols` return table consistently

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -180,6 +180,7 @@ utils.filter_symbols = function(results, opts, post_filter)
       level = "WARN",
     })
   end
+  return {}
 end
 
 local path_filename_first = function(path, reverse_directories)


### PR DESCRIPTION
Previously, filter_symbols returned nil in certain cases, which could lead to unexpected behavior. This change ensures that an empty table is always returned, maintaining consistency.

closes https://github.com/nvim-telescope/telescope.nvim/issues/3380