### PR TITLE
fix(lsp): don't return negative values from `item_to_location`

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -125,8 +125,8 @@ end
 ---@param offset_encoding string|nil utf-8|utf-16|utf-32
 ---@return lsp.Location
 local function item_to_location(item, offset_encoding)
-  local line = item.lnum - 1
-  local character = utils.str_byteindex(item.text, item.col, offset_encoding or "utf-16") - 1
+  local line = math.max(0, item.lnum - 1)
+  local character = math.max(0, utils.str_byteindex(item.text, item.col, offset_encoding or "utf-16") - 1)
   local uri
   if utils.is_uri(item.filename) then
     uri = item.filename


### PR DESCRIPTION
# Description

Detailed description and repro in #3432. When `telescope.builtin.lsp.definitions()` is invoked and the target is an empty file, invalid (negative) position values are supplied to nvim's `vim.lsp.util.show_document()` function resulting in an error. This change clamps the `line` and `character` values to a minimum of 0. 

Fixes #3432

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Tested via the repro in #3432
- [x] Tested via rust-analyzer in a separate project.
- I wasn't sure how else to test this, but would be happy to spend some more time on this if anyone has some ideas :).

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.11.0-dev-2016+gf5714994bc
Build type: RelWithDebInfo
LuaJIT 2.1.1741730670
* Operating system and version:
Ubuntu 22.04

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
    - I don't think a comment is needed with these changes, but I'm happy to add one if it's desired.
- [x] I have made corresponding changes to the documentation (lua annotations)
