### PR TITLE
Add container name to lsp symbol entry

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -472,6 +472,16 @@ local function get_workspace_symbols_requester(bufnr, opts)
         else
           vim.list_extend(locations, vim.lsp.util.symbols_to_items(client_res.result, bufnr))
         end
+
+        local result = {}
+        for i = 1, #locations do
+          table.insert(
+            result,
+            vim.tbl_extend("force", locations[i], { container_name = client_res.result[i].containerName })
+          )
+        end
+
+        locations = result
       end
     end
 


### PR DESCRIPTION
# Description

'worspace/symbol` returns context information (`containerName`) for each symbol (see [spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_symbol)).
However, neovims `symbols_to_items` ignores `containerName`, so we add it manually to the picker entry.

This is the smallest change required to use the existing `lsp_dynamic_workspace_symbols` picker and friends with a custom entry_maker, that includes `containerName`.

I am new to this codebase and don't know the reason behind using `symbols_to_items`. It returns `vim.quickfix.entry[]` which seems inappropriate for `workspace/symbols`. Maybe, it could be dropped altogether.

Fixes #2695 

## Type of change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

I used the following custom entry_maker with `seblyng/roslyn.nvim`.
<details>
<summary>custom entry_maker</summary>
  M.workspace_symbols = function()
	  telescope_builtin.lsp_dynamic_workspace_symbols({
		  entry_maker = workspace_symbols_entry_maker,
	  })
  end
  
  local lsp_type_highlight;
  workspace_symbols_entry_maker = function(entry)
	local symbol_type, symbol_name = entry.text:match("%[(.+)%]%s+(.*)")

	local displayer = entry_display.create({
		separator = " | ",
		items = {
			{ width = 8 },
			{ width = 10 },
			{ remaining = true },
		},
	})

	local make_display = function()
		return displayer({
			{ symbol_type:lower(), lsp_type_highlight[symbol_type] },
			symbol_name,
			entry.container_name,
		})
	end

	return {
		value = entry,
		ordinal = symbol_type,
		display = make_display,
		lnum = entry.lnum,
		col = entry.col,
		filename = entry.filename,
	}
end

lsp_type_highlight = {
	["Class"] = "TelescopeResultsClass",
	["Constant"] = "TelescopeResultsConstant",
	["Field"] = "TelescopeResultsField",
	["Function"] = "TelescopeResultsFunction",
	["Method"] = "TelescopeResultsMethod",
	["Property"] = "TelescopeResultsOperator",
	["Struct"] = "TelescopeResultsStruct",
	["Variable"] = "TelescopeResultsVariable",
}
</details>
to get
<img width="707" alt="image" src="https://github.com/user-attachments/assets/d61fb739-787c-4370-b6a8-a17af5e039bd" />

**Configuration**:
* Neovim version (nvim --version):
NVIM v0.12.0-dev-92+gfece489794                                                                                                          
Build type: RelWithDebInfo                                                                                                               
LuaJIT 2.1.1741730670

* Operating system and version: macOS 15.3.1

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
