### PR TITLE
Add hidden file  and directory filter option toggle to `grep_string`

### DIFF
--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -224,6 +224,10 @@ files.grep_string = function(opts)
     additional_args[#additional_args + 1] = "--encoding=" .. opts.file_encoding
   end
 
+  if opts.hidden then
+    additional_args[#additional_args + 1] = "--hidden"
+  end
+
   local args
   if visual == true then
     args = flatten {

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -70,6 +70,7 @@ builtin.live_grep = require_on_exported_call("telescope.builtin.__files").live_g
 ---@field disable_coordinates boolean: don't show the line and row numbers (default: false)
 ---@field only_sort_text boolean: only sort the text, not the file, line or row (default: false)
 ---@field file_encoding string: file encoding for the entry & previewer
+---@field hidden boolean: if true, hidden directories and files will be searched (default: false)
 builtin.grep_string = require_on_exported_call("telescope.builtin.__files").grep_string
 
 --- Search for files (respecting .gitignore)


### PR DESCRIPTION
# Description

Add option `hidden` for toggling if hidden files and directories should appear when running `grep_string` from `builtin.files`.

Fixes #3453 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

```lua
local telescope = require "telescope"
local builtin = require "telescope.builtin"

vim.keymap.set("n", "<space>fg", function()
  builtin.grep_string {
    search = vim.fn.input "grep: ",
    hidden = true,
  }
end, { desc = "Grep files in current working directory" })
```

After running `<space>fg` and typing a string to grep for in a directory containing hidden objects, they appear. Likewise, commenting out the `hidden = true`, the hidden files and directories do not appear.

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.11.0-dev-1315+g668d2569b4
Build type: RelWithDebInfo
LuaJIT 2.1.1732813678
```
* Operating system and version:
```
OS: Arch linux
Kernel: 6.13.8-arch1-1
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
