### PR TITLE
Fix: Add unokai theme to builtins list

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1042,7 +1042,7 @@ internal.colorscheme = function(opts)
       "blue", "darkblue", "default", "delek", "desert", "elflord", "evening",
       "habamax", "industry", "koehler", "lunaperche", "morning", "murphy",
       "pablo", "peachpuff", "quiet", "retrobox", "ron", "shine", "slate",
-      "sorbet", "torte", "vim", "wildcharm", "zaibatsu", "zellner",
+      "sorbet", "torte", "unokai", "vim", "wildcharm", "zaibatsu", "zellner",
     }
     colors = vim.tbl_filter(function(color)
       return not vim.tbl_contains(builtins, color)


### PR DESCRIPTION
# Description

This PR adds the `unokai` builtin vim theme to the builtins list. Currently, if you open the `colorscheme` picker with `ignore_builtins = true` set, the `unokai` option is still present.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
It's a miniature change - you open the `colorscheme` picker and the `unokai` theme is not present anymore :)

**Configuration**:
* Neovim version (nvim --version): v0.11.0
* Operating system and version: Linux 6.14.3-arch1-1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
