### PR TITLE
docs(developers.md): Add sentence to ensure integer indexing (#3451)

### DIFF
--- a/developers.md
+++ b/developers.md
@@ -224,6 +224,9 @@ values we need. It's best practice to have a `value` reference to the
 original entry, that way we will always have access to the complete table in our
 action.
 
+:bulb: Make sure that the table you are providing as `results`
+is indexed by integers. :bulb:
+
 The `display` key is required and is either a string or a `function(tbl)`,
 where `tbl` is the table returned by `entry_maker`. So in this example `tbl` would
 give our `display` function access to `value` and `ordinal`.


### PR DESCRIPTION
# Description

This commit adds a single sentence to the developer.md about integer-indexing. 

Fixes #3451 

## Type of change

Improvement to documentation. 

# How Has This Been Tested?

Does not apply to this pr. 

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
