### PR TITLE
Fix builtin.registers

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -447,21 +447,26 @@ actions.edit_register = function(prompt_bufnr)
   local selection = action_state.get_selected_entry()
   local picker = action_state.get_current_picker(prompt_bufnr)
 
+  if string.find("%:.", selection.value, 1, true) then
+    -- %, : and . are read-only registers
+    return false
+  end
+
   vim.fn.inputsave()
   local updated_value = vim.fn.input("Edit [" .. selection.value .. "] ❯ ", selection.content)
   vim.fn.inputrestore()
   if updated_value ~= selection.content then
-    vim.fn.setreg(selection.value, updated_value)
+    vim.fn.setreg(string.lower(selection.value), updated_value)
     selection.content = updated_value
   end
 
   -- update entry in results table
-  -- TODO: find way to redraw finder content
   for _, v in pairs(picker.finder.results) do
     if v == selection then
       v.content = updated_value
     end
   end
+  picker:refresh()
 end
 
 --- Paste the selected register into the buffer


### PR DESCRIPTION
Fix editing a letter register (A-Z) would always append to the register, fixed by editing a-z instead.

Fix picker not updating after editing a register.

Fix editing of read-only registers

# Description

Fix three small bugs reported in #3462:
 - Editing read-only registers results in error
 - Editing named registers appends to content instead of replace
 - Editing a register does not refresh the picker.

Fixes #3462

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ x]  Edited named and read-only registers, named registers are updated as expected, read-only are ignored, picker is refrshed.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.11.0
Build type: Release
LuaJIT 2.1.1741730670
* Operating system and version: Debian Testing 13

# Checklist:

- [ x] My code follows the style guidelines of this project (stylua)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations) ((Not applicable)
