### PR TITLE
fix(lsp): stop using deprecated `client.supports_method` function

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -506,8 +506,14 @@ local function check_capabilities(method, bufnr)
   local clients = get_clients { bufnr = bufnr }
 
   for _, client in pairs(clients) do
-    if client.supports_method(method, { bufnr = bufnr }) then
-      return true
+    if vim.fn.has "nvim-0.11" == 1 then
+      if client:supports_method(method, bufnr) then
+        return true
+      end
+    else
+      if client.supports_method(method, { bufnr = bufnr }) then
+        return true
+      end
     end
   end
 


### PR DESCRIPTION
# Description
Function `client.supports_method` was deprecated in v0.11 and replaced with `client:supports_method`. This commit starts using `client:supports_method` for newer version of Neovim, and keeps the deprecated `client.supports_method` for older versions

Fixes #3467 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I went through the same process as I described in issue #3467 but using a Telescope version with my patch applied

**Configuration**:
* Neovim version (nvim --version): v0.12.0-dev-292+g03d378fda6
* Operating system and version: Arch Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
