### PR TITLE
Allows listing commits from a specific branch

### DIFF
--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -66,8 +66,10 @@ end
 
 git.commits = function(opts)
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
-  opts.git_command =
-    vim.F.if_nil(opts.git_command, git_command({ "log", "--pretty=oneline", "--abbrev-commit", "--", "." }, opts))
+  opts.git_command = vim.F.if_nil(
+    opts.git_command,
+    git_command({ "log", "--pretty=oneline", opts.branch, "--abbrev-commit", "--", "." }, opts)
+  )
 
   pickers
     .new(opts, {


### PR DESCRIPTION
# Description

While adding a "cherry-pick" command to neovim, I couldn't figure how to list commits from a specific branch and needed such change to allow that.

With this patch I could successfully implement the sequence:

- pick a branch
- pick a commit from that branch
- cherry-pick that commit


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- tested on code requiring this new feature
- tested "plain" (no arguments) `git_commits` too


**Configuration**:
* Neovim version (nvim --version): v0.11.1
* Operating system and version: Arch Linux

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
