### PR TITLE
fixed deprecated version of vim.validate()

### DIFF
--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -35,9 +35,7 @@ local utils = {}
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto entries of picker that takes (entry, index, row) as viable arguments
 function utils.map_entries(prompt_bufnr, f)
-  vim.validate {
-    f = { f, "function" },
-  }
+  vim.validate("f", f, "function")
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local index = 1
   -- indices are 1-indexed, rows are 0-indexed
@@ -72,9 +70,7 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto selection of picker that takes (selection) as a viable argument
 function utils.map_selections(prompt_bufnr, f)
-  vim.validate {
-    f = { f, "function" },
-  }
+  vim.validate("f", f, "function")
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   for _, selection in ipairs(current_picker:get_multi_selection()) do
     f(selection)

--- a/lua/telescope/debounce.lua
+++ b/lua/telescope/debounce.lua
@@ -5,16 +5,10 @@ local M = {}
 
 ---Validates args for `throttle()` and  `debounce()`.
 local function td_validate(fn, ms)
-  vim.validate {
-    fn = { fn, "f" },
-    ms = {
-      ms,
-      function(v)
-        return type(v) == "number" and v > 0
-      end,
-      "number > 0",
-    },
-  }
+  vim.validate("fn", fn, "function")
+  vim.validate("ms", ms, function(v)
+    return type(v) == "number" and v > 0
+  end, "number > 0")
 end
 
 --- Throttles a function on the leading edge. Automatically `schedule_wrap()`s.

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -816,7 +816,7 @@ end
 ---   - `actions.delete_buffer()`
 ---@param delete_cb function: called for each selection fn(s) -> bool|nil (true|nil removes the entry from the results)
 function Picker:delete_selection(delete_cb)
-  vim.validate { delete_cb = { delete_cb, "f" } }
+  vim.validate("delete_cb", delete_cb, "function")
   local original_selection_strategy = self.selection_strategy
   self.selection_strategy = "row"
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -54,9 +54,7 @@ utils.flatten = vim.fn.has "nvim-0.11" == 1 and flatten or vim.tbl_flatten
 ---@param path string
 ---@return string
 utils.path_expand = function(path)
-  vim.validate {
-    path = { path, { "string" } },
-  }
+  vim.validate("path", path, "string")
 
   if utils.is_uri(path) then
     return path


### PR DESCRIPTION
# Description

The use of `vim.validate(spec)` is deprecated. 

## Type of change

Changed all calls to `vim.validate(spec)` into calls to
`vim.validate(name, value, validator[, optional][, message])`

**Configuration**:
* Neovim version (nvim --version): v0.11.2
* Operating system and version: Debian GNU/Linux bookworm 12.11 x86_64

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
