### PR TITLE
feat(make_entry): add `icon_separator` option

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -154,6 +154,7 @@ do
     local cwd = utils.path_expand(opts.cwd or vim.uv.cwd())
 
     local disable_devicons = opts.disable_devicons
+    local icon_separator = opts.icon_separator
 
     local mt_file_entry = {}
 
@@ -162,7 +163,7 @@ do
       local hl_group, icon
       local display, path_style = utils.transform_path(opts, entry.value)
 
-      display, hl_group, icon = utils.transform_devicons(entry.value, display, disable_devicons)
+      display, hl_group, icon = utils.transform_devicons(entry.value, display, disable_devicons, icon_separator)
 
       if hl_group then
         local style = { { { 0, #icon + 1 }, hl_group } }
@@ -275,6 +276,7 @@ do
     end
 
     local disable_devicons = opts.disable_devicons
+    local icon_separator = opts.icon_separator
     local disable_coordinates = opts.disable_coordinates
     local only_sort_text = opts.only_sort_text
 
@@ -333,7 +335,8 @@ do
         local display, hl_group, icon = utils.transform_devicons(
           entry.filename,
           string.format(display_string, display_filename, coordinates, entry.text),
-          disable_devicons
+          disable_devicons,
+          icon_separator
         )
 
         if hl_group then
@@ -587,6 +590,7 @@ function make_entry.gen_from_buffer(opts)
   opts = opts or {}
 
   local disable_devicons = opts.disable_devicons
+  local icon_separator = opts.icon_separator or ""
 
   local icon_width = 0
   if not disable_devicons then
@@ -600,6 +604,7 @@ function make_entry.gen_from_buffer(opts)
       { width = opts.bufnr_width },
       { width = 4 },
       { width = icon_width },
+      { width = #icon_separator },
       { remaining = true },
     },
   }
@@ -616,6 +621,7 @@ function make_entry.gen_from_buffer(opts)
       { entry.bufnr, "TelescopeResultsNumber" },
       { entry.indicator, "TelescopeResultsComment" },
       { icon, hl_group },
+      { icon_separator },
       {
         display_bufname .. ":" .. entry.lnum,
         function()

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -615,7 +615,9 @@ utils.transform_devicons = load_once(function()
       devicons.setup()
     end
 
-    return function(filename, display, disable_devicons)
+    return function(filename, display, disable_devicons, icon_separator)
+      icon_separator = icon_separator or " "
+
       local conf = require("telescope.config").values
       if disable_devicons or not filename then
         return display
@@ -627,7 +629,7 @@ utils.transform_devicons = load_once(function()
         icon, icon_highlight = devicons.get_icon(basename, nil, { default = true })
         icon = icon or " "
       end
-      local icon_display = icon .. " " .. (display or "")
+      local icon_display = icon .. icon_separator .. (display or "")
 
       if conf.color_devicons then
         return icon_display, icon_highlight, icon


### PR DESCRIPTION
# Description

Adds a new `icon_separator` option to allow users to customize the spacing between the icon and entry text in pickers. This improves visual alignment and allows users to customize the entry appearance.

Fixes #3483

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Manually tested with find_files, live_grep, and buffers pickers using different icon_separator values.
- [x] Confirmed default behavior is unchanged when icon_separator is not set.

**Configuration**:
* Neovim version (nvim --version):
```
$ nvim --version
NVIM v0.11.2
Build type: Release
LuaJIT 2.1.1748459687
```
* Operating system and version:
```
$ sw_vers
ProductName:		macOS
ProductVersion:		15.5
BuildVersion:		24F74
```

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
