### PR TITLE
docs: explicitly specify nvim-treesitter branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ wiki.
 ### Optional dependencies
 
 - [sharkdp/fd](https://github.com/sharkdp/fd) (finder)
-- [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) (finder/preview)
+- [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) (finder/preview) (`master` branch)
 - [neovim LSP](https://neovim.io/doc/user/lsp.html) (picker)
 - [devicons](https://github.com/nvim-tree/nvim-web-devicons) (icons)
 


### PR DESCRIPTION
# Description

Since [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) currently working on complete rewrite in `main` branch and `main` is incompatible with telescope.nvim we should explicitly state that `master` branch required.
This is a bit confusing because `nvim-treesitter` states in `README` that:
> The master branch is frozen and provided for backward compatibility only.

## Type of change

Documentation update

# How Has This Been Tested?

No testing required. README change

**Configuration**:
N/A

# Checklist:
N/A
