### PR TITLE
Improve center strategy

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2308,6 +2308,7 @@ layout_strategies.center()                         *telescope.layout.center()*
 
     `picker.layout_config` unique options:
       - preview_cutoff: When lines are less than this value, the preview will be disabled
+      - results_height: Sets the height of the results window in number of lines.
 
 
 layout_strategies.cursor()                         *telescope.layout.cursor()*

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -466,36 +466,37 @@ layout_strategies.center = make_documented_layout(
     results.width = width - w_space
     preview.width = width - w_space
 
-    local h_space
-    -- Cap over/undersized height
-    height, h_space = calc_size_and_spacing(height, max_lines, bs, 2, 3, 0)
+    -- if the previewer is enabled, we need to subtract the size of 5 borders
+    -- or 3 borders if not
+    local border_count = self.previewer and 5 or 3
+    height = height - border_count * bs
 
     prompt.height = 1
-    results.height = height - prompt.height - h_space
 
-    local topline = math.floor((max_lines / 2) - ((results.height + (2 * bs)) / 2) + 1)
-    -- Align the prompt and results so halfway up the screen is
-    -- in the middle of this combined block
-    if layout_config.prompt_position == "top" then
-      prompt.line = topline
-      results.line = prompt.line + 1 + bs
-    elseif layout_config.prompt_position == "bottom" then
-      results.line = topline
-      prompt.line = results.line + results.height + bs
-      if type(prompt.title) == "string" then
-        prompt.title = { { pos = "S", text = prompt.title } }
-      end
+    local results_height = layout_config.results_height
+    if self.previewer and results_height and results_height < height then
+      results.height = results_height
     else
-      error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
+      results.height = height - prompt.height
     end
 
-    local width_padding = math.floor((max_columns - width) / 2) + bs + 1
-    results.col, preview.col, prompt.col = width_padding, width_padding, width_padding
+    preview.height = height - results.height - prompt.height
+
+    -- if border size is 0, we decrease the preview height by 1 to account for the
+    -- the gap between the results and preview windows
+    if bs <= 0 then
+      preview.height = preview.height - 1
+    end
+
+    -- if the preview height is less than the cutoff, we set it to 0
+    -- and increase the results height by 2 borders that the preview would have taken
+    if preview.height <= layout_config.preview_cutoff then
+      results.height = results.height + (2 * bs)
+      preview.height = 0
+    end
 
     local anchor = layout_config.anchor or ""
-    local anchor_padding = layout_config.anchor_padding or 1
-
-    local anchor_pos = resolve.resolve_anchor_pos(anchor, width, height, max_columns, max_lines, anchor_padding)
+    local anchor_pos = resolve.resolve_anchor_pos(anchor, width, height, max_columns, max_lines)
     adjust_pos(anchor_pos, prompt, results, preview)
 
     -- Vertical anchoring (S or N variations) ignores layout_config.mirror
@@ -509,19 +510,47 @@ layout_strategies.center = make_documented_layout(
       mirror = layout_config.mirror
     end
 
+    local borderd_height = height + (border_count * bs)
+    local topline = math.floor((max_lines / 2) - (borderd_height / 2) + 1)
+
     -- Set preview position
-    local block_line = math.min(results.line, prompt.line)
     if not mirror then -- Preview at top
-      preview.line = 1 + bs
-      preview.height = block_line - (2 + 2 * bs)
+      preview.line = topline
+      if preview.height > 0 then
+        preview.line = topline + bs + 1
+      end
+
+      if layout_config.prompt_position == "top" then
+        prompt.line = preview.line + preview.height + bs + 1
+        results.line = prompt.line + bs + 1
+      elseif layout_config.prompt_position == "bottom" then
+        results.line = preview.line + preview.height + bs + 1
+        prompt.line = results.line + results.height + bs
+        if type(prompt.title) == "string" then
+          prompt.title = { { pos = "S", text = prompt.title } }
+        end
+      else
+        error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
+      end
     else -- Preview at bottom
-      preview.line = block_line + results.height + 2 + 2 * bs
-      preview.height = max_lines - preview.line - bs + 1
+      if layout_config.prompt_position == "top" then
+        prompt.line = topline
+        results.line = prompt.line + bs + 1
+        preview.line = results.line + results.height + bs + 1
+      elseif layout_config.prompt_position == "bottom" then
+        results.line = topline
+        prompt.line = results.line + results.height + bs
+        preview.line = prompt.line + prompt.height + bs + 1
+        if type(prompt.title) == "string" then
+          prompt.title = { { pos = "S", text = prompt.title } }
+        end
+      else
+        error(string.format("Unknown prompt_position: %s\n%s", self.window.prompt_position, vim.inspect(layout_config)))
+      end
     end
 
-    if not (self.previewer and max_lines >= layout_config.preview_cutoff) then
-      preview.height = 0
-    end
+    local width_padding = math.floor((max_columns - width) / 2) + bs + 1
+    results.col, preview.col, prompt.col = width_padding, width_padding, width_padding
 
     if tbln then
       prompt.line = prompt.line + 1

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -36,13 +36,14 @@ function themes.get_dropdown(opts)
     layout_strategy = "center",
     layout_config = {
       preview_cutoff = 1, -- Preview should always show (unless previewer = false)
+      results_width = 15,
 
       width = function(_, max_columns, _)
         return math.min(max_columns, 80)
       end,
 
       height = function(_, _, max_lines)
-        return math.min(max_lines, 15)
+        return math.min(max_lines, 30)
       end,
     },
 


### PR DESCRIPTION
# Description
I've been using this patched version of the `center` layout strategy for a while and thought it was worth proposing upstream. It introduces a new layout option, results_height, allowing users to explicitly set the height of the results panel.

In addition, this refactors how window dimensions and positions are calculated, properly centring the entire layout (including preview, results, and prompt), rather than just the prompt + results block.


## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've tested this change with different configurations, such as `mirror`, `prompt_position`, `height` and with the new option `results_height`

### Dropdown theme
```lua
pickers = {
    find_files = {
        theme = "dropdown",
    }
}
```
![image](https://github.com/user-attachments/assets/d6b06ce4-113e-4f01-a8f3-c485232bc83f)

with `mirror = true`
```lua
pickers = {
    find_files = {
        theme = "dropdown",
       layout_config = {
            mirror = true,
       },
    }
}
```
![image](https://github.com/user-attachments/assets/e595bb49-e71d-4406-a713-48e015c1549e)

with `results_height = 5`
```lua
pickers = {
    find_files = {
        theme = "dropdown",
       layout_config = {
            results_height = 5,
       },
    }
}
```
![image](https://github.com/user-attachments/assets/5247f510-911e-44c8-87aa-566cdd1c47e4)

with `results_height = 5` and  `mirror = true`
```lua
pickers = {
    find_files = {
        theme = "dropdown",
       layout_config = {
            results_height = 5,
            mirror = true,
       },
    }
}
```
![image](https://github.com/user-attachments/assets/2f88829b-1b69-4124-ab30-cb7569264b07)

with `prompt_position = 'bottom'`
```lua
pickers = {
    find_files = {
        theme = "dropdown",
       layout_config = {
            results_height = 5,
            mirror = true,
            prompt_position = 'bottom',
       },
    }
}
```

![image](https://github.com/user-attachments/assets/fdcb0e1b-ccee-4c1c-b3c1-63409829113a)

with `height = 40` and `results_height = 10`
```lua
pickers = {
    find_files = {
        theme = "dropdown",
       layout_config = {
            height = 10
            results_height = 10,
       },
    }
}
```
![image](https://github.com/user-attachments/assets/392793c0-f1cd-4458-a55f-d7b61a155df0)


### Configuration
* Neovim version (nvim --version):
```
NVIM v0.10.4
Build type: RelWithDebInfo
LuaJIT 2.1.1720049189
Run "nvim -V1 -v" for more info
```
* Operating system and version: Fedora 41

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
