### PR TITLE
fix(pickers): respect default_selection_index

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1466,10 +1466,10 @@ function Picker:get_result_completor(results_bufnr, _, prompt, status_updater)
     if self.sorting_strategy == "descending" then
       local visible_result_rows = vim.api.nvim_win_get_height(self.results_win)
       vim.api.nvim_win_set_cursor(self.results_win, { self.max_results - visible_result_rows, 1 })
-      vim.api.nvim_win_set_cursor(self.results_win, { self.max_results, 1 })
-    else
-      vim.api.nvim_win_set_cursor(self.results_win, { 1, 0 })
     end
+    -- Move the cursor back to the row selected in _do_selection()
+    local target_pos = { (self._selection_row or 0) + 1, 0 }
+    vim.api.nvim_win_set_cursor(self.results_win, target_pos)
     self:_on_complete()
   end)
 end


### PR DESCRIPTION
# Description

Make sure to move the cursor to the row selected by self:_do_selection() instead of placing it onto the first (or last, depending on the sorting method) line of the picker window.

Fixes #3492

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With a custom picker that generates a list of stgit patches and uses default_slection_index to select the "top" patch of the stack. Number of patches is sufficiently large.