### PR TITLE
fix: ignore TermOpen event in terminal previewer

### DIFF
--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -204,9 +204,12 @@ previewers.new_termopen_previewer = function(opts)
 
       local cmd = opts.get_command(entry, status)
       if cmd then
+        local save_ei = vim.o.eventignore
+        vim.o.eventignore = "TermOpen"
         vim.api.nvim_buf_call(bufnr, function()
           set_term_id(self, vim.fn.termopen(cmd, term_opts))
         end)
+        vim.o.eventignore = save_ei
       end
       set_bufentry(self, entry)
     end


### PR DESCRIPTION
# Description
When a terminal previewer is created, the TermOpen event is registered. This can mess up with user autcomds.
I think the event should be ignored to prevent this.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)