### PR TITLE
Fix vim.validate deprecation warnings in telescope.actions.utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ lint:
 
 docgen:
 	nvim --headless --noplugin -u scripts/minimal_init.vim -c "luafile ./scripts/gendocs.lua" -c 'qa'
+
+test-utils:
+	nvim --headless --noplugin -u scripts/minimal_init.vim -c "lua require('plenary.busted').run('lua/tests/automated/actions/utils_spec.lua', { minimal_init = './scripts/minimal_init.vim' })" -c "qa"

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -70,9 +70,7 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto selection of picker that takes (selection) as a viable argument
 function utils.map_selections(prompt_bufnr, f)
-  vim.validate {
-    f = { f, "function" },
-  }
+  vim.validate("f", f, "function")
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   for _, selection in ipairs(current_picker:get_multi_selection()) do
     f(selection)

--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -35,9 +35,7 @@ local utils = {}
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto entries of picker that takes (entry, index, row) as viable arguments
 function utils.map_entries(prompt_bufnr, f)
-  vim.validate {
-    f = { f, "function" },
-  }
+  vim.validate("f", f, "function")
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local index = 1
   -- indices are 1-indexed, rows are 0-indexed

--- a/lua/tests/automated/actions/utils_spec.lua
+++ b/lua/tests/automated/actions/utils_spec.lua
@@ -7,8 +7,8 @@ describe("telescope.actions.utils", function()
   -- Set up the module before each test
   before_each(function()
     -- Load the utils module
-    utils = require("telescope.actions.utils")
-    action_state = require("telescope.actions.state")
+    utils = require "telescope.actions.utils"
+    action_state = require "telescope.actions.state"
   end)
 
   -- Clean up after each test
@@ -26,7 +26,6 @@ describe("telescope.actions.utils", function()
 
   -- Test the map_entries function parameter validation
   describe("map_entries function validation", function()
-
     it("should exist as a function", function()
       assert.is_function(utils.map_entries)
     end)
@@ -62,7 +61,7 @@ describe("telescope.actions.utils", function()
           },
           get_row = function(index)
             return index
-          end
+          end,
         }
       end
 
@@ -125,14 +124,14 @@ describe("telescope.actions.utils", function()
           },
           get_row = function(index)
             return index
-          end
+          end,
         }
       end
 
       local valid_function = function(entry, index, row) end
 
       -- Test with different number types that could be valid buffer numbers
-      local test_cases = {0, 1, 999}  -- Common buffer number patterns
+      local test_cases = { 0, 1, 999 } -- Common buffer number patterns
 
       for _, bufnr in ipairs(test_cases) do
         local success, error_msg = pcall(function()
@@ -141,8 +140,10 @@ describe("telescope.actions.utils", function()
 
         -- Should not fail due to vim.validate function parameter errors
         if not success then
-          assert.is_false(string.match(error_msg or "", "expected function") ~= nil,
-            "Buffer number " .. bufnr .. " should not cause function validation error")
+          assert.is_false(
+            string.match(error_msg or "", "expected function") ~= nil,
+            "Buffer number " .. bufnr .. " should not cause function validation error"
+          )
         end
       end
 
@@ -162,7 +163,7 @@ describe("telescope.actions.utils", function()
       local validate_call_args = {}
 
       vim.validate = function(...)
-        validate_call_args = {...}
+        validate_call_args = { ... }
         return original_vim_validate(...)
       end
 
@@ -173,10 +174,14 @@ describe("telescope.actions.utils", function()
         return {
           manager = {
             iter = function()
-              return function() return nil end
+              return function()
+                return nil
+              end
             end,
           },
-          get_row = function(index) return index end
+          get_row = function(index)
+            return index
+          end,
         }
       end
 
@@ -194,14 +199,13 @@ describe("telescope.actions.utils", function()
       -- With new syntax: validate_call_args would be {"f", function_value, "function"}
 
       if success then
-        assert.is_true(#validate_call_args == 3,
-          "Expected 3 arguments to vim.validate (name, value, type), got " .. #validate_call_args)
-        assert.are.equal("f", validate_call_args[1],
-          "First argument should be parameter name 'f'")
-        assert.are.equal("function", validate_call_args[3],
-          "Third argument should be type 'function'")
-        assert.is_function(validate_call_args[2],
-          "Second argument should be the actual function value")
+        assert.is_true(
+          #validate_call_args == 3,
+          "Expected 3 arguments to vim.validate (name, value, type), got " .. #validate_call_args
+        )
+        assert.are.equal("f", validate_call_args[1], "First argument should be parameter name 'f'")
+        assert.are.equal("function", validate_call_args[3], "Third argument should be type 'function'")
+        assert.is_function(validate_call_args[2], "Second argument should be the actual function value")
       end
     end)
 
@@ -225,10 +229,14 @@ describe("telescope.actions.utils", function()
         return {
           manager = {
             iter = function()
-              return function() return nil end
+              return function()
+                return nil
+              end
             end,
           },
-          get_row = function(index) return index end
+          get_row = function(index)
+            return index
+          end,
         }
       end
 
@@ -242,10 +250,11 @@ describe("telescope.actions.utils", function()
       action_state.get_current_picker = original_get_current_picker
 
       -- This should FAIL with old syntax, PASS with new syntax
-      assert.is_false(used_table_syntax,
-        "Should not use old table-based vim.validate syntax like vim.validate({ f = { f, 'function' } })")
+      assert.is_false(
+        used_table_syntax,
+        "Should not use old table-based vim.validate syntax like vim.validate({ f = { f, 'function' } })"
+      )
     end)
-
   end) -- Close map_entries function validation describe block
 
   -- Test the map_selections function parameter validation (LINE 75)
@@ -256,7 +265,7 @@ describe("telescope.actions.utils", function()
 
     -- Test valid parameter types for map_selections
     it("should accept valid parameter types without vim.validate errors", function()
-      local action_state = require("telescope.actions.state")
+      local action_state = require "telescope.actions.state"
       local original_get_current_picker = action_state.get_current_picker
 
       -- Set up mock picker with minimal structure for map_selections
@@ -267,7 +276,7 @@ describe("telescope.actions.utils", function()
               { value = "selected_first" },
               { value = "selected_second" },
             }
-          end
+          end,
         }
       end
 
@@ -324,7 +333,7 @@ describe("telescope.actions.utils", function()
 
     -- Test different buffer number types
     it("should handle different buffer number types", function()
-      local action_state = require("telescope.actions.state")
+      local action_state = require "telescope.actions.state"
       local original_get_current_picker = action_state.get_current_picker
 
       -- Set up mock that works for all buffer numbers
@@ -332,14 +341,14 @@ describe("telescope.actions.utils", function()
         return {
           get_multi_selection = function()
             return {} -- empty selection
-          end
+          end,
         }
       end
 
       local valid_function = function(selection) end
 
       -- Test with different number types that could be valid buffer numbers
-      local test_cases = {0, 1, 999}  -- Common buffer number patterns
+      local test_cases = { 0, 1, 999 } -- Common buffer number patterns
 
       for _, bufnr in ipairs(test_cases) do
         local success, error_msg = pcall(function()
@@ -348,8 +357,10 @@ describe("telescope.actions.utils", function()
 
         -- We expect these might fail due to telescope setup, but NOT due to vim.validate
         if not success then
-          assert.is_false(string.match(error_msg or "", "expected function") ~= nil,
-            "Buffer number " .. bufnr .. " should not cause function validation error")
+          assert.is_false(
+            string.match(error_msg or "", "expected function") ~= nil,
+            "Buffer number " .. bufnr .. " should not cause function validation error"
+          )
         end
       end
 
@@ -369,7 +380,7 @@ describe("telescope.actions.utils", function()
       local validate_call_args = {}
 
       vim.validate = function(...)
-        validate_call_args = {...}
+        validate_call_args = { ... }
         return original_vim_validate(...)
       end
 
@@ -378,7 +389,7 @@ describe("telescope.actions.utils", function()
         return {
           get_multi_selection = function()
             return {} -- empty selection
-          end
+          end,
         }
       end
 
@@ -396,14 +407,13 @@ describe("telescope.actions.utils", function()
       -- With new syntax: validate_call_args would be {"f", function_value, "function"}
 
       if success then
-        assert.is_true(#validate_call_args == 3,
-          "Expected 3 arguments to vim.validate (name, value, type), got " .. #validate_call_args)
-        assert.are.equal("f", validate_call_args[1],
-          "First argument should be parameter name 'f'")
-        assert.are.equal("function", validate_call_args[3],
-          "Third argument should be type 'function'")
-        assert.is_function(validate_call_args[2],
-          "Second argument should be the actual function value")
+        assert.is_true(
+          #validate_call_args == 3,
+          "Expected 3 arguments to vim.validate (name, value, type), got " .. #validate_call_args
+        )
+        assert.are.equal("f", validate_call_args[1], "First argument should be parameter name 'f'")
+        assert.are.equal("function", validate_call_args[3], "Third argument should be type 'function'")
+        assert.is_function(validate_call_args[2], "Second argument should be the actual function value")
       end
     end)
 
@@ -425,7 +435,7 @@ describe("telescope.actions.utils", function()
         return {
           get_multi_selection = function()
             return {} -- empty selection
-          end
+          end,
         }
       end
 
@@ -439,13 +449,12 @@ describe("telescope.actions.utils", function()
       action_state.get_current_picker = original_get_current_picker
 
       -- This should FAIL with old syntax, PASS with new syntax
-      assert.is_false(used_table_syntax,
-        "Should not use old table-based vim.validate syntax in map_selections")
+      assert.is_false(used_table_syntax, "Should not use old table-based vim.validate syntax in map_selections")
     end)
 
     -- Test that map_selections properly iterates through selections
     it("should properly iterate through multi-selections", function()
-      local action_state = require("telescope.actions.state")
+      local action_state = require "telescope.actions.state"
       local original_get_current_picker = action_state.get_current_picker
 
       local test_selections = {
@@ -459,7 +468,7 @@ describe("telescope.actions.utils", function()
         return {
           get_multi_selection = function()
             return test_selections
-          end
+          end,
         }
       end
 
@@ -480,7 +489,5 @@ describe("telescope.actions.utils", function()
       assert.are.equal("second_selection", processed_selections[2])
       assert.are.equal("third_selection", processed_selections[3])
     end)
-
   end) -- Close map_selections function validation describe block
-
 end) -- Close the main describe block

--- a/lua/tests/automated/actions/utils_spec.lua
+++ b/lua/tests/automated/actions/utils_spec.lua
@@ -1,6 +1,22 @@
 -- File: /lua/tests/automated/actions/utils_spec.lua
 
 describe("telescope.actions.utils", function()
+  local utils
+  local action_state
+
+  -- Set up the module before each test
+  before_each(function()
+    -- Load the utils module
+    utils = require("telescope.actions.utils")
+    action_state = require("telescope.actions.state")
+  end)
+
+  -- Clean up after each test
+  after_each(function()
+    -- Reset any global state if needed
+    package.loaded["telescope.actions.utils"] = nil
+    package.loaded["telescope.actions.state"] = nil
+  end)
 
   -- Verify module loads correctly
   it("should load the utils module without errors", function()
@@ -17,7 +33,6 @@ describe("telescope.actions.utils", function()
 
     -- Test valid parameter types
     it("should accept valid parameter types without vim.validate errors", function()
-      local action_state = require("telescope.actions.state")
       local original_get_current_picker = action_state.get_current_picker
 
       -- Set up mock picker with minimal structure
@@ -95,7 +110,6 @@ describe("telescope.actions.utils", function()
 
     -- Test handling of different buffer number types
     it("should handle different buffer number types", function()
-      local action_state = require("telescope.actions.state")
       local original_get_current_picker = action_state.get_current_picker
 
       -- Set up mock that works for all buffer numbers
@@ -152,6 +166,8 @@ describe("telescope.actions.utils", function()
         return original_vim_validate(...)
       end
 
+      local original_get_current_picker = action_state.get_current_picker
+
       -- Set up minimal mock
       action_state.get_current_picker = function(bufnr)
         return {
@@ -169,7 +185,7 @@ describe("telescope.actions.utils", function()
         utils.map_entries(1, function() end)
       end)
 
-      -- Restore original vim.validate
+      -- Restore original functions
       vim.validate = original_vim_validate
       action_state.get_current_picker = original_get_current_picker
 
@@ -202,6 +218,8 @@ describe("telescope.actions.utils", function()
         return original_vim_validate(arg1, ...)
       end
 
+      local original_get_current_picker = action_state.get_current_picker
+
       -- Set up minimal mock
       action_state.get_current_picker = function(bufnr)
         return {
@@ -219,7 +237,7 @@ describe("telescope.actions.utils", function()
         utils.map_entries(1, function() end)
       end)
 
-      -- Restore original vim.validate
+      -- Restore original functions
       vim.validate = original_vim_validate
       action_state.get_current_picker = original_get_current_picker
 

--- a/lua/tests/automated/actions/utils_spec.lua
+++ b/lua/tests/automated/actions/utils_spec.lua
@@ -1,0 +1,163 @@
+-- File: /lua/tests/automated/actions/utils_spec.lua
+
+describe("telescope.actions.utils", function()
+
+  -- Verify module loads correctly
+  it("should load the utils module without errors", function()
+    assert.is_not_nil(utils)
+    assert.is_table(utils)
+  end)
+
+  -- Test the map_entries function parameter validation
+  describe("map_entries function validation", function()
+
+    it("should exist as a function", function()
+      assert.is_function(utils.map_entries)
+    end)
+
+    -- Test valid parameter types
+    it("should accept valid parameter types without vim.validate errors", function()
+      local action_state = require("telescope.actions.state")
+      local original_get_current_picker = action_state.get_current_picker
+
+      -- Set up mock picker with minimal structure
+      action_state.get_current_picker = function(bufnr)
+        return {
+          manager = {
+            get_entries = function()
+              return {
+                { value = "first" },
+                { value = "second" },
+              }
+            end,
+            iter = function()
+              local entries = {
+                { value = "first" },
+                { value = "second" },
+              }
+              local i = 0
+              return function()
+                i = i + 1
+                if i <= #entries then
+                  return entries[i], i
+                end
+                return nil
+              end
+            end,
+          },
+          get_row = function(index)
+            return index
+          end
+        }
+      end
+
+      local valid_bufnr = 1
+      local valid_function = function(entry, index, row)
+        -- No-op test function
+      end
+
+      local success, error_msg = pcall(function()
+        utils.map_entries(valid_bufnr, valid_function)
+      end)
+
+      -- Restore the original function
+      action_state.get_current_picker = original_get_current_picker
+
+      -- Test should pass without vim.validate errors
+      assert.is_true(success, "map_entries should accept valid parameters: " .. (error_msg or ""))
+    end)
+
+    -- Test vim.validate rejects non-function for second parameter
+    it("should reject non-function for second parameter", function()
+      local valid_bufnr = 1
+
+      assert.has_error(function()
+        utils.map_entries(valid_bufnr, "not a function")
+      end, "f: expected function, got string")
+    end)
+
+    -- Test vim.validate rejects table for second parameter
+    it("should reject table for second parameter", function()
+      local valid_bufnr = 1
+      assert.has_error(function()
+        utils.map_entries(valid_bufnr, {})
+      end, "f: expected function, got table")
+    end)
+
+    -- Test vim.validate rejects number for second parameter
+    it("should reject number for second parameter", function()
+      local valid_bufnr = 1
+
+      assert.has_error(function()
+        utils.map_entries(valid_bufnr, 123)
+      end, "f: expected function, got number")
+    end)
+
+    -- Test handling of different buffer number types
+    it("should handle different buffer number types", function()
+      local action_state = require("telescope.actions.state")
+      local original_get_current_picker = action_state.get_current_picker
+
+      -- Set up mock that works for all buffer numbers
+      action_state.get_current_picker = function(bufnr)
+        return {
+          manager = {
+            iter = function()
+              -- Return an empty iterator
+              return function()
+                return nil
+              end
+            end,
+          },
+          get_row = function(index)
+            return index
+          end
+        }
+      end
+
+      local valid_function = function(entry, index, row) end
+
+      -- Test with different number types that could be valid buffer numbers
+      local test_cases = {0, 1, 999}  -- Common buffer number patterns
+
+      for _, bufnr in ipairs(test_cases) do
+        local success, error_msg = pcall(function()
+          utils.map_entries(bufnr, valid_function)
+        end)
+
+        -- Should not fail due to vim.validate function parameter errors
+        if not success then
+          assert.is_false(string.match(error_msg or "", "expected function") ~= nil,
+            "Buffer number " .. bufnr .. " should not cause function validation error")
+        end
+      end
+
+      -- Restore original function
+      action_state.get_current_picker = original_get_current_picker
+    end)
+
+  -- You can add a similar describe block for the function on line 75
+  describe("function with vim.validate on line 75", function()
+    -- Similar structure as above, but for the second function
+  end)
+
+  -- Restore original function after test
+  action_state.get_current_picker = original_get_current_picker
+
+
+end) -- Close the main describe block
+
+-- NEXT STEPS TO GET THIS WORKING:
+-- 1. Look at your utils.lua file and find the function names that contain the vim.validate calls
+-- 2. Replace "your_function_name" with the actual function names
+-- 3. Run this test to see what happens
+-- 4. Based on the errors you get, you'll learn what parameters the functions expect
+-- 5. Gradually build up your test cases based on what you learn
+
+-- DEBUGGING TIP:
+-- If you're not sure what functions are available, you can add this temporary test:
+-- it("should show available functions", function()
+--   for k, v in pairs(utils) do
+--     print(k, type(v))
+--   end
+-- end)

--- a/lua/tests/automated/actions/utils_spec.lua
+++ b/lua/tests/automated/actions/utils_spec.lua
@@ -11,30 +11,70 @@ describe("telescope.actions.utils", function()
     action_state = require "telescope.actions.state"
   end)
 
-  -- Clean up after each test
+  -- Reset module cache after each test to prevent test interference
   after_each(function()
     -- Reset any global state if needed
     package.loaded["telescope.actions.utils"] = nil
     package.loaded["telescope.actions.state"] = nil
   end)
 
-  -- Verify module loads correctly
+  -- Helper function to create a mock picker with specified entries
+  -- This simulates the picker's manager interface for testing map_entries
+  local function create_mock_picker_with_entries(entries)
+    return {
+      manager = {
+        get_entries = function()
+          return entries
+        end,
+        -- Iterator function returns entries one by one (without index as second return value)
+        -- This matches the actual telescope picker manager behavior
+        iter = function()
+          local i = 0
+          return function()
+            i = i + 1
+            if i <= #entries then
+              return entries[i] -- Return only the entry, not the index
+            end
+            return nil
+          end
+        end,
+      },
+      -- Convert 1-based index to 0-based row number (telescope display convention)
+      get_row = function(self, index)
+        return index - 1 -- 0-indexed rows
+      end,
+    }
+  end
+
+  -- Helper function to create a mock picker with specified selections
+  -- This simulates the picker's multi-selection interface for testing map_selections
+  local function create_mock_picker_with_selections(selections)
+    return {
+      get_multi_selection = function()
+        return selections
+      end,
+    }
+  end
+
+  -- Smoke test to verify the module loads correctly
   it("should load the utils module without errors", function()
     assert.is_not_nil(utils)
     assert.is_table(utils)
   end)
 
-  -- Test the map_entries function parameter validation
+  -- ============================================================================
+  -- Test suite for map_entries function parameter validation
+  -- ============================================================================
   describe("map_entries function validation", function()
     it("should exist as a function", function()
       assert.is_function(utils.map_entries)
     end)
 
-    -- Test valid parameter types
+    -- Test that valid parameter types are accepted by vim.validate
     it("should accept valid parameter types without vim.validate errors", function()
       local original_get_current_picker = action_state.get_current_picker
 
-      -- Set up mock picker with minimal structure
+      -- Mock picker with minimal required structure for map_entries
       action_state.get_current_picker = function(bufnr)
         return {
           manager = {
@@ -44,6 +84,7 @@ describe("telescope.actions.utils", function()
                 { value = "second" },
               }
             end,
+            -- Iterator returns entry and index (telescope manager convention)
             iter = function()
               local entries = {
                 { value = "first" },
@@ -67,17 +108,17 @@ describe("telescope.actions.utils", function()
 
       local valid_bufnr = 1
       local valid_function = function(entry, index, row)
-        -- No-op test function
+        -- Test callback function - intentionally empty
       end
 
       local success, error_msg = pcall(function()
         utils.map_entries(valid_bufnr, valid_function)
       end)
 
-      -- Restore the original function
+      -- Restore original function to avoid side effects
       action_state.get_current_picker = original_get_current_picker
 
-      -- Test should pass without vim.validate errors
+      -- Verify that vim.validate accepts the valid parameters
       assert.is_true(success, "map_entries should accept valid parameters: " .. (error_msg or ""))
     end)
 
@@ -107,16 +148,16 @@ describe("telescope.actions.utils", function()
       end, "f: expected function, got number")
     end)
 
-    -- Test handling of different buffer number types
+    -- Test that different valid buffer number types are handled properly
     it("should handle different buffer number types", function()
       local original_get_current_picker = action_state.get_current_picker
 
-      -- Set up mock that works for all buffer numbers
+      -- Mock that accepts any buffer number and returns minimal picker
       action_state.get_current_picker = function(bufnr)
         return {
           manager = {
             iter = function()
-              -- Return an empty iterator
+              -- Return an empty iterator for testing
               return function()
                 return nil
               end
@@ -138,7 +179,7 @@ describe("telescope.actions.utils", function()
           utils.map_entries(bufnr, valid_function)
         end)
 
-        -- Should not fail due to vim.validate function parameter errors
+        -- Verify that failures are not due to vim.validate function parameter errors
         if not success then
           assert.is_false(
             string.match(error_msg or "", "expected function") ~= nil,
@@ -151,12 +192,131 @@ describe("telescope.actions.utils", function()
       action_state.get_current_picker = original_get_current_picker
     end)
 
+    -- Test edge case: empty entries list
+    it("should handle empty entries gracefully", function()
+      local original_get_current_picker = action_state.get_current_picker
+
+      action_state.get_current_picker = function(bufnr)
+        return create_mock_picker_with_entries {} -- Empty entries
+      end
+
+      local call_count = 0
+      local success, error_msg = pcall(function()
+        utils.map_entries(1, function(entry, index, row)
+          call_count = call_count + 1
+        end)
+      end)
+
+      action_state.get_current_picker = original_get_current_picker
+
+      assert.is_true(success, "Should handle empty entries without error: " .. (error_msg or ""))
+      assert.are.equal(0, call_count, "Should not call function for emptry entries")
+    end)
+
+    -- Performance test: ensure large datasets are handled efficiently
+    it("should handle large numbers of entries efficiently", function()
+      local original_get_current_picker = action_state.get_current_picker
+
+      -- Create 1000 mock entries
+      local large_entries = {}
+      for i = 1, 1000 do
+        table.insert(large_entries, { value = "entry_" .. i })
+      end
+
+      action_state.get_current_picker = function(bufnr)
+        local picker = create_mock_picker_with_entries(large_entries)
+        return picker
+      end
+
+      local processed_entries = {}
+      local start_time = os.clock()
+      local success, error_msg = pcall(function()
+        utils.map_entries(1, function(entry, index, row)
+          table.insert(processed_entries, {
+            value = entry.value,
+            index = index,
+            row = row,
+          })
+          -- Verify parameter contracts are maintained at scale
+          assert.is_table(entry, "Entry should be a table")
+          assert.is_number(index, "Index should be a number")
+          assert.is_number(row, "Row should be a number")
+          assert.are.equal(index - 1, row, "Row should be index - 1")
+        end)
+      end)
+      local end_time = os.clock()
+
+      local duration = end_time - start_time
+      action_state.get_current_picker = original_get_current_picker
+
+      -- Verify correctness and performance
+      assert.is_true(success, "Should handle large entries without error: " .. (error_msg or ""))
+      assert.are.equal(1000, #processed_entries, "Should process exactly 1000 entries")
+      assert.are.equal("entry_1", processed_entries[1].value, "First entry should be correct")
+      assert.are.equal("entry_1000", processed_entries[1000].value, "Last entry should be correct")
+      assert.are.equal(1, processed_entries[1].index, "First index should be 1")
+      assert.are.equal(0, processed_entries[1].row, "First row should be 0")
+      assert.is_true(duration < 1.0, "Should complete within reasonable time (< 1 second), took: " .. duration)
+    end)
+
+    it("should work end-to-end with minimal mocking", function()
+      local original_get_current_picker = action_state.get_current_picker
+
+      -- Minimal mock that just provides the essential interface
+      local test_entries = {
+        { value = "file1.txt", ordinal = "file1.txt" },
+        { value = "file2.txt", ordinal = "file2.txt" },
+        { value = "file3.txt", ordinal = "file3.txt" },
+      }
+
+      action_state.get_current_picker = function(bufnr)
+        return create_mock_picker_with_entries(test_entries)
+      end
+
+      -- Small delay to allow initialization
+      vim.wait(1) -- Wait 1ms
+
+      local results = {}
+      local success, error_msg = pcall(function()
+        utils.map_entries(1, function(entry, index, row)
+          results[row] = {
+            value = entry.value,
+            index = index,
+            row = row,
+          }
+        end)
+      end)
+
+      action_state.get_current_picker = original_get_current_picker
+
+      assert.is_true(success, "Integration test should succeed: " .. (error_msg or ""))
+
+      -- Count actual entries
+      local count = 0
+      for _ in pairs(results) do
+        count = count + 1
+      end
+
+      assert.are.equal(3, count, "Should have processed 3 entries")
+
+      -- Verify telescope's row indexing convention (0-based display rows)
+      assert.are.equal("file1.txt", results[0].value, "First entry should be at row 0")
+      assert.are.equal("file2.txt", results[1].value, "Second entry should be at row 1")
+      assert.are.equal("file3.txt", results[2].value, "Third entry should be at row 2")
+
+      -- Verify index/row relationship maintains telescope conventions
+      for i = 0, 2 do
+        assert.are.equal(i + 1, results[i].index, "Index should be row + 1")
+        assert.are.equal(i, results[i].row, "Row should be 0-indexed")
+      end
+    end)
+
     -- =================================================================
-    -- TDD TESTS FOR vim.validate SYNTAX MIGRATION (line 38)
+    -- TDD TESTS FOR vim.validate SYNTAX MIGRATION (map_entries function)
     -- These should FAIL with old syntax and PASS with new syntax
     -- =================================================================
 
-    -- Test that demonstrates the new vim.validate argument-based syntax
+    -- Test that verifies the new vim.validate argument-based syntax is used
     it("should use new vim.validate argument syntax (not table syntax)", function()
       -- Mock vim.validate to track how it's called
       local original_vim_validate = vim.validate
@@ -194,10 +354,9 @@ describe("telescope.actions.utils", function()
       vim.validate = original_vim_validate
       action_state.get_current_picker = original_get_current_picker
 
-      -- This test expects the NEW argument-based syntax: vim.validate("f", f, "function")
-      -- With old syntax: validate_call_args[1] would be a table like { f = { f, "function" } }
-      -- With new syntax: validate_call_args would be {"f", function_value, "function"}
-
+      -- Verify the NEW argument-based syntax: vim.validate("f", f, "function")
+      -- Old syntax would pass a table: vim.validate({ f = { f, "function" } })
+      -- New syntax passes separate arguments: vim.validate("f", function_value, "function")
       if success then
         assert.is_true(
           #validate_call_args == 3,
@@ -209,7 +368,7 @@ describe("telescope.actions.utils", function()
       end
     end)
 
-    -- Additional test to ensure we're not accidentally calling the old table syntax
+    -- Test that confirms we're not using the deprecated table-based syntax
     it("should not use old table-based vim.validate syntax", function()
       -- Mock vim.validate to detect table-based calls
       local original_vim_validate = vim.validate
@@ -255,20 +414,22 @@ describe("telescope.actions.utils", function()
         "Should not use old table-based vim.validate syntax like vim.validate({ f = { f, 'function' } })"
       )
     end)
-  end) -- Close map_entries function validation describe block
+  end) -- End map_entries function validation tests
 
-  -- Test the map_selections function parameter validation (LINE 75)
+  -- ============================================================================
+  -- Test suite for map_entries function parameter validation
+  -- ============================================================================
   describe("map_selections function validation", function()
     it("should exist as a function", function()
       assert.is_function(utils.map_selections)
     end)
 
-    -- Test valid parameter types for map_selections
+    -- Test that valid parameter types are accepted by vim.validate
     it("should accept valid parameter types without vim.validate errors", function()
       local action_state = require "telescope.actions.state"
       local original_get_current_picker = action_state.get_current_picker
 
-      -- Set up mock picker with minimal structure for map_selections
+      -- Mock picker with multi-selection capability
       action_state.get_current_picker = function(bufnr)
         return {
           get_multi_selection = function()
@@ -282,17 +443,17 @@ describe("telescope.actions.utils", function()
 
       local valid_bufnr = 1
       local valid_function = function(selection)
-        -- Just a no-op, could also print or assert if needed
+        -- Test callback function - intentionally empty
       end
 
       local success, error_msg = pcall(function()
         utils.map_selections(valid_bufnr, valid_function)
       end)
 
-      -- Clean up: restore the original function
+      -- Restore original function to avoid side effects
       action_state.get_current_picker = original_get_current_picker
 
-      -- Test should pass without vim.validate errors
+      -- Verify that vim.validate accepts the valid parameters
       assert.is_true(success, "map_selections should accept valid parameters: " .. (error_msg or ""))
     end)
 
@@ -305,7 +466,6 @@ describe("telescope.actions.utils", function()
       end, "f: expected function, got string")
     end)
 
-    -- Test vim.validate rejects table for second parameter
     it("should reject table for second parameter", function()
       local valid_bufnr = 1
       assert.has_error(function()
@@ -313,7 +473,6 @@ describe("telescope.actions.utils", function()
       end, "f: expected function, got table")
     end)
 
-    -- Test vim.validate rejects number for second parameter
     it("should reject number for second parameter", function()
       local valid_bufnr = 1
 
@@ -322,7 +481,6 @@ describe("telescope.actions.utils", function()
       end, "f: expected function, got number")
     end)
 
-    -- Test vim.validate rejects nil for second parameter
     it("should reject nil for second parameter", function()
       local valid_bufnr = 1
 
@@ -331,12 +489,12 @@ describe("telescope.actions.utils", function()
       end, "f: expected function, got nil")
     end)
 
-    -- Test different buffer number types
+    -- Test that different valid buffer number types are handled properly
     it("should handle different buffer number types", function()
       local action_state = require "telescope.actions.state"
       local original_get_current_picker = action_state.get_current_picker
 
-      -- Set up mock that works for all buffer numbers
+      -- Mock that accepts any buffer number and returns minimal picker
       action_state.get_current_picker = function(bufnr)
         return {
           get_multi_selection = function()
@@ -355,7 +513,7 @@ describe("telescope.actions.utils", function()
           utils.map_selections(bufnr, valid_function)
         end)
 
-        -- We expect these might fail due to telescope setup, but NOT due to vim.validate
+        -- Verify that failures are not due to vim.validate function parameter errors
         if not success then
           assert.is_false(
             string.match(error_msg or "", "expected function") ~= nil,
@@ -364,16 +522,111 @@ describe("telescope.actions.utils", function()
         end
       end
 
-      -- Clean up: restore the original function
+      -- Restore original function to avoid side effects
       action_state.get_current_picker = original_get_current_picker
     end)
 
+    -- Test edge case: empty selections list
+    it("should handle empty selections gracefully", function()
+      local original_get_current_picker = action_state.get_current_picker
+
+      action_state.get_current_picker = function(bufnr)
+        return create_mock_picker_with_selections {} -- Empty selections
+      end
+
+      local call_count = 0
+      local success, error_msg = pcall(function()
+        utils.map_selections(1, function(selection)
+          call_count = call_count + 1
+        end)
+      end)
+
+      action_state.get_current_picker = original_get_current_picker
+
+      assert.is_true(success, "Should handle empty selections without error: " .. (error_msg or ""))
+      assert.are.equal(0, call_count, "Should not call function for empty selections")
+    end)
+
+    -- Performance test: ensure large selection sets are handled efficiently
+    it("should handle large numbers of selections efficiently", function()
+      local original_get_current_picker = action_state.get_current_picker
+
+      -- Create substantial multi-selection dataset (realistic for bulk operations)
+      local large_selections = {}
+      for i = 1, 500 do
+        table.insert(large_selections, { value = "selection_" .. i })
+      end
+
+      action_state.get_current_picker = function(bufnr)
+        return create_mock_picker_with_selections(large_selections)
+      end
+
+      local processed_count = 0
+      local start_time = os.clock()
+
+      local success, error_msg = pcall(function()
+        utils.map_selections(1, function(selection)
+          processed_count = processed_count + 1
+          assert.is_table(selection, "Selection should be a table")
+          assert.is_string(selection.value, "Selection should have a value")
+        end)
+      end)
+
+      local end_time = os.clock()
+      local duration = end_time - start_time
+
+      action_state.get_current_picker = original_get_current_picker
+
+      assert.is_true(success, "Should handle large selections without error: " .. (error_msg or ""))
+      assert.are.equal(500, processed_count, "Should process all 500 selections")
+      assert.is_true(duration < 0.5, "Should complete within reasonable time (< 0.5 seconds), took: " .. duration)
+    end)
+
+    -- Integration test with realistic multi-selection scenario
+    it("should work end-to-end with realistic multi-selection scenario", function()
+      local original_get_current_picker = action_state.get_current_picker
+
+      -- Simulate a realistic multi-selection scenario
+      local test_selections = {
+        { value = "src/main.lua", ordinal = "src/main.lua", filename = "main.lua" },
+        { value = "src/utils.lua", ordinal = "src/utils.lua", filename = "utils.lua" },
+        { value = "tests/test_main.lua", ordinal = "tests/test_main.lua", filename = "test_main.lua" },
+      }
+
+      action_state.get_current_picker = function(bufnr)
+        return create_mock_picker_with_selections(test_selections)
+      end
+
+      local processed_files = {}
+      local success, error_msg = pcall(function()
+        utils.map_selections(1, function(selection)
+          table.insert(processed_files, {
+            path = selection.value,
+            filename = selection.filename,
+          })
+        end)
+      end)
+
+      action_state.get_current_picker = original_get_current_picker
+
+      assert.is_true(success, "Integration test should succeed: " .. (error_msg or ""))
+      assert.are.equal(3, #processed_files, "Should have processed 3 selections")
+
+      -- Verify the integration worked correctly
+      assert.are.equal("src/main.lua", processed_files[1].path)
+      assert.are.equal("main.lua", processed_files[1].filename)
+      assert.are.equal("src/utils.lua", processed_files[2].path)
+      assert.are.equal("utils.lua", processed_files[2].filename)
+      assert.are.equal("tests/test_main.lua", processed_files[3].path)
+      assert.are.equal("test_main.lua", processed_files[3].filename)
+    end)
+
     -- =================================================================
-    -- TDD TESTS FOR vim.validate SYNTAX MIGRATION (line 75)
+    -- TDD TESTS FOR vim.validate SYNTAX MIGRATION (map_selections)
     -- These should FAIL with old syntax and PASS with new syntax
     -- =================================================================
 
-    -- Test that demonstrates the new vim.validate argument-based syntax for map_selections
+    -- Test that verifies the new vim.validate argument-based syntax is used
     it("should use new vim.validate argument syntax for map_selections (not table syntax)", function()
       -- Mock vim.validate to track how it's called
       local original_vim_validate = vim.validate
@@ -398,14 +651,13 @@ describe("telescope.actions.utils", function()
         utils.map_selections(1, function() end)
       end)
 
-      -- Restore original vim.validate
+      -- Restore original functions
       vim.validate = original_vim_validate
       action_state.get_current_picker = original_get_current_picker
 
-      -- This test expects the NEW argument-based syntax: vim.validate("f", f, "function")
-      -- With old syntax: validate_call_args[1] would be a table like { f = { f, "function" } }
-      -- With new syntax: validate_call_args would be {"f", function_value, "function"}
-
+      -- Verify the NEW argument-based syntax: vim.validate("f", f, "function")
+      -- Old syntax would pass a table: vim.validate({ f = { f, "function" } })
+      -- New syntax passes separate arguments: vim.validate("f", function_value, "function")
       if success then
         assert.is_true(
           #validate_call_args == 3,
@@ -417,7 +669,7 @@ describe("telescope.actions.utils", function()
       end
     end)
 
-    -- Additional test to ensure we're not accidentally calling the old table syntax
+    -- Test that confirms we're not using the deprecated table-based syntax
     it("should not use old table-based vim.validate syntax in map_selections", function()
       -- Mock vim.validate to detect table-based calls
       local original_vim_validate = vim.validate
@@ -444,15 +696,15 @@ describe("telescope.actions.utils", function()
         utils.map_selections(1, function() end)
       end)
 
-      -- Restore original vim.validate
+      -- Restore original functions
       vim.validate = original_vim_validate
       action_state.get_current_picker = original_get_current_picker
 
-      -- This should FAIL with old syntax, PASS with new syntax
+      -- This test ensures we're using the modern vim.validate syntax
       assert.is_false(used_table_syntax, "Should not use old table-based vim.validate syntax in map_selections")
     end)
 
-    -- Test that map_selections properly iterates through selections
+    -- Test that verifies proper iteration through multi-selections
     it("should properly iterate through multi-selections", function()
       local action_state = require "telescope.actions.state"
       local original_get_current_picker = action_state.get_current_picker
@@ -479,15 +731,15 @@ describe("telescope.actions.utils", function()
         end)
       end)
 
-      -- Clean up: restore the original function
+      -- Restore original function to avoid side effects
       action_state.get_current_picker = original_get_current_picker
 
-      -- Verify the function worked correctly
+      -- Verify successful iteration through all selections
       assert.is_true(success, "map_selections should execute without errors")
       assert.are.equal(3, #processed_selections, "Should have processed 3 selections")
       assert.are.equal("first_selection", processed_selections[1])
       assert.are.equal("second_selection", processed_selections[2])
       assert.are.equal("third_selection", processed_selections[3])
     end)
-  end) -- Close map_selections function validation describe block
-end) -- Close the main describe block
+  end) -- End map_selections function validation tests
+end) -- End main describe block


### PR DESCRIPTION
# Description
This PR addresses deprecation warnings caused by the old, table-based vim.validate syntax in two functions within telescope.actions.utils. The validation calls are updated to use the new argument-based syntax recommended by Neovim.

While using Telescope (master branch at commit b4da76b), I began seeing repeated deprecation warnings related to calls like vim.validate({}).

I searched the codebase and found five instances of the deprecated syntax. While there wasn't an open issue for this, I decided to start addressing it incrementally — beginning with the two usages in `telescope.actions.utils`.

**Example warning**:
```
WARNING vim.validate is deprecated. Feature will be removed in Nvim 1.0
  ADVICE:
      - use vim.validate(name, value, validator, optional_or_msg) instead.
```

### Motivation and Context
One of my 2025 goals is to contribute meaningfully to an open-source Neovim plugin I use regularly. I’ve been looking for small, self-contained improvements that would let me practice writing and testing Lua code in the Neovim ecosystem — ideally in a way that supports test-driven development approach.

This change gave me an opportunity to explore Neovim plugin internals while also getting some hands-on experience writing tests before modifying behavior, which helped build confidence in the refactor.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Added unit tests for** `map_entries` and `map_selections`  
Located in `tests/automated/actions/utils_spec.lua`  
Covers:
- Input validation (e.g. `nil`, wrong types)
- Edge cases (empty or malformed inputs)
- Row/index mapping per Telescope conventions
- Integration scenarios with realistic selections
- Performance (1000+ entries, 500+ selections)
- TDD-style validation tests for both functions that only pass with the new `vim.validate` syntax

**Reproduction Instructions**:

Clone branch: `git checkout feat/improve-actions-utils-validation`
To run only newly added tests use:
```
make test-utils
```
(Temporary Makefile helper I added for local dev; happy to remove before merge)

**Configuration**:
* Neovim version: NVIM v0.11.0 Build type: Release LuaJIT 2.1.1744318430
* Operating system and version: macOS Sequoia 15.5 (Apple Silicon - M2)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
> N/A – no new public API or parameter changes
