### PR TITLE
Add first line in doc for local-additions

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1,3 +1,4 @@
+*telescope.txt*                                           Plugin for fuzzy finding
 ================================================================================
 INTRODUCTION                                                    *telescope.nvim*
 


### PR DESCRIPTION
# Description

The documentation for vim help pages states that a first line is required for the file to appear under `:help local-additions`, with the following format: `*tag* description`

This change adds such line

There was no issue created for this, but I can create one if required

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

After applying the change, a new entry appears under `:help local-additions` (or at the end of the main `:help`page)

- [x] Test A: enter `:help local-additions` and verify that a new `telescope.txt` entry is present

**Configuration**:
* Neovim version (nvim --version): NVIM v0.11.3a (with LazyVim)
* Operating system and version: Debian 12.11 (running under WSL)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)

# Notes:
When modifiying directly on my running system, I had to run manually `helptags ++t $HOME/.local/share/nvim/lazy/telescope.nvim/doc` before a double click on the new entry was effective. But since the github repository does not contain any `tags` file, I assume that tags generation happens automatically with plugin installation
