### PR TITLE
feat(builtin.colorscheme): update option ignore_builtins

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1048,7 +1048,7 @@ internal.colorscheme = function(opts)
       "blue", "darkblue", "default", "delek", "desert", "elflord", "evening",
       "habamax", "industry", "koehler", "lunaperche", "morning", "murphy",
       "pablo", "peachpuff", "quiet", "retrobox", "ron", "shine", "slate",
-      "sorbet", "torte", "vim", "wildcharm", "zaibatsu", "zellner",
+      "sorbet", "torte", "unokai", "vim", "wildcharm", "zaibatsu", "zellner",
     }
     colors = vim.tbl_filter(function(color)
       return not vim.tbl_contains(builtins, color)


### PR DESCRIPTION
# Description

Add `unokai` to the list of builtins. It has been added here: https://github.com/vim/vim/commit/045564d0a73218594691953c0c8bf2035e1e176e

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
