### PR TITLE
feat: add strip_path_prefix config option

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -930,6 +930,19 @@ append(
     Default: require("telescope.previewers").buffer_previewer_maker]]
 )
 
+append(
+  "strip_path_prefix",
+  nil,
+  [[
+    String that will be stripped from the beginning of file paths.
+    This is useful when running in containers where file paths start
+    with a specific prefix that you want to remove for better display.
+
+    Example: "/app/"
+
+    Default: nil]]
+)
+
 -- @param user_defaults table: a table where keys are the names of options,
 --    and values are the ones the user wants
 -- @param tele_defaults table: (optional) a table containing all of the defaults

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -38,6 +38,7 @@ local entry_display = require "telescope.pickers.entry_display"
 local utils = require "telescope.utils"
 local strings = require "plenary.strings"
 local Path = require "plenary.path"
+local config = require "telescope.config"
 
 local treesitter_type_highlight = {
   ["associated"] = "TSConstant",
@@ -454,6 +455,7 @@ end
 function make_entry.gen_from_quickfix(opts)
   opts = opts or {}
   local show_line = vim.F.if_nil(opts.show_line, true)
+  local strip_prefix = vim.F.if_nil(opts.strip_path_prefix, config.values.strip_path_prefix)
 
   local hidden = utils.is_path_hidden(opts)
 
@@ -479,6 +481,9 @@ function make_entry.gen_from_quickfix(opts)
   local get_filename = get_filename_fn()
   return function(entry)
     local filename = vim.F.if_nil(entry.filename, get_filename(entry.bufnr))
+    if filename and strip_prefix and filename:match("^" .. vim.pesc(strip_prefix)) then
+      filename = filename:gsub("^" .. vim.pesc(strip_prefix), "")
+    end
 
     return make_entry.set_default_entry_mt({
       value = entry,


### PR DESCRIPTION
Add strip_path_prefix configuration option to remove specified prefixes from file paths in telescope displays. This is useful when running in containers where file paths contain unwanted prefixes that clutter the display.

- Add strip_path_prefix config option with documentation
- Implement path prefix stripping in gen_from_quickfix
- Use vim.pesc for safe pattern escaping
- Default value is nil (no stripping)

Example usage: strip_path_prefix = "/app/"

modified:   lua/telescope/config.lua
modified:   lua/telescope/make_entry.lua

# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Test A
- [ ] Test B

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
