### PR TITLE
Fix error logging in call hierarchy handler

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -100,7 +100,7 @@ local function calls(opts, direction)
   local params = client_position_params()
   lsp.buf_request(opts.bufnr, "textDocument/prepareCallHierarchy", params, function(err, result)
     if err then
-      utils.notify("lsp.calls", { msg = err, level = "ERROR" })
+      utils.notify("lsp.calls", { msg = err.message, level = "ERROR" })
       return
     end
 

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -149,7 +149,7 @@ end
 ---@param items vim.quickfix.entry[]
 ---@param opts table
 ---@return vim.quickfix.entry[]
-local function filter_file_ignore_patters(items, opts)
+local function filter_file_ignore_patterns(items, opts)
   local file_ignore_patterns = vim.F.if_nil(opts.file_ignore_patterns, conf.file_ignore_patterns)
   file_ignore_patterns = file_ignore_patterns or {}
   if vim.tbl_isempty(file_ignore_patterns) then
@@ -210,7 +210,7 @@ local function list_or_jump(action, title, funname, params, opts)
     end
 
     items = apply_action_handler(action, items, opts)
-    items = filter_file_ignore_patters(items, opts)
+    items = filter_file_ignore_patterns(items, opts)
 
     if vim.tbl_isempty(items) then
       utils.notify(funname, {


### PR DESCRIPTION
# Description

- vim.lsp.buf_request() handlers receive err as a lsp.ResponseError in failure cases. The table is currently being concatenated directly.
- typo in the word "patterns"

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Not really sure how to trigger this error.

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
