### PR TITLE
default line number to 0 to fix issue #3526

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -633,7 +633,7 @@ function make_entry.gen_from_buffer(opts)
     local readonly = vim.bo[entry.bufnr].readonly and "=" or " "
     local changed = entry.info.changed == 1 and "+" or " "
     local indicator = entry.flag .. hidden .. readonly .. changed
-    local lnum = 1
+    local lnum = 0
 
     -- account for potentially stale lnum as getbufinfo might not be updated or from resuming buffers picker
     if entry.info.lnum ~= 0 then


### PR DESCRIPTION
# Description

Default line number to 0 at make_entry.lua:634 to fix issue #3526, when opening multiple files using buffer picker resets cursor position.

Thanks to reddit user /u/junxblah for the fix!

Fixes # 3526

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Included tests pass, more regression tests are welcome.

**Configuration**:
* Neovim version (nvim --version): NVIM v0.12.0-dev-906+g5151f635ca
* Operating system and version: Linux 6.16.1-zen1-1-zen

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
