### PR TITLE
Extend `vim.tbl_islist` deprecation for `nvim`>0.10

### DIFF
--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -30,7 +30,7 @@ utils.str_byteindex = function(s, i, encoding)
 end
 
 --TODO(clason): Remove when dropping support for Nvim 0.9
-utils.islist = vim.fn.has "nvim-0.10" == 1 and vim.islist or vim.tbl_islist
+utils.islist = vim.fn.has "nvim-0.9" == 1 and vim.islist or vim.tbl_islist
 local flatten = function(t)
   return vim.iter(t):flatten():totable()
 end

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -30,7 +30,7 @@ utils.str_byteindex = function(s, i, encoding)
 end
 
 --TODO(clason): Remove when dropping support for Nvim 0.9
-utils.islist = vim.fn.has "nvim-0.9" == 1 and vim.islist or vim.tbl_islist
+utils.islist = vim.fn.has "nvim-0.10" == 0 and vim.tbl_islist or vim.islist
 local flatten = function(t)
   return vim.iter(t):flatten():totable()
 end


### PR DESCRIPTION
# Description

This PR fixes the deprecation warning for `nvim` 0.11+ due to the usage of `vim.tbl_islist` instead of `vim.islist`, given that the former former check was only using `vim.islist` for `nvim-0.10` (or any other subversion), hence the `vim.tbl_islist` was being used in `nvim-0.11` due to not matching the aforementioned condition. Now it captures both, as it reverses the condition to use `vim.tbl_islist` only for `nvim-0.9`.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Install `telescope.nvim` from `main` on `nvim` 0.11.4 (current latest prior 0.12 release soon) and then `:checkhealth vim.deprecated`, it will indeed show the deprecation warning around `vim.tbl_islist`
- [x] Install `telescope.nvim` from this commit on `nvim` 0.11.4 and then `:checkhealth vim.deprecated` won't show the deprecation warning around `vim.tbl_islist`, whilst working normally

**Configuration**:
* Neovim version (nvim --version): 
```
NVIM v0.11.4
Build type: Release
LuaJIT 2.1.1753364724
Run "nvim -V1 -v" for more info
```
* Operating system and version: N/A

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)