### PR TITLE
feat(lsp_jump_type): pass jump_type as a function

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1558,7 +1558,9 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
                                           only one and the definition file is
                                           different from the current file,
                                           values: "tab", "tab drop", "split",
-                                          "vsplit", "never"
+                                          "vsplit", "never" or a function,
+					  which will be executed before the
+					  jump
         {show_line}            (boolean)  show results text (default: true)
         {trim_text}            (boolean)  trim results text (default: false)
         {file_encoding}        (string)   file encoding for the previewer
@@ -1604,7 +1606,9 @@ builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
         {jump_type}     (string)   how to goto definition if there is only one
                                    and the definition file is different from
                                    the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never"
+                                   drop", "split", "vsplit", "never" or a function,
+				   which will be executed before the
+				   jump
         {show_line}     (boolean)  show results text (default: true)
         {trim_text}     (boolean)  trim results text (default: false)
         {reuse_win}     (boolean)  jump to existing window if buffer is
@@ -1624,7 +1628,9 @@ builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
         {jump_type}     (string)   how to goto definition if there is only one
                                    and the definition file is different from
                                    the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never"
+                                   drop", "split", "vsplit", "never" or a function,
+				   which will be executed before the
+				   jump
         {show_line}     (boolean)  show results text (default: true)
         {trim_text}     (boolean)  trim results text (default: false)
         {reuse_win}     (boolean)  jump to existing window if buffer is
@@ -1644,7 +1650,9 @@ builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
         {jump_type}     (string)   how to goto implementation if there is only
                                    one and the definition file is different
                                    from the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never"
+                                   drop", "split", "vsplit", "never" or a function,
+				   which will be executed before the
+				   jump
         {show_line}     (boolean)  show results text (default: true)
         {trim_text}     (boolean)  trim results text (default: false)
         {reuse_win}     (boolean)  jump to existing window if buffer is

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1605,22 +1605,22 @@ builtin.lsp_references({opts})            *telescope.builtin.lsp_references()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {include_declaration}  (boolean)  include symbol declaration in the
-                                          lsp references (default: true)
-        {include_current_line} (boolean)  include current line (default:
-                                          false)
-        {jump_type}            (string)   how to goto reference if there is
-                                          only one and the definition file is
-                                          different from the current file,
-                                          values: "tab", "tab drop", "split",
-                                          "vsplit", "never" or a function,
-					  which will be executed before the
-					  jump
-        {show_line}            (boolean)  show results text (default: true)
-        {trim_text}            (boolean)  trim results text (default: false)
-        {reuse_win}            (boolean)  jump to existing window if buffer is
-                                          already opened (default: false)
-        {file_encoding}        (string)   file encoding for the previewer
+        {include_declaration}  (boolean)          include symbol declaration in the
+                                                  lsp references (default: true)
+        {include_current_line} (boolean)          include current line (default:
+                                                  false)
+        {jump_type}            (string|function)  how to goto reference if there is
+                                                  only one and the definition file is
+                                                  different from the current file,
+                                                  values: "tab", "tab drop", "split",
+                                                  "vsplit", "never" or a function,
+                                                  which will be executed before the
+                                                  jump
+        {show_line}            (boolean)          show results text (default: true)
+        {trim_text}            (boolean)          trim results text (default: false)
+        {reuse_win}            (boolean)          jump to existing window if buffer is
+                                                  already opened (default: false)
+        {file_encoding}        (string)           file encoding for the previewer
 
 
 builtin.lsp_incoming_calls({opts})    *telescope.builtin.lsp_incoming_calls()*
@@ -1660,17 +1660,17 @@ builtin.lsp_definitions({opts})          *telescope.builtin.lsp_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}     (string)   how to goto definition if there is only one
-                                   and the definition file is different from
-                                   the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never" or a function,
-				   which will be executed before the
-				   jump
-        {show_line}     (boolean)  show results text (default: true)
-        {trim_text}     (boolean)  trim results text (default: false)
-        {reuse_win}     (boolean)  jump to existing window if buffer is
-                                   already opened (default: false)
-        {file_encoding} (string)   file encoding for the previewer
+        {jump_type}     (string|function)   how to goto definition if there is only one
+                                            and the definition file is different from
+                                            the current file, values: "tab", "tab
+                                            drop", "split", "vsplit", "never" or a function,
+                                            which will be executed before the
+                                            jump
+        {show_line}     (boolean)           show results text (default: true)
+        {trim_text}     (boolean)           trim results text (default: false)
+        {reuse_win}     (boolean)           jump to existing window if buffer is
+                                            already opened (default: false)
+        {file_encoding} (string)            file encoding for the previewer
 
 
 builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
@@ -1682,17 +1682,17 @@ builtin.lsp_type_definitions({opts}) *telescope.builtin.lsp_type_definitions()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}     (string)   how to goto definition if there is only one
-                                   and the definition file is different from
-                                   the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never" or a function,
-				   which will be executed before the
-				   jump
-        {show_line}     (boolean)  show results text (default: true)
-        {trim_text}     (boolean)  trim results text (default: false)
-        {reuse_win}     (boolean)  jump to existing window if buffer is
-                                   already opened (default: false)
-        {file_encoding} (string)   file encoding for the previewer
+        {jump_type}     (string|function)   how to goto definition if there is only one
+                                            and the definition file is different from
+                                            the current file, values: "tab", "tab
+                                            drop", "split", "vsplit", "never" or a function,
+                                            which will be executed before the
+                                            jump
+        {show_line}     (boolean)           show results text (default: true)
+        {trim_text}     (boolean)           trim results text (default: false)
+        {reuse_win}     (boolean)           jump to existing window if buffer is
+                                            already opened (default: false)
+        {file_encoding} (string)            file encoding for the previewer
 
 
 builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
@@ -1704,17 +1704,17 @@ builtin.lsp_implementations({opts})  *telescope.builtin.lsp_implementations()*
         {opts} (table)  options to pass to the picker
 
     Options: ~
-        {jump_type}     (string)   how to goto implementation if there is only
-                                   one and the definition file is different
-                                   from the current file, values: "tab", "tab
-                                   drop", "split", "vsplit", "never" or a function,
-				   which will be executed before the
-				   jump
-        {show_line}     (boolean)  show results text (default: true)
-        {trim_text}     (boolean)  trim results text (default: false)
-        {reuse_win}     (boolean)  jump to existing window if buffer is
-                                   already opened (default: false)
-        {file_encoding} (string)   file encoding for the previewer
+        {jump_type}     (string|function)   how to goto implementation if there is only
+                                            one and the definition file is different
+                                            from the current file, values: "tab", "tab
+                                            drop", "split", "vsplit", "never" or a function,
+                                            which will be executed before the
+                                            jump
+        {show_line}     (boolean)           show results text (default: true)
+        {trim_text}     (boolean)           trim results text (default: false)
+        {reuse_win}     (boolean)           jump to existing window if buffer is
+                                            already opened (default: false)
+        {file_encoding} (string)            file encoding for the previewer
 
 
 builtin.lsp_document_symbols({opts}) *telescope.builtin.lsp_document_symbols()*

--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -162,6 +162,8 @@ local function list_or_jump(action, title, params, opts)
         elseif opts.jump_type == "tab drop" then
           local file_path = vim.uri_to_fname(target_uri)
           vim.cmd("tab drop " .. file_path)
+        elseif type(opts.jump_type) == "function" then
+          opts.jump_type()
         end
       end
 

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -416,7 +416,7 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@param opts table: options to pass to the picker
 ---@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
 ---@field include_current_line boolean: include current line (default: false)
----@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
+---@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field file_encoding string: file encoding for the previewer
@@ -438,7 +438,7 @@ builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp")
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
+---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
@@ -448,7 +448,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 --- Goto the definition of the type of the word under the cursor, if there's only one,
 --- otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
+---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
@@ -457,7 +457,7 @@ builtin.lsp_type_definitions = require_on_exported_call("telescope.builtin.__lsp
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"
+---@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -423,7 +423,7 @@ builtin.jumplist = require_on_exported_call("telescope.builtin.__internal").jump
 ---@param opts table: options to pass to the picker
 ---@field include_declaration boolean: include symbol declaration in the lsp references (default: true)
 ---@field include_current_line boolean: include current line (default: false)
----@field jump_type string: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
+---@field jump_type string|function: how to goto reference if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
@@ -446,7 +446,7 @@ builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp")
 
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
+---@field jump_type string|function: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
@@ -456,7 +456,7 @@ builtin.lsp_definitions = require_on_exported_call("telescope.builtin.__lsp").de
 --- Goto the definition of the type of the word under the cursor, if there's only one,
 --- otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
+---@field jump_type string|function: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)
@@ -465,7 +465,7 @@ builtin.lsp_type_definitions = require_on_exported_call("telescope.builtin.__lsp
 
 --- Goto the implementation of the word under the cursor if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
----@field jump_type string: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
+---@field jump_type string|function: how to goto implementation if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never" or a function, which will be executed before the jump
 ---@field show_line boolean: show results text (default: true)
 ---@field trim_text boolean: trim results text (default: false)
 ---@field reuse_win boolean: jump to existing window if buffer is already opened (default: false)


### PR DESCRIPTION
# Description

When calling LSP-Telescope functions (`lsp_definitions`, `lsp_references`, etc.), users may want to customize how the target buffer opens.

Currently:

 - With multiple results, customization is possible using the get_selection_window option:
```lua
require('telescope.builtin').lsp_definitions({
  get_selection_window = function() ... end,
})
```
 - With a single result, Telescope bypasses the picker and relies on jump_type, which only accepts string values (`tab`, `tab drop`, `split`, `vsplit`, `never`).
 - This makes customization in the single-result case very limited.

This PR extends `jump_type` to also accept a function.
When a function is provided, it will be executed instead of the predefined commands, giving users the same level of flexibility as in the multi-result case.

## Example use case

I want to choose the exact window in which a reference is opened when navigating with `lsp_definitions`.

Today: I can do this with a window-picker when multiple definitions are found.
Limitation: When only one definition is found, I have no such option.

With this PR, I can achieve it like so:

```lua
require('telescope.builtin').lsp_definitions(
    {
      get_selection_window = function()
        return require('window-picker').pick_window({ include_current_win = true });
      end,
      jump_type = function ()
        local window = require('window-picker').pick_window({ include_current_win = true, reuse_win = false });
        vim.api.nvim_set_current_win(window)
      end
    })
```

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Manually tested with the configuration shown above.
- [x] Verified that behavior with multiple references remains unchanged
- [x] Verified that with a single reference, the provided function is executed (e.g. window-picker is triggered) and the reference opens in the selected window

**Configuration**:
* Neovim version (nvim --version): 0.11.2
* Operating system and version: MacOS

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)
