### PR TITLE
(fix): example code in the docs

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2188,7 +2188,7 @@ All layout strategies are functions with the following signature:
   function(picker, columns, lines, layout_config)
     -- Do some calculations here...
     return {
-      preview = preview_configuration
+      preview = preview_configuration,
       results = results_configuration,
       prompt = prompt_configuration,
     }


### PR DESCRIPTION
# Description

the example code was without comma, this should fix the code

Fixes # (no current issue found)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A:
  - copy code
  - paste code in any lua file
  - lsps meant for lua would complain and because of the non existent comma, lua would throw an error


**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.12.0-dev-1472+g869e55f2aa
Build type: RelWithDebInfo
LuaJIT 2.1.1753364724
```
* Operating system and version:
```
❯ cat /etc/os-release
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://gitlab.archlinux.org/groups/archlinux/-/issues"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=archlinux-logo
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)


# PS:
<img width="1276" height="320" alt="image" src="https://github.com/user-attachments/assets/cb72e970-e4ee-4d27-9de4-183613daeb4f" />
i literally have this in my task for like 8 weeks but didn't get the chance to fix it cz no internet. this is incredibly funny