### PR TITLE
fix: add `vim.validate` safeguards

### DIFF
--- a/lua/telescope/actions/utils.lua
+++ b/lua/telescope/actions/utils.lua
@@ -35,9 +35,13 @@ local utils = {}
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto entries of picker that takes (entry, index, row) as viable arguments
 function utils.map_entries(prompt_bufnr, f)
-  vim.validate {
-    f = { f, "function" },
-  }
+  if vim.fn.has "nvim-0.11" == 1 then
+    vim.validate("f", f, "function")
+  else
+    vim.validate {
+      f = { f, "function" },
+    }
+  end
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   local index = 1
   -- indices are 1-indexed, rows are 0-indexed
@@ -72,9 +76,13 @@ end
 ---@param prompt_bufnr number: The prompt bufnr
 ---@param f function: Function to map onto selection of picker that takes (selection) as a viable argument
 function utils.map_selections(prompt_bufnr, f)
-  vim.validate {
-    f = { f, "function" },
-  }
+  if vim.fn.has "nvim-0.11" == 1 then
+    vim.validate("f", f, "function")
+  else
+    vim.validate {
+      f = { f, "function" },
+    }
+  end
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   for _, selection in ipairs(current_picker:get_multi_selection()) do
     f(selection)

--- a/lua/telescope/debounce.lua
+++ b/lua/telescope/debounce.lua
@@ -5,16 +5,23 @@ local M = {}
 
 ---Validates args for `throttle()` and  `debounce()`.
 local function td_validate(fn, ms)
-  vim.validate {
-    fn = { fn, "f" },
-    ms = {
-      ms,
-      function(v)
-        return type(v) == "number" and v > 0
-      end,
-      "number > 0",
-    },
-  }
+  if vim.fn.has "nvim-0.11" == 1 then
+    vim.validate("fn", fn, "function")
+    vim.validate("ms", ms, function(v)
+      return type(v) == "number" and v > 0
+    end, false, "number > 0")
+  else
+    vim.validate {
+      fn = { fn, "function" },
+      ms = {
+        ms,
+        function(v)
+          return type(v) == "number" and v > 0
+        end,
+        "number > 0",
+      },
+    }
+  end
 end
 
 --- Throttles a function on the leading edge. Automatically `schedule_wrap()`s.

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -816,7 +816,11 @@ end
 ---   - `actions.delete_buffer()`
 ---@param delete_cb function: called for each selection fn(s) -> bool|nil (true|nil removes the entry from the results)
 function Picker:delete_selection(delete_cb)
-  vim.validate { delete_cb = { delete_cb, "f" } }
+  if vim.fn.has "nvim-0.11" == 1 then
+    vim.validate("delete_cb", delete_cb, "function")
+  else
+    vim.validate { delete_cb = { delete_cb, "function" } }
+  end
   local original_selection_strategy = self.selection_strategy
   self.selection_strategy = "row"
 

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -54,9 +54,13 @@ utils.flatten = vim.fn.has "nvim-0.11" == 1 and flatten or vim.tbl_flatten
 ---@param path string
 ---@return string
 utils.path_expand = function(path)
-  vim.validate {
-    path = { path, { "string" } },
-  }
+  if vim.fn.has "nvim-0.11" == 1 then
+    vim.validate("path", path, "string")
+  else
+    vim.validate {
+      path = { path, { "string" } },
+    }
+  end
 
   if utils.is_uri(path) then
     return path


### PR DESCRIPTION
# Description

(Originally part of #3540).

`vim.validate` is causing deprecation warnings as reported [here](https://www.reddit.com/r/neovim/comments/1nyhh56/how_to_solve_these_deprecated_warnings_in_my/) and in #3499.

I added `if vim.fn.has "nvim-0.11" == 1 then ... else ... end` conditionals for robust `vim.validate()` checks. Compatible with older versions.

Fixes #3499

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

_I have ran `make test`  with no failures nor warnings._

**Configuration**: [`DrKJeff16/nvim`](https://github.com/DrKJeff16/nvim)
* Neovim version (nvim --version): `NVIM v0.12.0-dev-1565+gb80d390765`
* Operating system and version: Arch Linux (`Linux 6.17.6-arch1-1`)

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)

The last two checkboxes were not needed, in my opinion.