### PR TITLE
fix: removed 'autoload' from rockspec build.copy_directories

### DIFF
--- a/telescope.nvim-scm-1.rockspec
+++ b/telescope.nvim-scm-1.rockspec
@@ -6,8 +6,8 @@ version = MODREV .. SPECREV
 description = {
   summary = 'Find, Filter, Preview, Pick. All lua, all the time.',
   detailed = [[
-  A highly extendable fuzzy finder over lists. 
-  Built on the latest awesome features from neovim core. 
+  A highly extendable fuzzy finder over lists.
+  Built on the latest awesome features from neovim core.
   Telescope is centered around modularity, allowing for easy customization.
   ]],
   labels = { 'neovim', 'plugin', },
@@ -31,7 +31,6 @@ build = {
     'ftplugin',
     'plugin',
     'scripts',
-    'autoload',
     'data',
   }
 }


### PR DESCRIPTION
# Description

Installing telescope via luarocks broke after this commit <https://github.com/nvim-telescope/telescope.nvim/commit/02ec064019d607ff279988496334c3a7b14e95bd>, this was because the `autoload` directory was removed, which caused luarocks to fail when copying this (non-existent) directory. 

The solution was to simply remove the relevant entry from the rockspec.

Fixes #3558 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

commands:
```
> luarocks purge
Removing luassert 1.9.0-1...
Removing plenary.nvim scm-1...
Removing say 1.4.1-3...
Removing telescope.nvim scm-1...
> luarocks install .\telescope.nvim-scm-1.rockspec
Cloning into 'telescope.nvim'...
remote: Enumerating objects: 11672, done.
remote: Counting objects: 100% (104/104), done.
remote: Compressing objects: 100% (76/76), done.
remote: Total 11672 (delta 56), reused 36 (delta 28), pack-reused 11568 (from 2)
Receiving objects: 100% (11672/11672), 4.48 MiB | 8.75 MiB/s, done.
Resolving deltas: 100% (7318/7318), done.

Missing dependencies for telescope.nvim scm-1:
   plenary.nvim (not installed)

telescope.nvim scm-1 depends on lua 5.1 (5.1-1 provided by VM: success)
telescope.nvim scm-1 depends on plenary.nvim (not installed)
Installing https://luarocks.org/plenary.nvim-scm-1.rockspec
Cloning into 'plenary.nvim'...
remote: Enumerating objects: 3069, done.
remote: Counting objects: 100% (920/920), done.
remote: Compressing objects: 100% (206/206), done.
remote: Total 3069 (delta 815), reused 714 (delta 714), pack-reused 2149 (from 2)
Receiving objects: 100% (3069/3069), 11.56 MiB | 38.68 MiB/s, done.
Resolving deltas: 100% (1669/1669), done.

Missing dependencies for plenary.nvim scm-1:
   luassert (not installed)

plenary.nvim scm-1 depends on lua >= 5.1, < 5.4 (5.1-1 provided by VM: success)
plenary.nvim scm-1 depends on luassert (not installed)
Installing https://luarocks.org/luassert-1.9.0-1.src.rock

Missing dependencies for luassert 1.9.0-1:
   say >= 1.4.0-1 (not installed)

luassert 1.9.0-1 depends on lua >= 5.1 (5.1-1 provided by VM: success)
luassert 1.9.0-1 depends on say >= 1.4.0-1 (not installed)
Installing https://luarocks.org/say-1.4.1-3.src.rock


say 1.4.1-3 depends on lua >= 5.1 (5.1-1 provided by VM: success)
say 1.4.1-3 is now installed in C:\Users\caeta\AppData\Roaming\LuaRocks\systree (license: MIT)

luassert 1.9.0-1 is now installed in C:\Users\caeta\AppData\Roaming\LuaRocks\systree (license: MIT <http://opensource.org/licenses/MIT>)

plenary.nvim scm-1 is now installed in C:\Users\caeta\AppData\Roaming\LuaRocks\systree (license: MIT/X11)

telescope.nvim scm-1 is now installed in C:\Users\caeta\AppData\Roaming\LuaRocks\systree (license: MIT)
```

**Configuration**: N/A
* Neovim version (nvim --version): N/A
* Operating system and version: Windows 11 Home 10.0.26200 N/A Build 26200

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
