### PR TITLE
refactor: remaining deprecations

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -478,7 +478,7 @@ actions.paste_register = function(prompt_bufnr)
   actions.close(prompt_bufnr)
 
   -- ensure that the buffer can be written to
-  if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), "modifiable") then
+  if vim.bo[0].modifiable then
     vim.api.nvim_paste(selection.content, true, -1)
   end
 end
@@ -1179,7 +1179,7 @@ actions.delete_buffer = function(prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
 
   current_picker:delete_selection(function(selection)
-    local force = vim.api.nvim_buf_get_option(selection.bufnr, "buftype") == "terminal"
+    local force = vim.bo[selection.bufnr].buftype == "terminal"
     local ok = pcall(vim.api.nvim_buf_delete, selection.bufnr, { force = force })
 
     -- If the current buffer is deleted, switch to the previous buffer
@@ -1399,10 +1399,10 @@ actions.which_key = function(prompt_bufnr, opts)
   local km_buf = a.nvim_win_get_buf(km_win_id)
   a.nvim_buf_set_name(km_buf, "_TelescopeWhichKey")
   a.nvim_buf_set_name(km_opts.border.bufnr, "_TelescopeTelescopeWhichKeyBorder")
-  a.nvim_win_set_option(km_win_id, "winhl", "Normal:" .. opts.normal_hl)
-  a.nvim_win_set_option(km_opts.border.win_id, "winhl", "Normal:" .. opts.border_hl)
-  a.nvim_win_set_option(km_win_id, "winblend", opts.winblend)
-  a.nvim_win_set_option(km_win_id, "foldenable", false)
+  vim.wo[km_win_id].winhl = "Normal:" .. opts.normal_hl
+  vim.wo[km_opts.border.win_id].winhl = "Normal:" .. opts.border_hl
+  vim.wo[km_win_id].winblend = opts.winblend
+  vim.wo[km_win_id].foldenable = false
 
   vim.api.nvim_create_autocmd("BufLeave", {
     buffer = km_buf,

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -188,8 +188,8 @@ action_set.edit = function(prompt_bufnr, command)
   end
 
   if entry_bufnr then
-    if not vim.api.nvim_buf_get_option(entry_bufnr, "buflisted") then
-      vim.api.nvim_buf_set_option(entry_bufnr, "buflisted", true)
+    if not vim.bo[entry_bufnr].buflisted then
+      vim.bo[entry_bufnr].buflisted = true
     end
     edit_buffer(command, entry_bufnr)
   else

--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -101,7 +101,7 @@ local diagnostics_to_tbl = function(opts)
 
     local root_dir_test = not opts.root_dir
       or string.sub(bufnr_name_map[diagnostic.bufnr], 1, #opts.root_dir) == opts.root_dir
-    local listed_test = not opts.no_unlisted or vim.api.nvim_buf_get_option(diagnostic.bufnr, "buflisted")
+    local listed_test = not opts.no_unlisted or vim.bo[diagnostic.bufnr].buflisted
 
     return root_dir_test and listed_test
   end

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -471,7 +471,7 @@ end
 files.current_buffer_fuzzy_find = function(opts)
   -- All actions are on the current buffer
   local filename = vim.api.nvim_buf_get_name(opts.bufnr)
-  local filetype = vim.api.nvim_buf_get_option(opts.bufnr, "filetype")
+  local filetype = vim.bo[opts.bufnr].filetype
 
   local lines = vim.api.nvim_buf_get_lines(opts.bufnr, 0, -1, false)
   local lines_with_numbers = {}

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -628,7 +628,7 @@ function make_entry.gen_from_buffer(opts)
     local bufname = filename and Path:new(filename):normalize(cwd) or "[No Name]"
 
     local hidden = entry.info.hidden == 1 and "h" or "a"
-    local readonly = vim.api.nvim_buf_get_option(entry.bufnr, "readonly") and "=" or " "
+    local readonly = vim.bo[entry.bufnr].readonly and "=" or " "
     local changed = entry.info.changed == 1 and "+" or " "
     local indicator = entry.flag .. hidden .. readonly .. changed
     local lnum = 1

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -513,10 +513,10 @@ function Picker:_create_window(bufnr, popup_opts)
   local what = bufnr or ""
   local win, opts = popup.create(what, popup_opts)
 
-  a.nvim_win_set_option(win, "winblend", self.window.winblend)
+  vim.wo[win].winblend = self.window.winblend
   local border_win = opts and opts.border and opts.border.win_id
   if border_win then
-    a.nvim_win_set_option(border_win, "winblend", self.window.winblend)
+    vim.wo[border_win].winblend = self.window.winblend
   end
   return win, opts, border_win
 end
@@ -557,13 +557,13 @@ function Picker:find()
     self.preview_win, self.preview_bufnr, self.preview_border = nil, nil, nil
   end
 
-  pcall(a.nvim_buf_set_option, self.results_bufnr, "tabstop", 1) -- #1834
-  pcall(a.nvim_buf_set_option, self.prompt_bufnr, "tabstop", 1) -- #1834
-  a.nvim_buf_set_option(self.prompt_bufnr, "buftype", "prompt")
-  a.nvim_win_set_option(self.results_win, "wrap", self.wrap_results)
-  a.nvim_win_set_option(self.prompt_win, "wrap", true)
+  pcall(a.nvim_set_option_value, "tabstop", 1, { buf = self.results_bufnr }) -- #1834
+  pcall(a.nvim_set_option_value, "tabstop", 1, { buf = self.prompt_bufnr }) -- #1834
+  vim.bo[self.prompt_bufnr].buftype = "prompt"
+  vim.wo[self.results_win].wrap = self.wrap_results
+  vim.wo[self.prompt_win].wrap = true
   if self.preview_win then
-    a.nvim_win_set_option(self.preview_win, "wrap", true)
+    vim.wo[self.preview_win].wrap = true
   end
 
   -- Prompt prefix
@@ -613,8 +613,8 @@ function Picker:find()
     self.sorter:_init()
 
     -- Do filetype last, so that users can register at the last second.
-    pcall(a.nvim_buf_set_option, self.prompt_bufnr, "filetype", "TelescopePrompt")
-    pcall(a.nvim_buf_set_option, self.results_bufnr, "filetype", "TelescopeResults")
+    pcall(a.nvim_set_option_value, "filetype", "TelescopePrompt", { buf = self.prompt_bufnr })
+    pcall(a.nvim_set_option_value, "filetype", "TelescopeResults", { buf = self.results_bufnr })
 
     await_schedule()
 
@@ -1000,7 +1000,7 @@ function Picker:change_prompt_prefix(new_prefix, hl_group)
     vim.fn.prompt_setprompt(self.prompt_bufnr, new_prefix)
   else
     vim.api.nvim_buf_set_text(self.prompt_bufnr, 0, 0, 0, #self.prompt_prefix, {})
-    vim.api.nvim_buf_set_option(self.prompt_bufnr, "buftype", "")
+    vim.bo[self.prompt_bufnr].buftype = ""
   end
   self.prompt_prefix = new_prefix
   self:_reset_prefix_color(hl_group)

--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -326,7 +326,7 @@ local scroll_horizontal_fn = function(self, direction)
   local count = math.abs(direction)
 
   vim.api.nvim_win_call(self.state.winid, function()
-    vim.api.nvim_win_set_option(self.state.winid, "virtualedit", "all")
+    vim.wo[self.state.winid].virtualedit = "all"
     vim.cmd([[normal! ]] .. count .. input)
   end)
 end
@@ -423,7 +423,7 @@ previewers.new_buffer_previewer = function(opts)
     else
       local bufnr = vim.api.nvim_create_buf(false, true)
       set_bufnr(self, bufnr)
-      vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
+      vim.bo[bufnr].modifiable = true
 
       vim.schedule(function()
         if vim.api.nvim_buf_is_valid(bufnr) then
@@ -431,11 +431,11 @@ previewers.new_buffer_previewer = function(opts)
         end
       end)
 
-      vim.api.nvim_win_set_option(preview_winid, "winhl", "Normal:TelescopePreviewNormal")
-      vim.api.nvim_win_set_option(preview_winid, "signcolumn", "no")
-      vim.api.nvim_win_set_option(preview_winid, "foldlevel", 100)
-      vim.api.nvim_win_set_option(preview_winid, "wrap", false)
-      vim.api.nvim_win_set_option(preview_winid, "scrollbind", false)
+      vim.wo[preview_window_id].winhl = "Normal:TelescopePreviewNormal"
+      vim.wo[preview_window_id].signcolumn = "no"
+      vim.wo[preview_window_id].foldlevel = 100
+      vim.wo[preview_window_id].wrap = false
+      vim.wo[preview_window_id].scrollbind = false
 
       self.state.winid = preview_winid
       self.state.bufname = nil
@@ -561,9 +561,7 @@ previewers.vimgrep = defaulter(function(opts)
 
     define_preview = function(self, entry)
       -- builtin.buffers: bypass path validation for terminal buffers that don't have appropriate path
-      local has_buftype = entry.bufnr
-          and vim.api.nvim_buf_is_valid(entry.bufnr)
-          and vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= ""
+      local has_buftype = entry.bufnr and vim.api.nvim_buf_is_valid(entry.bufnr) and vim.bo[entry.bufnr].buftype ~= ""
         or false
       local p
       if not has_buftype then
@@ -1040,7 +1038,7 @@ previewers.autocommands = defaulter(function(_)
           )
         end
 
-        vim.api.nvim_buf_set_option(self.state.bufnr, "filetype", "vim")
+        vim.bo[self.state.bufnr].filetype = "vim"
         vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, display)
         utils.hl_range(self.state.bufnr, 0, "TelescopeBorder", { 1, 0 }, { 1, -1 })
       else

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -205,6 +205,7 @@ previewers.new_termopen_previewer = function(opts)
       local cmd = opts.get_command(entry, status)
       if cmd then
         vim.api.nvim_buf_call(bufnr, function()
+          --TODO(clason): replace with jobstart when dropping support for Nvim 0.10
           set_term_id(self, vim.fn.termopen(cmd, term_opts))
         end)
       end
@@ -286,7 +287,7 @@ previewers.vimgrep = defaulter(function(opts)
       if p == nil or p == "" then
         return
       end
-      if entry.bufnr and (p == "[No Name]" or vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= "") then
+      if entry.bufnr and (p == "[No Name]" or vim.bo[entry.bufnr].buftype ~= "") then
         return
       end
 

--- a/lua/telescope/previewers/utils.lua
+++ b/lua/telescope/previewers/utils.lua
@@ -161,7 +161,7 @@ end
 --- Attach regex highlighter
 utils.regex_highlighter = function(bufnr, ft)
   if has_filetype(ft) then
-    return pcall(vim.api.nvim_buf_set_option, bufnr, "syntax", ft)
+    return pcall(vim.api.nvim_set_option_value, "syntax", ft, { buf = bufnr })
   end
   return false
 end


### PR DESCRIPTION
- **refactor: replace deprecated nvim_*_{get,set}_option** (went with `vim.{bo,go}` over `{get,set}_option_value` where possible since those were already used in the codebase)
- ~~**refactor: replace deprecated termopen with jobstart**~~

~~@nvim-telescope/core I'd appreciate if someone could double-check whether the second commit broke something~~

Never mind, deprecation (and replacement) only happened after Nvim 0.10, so we will have to live with this one remaining deprecated API until we can move to Nvim 0.11+ only.