### PR TITLE
refactor: prefer local alias for vim.api, vim.lsp

### DIFF
--- a/lua/telescope/actions/init.lua
+++ b/lua/telescope/actions/init.lua
@@ -52,7 +52,7 @@
 --- file.
 ---@brief ]]
 
-local a = vim.api
+local api = vim.api
 
 local conf = require("telescope.config").values
 local state = require "telescope.state"
@@ -370,7 +370,7 @@ end
 
 actions.close_pum = function(_)
   if 0 ~= vim.fn.pumvisible() then
-    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<c-y>", true, true, true), "n", true)
+    api.nvim_feedkeys(api.nvim_replace_termcodes("<c-y>", true, true, true), "n", true)
   end
 end
 
@@ -379,14 +379,14 @@ end
 actions.close = function(prompt_bufnr)
   local picker = action_state.get_current_picker(prompt_bufnr)
   local original_win_id = picker.original_win_id
-  local cursor_valid, original_cursor = pcall(a.nvim_win_get_cursor, original_win_id)
+  local cursor_valid, original_cursor = pcall(api.nvim_win_get_cursor, original_win_id)
 
   actions.close_pum(prompt_bufnr)
 
   require("telescope.pickers").on_close_prompt(prompt_bufnr)
-  pcall(a.nvim_set_current_win, original_win_id)
-  if cursor_valid and a.nvim_get_mode().mode == "i" and picker._original_mode ~= "i" then
-    pcall(a.nvim_win_set_cursor, original_win_id, { original_cursor[1], original_cursor[2] + 1 })
+  pcall(api.nvim_set_current_win, original_win_id)
+  if cursor_valid and api.nvim_get_mode().mode == "i" and picker._original_mode ~= "i" then
+    pcall(api.nvim_win_set_cursor, original_win_id, { original_cursor[1], original_cursor[2] + 1 })
   end
 end
 
@@ -400,14 +400,14 @@ end
 
 local set_edit_line = function(prompt_bufnr, fname, prefix, postfix)
   postfix = vim.F.if_nil(postfix, "")
-  postfix = a.nvim_replace_termcodes(postfix, true, false, true)
+  postfix = api.nvim_replace_termcodes(postfix, true, false, true)
   local selection = action_state.get_selected_entry()
   if selection == nil then
     utils.__warn_no_selection(fname)
     return
   end
   actions.close(prompt_bufnr)
-  a.nvim_feedkeys(prefix .. selection.value .. postfix, "n", true)
+  api.nvim_feedkeys(prefix .. selection.value .. postfix, "n", true)
 end
 
 --- Set a value in the command line and don't run it, making it editable.
@@ -479,7 +479,7 @@ actions.paste_register = function(prompt_bufnr)
 
   -- ensure that the buffer can be written to
   if vim.bo[0].modifiable then
-    vim.api.nvim_paste(selection.content, true, -1)
+    api.nvim_paste(selection.content, true, -1)
   end
 end
 
@@ -489,7 +489,7 @@ actions.insert_symbol = function(prompt_bufnr)
   local symbol = action_state.get_selected_entry().value[1]
   actions.close(prompt_bufnr)
   vim.schedule(function()
-    vim.api.nvim_put({ symbol }, "", true, true)
+    api.nvim_put({ symbol }, "", true, true)
   end)
 end
 
@@ -500,7 +500,7 @@ actions.insert_symbol_i = function(prompt_bufnr)
   actions.close(prompt_bufnr)
   vim.schedule(function()
     vim.cmd [[startinsert]]
-    vim.api.nvim_put({ symbol }, "", true, true)
+    api.nvim_put({ symbol }, "", true, true)
   end)
 end
 
@@ -928,7 +928,7 @@ local send_selected_to_qf = function(prompt_bufnr, mode, target)
   local prompt = picker:_get_prompt()
   actions.close(prompt_bufnr)
 
-  vim.api.nvim_exec_autocmds("QuickFixCmdPre", {})
+  api.nvim_exec_autocmds("QuickFixCmdPre", {})
   if target == "loclist" then
     vim.fn.setloclist(picker.original_win_id, qf_entries, mode)
   else
@@ -936,7 +936,7 @@ local send_selected_to_qf = function(prompt_bufnr, mode, target)
     vim.fn.setqflist(qf_entries, mode)
     vim.fn.setqflist({}, "a", { title = qf_title })
   end
-  vim.api.nvim_exec_autocmds("QuickFixCmdPost", {})
+  api.nvim_exec_autocmds("QuickFixCmdPost", {})
 end
 
 local send_all_to_qf = function(prompt_bufnr, mode, target)
@@ -951,7 +951,7 @@ local send_all_to_qf = function(prompt_bufnr, mode, target)
   local prompt = picker:_get_prompt()
   actions.close(prompt_bufnr)
 
-  vim.api.nvim_exec_autocmds("QuickFixCmdPre", {})
+  api.nvim_exec_autocmds("QuickFixCmdPre", {})
   local qf_title = string.format([[%s (%s)]], picker.prompt_title, prompt)
   if target == "loclist" then
     vim.fn.setloclist(picker.original_win_id, qf_entries, mode)
@@ -960,7 +960,7 @@ local send_all_to_qf = function(prompt_bufnr, mode, target)
     vim.fn.setqflist(qf_entries, mode)
     vim.fn.setqflist({}, "a", { title = qf_title })
   end
-  vim.api.nvim_exec_autocmds("QuickFixCmdPost", {})
+  api.nvim_exec_autocmds("QuickFixCmdPost", {})
 end
 
 --- Sends the selected entries to the quickfix list, replacing the previous entries.
@@ -1120,7 +1120,7 @@ actions.complete_tag = function(prompt_bufnr)
   end
 
   -- incremental completion by substituting string starting from col - #line byte offset
-  local col = vim.api.nvim_win_get_cursor(0)[2] + 1
+  local col = api.nvim_win_get_cursor(0)[2] + 1
   vim.fn.complete(col - #line, filtered_tags)
 end
 
@@ -1180,33 +1180,33 @@ actions.delete_buffer = function(prompt_bufnr)
 
   current_picker:delete_selection(function(selection)
     local force = vim.bo[selection.bufnr].buftype == "terminal"
-    local ok = pcall(vim.api.nvim_buf_delete, selection.bufnr, { force = force })
+    local ok = pcall(api.nvim_buf_delete, selection.bufnr, { force = force })
 
     -- If the current buffer is deleted, switch to the previous buffer
     -- according to bdelete behavior
     if ok and selection.bufnr == current_picker.original_bufnr then
-      if vim.api.nvim_win_is_valid(current_picker.original_win_id) then
+      if api.nvim_win_is_valid(current_picker.original_win_id) then
         local jumplist = vim.fn.getjumplist(current_picker.original_win_id)[1]
         for i = #jumplist, 1, -1 do
           if jumplist[i].bufnr ~= selection.bufnr and vim.fn.bufloaded(jumplist[i].bufnr) == 1 then
-            vim.api.nvim_win_set_buf(current_picker.original_win_id, jumplist[i].bufnr)
+            api.nvim_win_set_buf(current_picker.original_win_id, jumplist[i].bufnr)
             current_picker.original_bufnr = jumplist[i].bufnr
             return ok
           end
         end
 
         -- no more valid buffers in jumplist, create an empty buffer
-        local empty_buf = vim.api.nvim_create_buf(true, true)
-        vim.api.nvim_win_set_buf(current_picker.original_win_id, empty_buf)
+        local empty_buf = api.nvim_create_buf(true, true)
+        api.nvim_win_set_buf(current_picker.original_win_id, empty_buf)
         current_picker.original_bufnr = empty_buf
-        vim.api.nvim_buf_delete(selection.bufnr, { force = true })
+        api.nvim_buf_delete(selection.bufnr, { force = true })
         return ok
       end
 
       -- window of the selected buffer got wiped, switch to first valid window
       local win_id = vim.fn.win_getid(1, current_picker.original_tabpage)
       current_picker.original_win_id = win_id
-      current_picker.original_bufnr = vim.api.nvim_win_get_buf(win_id)
+      current_picker.original_bufnr = api.nvim_win_get_buf(win_id)
     end
     return ok
   end)
@@ -1284,10 +1284,10 @@ actions.which_key = function(prompt_bufnr, opts)
   -- close on repeated keypress
   local km_bufs = (function()
     local ret = {}
-    local bufs = a.nvim_list_bufs()
+    local bufs = api.nvim_list_bufs()
     for _, buf in ipairs(bufs) do
       for _, bufname in ipairs { "_TelescopeWhichKey", "_TelescopeWhichKeyBorder" } do
-        if string.find(a.nvim_buf_get_name(buf), bufname) then
+        if string.find(api.nvim_buf_get_name(buf), bufname) then
           table.insert(ret, buf)
         end
       end
@@ -1299,7 +1299,7 @@ actions.which_key = function(prompt_bufnr, opts)
       utils.buf_delete(buf)
       local win_ids = vim.fn.win_findbuf(buf)
       for _, win_id in ipairs(win_ids) do
-        pcall(a.nvim_win_close, win_id, true)
+        pcall(api.nvim_win_close, win_id, true)
       end
     end
     return
@@ -1323,7 +1323,7 @@ actions.which_key = function(prompt_bufnr, opts)
   end
 
   local mappings = {}
-  local mode = a.nvim_get_mode().mode
+  local mode = api.nvim_get_mode().mode
   for _, v in pairs(action_utils.get_registered_mappings(prompt_bufnr)) do
     if v.desc and v.desc ~= "which_key" and v.desc ~= "nop" then
       if not opts.only_show_current_mode or mode == v.mode then
@@ -1367,7 +1367,7 @@ actions.which_key = function(prompt_bufnr, opts)
 
   -- place hints at top or bottom relative to prompt
   local win_central_row = function(win_nr)
-    return a.nvim_win_get_position(win_nr)[1] + 0.5 * a.nvim_win_get_height(win_nr)
+    return api.nvim_win_get_position(win_nr)[1] + 0.5 * api.nvim_win_get_height(win_nr)
   end
   -- TODO(fdschmidt93|l-kershaw): better generalization of where to put which key float
   local picker = action_state.get_current_picker(prompt_bufnr)
@@ -1396,43 +1396,49 @@ actions.which_key = function(prompt_bufnr, opts)
     zindex = opts.zindex,
   }
   local km_win_id, km_opts = popup.create("", popup_opts)
-  local km_buf = a.nvim_win_get_buf(km_win_id)
-  a.nvim_buf_set_name(km_buf, "_TelescopeWhichKey")
-  a.nvim_buf_set_name(km_opts.border.bufnr, "_TelescopeTelescopeWhichKeyBorder")
+  local km_buf = api.nvim_win_get_buf(km_win_id)
+  api.nvim_buf_set_name(km_buf, "_TelescopeWhichKey")
+  api.nvim_buf_set_name(km_opts.border.bufnr, "_TelescopeTelescopeWhichKeyBorder")
   vim.wo[km_win_id].winhl = "Normal:" .. opts.normal_hl
   vim.wo[km_opts.border.win_id].winhl = "Normal:" .. opts.border_hl
   vim.wo[km_win_id].winblend = opts.winblend
   vim.wo[km_win_id].foldenable = false
 
-  vim.api.nvim_create_autocmd("BufLeave", {
+  api.nvim_create_autocmd("BufLeave", {
     buffer = km_buf,
     once = true,
     callback = function()
-      pcall(vim.api.nvim_win_close, km_win_id, true)
-      pcall(vim.api.nvim_win_close, km_opts.border.win_id, true)
+      pcall(api.nvim_win_close, km_win_id, true)
+      pcall(api.nvim_win_close, km_opts.border.win_id, true)
       require("telescope.utils").buf_delete(km_buf)
     end,
   })
 
-  a.nvim_buf_set_lines(km_buf, 0, -1, false, utils.repeated_table(opts.num_rows + 2 * opts.line_padding, column_indent))
+  api.nvim_buf_set_lines(
+    km_buf,
+    0,
+    -1,
+    false,
+    utils.repeated_table(opts.num_rows + 2 * opts.line_padding, column_indent)
+  )
 
-  local keymap_highlights = a.nvim_create_namespace "telescope_whichkey"
+  local keymap_highlights = api.nvim_create_namespace "telescope_whichkey"
   local highlights = {}
   for index, mapping in ipairs(mappings) do
     local row = utils.cycle(index, opts.num_rows) - 1 + opts.line_padding
-    local prev_line = a.nvim_buf_get_lines(km_buf, row, row + 1, false)[1]
+    local prev_line = api.nvim_buf_get_lines(km_buf, row, row + 1, false)[1]
     if index == total_available_entries and total_available_entries > #mappings then
       local new_line = prev_line .. "..."
-      a.nvim_buf_set_lines(km_buf, row, row + 1, false, { new_line })
+      api.nvim_buf_set_lines(km_buf, row, row + 1, false, { new_line })
       break
     end
     local display, display_hl = make_display(mapping)
     local new_line = prev_line .. display .. opts.column_padding -- incl. padding
-    a.nvim_buf_set_lines(km_buf, row, row + 1, false, { new_line })
+    api.nvim_buf_set_lines(km_buf, row, row + 1, false, { new_line })
     table.insert(highlights, { hl = display_hl, row = row, col = #prev_line })
   end
 
-  -- highlighting only after line setting as vim.api.nvim_buf_set_lines removes hl otherwise
+  -- highlighting only after line setting as a.nvim_buf_set_lines removes hl otherwise
   for _, highlight_tbl in pairs(highlights) do
     local highlight = highlight_tbl.hl
     local row_ = highlight_tbl.row
@@ -1458,14 +1464,14 @@ actions.which_key = function(prompt_bufnr, opts)
   end
   -- only set up autocommand after showing preview completed
   vim.schedule(function()
-    vim.api.nvim_create_autocmd(close_event, {
+    api.nvim_create_autocmd(close_event, {
       pattern = close_pattern,
       buffer = close_buffer,
       once = true,
       callback = function()
         vim.schedule(function()
-          pcall(vim.api.nvim_win_close, km_win_id, true)
-          pcall(vim.api.nvim_win_close, km_opts.border.win_id, true)
+          pcall(api.nvim_win_close, km_win_id, true)
+          pcall(api.nvim_win_close, km_opts.border.win_id, true)
           utils.buf_delete(km_buf)
         end)
       end,
@@ -1516,9 +1522,9 @@ actions.delete_mark = function(prompt_bufnr)
 
     local success
     if mark:match "%u" then
-      success = pcall(vim.api.nvim_del_mark, mark)
+      success = pcall(api.nvim_del_mark, mark)
     else
-      success = pcall(vim.api.nvim_buf_del_mark, bufnr, mark)
+      success = pcall(api.nvim_buf_del_mark, bufnr, mark)
     end
     return success
   end)

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -11,7 +11,7 @@
 --- replace the `set` itself and then it will work great and they're done.
 ---@brief ]]
 
-local a = vim.api
+local api = vim.api
 
 local log = require "telescope.log"
 local Path = require "plenary.path"
@@ -35,7 +35,7 @@ local action_set = setmetatable({}, {
 action_set.shift_selection = function(prompt_bufnr, change)
   local count = vim.v.count
   count = count == 0 and 1 or count
-  count = a.nvim_get_mode().mode == "n" and count or 1
+  count = api.nvim_get_mode().mode == "n" and count or 1
   action_state.get_current_picker(prompt_bufnr):move_selection(change * count)
 end
 
@@ -101,7 +101,7 @@ do
     if buf_command ~= "drop" and buf_command ~= "tab drop" then
       vim.cmd(string.format("%s %d", buf_command, bufnr))
     else
-      vim.cmd(string.format("%s %s", buf_command, vim.fn.fnameescape(vim.api.nvim_buf_get_name(bufnr))))
+      vim.cmd(string.format("%s %s", buf_command, vim.fn.fnameescape(api.nvim_buf_get_name(bufnr))))
     end
   end
 end
@@ -170,7 +170,7 @@ action_set.edit = function(prompt_bufnr, command)
 
   local picker = action_state.get_current_picker(prompt_bufnr)
   require("telescope.pickers").on_close_prompt(prompt_bufnr)
-  pcall(vim.api.nvim_set_current_win, picker.original_win_id)
+  pcall(api.nvim_set_current_win, picker.original_win_id)
   local win_id = picker.get_selection_window(picker, entry)
 
   if picker.push_cursor_on_edit then
@@ -183,8 +183,8 @@ action_set.edit = function(prompt_bufnr, command)
     vim.fn.settagstack(vim.fn.win_getid(), { items = items }, "t")
   end
 
-  if win_id ~= 0 and a.nvim_get_current_win() ~= win_id then
-    vim.api.nvim_set_current_win(win_id)
+  if win_id ~= 0 and api.nvim_get_current_win() ~= win_id then
+    api.nvim_set_current_win(win_id)
   end
 
   if entry_bufnr then
@@ -195,7 +195,7 @@ action_set.edit = function(prompt_bufnr, command)
   else
     -- check if we didn't pick a different buffer
     -- prevents restarting lsp server
-    if vim.api.nvim_buf_get_name(0) ~= filename or command ~= "edit" then
+    if api.nvim_buf_get_name(0) ~= filename or command ~= "edit" then
       filename = Path:new(filename):normalize(vim.uv.cwd())
       pcall(vim.cmd, string.format("%s %s", command, vim.fn.fnameescape(filename)))
     end
@@ -208,7 +208,7 @@ action_set.edit = function(prompt_bufnr, command)
     end)
   end
 
-  local pos = vim.api.nvim_win_get_cursor(0)
+  local pos = api.nvim_win_get_cursor(0)
   if col == nil then
     if row == pos[1] then
       col = pos[2] + 1
@@ -220,10 +220,10 @@ action_set.edit = function(prompt_bufnr, command)
   end
 
   if row and col then
-    if vim.api.nvim_buf_get_name(0) == filename then
+    if api.nvim_buf_get_name(0) == filename then
       vim.cmd [[normal! m']]
     end
-    local ok, err_msg = pcall(a.nvim_win_set_cursor, 0, { row, col })
+    local ok, err_msg = pcall(api.nvim_win_set_cursor, 0, { row, col })
     if not ok then
       log.debug("Failed to move to cursor:", err_msg, row, col)
     end
@@ -243,7 +243,7 @@ local __scroll_previewer = function(prompt_bufnr)
     return
   end
 
-  local default_speed = vim.api.nvim_win_get_height(preview_winid) / 2
+  local default_speed = api.nvim_win_get_height(preview_winid) / 2
   local speed = status.picker.layout_config.scroll_speed or default_speed
   return previewer, speed
 end
@@ -282,12 +282,12 @@ end
 --      Valid directions include: "1", "-1"
 action_set.scroll_results = function(prompt_bufnr, direction)
   local status = state.get_status(prompt_bufnr)
-  local default_speed = vim.api.nvim_win_get_height(status.layout.results.winid) / 2
+  local default_speed = api.nvim_win_get_height(status.layout.results.winid) / 2
   local speed = status.picker.layout_config.scroll_speed or default_speed
 
   local input = direction > 0 and [[]] or [[]]
 
-  vim.api.nvim_win_call(status.layout.results.winid, function()
+  api.nvim_win_call(status.layout.results.winid, function()
     vim.cmd([[normal! ]] .. math.floor(speed) .. input)
   end)
 
@@ -302,12 +302,12 @@ end
 --      Valid directions include: "1", "-1"
 action_set.scroll_horizontal_results = function(prompt_bufnr, direction)
   local status = state.get_status(prompt_bufnr)
-  local default_speed = vim.api.nvim_win_get_height(status.results_win) / 2
+  local default_speed = api.nvim_win_get_height(status.results_win) / 2
   local speed = status.picker.layout_config.scroll_speed or default_speed
 
   local input = direction > 0 and [[zl]] or [[zh]]
 
-  vim.api.nvim_win_call(status.results_win, function()
+  api.nvim_win_call(status.results_win, function()
     vim.cmd([[normal! ]] .. math.floor(speed) .. input)
   end)
 end

--- a/lua/telescope/builtin/__files.lua
+++ b/lua/telescope/builtin/__files.lua
@@ -1,3 +1,5 @@
+local api = vim.api
+
 local action_state = require "telescope.actions.state"
 local action_set = require "telescope.actions.set"
 local actions = require "telescope.actions"
@@ -66,14 +68,14 @@ local get_open_filelist = function(grep_open_files, cwd)
       return false
     end
     return true
-  end, vim.api.nvim_list_bufs())
+  end, api.nvim_list_bufs())
   if not next(bufnrs) then
     return
   end
 
   local filelist = {}
   for _, bufnr in ipairs(bufnrs) do
-    local file = vim.api.nvim_buf_get_name(bufnr)
+    local file = api.nvim_buf_get_name(bufnr)
     table.insert(filelist, Path:new(file):make_relative(cwd))
   end
   return filelist
@@ -470,10 +472,10 @@ end
 
 files.current_buffer_fuzzy_find = function(opts)
   -- All actions are on the current buffer
-  local filename = vim.api.nvim_buf_get_name(opts.bufnr)
+  local filename = api.nvim_buf_get_name(opts.bufnr)
   local filetype = vim.bo[opts.bufnr].filetype
 
-  local lines = vim.api.nvim_buf_get_lines(opts.bufnr, 0, -1, false)
+  local lines = api.nvim_buf_get_lines(opts.bufnr, 0, -1, false)
   local lines_with_numbers = {}
 
   for lnum, line in ipairs(lines) do
@@ -569,7 +571,7 @@ files.current_buffer_fuzzy_find = function(opts)
           actions.close(prompt_bufnr)
           vim.schedule(function()
             vim.cmd "normal! m'"
-            vim.api.nvim_win_set_cursor(0, { selection.lnum, first_col })
+            api.nvim_win_set_cursor(0, { selection.lnum, first_col })
           end)
         end)
 
@@ -619,7 +621,7 @@ files.tags = function(opts)
               vim.fn.search(scode)
               vim.cmd "norm! zz"
             else
-              vim.api.nvim_win_set_cursor(0, { selection.lnum, 0 })
+              api.nvim_win_set_cursor(0, { selection.lnum, 0 })
             end
           end,
         }

--- a/lua/telescope/builtin/__git.lua
+++ b/lua/telescope/builtin/__git.lua
@@ -1,3 +1,5 @@
+local api = vim.api
+
 local actions = require "telescope.actions"
 local action_state = require "telescope.actions.state"
 local finders = require "telescope.finders"
@@ -111,8 +113,8 @@ git.stash = function(opts)
 end
 
 local get_current_buf_line = function(winnr)
-  local lnum = vim.api.nvim_win_get_cursor(winnr)[1]
-  return vim.trim(vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(winnr), lnum - 1, lnum, false)[1])
+  local lnum = api.nvim_win_get_cursor(winnr)[1]
+  return vim.trim(api.nvim_buf_get_lines(api.nvim_win_get_buf(winnr), lnum - 1, lnum, false)[1])
 end
 
 local bcommits_picker = function(opts, title, finder)
@@ -136,9 +138,9 @@ local bcommits_picker = function(opts, title, finder)
         local value = selection.value .. ":" .. transfrom_file()
         local content = utils.get_os_command_output({ "git", "--no-pager", "show", value }, opts.cwd)
 
-        local bufnr = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, content)
-        vim.api.nvim_buf_set_name(bufnr, "Original")
+        local bufnr = api.nvim_create_buf(false, true)
+        api.nvim_buf_set_lines(bufnr, 0, -1, false, content)
+        api.nvim_buf_set_name(bufnr, "Original")
         return bufnr
       end
 
@@ -151,12 +153,12 @@ local bcommits_picker = function(opts, title, finder)
         vim.bo.filetype = ft
         vim.cmd "diffthis"
 
-        vim.api.nvim_create_autocmd("WinClosed", {
+        api.nvim_create_autocmd("WinClosed", {
           buffer = bufnr,
           nested = true,
           once = true,
           callback = function()
-            vim.api.nvim_buf_delete(bufnr, { force = true })
+            api.nvim_buf_delete(bufnr, { force = true })
           end,
         })
       end
@@ -186,7 +188,7 @@ end
 
 git.bcommits = function(opts)
   opts.current_line = (opts.current_file == nil) and get_current_buf_line(opts.winnr) or nil
-  opts.current_file = vim.F.if_nil(opts.current_file, vim.api.nvim_buf_get_name(opts.bufnr))
+  opts.current_file = vim.F.if_nil(opts.current_file, api.nvim_buf_get_name(opts.bufnr))
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
   opts.git_command =
     vim.F.if_nil(opts.git_command, git_command({ "log", "--pretty=oneline", "--abbrev-commit", "--follow" }, opts))
@@ -204,7 +206,7 @@ end
 
 git.bcommits_range = function(opts)
   opts.current_line = (opts.current_file == nil) and get_current_buf_line(opts.winnr) or nil
-  opts.current_file = vim.F.if_nil(opts.current_file, vim.api.nvim_buf_get_name(opts.bufnr))
+  opts.current_file = vim.F.if_nil(opts.current_file, api.nvim_buf_get_name(opts.bufnr))
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
   opts.git_command = vim.F.if_nil(
     opts.git_command,

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -1,3 +1,5 @@
+local api = vim.api
+
 local actions = require "telescope.actions"
 local action_set = require "telescope.actions.set"
 local action_state = require "telescope.actions.state"
@@ -73,8 +75,8 @@ internal.builtin = function(opts)
     return a.text < b.text
   end)
 
-  opts.bufnr = vim.api.nvim_get_current_buf()
-  opts.winnr = vim.api.nvim_get_current_win()
+  opts.bufnr = api.nvim_get_current_buf()
+  opts.winnr = api.nvim_get_current_win()
   pickers
     .new(opts, {
       prompt_title = title,
@@ -281,7 +283,7 @@ end
 
 internal.symbols = function(opts)
   local initial_mode = vim.fn.mode()
-  local files = vim.api.nvim_get_runtime_file("data/telescope-sources/*.json", true)
+  local files = api.nvim_get_runtime_file("data/telescope-sources/*.json", true)
   local data_path = (function()
     if not opts.symbol_path then
       return Path:new { vim.fn.stdpath "data", "telescope", "symbols" }
@@ -361,7 +363,7 @@ internal.commands = function(opts)
       prompt_title = "Commands",
       finder = finders.new_table {
         results = (function()
-          local command_iter = vim.api.nvim_get_commands {}
+          local command_iter = api.nvim_get_commands {}
           local commands = {}
 
           for _, cmd in pairs(command_iter) do
@@ -371,7 +373,7 @@ internal.commands = function(opts)
           local need_buf_command = vim.F.if_nil(opts.show_buf_command, true)
 
           if need_buf_command then
-            local buf_command_iter = vim.api.nvim_buf_get_commands(0, {})
+            local buf_command_iter = api.nvim_buf_get_commands(0, {})
             buf_command_iter[true] = nil -- remove the redundant entry
             for _, cmd in pairs(buf_command_iter) do
               table.insert(commands, cmd)
@@ -396,11 +398,11 @@ internal.commands = function(opts)
           local cmd = string.format([[:%s ]], val.name)
 
           if val.nargs == "0" then
-            local cr = vim.api.nvim_replace_termcodes("<cr>", true, false, true)
+            local cr = api.nvim_replace_termcodes("<cr>", true, false, true)
             cmd = cmd .. cr
           end
           vim.cmd [[stopinsert]]
-          vim.api.nvim_feedkeys(cmd, "nt", false)
+          api.nvim_feedkeys(cmd, "nt", false)
         end)
 
         return true
@@ -476,7 +478,7 @@ internal.quickfixhistory = function(opts)
           local entries = vim.tbl_map(function(i)
             return qf_entry_maker(i):display()
           end, entry.items)
-          vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, entries)
+          api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, entries)
         end,
       },
       sorter = conf.generic_sorter(opts),
@@ -505,7 +507,7 @@ internal.loclist = function(opts)
   for _, value in pairs(locations) do
     local bufnr = value.bufnr
     if filenames[bufnr] == nil then
-      filenames[bufnr] = vim.api.nvim_buf_get_name(bufnr)
+      filenames[bufnr] = api.nvim_buf_get_name(bufnr)
     end
     value.filename = filenames[bufnr]
   end
@@ -532,8 +534,8 @@ internal.oldfiles = function(opts)
   opts = apply_cwd_only_aliases(opts)
   opts.include_current_session = vim.F.if_nil(opts.include_current_session, true)
 
-  local current_buffer = vim.api.nvim_get_current_buf()
-  local current_file = vim.api.nvim_buf_get_name(current_buffer)
+  local current_buffer = api.nvim_get_current_buf()
+  local current_file = api.nvim_buf_get_name(current_buffer)
   local results = {}
 
   if utils.iswin then -- for slash problem in windows
@@ -545,7 +547,7 @@ internal.oldfiles = function(opts)
       local match = tonumber(string.match(buffer, "%s*(%d+)"))
       local open_by_lsp = string.match(buffer, "line 0$")
       if match and not open_by_lsp then
-        local file = vim.api.nvim_buf_get_name(match)
+        local file = api.nvim_buf_get_name(match)
         if utils.iswin then
           file = file:gsub("/", "\\")
         end
@@ -659,8 +661,8 @@ end
 
 internal.vim_options = function(opts)
   local res = {}
-  for _, v in pairs(vim.api.nvim_get_all_options_info()) do
-    local ok, value = pcall(vim.api.nvim_get_option_value, v.name, {})
+  for _, v in pairs(api.nvim_get_all_options_info()) do
+    local ok, value = pcall(api.nvim_get_option_value, v.name, {})
     if ok then
       v.value = value
       table.insert(res, v)
@@ -688,10 +690,10 @@ internal.vim_options = function(opts)
 
           local esc = ""
           if vim.fn.mode() == "i" then
-            esc = vim.api.nvim_replace_termcodes("<esc>", true, false, true)
+            esc = api.nvim_replace_termcodes("<esc>", true, false, true)
           end
 
-          vim.api.nvim_feedkeys(
+          api.nvim_feedkeys(
             selection.value.type == "boolean" and string.format("%s:set %s!", esc, selection.value.name)
               or string.format("%s:set %s=%s", esc, selection.value.name, selection.value.value),
             "m",
@@ -928,14 +930,14 @@ internal.buffers = function(opts)
       return false
     end
     -- only hide unloaded buffers if opts.show_all_buffers is false, keep them listed if true or nil
-    if opts.show_all_buffers == false and not vim.api.nvim_buf_is_loaded(bufnr) then
+    if opts.show_all_buffers == false and not api.nvim_buf_is_loaded(bufnr) then
       return false
     end
-    if opts.ignore_current_buffer and bufnr == vim.api.nvim_get_current_buf() then
+    if opts.ignore_current_buffer and bufnr == api.nvim_get_current_buf() then
       return false
     end
 
-    local bufname = vim.api.nvim_buf_get_name(bufnr)
+    local bufname = api.nvim_buf_get_name(bufnr)
 
     if opts.cwd_only and not buf_in_cwd(bufname, vim.uv.cwd()) then
       return false
@@ -944,7 +946,7 @@ internal.buffers = function(opts)
       return false
     end
     return true
-  end, vim.api.nvim_list_bufs())
+  end, api.nvim_list_bufs())
 
   if not next(bufnrs) then
     utils.notify("builtin.buffers", { msg = "No buffers found with the provided options", level = "INFO" })
@@ -1012,7 +1014,7 @@ end
 
 internal.colorscheme = function(opts)
   local before_background = vim.o.background
-  local before_color = vim.api.nvim_exec2("colorscheme", { output = true }).output
+  local before_color = api.nvim_exec2("colorscheme", { output = true }).output
   local need_restore = not not opts.enable_preview
 
   local colors = opts.colors or { before_color }
@@ -1056,8 +1058,8 @@ internal.colorscheme = function(opts)
   local previewer
   if opts.enable_preview then
     -- define previewer
-    local bufnr = vim.api.nvim_get_current_buf()
-    local p = vim.api.nvim_buf_get_name(bufnr)
+    local bufnr = api.nvim_get_current_buf()
+    local p = api.nvim_buf_get_name(bufnr)
 
     -- show current buffer content in previewer
     previewer = previewers.new_buffer_previewer {
@@ -1068,8 +1070,8 @@ internal.colorscheme = function(opts)
         if vim.uv.fs_stat(p) then
           conf.buffer_previewer_maker(p, self.state.bufnr, { bufname = self.state.bufname })
         else
-          local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-          vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+          local lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
+          api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
         end
       end,
     }
@@ -1144,19 +1146,19 @@ internal.marks = function(opts)
   local local_marks = {
     items = vim.fn.getmarklist(opts.bufnr),
     name_func = function(_, line)
-      return vim.api.nvim_buf_get_lines(opts.bufnr, line - 1, line, false)[1]
+      return api.nvim_buf_get_lines(opts.bufnr, line - 1, line, false)[1]
     end,
   }
   local global_marks = {
     items = vim.fn.getmarklist(),
     name_func = function(mark, _)
       -- get buffer name if it is opened, otherwise get file name
-      return vim.api.nvim_get_mark(mark, {})[4]
+      return api.nvim_get_mark(mark, {})[4]
     end,
   }
   local marks_table = {}
   local marks_others = {}
-  local bufname = vim.api.nvim_buf_get_name(opts.bufnr)
+  local bufname = api.nvim_buf_get_name(opts.bufnr)
   local all_marks = {}
   opts.mark_type = vim.F.if_nil(opts.mark_type, "all")
   if opts.mark_type == "all" then
@@ -1265,8 +1267,8 @@ internal.keymaps = function(opts)
   end
 
   for _, mode in pairs(opts.modes) do
-    local global = vim.api.nvim_get_keymap(mode)
-    local buf_local = vim.api.nvim_buf_get_keymap(0, mode)
+    local global = api.nvim_get_keymap(mode)
+    local buf_local = api.nvim_buf_get_keymap(0, mode)
     if not opts.only_buf then
       extract_keymaps(global)
     end
@@ -1290,7 +1292,7 @@ internal.keymaps = function(opts)
             return
           end
 
-          vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(selection.value.lhs, true, false, true), "t", true)
+          api.nvim_feedkeys(api.nvim_replace_termcodes(selection.value.lhs, true, false, true), "t", true)
           return actions.close(prompt_bufnr)
         end)
         return true
@@ -1356,7 +1358,7 @@ internal.highlights = function(opts)
 end
 
 internal.autocommands = function(opts)
-  local autocmds = vim.api.nvim_get_autocmds {}
+  local autocmds = api.nvim_get_autocmds {}
   table.sort(autocmds, function(lhs, rhs)
     return lhs.event < rhs.event
   end)
@@ -1453,13 +1455,13 @@ internal.tagstack = function(opts)
   for i = #tagstack, 1, -1 do
     local tag = tagstack[i]
     tag.bufnr = tag.from[1]
-    if vim.api.nvim_buf_is_valid(tag.bufnr) then
+    if api.nvim_buf_is_valid(tag.bufnr) then
       tags[#tags + 1] = tag
       tag.filename = vim.fn.bufname(tag.bufnr)
       tag.lnum = tag.from[2]
       tag.col = tag.from[3]
 
-      tag.text = vim.api.nvim_buf_get_lines(tag.bufnr, tag.lnum - 1, tag.lnum, false)[1] or ""
+      tag.text = api.nvim_buf_get_lines(tag.bufnr, tag.lnum - 1, tag.lnum, false)[1] or ""
     end
   end
 
@@ -1491,8 +1493,8 @@ internal.jumplist = function(opts)
   -- reverse the list
   local sorted_jumplist = {}
   for i = #jumplist, 1, -1 do
-    if vim.api.nvim_buf_is_valid(jumplist[i].bufnr) then
-      jumplist[i].text = vim.api.nvim_buf_get_lines(jumplist[i].bufnr, jumplist[i].lnum - 1, jumplist[i].lnum, false)[1]
+    if api.nvim_buf_is_valid(jumplist[i].bufnr) then
+      jumplist[i].text = api.nvim_buf_get_lines(jumplist[i].bufnr, jumplist[i].lnum - 1, jumplist[i].lnum, false)[1]
         or ""
       table.insert(sorted_jumplist, jumplist[i])
     end

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -34,6 +34,8 @@
 --- TODO: Document something we call `entry_index`
 ---@brief ]]
 
+local api = vim.api
+
 local entry_display = require "telescope.pickers.entry_display"
 local utils = require "telescope.utils"
 local strings = require "plenary.strings"
@@ -71,7 +73,7 @@ local get_filename_fn = function()
       return c
     end
 
-    local n = vim.api.nvim_buf_get_name(bufnr)
+    local n = api.nvim_buf_get_name(bufnr)
     bufnr_name_cache[bufnr] = n
     return n
   end
@@ -499,7 +501,7 @@ end
 function make_entry.gen_from_lsp_symbols(opts)
   opts = opts or {}
 
-  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  local bufnr = opts.bufnr or api.nvim_get_current_buf()
 
   -- Default we have two columns, symbol and type(unbound)
   -- If path is not hidden then its, filepath, symbol and type(still unbound)
@@ -530,7 +532,7 @@ function make_entry.gen_from_lsp_symbols(opts)
     local msg
 
     if opts.show_line then
-      msg = vim.trim(vim.F.if_nil(vim.api.nvim_buf_get_lines(bufnr, entry.lnum - 1, entry.lnum, false)[1], ""))
+      msg = vim.trim(vim.F.if_nil(api.nvim_buf_get_lines(bufnr, entry.lnum - 1, entry.lnum, false)[1], ""))
     end
 
     if hidden then
@@ -636,8 +638,8 @@ function make_entry.gen_from_buffer(opts)
     -- account for potentially stale lnum as getbufinfo might not be updated or from resuming buffers picker
     if entry.info.lnum ~= 0 then
       -- but make sure the buffer is loaded, otherwise line_count is 0
-      if vim.api.nvim_buf_is_loaded(entry.bufnr) then
-        local line_count = vim.api.nvim_buf_line_count(entry.bufnr)
+      if api.nvim_buf_is_loaded(entry.bufnr) then
+        local line_count = api.nvim_buf_line_count(entry.bufnr)
         lnum = math.max(math.min(entry.info.lnum, line_count), 1)
       else
         lnum = entry.info.lnum
@@ -660,7 +662,7 @@ end
 function make_entry.gen_from_treesitter(opts)
   opts = opts or {}
 
-  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  local bufnr = opts.bufnr or api.nvim_get_current_buf()
 
   local display_items = {
     { width = opts.symbol_width or 25 },
@@ -680,7 +682,7 @@ function make_entry.gen_from_treesitter(opts)
   local type_highlight = opts.symbol_highlights or treesitter_type_highlight
 
   local make_display = function(entry)
-    local msg = vim.api.nvim_buf_get_lines(bufnr, entry.lnum, entry.lnum, false)[1] or ""
+    local msg = api.nvim_buf_get_lines(bufnr, entry.lnum, entry.lnum, false)[1] or ""
     msg = vim.trim(msg)
 
     local display_columns = {
@@ -1019,7 +1021,7 @@ function make_entry.gen_from_ctags(opts)
 
   local show_kind = vim.F.if_nil(opts.show_kind, true)
   local cwd = utils.path_expand(opts.cwd or vim.uv.cwd())
-  local current_file = Path:new(vim.api.nvim_buf_get_name(opts.bufnr)):normalize(cwd)
+  local current_file = Path:new(api.nvim_buf_get_name(opts.bufnr)):normalize(cwd)
 
   local display_items = {
     { width = 16 },

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -123,7 +123,7 @@
 --- </code>
 ---@brief ]]
 
-local a = vim.api
+local api = vim.api
 
 local actions = require "telescope.actions"
 local config = require "telescope.config"
@@ -291,7 +291,7 @@ local telescope_map = function(prompt_bufnr, mode, key_bind, key_func, opts)
 
   vim.keymap.set(mode, key_bind, function()
     local ret = key_func(prompt_bufnr)
-    vim.api.nvim_exec_autocmds("User", { pattern = "TelescopeKeymap" })
+    api.nvim_exec_autocmds("User", { pattern = "TelescopeKeymap" })
     return ret
   end, vim.tbl_extend("force", opts, { buffer = prompt_bufnr, desc = get_desc_for_keyfunc(key_func, opts) }))
 end
@@ -316,7 +316,7 @@ mappings.apply_keymap = function(prompt_bufnr, attach_mappings, buffer_keymap)
 
     for _, mode in pairs(modes) do
       mode = string.lower(mode)
-      local key_bind_internal = a.nvim_replace_termcodes(key_bind, true, true, true)
+      local key_bind_internal = api.nvim_replace_termcodes(key_bind, true, true, true)
       applied_mappings[mode][key_bind_internal] = true
 
       telescope_map(prompt_bufnr, mode, key_bind, key_func, opts)
@@ -342,7 +342,7 @@ mappings.apply_keymap = function(prompt_bufnr, attach_mappings, buffer_keymap)
     mode = string.lower(mode)
 
     for key_bind, key_func in pairs(mode_map) do
-      local key_bind_internal = a.nvim_replace_termcodes(key_bind, true, true, true)
+      local key_bind_internal = api.nvim_replace_termcodes(key_bind, true, true, true)
       if not applied_mappings[mode][key_bind_internal] then
         applied_mappings[mode][key_bind_internal] = true
         telescope_map(prompt_bufnr, mode, key_bind, key_func, extract_keymap_opts(key_func))
@@ -355,7 +355,7 @@ mappings.apply_keymap = function(prompt_bufnr, attach_mappings, buffer_keymap)
     mode = string.lower(mode)
 
     for key_bind, key_func in pairs(mode_map) do
-      local key_bind_internal = a.nvim_replace_termcodes(key_bind, true, true, true)
+      local key_bind_internal = api.nvim_replace_termcodes(key_bind, true, true, true)
       if not applied_mappings[mode][key_bind_internal] then
         applied_mappings[mode][key_bind_internal] = true
         telescope_map(prompt_bufnr, mode, key_bind, key_func, extract_keymap_opts(key_func))

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -1,6 +1,6 @@
 require "telescope"
 
-local a = vim.api
+local api = vim.api
 
 local async = require "plenary.async"
 local await_schedule = async.util.scheduler
@@ -27,9 +27,9 @@ local MultiSelect = require "telescope.pickers.multi"
 local truncate = require("plenary.strings").truncate
 local strdisplaywidth = require("plenary.strings").strdisplaywidth
 
-local ns_telescope_matching = a.nvim_create_namespace "telescope_matching"
-local ns_telescope_prompt = a.nvim_create_namespace "telescope_prompt"
-local ns_telescope_prompt_prefix = a.nvim_create_namespace "telescope_prompt_prefix"
+local ns_telescope_matching = api.nvim_create_namespace "telescope_matching"
+local ns_telescope_prompt = api.nvim_create_namespace "telescope_prompt"
+local ns_telescope_prompt_prefix = api.nvim_create_namespace "telescope_prompt_prefix"
 
 ---@class telescope_popup_options
 ---@field border table<1|2|3|4, integer>
@@ -91,7 +91,7 @@ local function default_create_layout(picker)
       end
 
       local results_win, results_opts = picker:_create_window("", popup_opts.results)
-      local results_bufnr = a.nvim_win_get_buf(results_win)
+      local results_bufnr = api.nvim_win_get_buf(results_win)
 
       self.results = Layout.Window {
         winid = results_win,
@@ -101,7 +101,7 @@ local function default_create_layout(picker)
 
       if popup_opts.preview then
         local preview_win, preview_opts = picker:_create_window("", popup_opts.preview)
-        local preview_bufnr = a.nvim_win_get_buf(preview_win)
+        local preview_bufnr = api.nvim_win_get_buf(preview_win)
 
         self.preview = Layout.Window {
           winid = preview_win,
@@ -111,7 +111,7 @@ local function default_create_layout(picker)
       end
 
       local prompt_win, prompt_opts = picker:_create_window("", popup_opts.prompt)
-      local prompt_bufnr = a.nvim_win_get_buf(prompt_win)
+      local prompt_bufnr = api.nvim_win_get_buf(prompt_win)
 
       self.prompt = Layout.Window {
         winid = prompt_win,
@@ -133,8 +133,8 @@ local function default_create_layout(picker)
       end
 
       -- we cant use win_delete. We first need to close and then delete the buffer
-      if vim.api.nvim_win_is_valid(self.prompt.winid) then
-        vim.api.nvim_win_close(self.prompt.winid, true)
+      if api.nvim_win_is_valid(self.prompt.winid) then
+        api.nvim_win_close(self.prompt.winid, true)
       end
       vim.schedule(function()
         utils.buf_delete(self.prompt.bufnr)
@@ -172,12 +172,12 @@ local function default_create_layout(picker)
           popup_opts.preview.borderhighlight = "TelescopePreviewBorder"
           popup_opts.preview.titlehighlight = "TelescopePreviewTitle"
           local preview_bufnr = (self.preview and self.preview.bufnr ~= nil)
-              and vim.api.nvim_buf_is_valid(self.preview.bufnr)
+              and api.nvim_buf_is_valid(self.preview.bufnr)
               and self.preview.bufnr
             or ""
           preview_win, preview_opts = picker:_create_window(preview_bufnr, popup_opts.preview)
           if preview_bufnr == "" then
-            preview_bufnr = a.nvim_win_get_buf(preview_win)
+            preview_bufnr = api.nvim_win_get_buf(preview_win)
           end
           self.preview = Layout.Window {
             winid = preview_win,
@@ -264,7 +264,7 @@ function Picker:new(opts)
     multi_icon = vim.F.if_nil(opts.multi_icon, config.values.multi_icon),
 
     initial_mode = vim.F.if_nil(opts.initial_mode, config.values.initial_mode),
-    _original_mode = vim.api.nvim_get_mode().mode,
+    _original_mode = api.nvim_get_mode().mode,
     debounce = vim.F.if_nil(tonumber(opts.debounce), nil),
 
     _finder_attached = true,
@@ -420,7 +420,7 @@ function Picker:clear_extra_rows(results_bufnr)
     return
   end
 
-  if not vim.api.nvim_buf_is_valid(results_bufnr) then
+  if not api.nvim_buf_is_valid(results_bufnr) then
     log.debug("Invalid results_bufnr for clearing:", results_bufnr)
     return
   end
@@ -429,7 +429,7 @@ function Picker:clear_extra_rows(results_bufnr)
   if self.sorting_strategy == "ascending" then
     local num_results = self.manager:num_results()
     worst_line = math.min(num_results, self.max_results)
-    ok, msg = pcall(vim.api.nvim_buf_set_lines, results_bufnr, worst_line, -1, false, {})
+    ok, msg = pcall(api.nvim_buf_set_lines, results_bufnr, worst_line, -1, false, {})
   else
     worst_line = self:get_row(self.manager:num_results())
     if worst_line <= 0 then
@@ -437,7 +437,7 @@ function Picker:clear_extra_rows(results_bufnr)
     end
 
     local empty_lines = utils.repeated_table(worst_line, "")
-    ok, msg = pcall(vim.api.nvim_buf_set_lines, results_bufnr, 0, worst_line, false, empty_lines)
+    ok, msg = pcall(api.nvim_buf_set_lines, results_bufnr, 0, worst_line, false, empty_lines)
   end
 
   if not ok then
@@ -527,17 +527,17 @@ function Picker:find()
   self.__original_mousemoveevent = vim.o.mousemoveevent
   vim.o.mousemoveevent = true
 
-  self.original_bufnr = a.nvim_get_current_buf()
-  self.original_win_id = a.nvim_get_current_win()
-  self.original_tabpage = a.nvim_get_current_tabpage()
+  self.original_bufnr = api.nvim_get_current_buf()
+  self.original_win_id = api.nvim_get_current_win()
+  self.original_tabpage = api.nvim_get_current_tabpage()
   _, self.original_cword = pcall(vim.fn.expand, "<cword>")
   _, self.original_cWORD = pcall(vim.fn.expand, "<cWORD>")
   _, self.original_cfile = pcall(vim.fn.expand, "<cfile>")
-  _, self.original_cline = pcall(vim.api.nvim_get_current_line)
+  _, self.original_cline = pcall(api.nvim_get_current_line)
   _, self.original_cline = pcall(vim.trim, self.original_cline)
 
   -- User autocmd run it before create Telescope window
-  vim.api.nvim_exec_autocmds("User", { pattern = "TelescopeFindPre" })
+  api.nvim_exec_autocmds("User", { pattern = "TelescopeFindPre" })
 
   local layout = self:create_layout()
   layout:mount()
@@ -554,8 +554,8 @@ function Picker:find()
     self.preview_win, self.preview_bufnr, self.preview_border = nil, nil, nil
   end
 
-  pcall(a.nvim_set_option_value, "tabstop", 1, { buf = self.results_bufnr }) -- #1834
-  pcall(a.nvim_set_option_value, "tabstop", 1, { buf = self.prompt_bufnr }) -- #1834
+  pcall(api.nvim_set_option_value, "tabstop", 1, { buf = self.results_bufnr }) -- #1834
+  pcall(api.nvim_set_option_value, "tabstop", 1, { buf = self.prompt_bufnr }) -- #1834
   vim.bo[self.prompt_bufnr].buftype = "prompt"
   vim.wo[self.results_win].wrap = self.wrap_results
   vim.wo[self.prompt_win].wrap = true
@@ -574,7 +574,7 @@ function Picker:find()
   -- This just lets us stop doing stuff after tons of  things.
   self.max_results = self.__scrolling_limit
 
-  vim.api.nvim_buf_set_lines(self.results_bufnr, 0, self.max_results, false, utils.repeated_table(self.max_results, ""))
+  api.nvim_buf_set_lines(self.results_bufnr, 0, self.max_results, false, utils.repeated_table(self.max_results, ""))
 
   local status_updater = self:get_status_updater(self.prompt_win, self.prompt_bufnr)
   local debounced_status = debounce.throttle_leading(status_updater, 50)
@@ -598,7 +598,7 @@ function Picker:find()
       -- always fully retrigger insert mode: required for going from one picker to next
       keys = mode ~= "n" and "<ESC>A" or "A"
     end
-    a.nvim_feedkeys(a.nvim_replace_termcodes(keys, true, false, true), "ni", true)
+    api.nvim_feedkeys(api.nvim_replace_termcodes(keys, true, false, true), "ni", true)
   else
     utils.notify("pickers.find", {
       msg = "`initial_mode` should be one of ['normal', 'insert'] but passed " .. self.initial_mode,
@@ -610,8 +610,8 @@ function Picker:find()
     self.sorter:_init()
 
     -- Do filetype last, so that users can register at the last second.
-    pcall(a.nvim_set_option_value, "filetype", "TelescopePrompt", { buf = self.prompt_bufnr })
-    pcall(a.nvim_set_option_value, "filetype", "TelescopeResults", { buf = self.results_bufnr })
+    pcall(api.nvim_set_option_value, "filetype", "TelescopePrompt", { buf = self.prompt_bufnr })
+    pcall(api.nvim_set_option_value, "filetype", "TelescopeResults", { buf = self.results_bufnr })
 
     await_schedule()
 
@@ -622,7 +622,7 @@ function Picker:find()
 
       self:_reset_track()
 
-      if not vim.api.nvim_buf_is_valid(self.prompt_bufnr) then
+      if not api.nvim_buf_is_valid(self.prompt_bufnr) then
         log.debug("ON_LINES: Invalid prompt_bufnr", self.prompt_bufnr)
         return
       end
@@ -681,7 +681,7 @@ function Picker:find()
   end)
 
   -- Register attach
-  vim.api.nvim_buf_attach(self.prompt_bufnr, false, {
+  api.nvim_buf_attach(self.prompt_bufnr, false, {
     on_lines = function(...)
       if self._finder_attached then
         find_id = self:_next_find_id()
@@ -696,9 +696,9 @@ function Picker:find()
     end,
   })
 
-  vim.api.nvim_create_augroup("PickerInsert", {})
+  api.nvim_create_augroup("PickerInsert", {})
   -- TODO: Use WinLeave as well?
-  vim.api.nvim_create_autocmd("BufLeave", {
+  api.nvim_create_autocmd("BufLeave", {
     buffer = self.prompt_bufnr,
     group = "PickerInsert",
     nested = true,
@@ -707,7 +707,7 @@ function Picker:find()
       require("telescope.pickers").on_close_prompt(self.prompt_bufnr)
     end,
   })
-  vim.api.nvim_create_autocmd("VimResized", {
+  api.nvim_create_autocmd("VimResized", {
     buffer = self.prompt_bufnr,
     group = "PickerInsert",
     nested = true,
@@ -769,13 +769,13 @@ end
 
 local update_scroll = function(win, oldinfo, oldcursor, strategy, buf_maxline)
   if strategy == "ascending" then
-    vim.api.nvim_win_set_cursor(win, { buf_maxline, 0 })
-    vim.api.nvim_win_set_cursor(win, { oldinfo.topline, 0 })
-    vim.api.nvim_win_set_cursor(win, oldcursor)
+    api.nvim_win_set_cursor(win, { buf_maxline, 0 })
+    api.nvim_win_set_cursor(win, { oldinfo.topline, 0 })
+    api.nvim_win_set_cursor(win, oldcursor)
   elseif strategy == "descending" then
-    vim.api.nvim_win_set_cursor(win, { 1, 0 })
-    vim.api.nvim_win_set_cursor(win, { oldinfo.botline, 0 })
-    vim.api.nvim_win_set_cursor(win, oldcursor)
+    api.nvim_win_set_cursor(win, { 1, 0 })
+    api.nvim_win_set_cursor(win, { oldinfo.botline, 0 })
+    api.nvim_win_set_cursor(win, oldcursor)
   else
     error(debug.traceback("Unknown sorting strategy: " .. (strategy or "")))
   end
@@ -784,12 +784,12 @@ end
 --- A wrapper for `Picker:recalculate_layout()` that also handles maintaining cursor position
 function Picker:full_layout_update()
   local oldinfo = vim.fn.getwininfo(self.results_win)[1]
-  local oldcursor = vim.api.nvim_win_get_cursor(self.results_win)
+  local oldcursor = api.nvim_win_get_cursor(self.results_win)
   self:recalculate_layout()
   self:refresh_previewer()
 
   -- update scrolled position
-  local buf_maxline = #vim.api.nvim_buf_get_lines(self.results_bufnr, 0, -1, false)
+  local buf_maxline = #api.nvim_buf_get_lines(self.results_bufnr, 0, -1, false)
   update_scroll(self.results_win, oldinfo, oldcursor, self.sorting_strategy, buf_maxline)
 end
 
@@ -971,7 +971,7 @@ end
 function Picker:_reset_prefix_color(hl_group)
   self._current_prefix_hl_group = hl_group or nil
 
-  if self.prompt_prefix ~= "" and a.nvim_buf_is_valid(self.prompt_bufnr) then
+  if self.prompt_prefix ~= "" and api.nvim_buf_is_valid(self.prompt_bufnr) then
     utils.hl_range(
       self.prompt_bufnr,
       ns_telescope_prompt_prefix,
@@ -996,7 +996,7 @@ function Picker:change_prompt_prefix(new_prefix, hl_group)
   if new_prefix ~= "" then
     vim.fn.prompt_setprompt(self.prompt_bufnr, new_prefix)
   else
-    vim.api.nvim_buf_set_text(self.prompt_bufnr, 0, 0, 0, #self.prompt_prefix, {})
+    api.nvim_buf_set_text(self.prompt_bufnr, 0, 0, 0, #self.prompt_prefix, {})
     vim.bo[self.prompt_bufnr].buftype = ""
   end
   self.prompt_prefix = new_prefix
@@ -1007,11 +1007,11 @@ end
 ---@param text string
 function Picker:reset_prompt(text)
   local prompt_text = self.prompt_prefix .. (text or "")
-  vim.api.nvim_buf_set_lines(self.prompt_bufnr, 0, -1, false, { prompt_text })
+  api.nvim_buf_set_lines(self.prompt_bufnr, 0, -1, false, { prompt_text })
   self:_reset_prefix_color(self._current_prefix_hl_group)
 
   if text then
-    vim.api.nvim_win_set_cursor(self.prompt_win, { 1, #prompt_text })
+    api.nvim_win_set_cursor(self.prompt_win, { 1, #prompt_text })
   end
 end
 
@@ -1064,13 +1064,13 @@ function Picker:set_selection(row)
   end
 
   local results_bufnr = self.results_bufnr
-  if not a.nvim_buf_is_valid(results_bufnr) then
+  if not api.nvim_buf_is_valid(results_bufnr) then
     return
   end
 
-  if row > a.nvim_buf_line_count(results_bufnr) then
+  if row > api.nvim_buf_line_count(results_bufnr) then
     log.debug(
-      string.format("Should not be possible to get row this large %s %s", row, a.nvim_buf_line_count(results_bufnr))
+      string.format("Should not be possible to get row this large %s %s", row, api.nvim_buf_line_count(results_bufnr))
     )
 
     return
@@ -1130,7 +1130,7 @@ function Picker:set_selection(row)
 
     -- TODO: You should go back and redraw the highlights for this line from the sorter.
     -- That's the only smart thing to do.
-    if not a.nvim_buf_is_valid(results_bufnr) then
+    if not api.nvim_buf_is_valid(results_bufnr) then
       log.debug "Invalid buf somehow..."
       return
     end
@@ -1156,7 +1156,7 @@ function Picker:set_selection(row)
   self._selection_entry = entry
   self._selection_row = row
 
-  vim.api.nvim_win_set_cursor(self.results_win, { row + 1, 0 })
+  api.nvim_win_set_cursor(self.results_win, { row + 1, 0 })
 end
 
 --- Update prefix for entry on a given row
@@ -1174,7 +1174,7 @@ function Picker:update_prefix(entry, row)
     return t
   end
 
-  local line = vim.api.nvim_buf_get_lines(self.results_bufnr, row, row + 1, false)[1]
+  local line = api.nvim_buf_get_lines(self.results_bufnr, row, row + 1, false)[1]
   if not line then
     log.trace(string.format("no line found at row %d in buffer %d", row, self.results_bufnr))
     return
@@ -1191,7 +1191,7 @@ function Picker:update_prefix(entry, row)
 
   local pre = prefix(entry == self._selection_entry, self:is_multi_selected(entry))
   -- Only change the first couple characters, nvim_buf_set_text leaves the existing highlights
-  a.nvim_buf_set_text(self.results_bufnr, row, 0, row, #old_caret, { pre })
+  api.nvim_buf_set_text(self.results_bufnr, row, 0, row, #old_caret, { pre })
   return pre
 end
 
@@ -1202,7 +1202,7 @@ function Picker:refresh_previewer()
     self.previewer
     and status.layout.preview
     and status.layout.preview.winid
-    and a.nvim_win_is_valid(status.layout.preview.winid)
+    and api.nvim_win_is_valid(status.layout.preview.winid)
   then
     self:_increment "previewed"
 
@@ -1274,25 +1274,25 @@ function Picker:entry_adder(index, entry, _, insert)
   self:_increment "displayed"
 
   local offset = insert and 0 or 1
-  if not vim.api.nvim_buf_is_valid(self.results_bufnr) then
+  if not api.nvim_buf_is_valid(self.results_bufnr) then
     log.debug "ON_ENTRY: Invalid buffer"
     return
   end
 
   -- TODO: Does this every get called?
-  -- local line_count = vim.api.nvim_win_get_height(self.results_win)
-  local line_count = vim.api.nvim_buf_line_count(self.results_bufnr)
+  -- local line_count = a.nvim_win_get_height(self.results_win)
+  local line_count = api.nvim_buf_line_count(self.results_bufnr)
   if row > line_count then
     return
   end
 
   if insert then
     if self.sorting_strategy == "descending" then
-      vim.api.nvim_buf_set_lines(self.results_bufnr, 0, 1, false, {})
+      api.nvim_buf_set_lines(self.results_bufnr, 0, 1, false, {})
     end
   end
 
-  local set_ok, msg = pcall(vim.api.nvim_buf_set_lines, self.results_bufnr, row, row + offset, false, { display })
+  local set_ok, msg = pcall(api.nvim_buf_set_lines, self.results_bufnr, row, row + offset, false, { display })
   if set_ok then
     if display_highlights then
       self.highlighter:hi_display(row, prefix, display_highlights)
@@ -1309,7 +1309,7 @@ function Picker:entry_adder(index, entry, _, insert)
   --  So we'll clean it up for them if it fails.
   if not set_ok and display:find "\n" then
     display = display:gsub("\n", " | ")
-    vim.api.nvim_buf_set_lines(self.results_bufnr, row, row + 1, false, { display })
+    api.nvim_buf_set_lines(self.results_bufnr, row, row + 1, false, { display })
   end
 end
 
@@ -1367,7 +1367,7 @@ end
 ---@return function
 function Picker:get_status_updater(prompt_win, prompt_bufnr)
   return function(opts)
-    if self.closed or not vim.api.nvim_buf_is_valid(prompt_bufnr) then
+    if self.closed or not api.nvim_buf_is_valid(prompt_bufnr) then
       return
     end
 
@@ -1376,13 +1376,13 @@ function Picker:get_status_updater(prompt_win, prompt_bufnr)
       return
     end
 
-    if not vim.api.nvim_win_is_valid(prompt_win) then
+    if not api.nvim_win_is_valid(prompt_win) then
       return
     end
 
     local text = self:get_status_text(opts)
-    vim.api.nvim_buf_clear_namespace(prompt_bufnr, ns_telescope_prompt, 0, -1)
-    vim.api.nvim_buf_set_extmark(prompt_bufnr, ns_telescope_prompt, 0, 0, {
+    api.nvim_buf_clear_namespace(prompt_bufnr, ns_telescope_prompt, 0, -1)
+    api.nvim_buf_set_extmark(prompt_bufnr, ns_telescope_prompt, 0, 0, {
       virt_text = { { text, "TelescopePromptCounter" } },
       virt_text_pos = "right_align",
     })
@@ -1461,11 +1461,11 @@ function Picker:get_result_completor(results_bufnr, _, prompt, status_updater)
     self.sorter:_finish(prompt)
 
     if self.sorting_strategy == "descending" then
-      local visible_result_rows = vim.api.nvim_win_get_height(self.results_win)
-      vim.api.nvim_win_set_cursor(self.results_win, { self.max_results - visible_result_rows, 1 })
-      vim.api.nvim_win_set_cursor(self.results_win, { self.max_results, 1 })
+      local visible_result_rows = api.nvim_win_get_height(self.results_win)
+      api.nvim_win_set_cursor(self.results_win, { self.max_results - visible_result_rows, 1 })
+      api.nvim_win_set_cursor(self.results_win, { self.max_results, 1 })
     else
-      vim.api.nvim_win_set_cursor(self.results_win, { 1, 0 })
+      api.nvim_win_set_cursor(self.results_win, { 1, 0 })
     end
     self:_on_complete()
   end)
@@ -1626,7 +1626,7 @@ function pickers.on_close_prompt(prompt_bufnr)
   end
 
   -- so we dont call close_windows multiple times we clear that autocmd
-  vim.api.nvim_clear_autocmds {
+  api.nvim_clear_autocmds {
     group = "PickerInsert",
     event = "BufLeave",
     buffer = prompt_bufnr,
@@ -1645,15 +1645,13 @@ end
 
 --- Get the prompt text without the prompt prefix.
 function Picker:_get_prompt()
-  local cursor_line = vim.api.nvim_win_get_cursor(self.prompt_win)[1] - 1
-  return vim.api
-    .nvim_buf_get_lines(self.prompt_bufnr, cursor_line, cursor_line + 1, false)[1]
-    :sub(#self.prompt_prefix + 1)
+  local cursor_line = api.nvim_win_get_cursor(self.prompt_win)[1] - 1
+  return api.nvim_buf_get_lines(self.prompt_bufnr, cursor_line, cursor_line + 1, false)[1]:sub(#self.prompt_prefix + 1)
 end
 
 function Picker:_reset_highlights()
   self.highlighter:clear_display()
-  vim.api.nvim_buf_clear_namespace(self.results_bufnr, ns_telescope_matching, 0, -1)
+  api.nvim_buf_clear_namespace(self.results_bufnr, ns_telescope_matching, 0, -1)
 end
 
 -- Toggles whether finder is attached to prompt buffer input
@@ -1700,8 +1698,8 @@ function Picker:_resume_picker()
   end
   self.cache_picker.is_cached = false
   local on_resume_complete = function()
-    if vim.api.nvim_buf_is_valid(self.prompt_bufnr) then
-      vim.api.nvim_buf_call(self.prompt_bufnr, function()
+    if api.nvim_buf_is_valid(self.prompt_bufnr) then
+      api.nvim_buf_call(self.prompt_bufnr, function()
         vim.cmd "do User TelescopeResumePost"
       end)
     end

--- a/lua/telescope/pickers/highlights.lua
+++ b/lua/telescope/pickers/highlights.lua
@@ -1,12 +1,12 @@
-local a = vim.api
+local api = vim.api
 local log = require "telescope.log"
 local conf = require("telescope.config").values
 
 local highlights = {}
 
-local ns_telescope_selection = a.nvim_create_namespace "telescope_selection"
-local ns_telescope_multiselection = a.nvim_create_namespace "telescope_multiselection"
-local ns_telescope_entry = a.nvim_create_namespace "telescope_entry"
+local ns_telescope_selection = api.nvim_create_namespace "telescope_selection"
+local ns_telescope_multiselection = api.nvim_create_namespace "telescope_multiselection"
+local ns_telescope_entry = api.nvim_create_namespace "telescope_entry"
 
 ---TODO(clason): remove when dropping support for Nvim 0.10
 local hl = vim.hl or vim.highlight
@@ -29,7 +29,7 @@ function Highlighter:hi_display(row, prefix, display_highlights)
 
   local results_bufnr = assert(self.picker.results_bufnr, "Must have a results bufnr")
 
-  a.nvim_buf_clear_namespace(results_bufnr, ns_telescope_entry, row, row + 1)
+  api.nvim_buf_clear_namespace(results_bufnr, ns_telescope_entry, row, row + 1)
   local len_prefix = #prefix
 
   for _, hl_block in ipairs(display_highlights) do
@@ -48,12 +48,12 @@ function Highlighter:clear_display()
     not self
     or not self.picker
     or not self.picker.results_bufnr
-    or not vim.api.nvim_buf_is_valid(self.picker.results_bufnr)
+    or not api.nvim_buf_is_valid(self.picker.results_bufnr)
   then
     return
   end
 
-  a.nvim_buf_clear_namespace(self.picker.results_bufnr, ns_telescope_entry, 0, -1)
+  api.nvim_buf_clear_namespace(self.picker.results_bufnr, ns_telescope_entry, 0, -1)
 end
 
 function Highlighter:hi_sorter(row, prompt, display)
@@ -70,10 +70,10 @@ function Highlighter:hi_selection(row, caret)
   caret = vim.F.if_nil(caret, "")
   local results_bufnr = assert(self.picker.results_bufnr, "Must have a results bufnr")
 
-  a.nvim_buf_clear_namespace(results_bufnr, ns_telescope_selection, 0, -1)
+  api.nvim_buf_clear_namespace(results_bufnr, ns_telescope_selection, 0, -1)
   hl.range(results_bufnr, ns_telescope_selection, "TelescopeSelectionCaret", { row, 0 }, { row, #caret })
 
-  a.nvim_buf_set_extmark(
+  api.nvim_buf_set_extmark(
     results_bufnr,
     ns_telescope_selection,
     row,
@@ -88,7 +88,7 @@ function Highlighter:hi_multiselect(row, is_selected)
   if is_selected then
     hl.range(results_bufnr, ns_telescope_multiselection, "TelescopeMultiSelection", { row, 0 }, { row, -1 })
     if self.picker.multi_icon then
-      local line = vim.api.nvim_buf_get_lines(results_bufnr, row, row + 1, false)[1]
+      local line = api.nvim_buf_get_lines(results_bufnr, row, row + 1, false)[1]
       local pos = line:find(self.picker.multi_icon)
       if pos and pos <= math.max(#self.picker.selection_caret, #self.picker.entry_prefix) then
         hl.range(
@@ -101,7 +101,7 @@ function Highlighter:hi_multiselect(row, is_selected)
       end
     end
   else
-    local existing_marks = vim.api.nvim_buf_get_extmarks(
+    local existing_marks = api.nvim_buf_get_extmarks(
       results_bufnr,
       ns_telescope_multiselection,
       { row, 0 },
@@ -114,7 +114,7 @@ function Highlighter:hi_multiselect(row, is_selected)
     if #existing_marks > 0 then
       log.trace("Clearing highlight multi select row: ", row)
 
-      vim.api.nvim_buf_clear_namespace(results_bufnr, ns_telescope_multiselection, row, row + 1)
+      api.nvim_buf_clear_namespace(results_bufnr, ns_telescope_multiselection, row, row + 1)
     end
   end
 end

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -50,6 +50,8 @@
 ---
 ---@brief ]]
 
+local api = vim.api
+
 local resolve = require "telescope.config.resolve"
 local p_window = require "telescope.pickers.window"
 
@@ -62,7 +64,7 @@ local get_border_size = function(opts)
 end
 
 local calc_tabline = function(max_lines)
-  local tbln = (vim.o.showtabline == 2) or (vim.o.showtabline == 1 and #vim.api.nvim_list_tabpages() > 1)
+  local tbln = (vim.o.showtabline == 2) or (vim.o.showtabline == 1 and #api.nvim_list_tabpages() > 1)
   if tbln then
     max_lines = max_lines - 1
   end
@@ -607,7 +609,7 @@ layout_strategies.cursor = make_documented_layout(
       results.width = prompt.width
     end
 
-    local position = vim.api.nvim_win_get_position(winid)
+    local position = api.nvim_win_get_position(winid)
     local winbar = (function()
       if vim.fn.exists "&winbar" == 1 then
         return vim.wo[winid].winbar == "" and 0 or 1
@@ -615,8 +617,8 @@ layout_strategies.cursor = make_documented_layout(
       return 0
     end)()
     local top_left = {
-      line = vim.api.nvim_win_call(winid, vim.fn.winline) + position[1] + bs + winbar,
-      col = vim.api.nvim_win_call(winid, vim.fn.wincol) + position[2],
+      line = api.nvim_win_call(winid, vim.fn.winline) + position[1] + bs + winbar,
+      col = api.nvim_win_call(winid, vim.fn.wincol) + position[2],
     }
     local bot_right = {
       line = top_left.line + height - 1,
@@ -804,8 +806,8 @@ layout_strategies.current_buffer = make_documented_layout("current_buffer", {
 }, function(self, _, _, _)
   local initial_options = p_window.get_initial_window_options(self)
 
-  local window_width = vim.api.nvim_win_get_width(0)
-  local window_height = vim.api.nvim_win_get_height(0)
+  local window_width = api.nvim_win_get_width(0)
+  local window_height = api.nvim_win_get_height(0)
 
   local preview = initial_options.preview
   local results = initial_options.results
@@ -832,7 +834,7 @@ layout_strategies.current_buffer = make_documented_layout("current_buffer", {
     preview.height = 0
   end
 
-  local win_position = vim.api.nvim_win_get_position(0)
+  local win_position = api.nvim_win_get_position(0)
 
   local line = win_position[1]
   if self.previewer then

--- a/lua/telescope/previewers/term_previewer.lua
+++ b/lua/telescope/previewers/term_previewer.lua
@@ -1,3 +1,5 @@
+local api = vim.api
+
 local conf = require("telescope.config").values
 local utils = require "telescope.utils"
 local Path = require "plenary.path"
@@ -184,7 +186,7 @@ previewers.new_termopen_previewer = function(opts)
   function opts.preview_fn(self, entry, status)
     local preview_winid = status.layout.preview and status.layout.preview.winid
     if get_bufnr(self) == nil then
-      set_bufnr(self, vim.api.nvim_win_get_buf(preview_winid))
+      set_bufnr(self, api.nvim_win_get_buf(preview_winid))
     end
 
     local prev_bufnr = get_bufnr_by_bufentry(self, entry)
@@ -193,7 +195,7 @@ previewers.new_termopen_previewer = function(opts)
       utils.win_set_buf_noautocmd(preview_winid, self.state.termopen_bufnr)
       self.state.termopen_id = term_ids[self.state.termopen_bufnr]
     else
-      local bufnr = vim.api.nvim_create_buf(false, true)
+      local bufnr = api.nvim_create_buf(false, true)
       set_bufnr(self, bufnr)
       utils.win_set_buf_noautocmd(preview_winid, bufnr)
 
@@ -204,7 +206,7 @@ previewers.new_termopen_previewer = function(opts)
 
       local cmd = opts.get_command(entry, status)
       if cmd then
-        vim.api.nvim_buf_call(bufnr, function()
+        api.nvim_buf_call(bufnr, function()
           --TODO(clason): replace with jobstart when dropping support for Nvim 0.10
           set_term_id(self, vim.fn.termopen(cmd, term_opts))
         end)
@@ -215,7 +217,7 @@ previewers.new_termopen_previewer = function(opts)
 
   if not opts.send_input then
     function opts.send_input(self, input)
-      local termcode = vim.api.nvim_replace_termcodes(input, true, false, true)
+      local termcode = api.nvim_replace_termcodes(input, true, false, true)
 
       local term_id = get_term_id(self)
       if term_id then
@@ -281,7 +283,7 @@ previewers.vimgrep = defaulter(function(opts)
 
     get_command = function(entry, status)
       local win_id = status.layout.preview and status.layout.preview.winid
-      local height = vim.api.nvim_win_get_height(win_id)
+      local height = api.nvim_win_get_height(win_id)
 
       local p = from_entry.path(entry, true, false)
       if p == nil or p == "" then
@@ -316,7 +318,7 @@ previewers.qflist = defaulter(function(opts)
 
     get_command = function(entry, status)
       local win_id = status.layout.preview and status.layout.preview.winid
-      local height = vim.api.nvim_win_get_height(win_id)
+      local height = api.nvim_win_get_height(win_id)
 
       local p = from_entry.path(entry, true, false)
       if p == nil or p == "" then

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -5,6 +5,8 @@
 --- Utilities for writing telescope pickers
 ---@brief ]]
 
+local api = vim.api
+
 local Path = require "plenary.path"
 local Job = require "plenary.job"
 
@@ -203,8 +205,8 @@ local path_filename_first = function(path, reverse_directories)
 end
 
 local calc_result_length = function(truncate_len)
-  local status = get_status(vim.api.nvim_get_current_buf())
-  local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
+  local status = get_status(api.nvim_get_current_buf())
+  local len = api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
   return type(truncate_len) == "number" and len - truncate_len or len
 end
 
@@ -475,8 +477,8 @@ function utils.buf_delete(bufnr)
     vim.o.report = 2
   end
 
-  if vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_is_loaded(bufnr) then
-    vim.api.nvim_buf_delete(bufnr, { force = true })
+  if api.nvim_buf_is_valid(bufnr) and api.nvim_buf_is_loaded(bufnr) then
+    api.nvim_buf_delete(bufnr, { force = true })
   end
 
   if start_report < 2 then
@@ -485,20 +487,20 @@ function utils.buf_delete(bufnr)
 end
 
 function utils.win_delete(name, win_id, force, bdelete)
-  if win_id == nil or not vim.api.nvim_win_is_valid(win_id) then
+  if win_id == nil or not api.nvim_win_is_valid(win_id) then
     return
   end
 
-  local bufnr = vim.api.nvim_win_get_buf(win_id)
+  local bufnr = api.nvim_win_get_buf(win_id)
   if bdelete then
     utils.buf_delete(bufnr)
   end
 
-  if not vim.api.nvim_win_is_valid(win_id) then
+  if not api.nvim_win_is_valid(win_id) then
     return
   end
 
-  if not pcall(vim.api.nvim_win_close, win_id, force) then
+  if not pcall(api.nvim_win_close, win_id, force) then
     log.trace("Unable to close window: ", name, "/", win_id)
   end
 end
@@ -577,7 +579,7 @@ end
 function utils.win_set_buf_noautocmd(win, buf)
   local save_ei = vim.o.eventignore
   vim.o.eventignore = "all"
-  vim.api.nvim_win_set_buf(win, buf)
+  api.nvim_win_set_buf(win, buf)
   vim.o.eventignore = save_ei
 end
 


### PR DESCRIPTION
* be consistent
* use longer name that isn't as likely to shadow
* rule of thumb: > 5 occurrences merits an alias