### PR TITLE
fix(treesitter): standalone implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ wiki.
 ### Optional dependencies
 
 - [sharkdp/fd](https://github.com/sharkdp/fd) (finder)
-- [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) (finder/preview)
 - [neovim LSP](https://neovim.io/doc/user/lsp.html) (picker)
 - [devicons](https://github.com/nvim-tree/nvim-web-devicons) (icons)
 
@@ -374,7 +373,7 @@ Built-in functions. Ready to be bound to any key you like.
 
 | Functions            | Description                                       |
 | -------------------- | ------------------------------------------------- |
-| `builtin.treesitter` | Lists Function names, variables, from Treesitter! |
+| `builtin.treesitter` | Lists Function names, variables, ... using treesitter [`locals` queries](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md#locals) |
 
 ### Lists Picker
 

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -959,6 +959,10 @@ builtin.fd()                                          *telescope.builtin.fd()*
 
 builtin.treesitter()                          *telescope.builtin.treesitter()*
     Lists function names, variables, and other symbols from treesitter queries
+    Requires parser and `locals` queries for the current buffer in
+    `runtimepath`, see |vim.treesitter-parsers|, |vim.treesitter.query|, and
+    https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md#locals
+
     - Default keymaps:
       - `<C-l>`: show autocompletion menu to prefilter your query by kind of ts
         node you want to see (i.e. `:var:`)

--- a/lua/telescope/health.lua
+++ b/lua/telescope/health.lua
@@ -30,11 +30,6 @@ local optional_dependencies = {
 
 local required_plugins = {
   { lib = "plenary", optional = false },
-  {
-    lib = "nvim-treesitter",
-    optional = true,
-    info = "(Required for `:Telescope treesitter`.)",
-  },
 }
 
 local check_binary_installed = function(package)


### PR DESCRIPTION
Drop hard nvim-treesitter requirement, but assumes parser and
`locals` query (using the captures documented here:
https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md#locals)
is available on `runtimepath`.
