### PR TITLE
fix: incorrect border rendering on latest neovim

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -511,9 +511,11 @@ function Picker:_create_window(bufnr, popup_opts)
   local win, opts = popup.create(what, popup_opts)
 
   vim.wo[win].winblend = self.window.winblend
+  vim.wo[win].statusline = ""
   local border_win = opts and opts.border and opts.border.win_id
   if border_win then
     vim.wo[border_win].winblend = self.window.winblend
+    vim.wo[border_win].statusline = ""
   end
   return win, opts, border_win
 end


### PR DESCRIPTION
# Description

Fixes #3580 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unfortunately we don't have any test about this so nah...

But I tested by hand and confirmed it's working (with my another patch on plenary).

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.12.0-dev-1701+ge4ce0c7270
Build type: RelWithDebInfo
LuaJIT 2.1.1763318511
```
* Operating system and version: Arch Linux ,latest

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
