### PR TITLE
fix(pickers): remove broken highlight call for autocmds

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -1045,7 +1045,6 @@ previewers.autocommands = defaulter(function(_)
 
         vim.bo[self.state.bufnr].filetype = "vim"
         api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, display)
-        utils.hl_range(self.state.bufnr, 0, "TelescopeBorder", { 1, 0 }, { 1, -1 })
       else
         for idx, item in ipairs(results) do
           if item == entry then


### PR DESCRIPTION
Problem: Preview buffer does not understand namespace 0.

Solution: Don't call `vim.hl.range` for cosmetic highlights.

This is obviously just a bandaid fix, but the additional
`TelescopeBorder` highlight is not worth spending time on.

Fixes #3593
