### PR TITLE
fix(actions): fixes #699

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -204,7 +204,7 @@ action_set.edit = function(prompt_bufnr, command)
   -- HACK: fixes folding: https://github.com/nvim-telescope/telescope.nvim/issues/699
   if vim.wo.foldmethod == "expr" then
     vim.schedule(function()
-      vim.opt.foldmethod = "expr"
+      vim.cmd "normal! zX"
     end)
   end
 


### PR DESCRIPTION
# Description

This is a small modification of #2726 where instead of changing the global options, it simply reloads the folds engine.

The original fix was too invasive to user's configuration, which motivated me to make a better hack. It's still a hack, but not as invasive.

I suspect that the issue is caused by a race condition, where the `foldexpr` isn't valid at the time of opening the file, but is valid after the file is opened, and thus we reload the engine to re-evaluate the `foldexpr`. I can't be sure though, a more thorough investigation might be necessary.

Fixes #699

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested with my full config. I don't believe that the config is relevant, and the change itself is very small.

**Configuration**:
* Neovim version (nvim --version): v0.11.5
* Operating system and version: Void Linux (latest)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)