### PR TITLE
refactor(scroller): use scroller.new instead of scroller.create

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -355,8 +355,7 @@ function Picker:new(opts)
     obj.hidden_previewer = nil
   end
 
-  -- TODO: It's annoying that this is create and everything else is "new"
-  obj.scroller = p_scroller.create(obj.scroll_strategy, obj.sorting_strategy)
+  obj.scroller = p_scroller.new(obj.scroll_strategy, obj.sorting_strategy)
 
   obj.highlighter = p_highlighter.new(obj)
 

--- a/lua/tests/automated/scroller_spec.lua
+++ b/lua/tests/automated/scroller_spec.lua
@@ -9,7 +9,7 @@ describe("scroller", function()
   local max_results = 10
 
   describe("ascending cycle", function()
-    local cycle_scroller = p_scroller.create("cycle", "ascending")
+    local cycle_scroller = p_scroller.new("cycle", "ascending")
 
     it("should return values within the max results", function()
       eq(5, cycle_scroller(max_results, max_results, 5))
@@ -33,7 +33,7 @@ describe("scroller", function()
   end)
 
   describe("ascending limit", function()
-    local limit_scroller = p_scroller.create("limit", "ascending")
+    local limit_scroller = p_scroller.new("limit", "ascending")
 
     it("should return values within the max results", function()
       eq(5, limit_scroller(max_results, max_results, 5))
@@ -58,7 +58,7 @@ describe("scroller", function()
   end)
 
   describe("descending cycle", function()
-    local cycle_scroller = p_scroller.create("cycle", "descending")
+    local cycle_scroller = p_scroller.new("cycle", "descending")
 
     it("should return values within the max results", function()
       eq(5, cycle_scroller(max_results, max_results, 5))
@@ -82,7 +82,7 @@ describe("scroller", function()
   end)
 
   describe("descending limit", function()
-    local limit_scroller = p_scroller.create("limit", "descending")
+    local limit_scroller = p_scroller.new("limit", "descending")
 
     it("should return values within the max results", function()
       eq(5, limit_scroller(max_results, max_results, 5))
@@ -108,7 +108,7 @@ describe("scroller", function()
 
   describe("https://github.com/nvim-telescope/telescope.nvim/pull/293#issuecomment-751463224", function()
     it("should handle having many more results than necessary", function()
-      local scroller = p_scroller.create("cycle", "descending")
+      local scroller = p_scroller.new("cycle", "descending")
 
       -- 23 112 23
       eq(0, scroller(23, 112, 23))


### PR DESCRIPTION
# Description

Fixed TODO
```lua
-- TODO: It's annoying that this is create and everything else is "new"
  obj.scroller = p_scroller.create(obj.scroll_strategy, obj.sorting_strategy)
```

# How Has This Been Tested?

- [x] Vibe
- [x] Pray

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
