### PR TITLE
fix(actions): re-set window-local(!) foldexpr

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -202,9 +202,9 @@ action_set.edit = function(prompt_bufnr, command)
   end
 
   -- HACK: fixes folding: https://github.com/nvim-telescope/telescope.nvim/issues/699
-  if vim.wo.foldmethod == "expr" then
+  if vim.wo[0][0].foldmethod == "expr" then
     vim.schedule(function()
-      vim.cmd "normal! zX"
+      vim.wo[0][0].foldmethod = "expr"
     end)
   end
 


### PR DESCRIPTION
Problem: Buffers opened from telescope do not have `foldexpr` set properly. Previous workarounds didn't respect foldenable.

Solution: Only reset window-local `foldexpr` value instead of global value.

Fixes #3601 

@alexmozaidze @chrs8