### PR TITLE
feat(lsp): add type heirarchy picker

### DIFF
--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -444,6 +444,14 @@ builtin.lsp_incoming_calls = require_on_exported_call("telescope.builtin.__lsp")
 ---@field file_encoding string: file encoding for the previewer
 builtin.lsp_outgoing_calls = require_on_exported_call("telescope.builtin.__lsp").outgoing_calls
 
+--- Lists LSP Supertypes for symbol under the cursor, jumps to reference on `<cr>`
+---@param opts table: options to pass to the picker
+builtin.lsp_super_types = require_on_exported_call("telescope.builtin.__lsp").super_types
+
+--- Lists LSP Subtypes for symbol under the cursor, jumps to reference on `<cr>`
+---@param opts table: options to pass to the picker
+builtin.lsp_sub_types = require_on_exported_call("telescope.builtin.__lsp").sub_types
+
 --- Goto the definition of the word under the cursor, if there's only one, otherwise show all options in Telescope
 ---@param opts table: options to pass to the picker
 ---@field jump_type string: how to goto definition if there is only one and the definition file is different from the current file, values: "tab", "tab drop", "split", "vsplit", "never"


### PR DESCRIPTION
# Description

I noticed that the call hierarchy feature is implemented in the built-in code, but the type hierarchy is not. Although new pickers are no longer allowed to be added, I still want to be able to complete the hierarchy functionality of the language server.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

**Configuration**:
* Neovim version (nvim --version): v0.11.5
* Operating system and version:

MacOS Sequoia 15.6.1

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
