### PR TITLE
docs(readme): fix lazy.nvim version spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ e.g. using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
 {
-    'nvim-telescope/telescope.nvim', tag = '*',
+    'nvim-telescope/telescope.nvim', version = '*',
     dependencies = {
         'nvim-lua/plenary.nvim',
         -- optional but recommended


### PR DESCRIPTION
# Description

Commit 3333a52ff548ba0a68af6d8da1e54f9cd96e9179 changed the suggested plugin spec for lazy.nvim, but lazy only supports the `"*"` version specifier with the `version` key and not the `tag` key. This causes a checkout failure when using the given plugin spec.

Change to use the `version` key.

## Type of change

Docs fix

# How Has This Been Tested?

Tested that installing telescope with the new spec works.

**Configuration**:

neovim v0.11.5
lazy.nvim commit 306a055 (lastest main as of writing)

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (lua annotations)