### PR TITLE
fix(previewer): use new winid after toggle preview window

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -436,11 +436,11 @@ previewers.new_buffer_previewer = function(opts)
         end
       end)
 
-      vim.wo[preview_window_id].winhl = "Normal:TelescopePreviewNormal"
-      vim.wo[preview_window_id].signcolumn = "no"
-      vim.wo[preview_window_id].foldlevel = 100
-      vim.wo[preview_window_id].wrap = false
-      vim.wo[preview_window_id].scrollbind = false
+      vim.wo[preview_winid].winhl = "Normal:TelescopePreviewNormal"
+      vim.wo[preview_winid].signcolumn = "no"
+      vim.wo[preview_winid].foldlevel = 100
+      vim.wo[preview_winid].wrap = false
+      vim.wo[preview_winid].scrollbind = false
 
       self.state.winid = preview_winid
       self.state.bufname = nil


### PR DESCRIPTION
# Description
Can not move selection cursor after toggle preview window.

1. `:Telescope find_files`
2. Press `toggle_preview` key, close and open preview window, keep preview window open.
3. move selection cursor.

<img width="950" height="221" alt="image" src="https://github.com/user-attachments/assets/c5bc7b51-1414-493e-b2aa-57a461c21686" />

All usages of buffer_preview are affected, for example `git_files`.
This was introduced after https://github.com/nvim-telescope/telescope.nvim/pull/3561 @clason
> Could it be a typo?

<img width="1510" height="129" alt="image" src="https://github.com/user-attachments/assets/d8384107-880a-4aaf-a846-4a614909d00f" />

Toggle preview will create a new preview window, `preview_winid` is the new winid, `preview_window_id` was captured and used in `opts.teardown()`, it should be a bug because this variable is no longer updated.

So the change is to set `preview_window_id = preview_winid`

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


**Configuration**:
* Neovim version (nvim --version):
NVIM v0.11.5
Build type: Release
LuaJIT 2.1.1741730670
Run "nvim -V1 -v" for more info
* Operating system and version:
debian 12

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
