### PR TITLE
feat(picker): cache apropos result to speed up

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -828,16 +828,70 @@ internal.man_pages = function(opts)
   assert(vim.islist(opts.sections), "sections should be a list")
   opts.man_cmd = utils.get_lazy_default(opts.man_cmd, function()
     local uname = vim.uv.os_uname()
-    local sysname = string.lower(uname.sysname)
-    if sysname == "darwin" then
-      local major_version = tonumber(vim.fn.matchlist(uname.release, [[^\(\d\+\)\..*]])[2]) or 0
-      return major_version >= 22 and { "apropos", "." } or { "apropos", " " }
-    elseif sysname == "freebsd" then
+    local sysname = uname.sysname:lower()
+    if sysname == "freebsd" then
       return { "apropos", "." }
-    else
+    elseif sysname ~= "darwin" then
       return { "apropos", "" }
     end
+
+    -- Cache apropos result on macOS speed up. macOS with SIP (System Integrity
+    -- Protection) cannot update the whatis database, so makes apropos much
+    -- slower. We cache results and invalidate it when the mtime's of man
+    -- directories are changed.
+    local mansects, cache_filename
+    if vim.env.MANSECT then
+      mansects = vim.split(vim.env.MANSECT, ":")
+      cache_filename = ("telescope-man-pages-%s"):format(vim.env.MANSECT:gsub(":", "-"))
+    else
+      -- This MANSECT default value is derived from apropos' man page
+      mansects = vim.split("1:8:2:3:3lua:n:4:5:6:7:9:l", ":")
+      cache_filename = "telescope-man-pages"
+    end
+    local cache_path = vim.fs.joinpath(vim.fn.stdpath "cache", cache_filename)
+    local cache_stat = vim.uv.fs_stat(cache_path)
+
+    if cache_stat and cache_stat.size > 0 then
+      local manpath = vim.env.MANPATH or vim.trim(vim.system({ "manpath" }):wait().stdout)
+      local man_dirs = vim.split(manpath, ":", { trimempty = true })
+
+      local mansects_map = vim.iter(mansects):fold({}, function(a, b)
+        a[b] = true
+        return a
+      end)
+      local function is_man_dir(path)
+        local s = vim.fs.basename(path):match "^man(.*)$"
+        return s and mansects_map[s] or false
+      end
+
+      -- Detect mtime of man directories that is newer than cache file
+      local cache_invalid = vim.iter(man_dirs):any(function(man_dir)
+        local search = vim.fs.dir(man_dir, {
+          depth = 2,
+          skip = function(dir_name)
+            return not is_man_dir(dir_name)
+          end,
+        })
+        return vim.iter(search):any(function(ent, typ)
+          if typ ~= "directory" or not is_man_dir(ent) then
+            return false
+          end
+          local dir = vim.fs.joinpath(man_dir, ent)
+          local stat = vim.uv.fs_stat(dir)
+          return stat and stat.mtime.sec > cache_stat.mtime.sec or false
+        end)
+      end)
+
+      if not cache_invalid then
+        return { "cat", cache_path }
+      end
+    end
+
+    local major_version = tonumber(vim.fn.matchlist(uname.release, [[^\(\d\+\)\..*]])[2]) or 0
+    local cmd = major_version >= 22 and "apropos ." or "apropos ' '"
+    return { "sh", "-c", ("%s | tee %s"):format(cmd, cache_path) }
   end)
+
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_apropos(opts)
   opts.env = { PATH = vim.env.PATH, MANPATH = vim.env.MANPATH }
 


### PR DESCRIPTION
# Description

This is a revised PR from #3399. This makes `:Telescope man_pages` faster on macOS.

I found `man_pages` picker is too slow on macOS. This is because the `apropos` command, that is used in this picker, is much slower on macOS than other UNIX-like systems (Linux, FreeBSD, etc.).

By further investigation, this is derived from SIP (System Integrity Protection) on macOS. `apropos` uses the DB: `/usr/share/man/whatis`, but the place is protected on macOS and cannot be written by userland commands. So `apropos` always scans the whole man directories every time.

[How to rebuild the whatis database? whati… - Apple Community](https://discussions.apple.com/thread/250806874)

I resolved this by caching the result from `apropos`. The cache file will be invalidated when man pages are updated. When the system creates, updates, or removes man pages, we can catch events by looking the parent directory's mtime. Directory names to look their mtime are found as below, for example.

* System man pages: /usr/share/man/man1 …… man8
* Homebrew's ones: /opt/homebrew/share/man/man1 …… man8
* Some has also language tags: /opt/homebrew/share/man/ja/man1
* And others listed by `manpath` command or `MANPATH` env var.

It also detects `MANSECT` env var to determine sections shown by `apropos`. When it detects custom `MANSECT`, cache filename will change as below. Each cache will be invalidated individually.

* default cache filename: `~/.cache/nvim/telescope-man-pages`
* when `MANSECT=1,3p,5,n`: `~/.cache/nvim/telescope-man-pages-1-3p-5-n`

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [x] Run `:Telescope man_pages`
   - At the first, slow as ever, and faster at next try.
   - It creates the cache: `~/.cache/nvim/telescope-man-pages`
- [x] Install a new man page
   - Slow again, but faster at next try.
   - It updates the same cache.

**Configuration**:
* Neovim version (nvim --version):

   ```
   NVIM v0.12.0-dev-2153+g36db6ff2c1-Homebrew
   Build type: Release
   LuaJIT 2.1.1767980792
   Run "nvim -V1 -v" for more info
   ```
* Operating system and version:

   ```
   $ sw_vers
   ProductName:            macOS
   ProductVersion:         26.2
   BuildVersion:           25C56
   ```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
