### PR TITLE
builtin.buffers: show_all_buffers should also apply to unlisted buffers

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1454,7 +1454,8 @@ builtin.buffers({opts})                          *telescope.builtin.buffers()*
         {cwd}                   (string)    specify a working directory to
                                             filter buffers list by
         {show_all_buffers}      (boolean)   if true, show all buffers,
-                                            including unloaded buffers
+                                            including unloaded buffers and
+                                            unlisted buffers
                                             (default: true)
         {ignore_current_buffer} (boolean)   if true, don't show the current
                                             buffer in the list (default:

--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -926,13 +926,17 @@ internal.buffers = function(opts)
   opts = apply_cwd_only_aliases(opts)
 
   local bufnrs = vim.tbl_filter(function(bufnr)
-    if 1 ~= vim.fn.buflisted(bufnr) then
-      return false
+    -- only hide unlisted and unloaded buffers if opts.show_all_buffers is
+    -- false, keep them listed if true or nil
+    if opts.show_all_buffers == false then
+      if 1 ~= vim.fn.buflisted(bufnr) then
+        return false
+      end
+      if not api.nvim_buf_is_loaded(bufnr) then
+        return false
+      end
     end
-    -- only hide unloaded buffers if opts.show_all_buffers is false, keep them listed if true or nil
-    if opts.show_all_buffers == false and not api.nvim_buf_is_loaded(bufnr) then
-      return false
-    end
+
     if opts.ignore_current_buffer and bufnr == api.nvim_get_current_buf() then
       return false
     end


### PR DESCRIPTION
# Description

Currently, `show_all_buffers` only shows unloaded buffers. This PR changes the behavior to include unlisted buffers as well, ensuring the option truly includes all buffers.


## Type of change

Please delete options that are not relevant.

- Breaking change: The behavior of `show_all_buffers` has changed.
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- [DONE] Tested for `setup({ pickers = { buffers = { show_all_buffers = true } }})`. It works for `:help` or `:Neogit log` buffers
- [DONE] Tested for `setup({ pickers = { buffers = { show_all_buffers = false } }})`

**Configuration**:
* Neovim version (nvim --version):
* Operating system and version:

# Checklist:

- [DONE] My code follows the style guidelines of this project (stylua)
- [DONE] I have performed a self-review of my own code
- [DONE] I have commented my code, particularly in hard-to-understand areas
- [DONE] I have made corresponding changes to the documentation (lua annotations)
