### PR TITLE
feat(diagnostic): add option for workspace/diagnostic

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1602,12 +1602,14 @@ builtin.diagnostics({opts})                  *telescope.builtin.diagnostics()*
                   diagnostics only for buffers under this dir otherwise cwd
                 • {no_unlisted}? (`boolean`) if true, get diagnostics only for
                   listed buffers
+                • {workspace}? (`boolean`) if true, call workspace/diagnostic
+                  before collecting diagnostics
+                • {namespace}? (`number`) limit your diagnostics to a specific
+                  namespace
                 • {no_sign}? (`boolean`, default: `false`) hide
                   DiagnosticSigns from Results
                 • {line_width}? (`string|number`) set length of diagnostic
                   entry text in Results. Use 'full' for full untruncated text
-                • {namespace}? (`number`) limit your diagnostics to a specific
-                  namespace
                 • {disable_coordinates}? (`boolean`, default: `false`) don't
                   show the line & row numbers
                 • {sort_by}? (`"buffer"|"severity"`, default: `"buffer"`) sort

--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -139,6 +139,24 @@ diagnostics.get = function(opts)
     opts.path_display = vim.F.if_nil(opts.path_display, "hidden")
   end
 
+  -- call `workspace/diagnostic` request and wait for response before proceeding
+  if opts.workspace and next(vim.lsp.get_clients { method = "workspace/diagnostic" }) then
+    local got_response = false
+    vim.api.nvim_create_autocmd("LspRequest", {
+      callback = function(ev)
+        local request = ev.data.request
+        if request.method == "workspace/diagnostic" and request.type == "complete" then
+          got_response = true
+          return got_response
+        end
+      end,
+    })
+    vim.lsp.buf.workspace_diagnostics()
+    vim.wait(1000, function()
+      return got_response
+    end)
+  end
+
   local locations = diagnostics_to_tbl(opts)
 
   if vim.tbl_isempty(locations) then

--- a/lua/telescope/builtin/init.lua
+++ b/lua/telescope/builtin/init.lua
@@ -645,9 +645,10 @@ builtin.lsp_dynamic_workspace_symbols = require_on_exported_call("telescope.buil
 ---@field severity_bound? (string|number) keep diagnostics equal or less severe wrt severity name (string) or id (number)
 ---@field root_dir? (string|boolean) if set to string, get diagnostics only for buffers under this dir otherwise cwd
 ---@field no_unlisted? boolean if true, get diagnostics only for listed buffers
+---@field workspace? boolean if true, call workspace/diagnostic before collecting diagnostics
+---@field namespace? number limit your diagnostics to a specific namespace
 ---@field no_sign? boolean hide DiagnosticSigns from Results (default: `false`)
 ---@field line_width? (string|number) set length of diagnostic entry text in Results. Use 'full' for full untruncated text
----@field namespace? number limit your diagnostics to a specific namespace
 ---@field disable_coordinates? boolean don't show the line & row numbers (default: `false`)
 --- sort order of the diagnostics results (default: `"buffer"`)
 ---   - "buffer": order by bufnr (prioritizing current bufnr), severity, lnum


### PR DESCRIPTION
Problem: Some language servers (e.g., emmyluals) only publish
diagnostics for the opened buffer(s), requiring a `workspace/diagnostic`
request to see diagnostics for the whole project.

Solution: Add `opts.workspace` (default false) option to `diagnostics`;
if enabled, it sends the `workspace/diagnostic` request and waits for
the response (max. 1 second) before collecting the diagnostics.
