### PR TITLE
fix(previewer): remove unexpected trailing blank line

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -74,6 +74,9 @@ local function split(s, sep, plain, opts)
       end
     end
   end
+  if t[#t] == "" then
+    t[#t] = nil
+  end
   return t
 end
 local bytes_to_megabytes = math.pow(1024, 2)


### PR DESCRIPTION
# Description

There will be a blank line in the previewer buffer if the file ends with
a line feed. Since Neovim treats `\n` (or `\r\n`) as the
"line terminator" instead of the "line separator", the previewer buffer
should be consistent with the standard behavior.

This removes the last empty string from the split result to fix that.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
