### PR TITLE
fix(builtin.lsp): discriminate 'from' to fix outgoingCalls resolution

### DIFF
--- a/lua/telescope/builtin/__lsp.lua
+++ b/lua/telescope/builtin/__lsp.lua
@@ -28,7 +28,8 @@ local function call_hierarchy(opts, method, title, direction, item)
     local locations = {}
     for _, ch_call in pairs(result) do
       local ch_item = ch_call[direction]
-      for _, rng in pairs(ch_call.fromRanges) do
+      local ranges = direction == "from" and ch_call.fromRanges or { ch_item.selectionRange }
+      for _, rng in pairs(ranges) do
         table.insert(locations, {
           filename = vim.uri_to_fname(ch_item.uri),
           text = ch_item.name,


### PR DESCRIPTION
# Description

I noticed `gopls call_hierarchy ...` would produce the expected positional information.

[callHierarchy/outgoingCalls](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#callHierarchy_incomingCalls) resolved incorrect positions for `telescope.nvim` and `neovim`.

This should be reproducible for any invocation in any file.

## Type of change

Bugfix (non-breaking, I believe).

# How Has This Been Tested?

Verified in editor. I did not find existing tests for which to add a case.

See https://github.com/neovim/neovim/pull/39284

**Configuration**:

```
NVIM v0.10.4
Build type: Release
LuaJIT 2.1.1713484068
```

```
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
```

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
