### PR TITLE
fix(ftplugin): disable folding in telescope results

### DIFF
--- a/ftplugin/TelescopeResults.lua
+++ b/ftplugin/TelescopeResults.lua
@@ -3,3 +3,5 @@ vim.opt_local.scrolloff = 0
 vim.opt_local.scrollbind = false
 
 vim.opt_local.signcolumn = "no"
+
+vim.opt_local.foldenable = false


### PR DESCRIPTION
# Description

Set `nofoldenable` in `ftplugin/TelescopeResults.lua`. 

When using `shiftwidth=0`, `foldmethod=indent`, and `foldlevelstart=0`, the results in the TelescopeResults window get folded as you scroll.

Fixes #3629 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added problematic settings to `minimal_init.vim` (see below) and reproduced the error
- [x] Re-ran after changes with the same `minimal_init.vim` and verified the results are no longer folded

**Configuration**: (Modified `minimal_init.vim` used for testing)
```vimscript
set rtp+=.
set rtp+=../plenary.nvim/

runtime! plugin/plenary.vim
runtime! plugin/telescope.lua

let g:telescope_test_delay = 100

set foldmethod=indent foldlevelstart=0 shiftwidth=0
```
* Neovim version (nvim --version):
    * NVIM v0.12.2
    * Build type: RelWithDebInfo
    * LuaJIT 2.1.1774896198
* Operating system and version: Arch Linux, last system update 01/05/2026

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
