### PR TITLE
Update telescope.txt

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1988,7 +1988,7 @@ layout_strategies.horizontal          *telescope.layout_strategies.horizontal*
         • Specifies an amount of additional padding around the anchor
         • Values should be a positive integer
       • height:
-        • How tall to make Telescope's entire layout
+        •How tall to make Telescope's entire layout
         • See |resolver.resolve_height()|
       • mirror: Flip the location of the results/prompt and preview windows
       • prompt_position:
@@ -2043,7 +2043,8 @@ layout_strategies.center                  *telescope.layout_strategies.center*
         • Specifies an amount of additional padding around the anchor
         • Values should be a positive integer
       • height:
-        • How tall to make Telescope's entire layout
+        • Controls the height of the results window in the center layout.
+        • Does not control the entire layout height — setting this too high can shrink or obscure the preview window.
         • See |resolver.resolve_height()|
       • mirror: Flip the location of the results/prompt and preview windows
       • prompt_position:


### PR DESCRIPTION
# Description

Clarifies the behavior of `height` in the `center` layout strategy. 
The previous wording ("How tall to make Telescope's entire layout") was 
misleading — in the center layout, `height` controls the results window 
height, not the full layout. Setting it too high can shrink or obscure 
the preview window.

Also reverts an incorrect edit to the `horizontal` layout section.

Fixes #3623

## Type of change

- This change requires a documentation update

# How Has This Been Tested?

N/A — documentation-only change, no code was modified.

**Configuration**:
N/A
# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
