### PR TITLE
docs: clarify that center layout height controls results window, not full layout

### DIFF
--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1988,7 +1988,7 @@ layout_strategies.horizontal          *telescope.layout_strategies.horizontal*
         • Specifies an amount of additional padding around the anchor
         • Values should be a positive integer
       • height:
-        •How tall to make Telescope's entire layout
+        • How tall to make Telescope's entire layout
         • See |resolver.resolve_height()|
       • mirror: Flip the location of the results/prompt and preview windows
       • prompt_position:
@@ -2043,7 +2043,8 @@ layout_strategies.center                  *telescope.layout_strategies.center*
         • Specifies an amount of additional padding around the anchor
         • Values should be a positive integer
       • height:
-        • How tall to make Telescope's entire layout 
+        • Controls the height of the results window in the center layout.
+        • Does not control the entire layout height — setting this too high can shrink or obscure the preview window.
         • See |resolver.resolve_height()|
       • mirror: Flip the location of the results/prompt and preview windows
       • prompt_position:

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -2043,8 +2043,7 @@ layout_strategies.center                  *telescope.layout_strategies.center*
         • Specifies an amount of additional padding around the anchor
         • Values should be a positive integer
       • height:
-        • Controls the height of the results window in the center layout.
-        • Does not control the entire layout height — setting this too high can shrink or obscure the preview window.
+        • How tall to make Telescope's entire layout 
         • See |resolver.resolve_height()|
       • mirror: Flip the location of the results/prompt and preview windows
       • prompt_position:

--- a/doc/telescope.txt
+++ b/doc/telescope.txt
@@ -1988,7 +1988,7 @@ layout_strategies.horizontal          *telescope.layout_strategies.horizontal*
         • Specifies an amount of additional padding around the anchor
         • Values should be a positive integer
       • height:
-        • How tall to make Telescope's entire layout
+        •How tall to make Telescope's entire layout
         • See |resolver.resolve_height()|
       • mirror: Flip the location of the results/prompt and preview windows
       • prompt_position:
@@ -2043,7 +2043,8 @@ layout_strategies.center                  *telescope.layout_strategies.center*
         • Specifies an amount of additional padding around the anchor
         • Values should be a positive integer
       • height:
-        • How tall to make Telescope's entire layout
+        • Controls the height of the results window in the center layout.
+        • Does not control the entire layout height — setting this too high can shrink or obscure the preview window.
         • See |resolver.resolve_height()|
       • mirror: Flip the location of the results/prompt and preview windows
       • prompt_position:

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -434,6 +434,11 @@ layout_strategies.center = make_documented_layout(
   "center",
   vim.tbl_extend("error", shared_options, {
     preview_cutoff = "When lines are less than this value, the preview will be disabled",
+    height = {
+      "Controls the height of the results window in the center layout.",
+      "Does not control the entire layout height — setting this too high can shrink or obscure the preview window.",
+      "See |resolver.resolve_height()|",
+    },
   }),
   function(self, max_columns, max_lines, layout_config)
     local initial_options = p_window.get_initial_window_options(self)
@@ -449,6 +454,7 @@ layout_strategies.center = make_documented_layout(
     local width = resolve.resolve_width(width_opt)(self, max_columns, max_lines)
 
     -- This sets the height for the whole layout
+    -- Setting this too high can shrink or obscure the preview window.
     local height_opt = layout_config.height
     local height = resolve.resolve_height(height_opt)(self, max_columns, max_lines)
 

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -432,7 +432,7 @@ layout_strategies.horizontal = make_documented_layout(
 ---
 layout_strategies.center = make_documented_layout(
   "center",
-  vim.tbl_extend("error", shared_options, {
+  vim.tbl_extend("force", shared_options, {
     preview_cutoff = "When lines are less than this value, the preview will be disabled",
     height = {
       "Controls the height of the results window in the center layout.",


### PR DESCRIPTION
# Description

Clarifies the behavior of `height` in the `center` layout strategy. 
The previous wording ("How tall to make Telescope's entire layout") was 
misleading — in the center layout, `height` controls the results window 
height, not the full layout. Setting it too high can shrink or obscure 
the preview window.

Also reverts an incorrect edit to the `horizontal` layout section.

Fixes #3623

## Type of change

- This change requires a documentation update

# How Has This Been Tested?

N/A — documentation-only change. The height description was updated in
the lua annotations, which auto-generates telescope.txt via make docgen.

- [ ] Test A
- [ ] Test B

**Configuration**:
N/A

# Checklist:

- [ ] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
