### PR TITLE
feat(highlights): add TelescopeResultsLineCol for line:col coordinates

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -459,10 +459,17 @@ function make_entry.gen_from_quickfix(opts)
 
   local make_display = function(entry)
     local display_filename, path_style = utils.transform_path(opts, entry.filename)
-    local display_string = string.format("%s:%d:%d", display_filename, entry.lnum, entry.col)
+    local coordinates = string.format(":%d:%d", entry.lnum, entry.col)
+    local display_string = display_filename .. coordinates
     if hidden then
-      display_string = string.format("%4d:%2d", entry.lnum, entry.col)
+      coordinates = string.format("%4d:%2d", entry.lnum, entry.col)
+      display_string = coordinates
     end
+
+    local display_highlights = path_style or {}
+    local coord_start = hidden and 0 or #display_filename
+    local coord_end = coord_start + #coordinates
+    table.insert(display_highlights, { { coord_start, coord_end }, "TelescopeResultsLineCol" })
 
     if show_line then
       local text = entry.text
@@ -473,7 +480,7 @@ function make_entry.gen_from_quickfix(opts)
       display_string = display_string .. ":" .. text
     end
 
-    return display_string, path_style
+    return display_string, display_highlights
   end
 
   local get_filename = get_filename_fn()

--- a/plugin/telescope.lua
+++ b/plugin/telescope.lua
@@ -78,6 +78,7 @@ local highlights = {
   TelescopeResultsVariable = { default = true, link = "SpecialChar" },
 
   TelescopeResultsLineNr = { default = true, link = "LineNr" },
+  TelescopeResultsLineCol = { default = true, link = "LineNr" },
   TelescopeResultsIdentifier = { default = true, link = "Identifier" },
   TelescopeResultsNumber = { default = true, link = "Number" },
   TelescopeResultsComment = { default = true, link = "Comment" },


### PR DESCRIPTION
When using the lsp_references picker or other quickfix-based pickers, the line:column coordinates are displayed alongside the filename. Previously there was no way to style this portion independently from other text using TelescopeResultsNormal.

I added a new highlight group `TelescopeResultsLineCol` that applies specifically to the `:lnum:col` portion of quickfix entries. It defaults to `LineNr` to maintain the current look, but users can now override it in their colorscheme:

```lua
vim.api.nvim_set_hl(0, "TelescopeResultsLineCol", { fg = "#808080" })
```

Closes #3117