### PR TITLE
feat(neoplen): restore minimal async.uv

### DIFF
--- a/lua/neoplen/async/init.lua
+++ b/lua/neoplen/async/init.lua
@@ -6,6 +6,7 @@
 local lookups = {
   util = "neoplen.async.util",
   control = "neoplen.async.control",
+  uv = "neoplen.async.uv_async",
 }
 
 local M = setmetatable(require "neoplen.async.async", {

--- a/lua/neoplen/async/uv_async.lua
+++ b/lua/neoplen/async/uv_async.lua
@@ -1,0 +1,19 @@
+local a = require "neoplen.async.async"
+local uv = vim.uv
+
+local M = {}
+
+local function add(name, argc)
+  M[name] = a.wrap(uv[name], argc)
+end
+
+-- filesystem operations
+add("fs_stat", 2)
+add("fs_open", 4)
+add("fs_close", 2)
+add("fs_read", 4)
+add("fs_write", 4)
+add("fs_unlink", 2)
+add("fs_realpath", 2)
+
+return M


### PR DESCRIPTION
Per #3647 ([comment](https://github.com/nvim-telescope/telescope.nvim/pull/3647#issuecomment-4452651201)) — restoring `neoplen.async.uv` with only the wrappers extensions actually depend on, per your "keep it minimal" preference.

Surveyed against [telescope-frecency draft PR #343](https://github.com/nvim-telescope/telescope-frecency.nvim/pull/343), which uses these 7:

- `fs_stat`
- `fs_open`
- `fs_close`
- `fs_read`
- `fs_write`
- `fs_unlink`
- `fs_realpath`

`init.lua` lookups gets a `uv = "neoplen.async.uv_async"` entry so `require("neoplen.async").uv.fs_*` keeps working unchanged. Adding more wrappers later is a 1-line `add(name, argc)` call when another extension shows up needing them.

## Test plan

- [x] `make test` green locally (Apple Silicon macOS / Neovim stable).
- [x] stylua clean.

Net diff: +20 / -0 across 2 files.