### PR TITLE
Fix oldfiles picker ignoring entries for remote files

### DIFF
--- a/lua/telescope/builtin/__internal.lua
+++ b/lua/telescope/builtin/__internal.lua
@@ -548,7 +548,11 @@ internal.oldfiles = function(opts)
   local current_file = api.nvim_buf_get_name(current_buffer)
   local results = {}
 
-  if utils.iswin then -- for slash problem in windows
+  local function has_protocol(path)
+    return string.match(path, "^[A-z0-9]+://")
+  end
+
+  if utils.iswin and not has_protocol(current_file) then -- for slash problem in windows
     current_file = current_file:gsub("/", "\\")
   end
 
@@ -558,10 +562,11 @@ internal.oldfiles = function(opts)
       local open_by_lsp = string.match(buffer, "line 0$")
       if match and not open_by_lsp then
         local file = api.nvim_buf_get_name(match)
+        local protocol = has_protocol(file)
         if utils.iswin then
           file = file:gsub("/", "\\")
         end
-        if vim.uv.fs_stat(file) and match ~= current_buffer then
+        if match ~= current_buffer and (protocol or vim.uv.fs_stat(file)) then
           table.insert(results, file)
         end
       end
@@ -569,11 +574,16 @@ internal.oldfiles = function(opts)
   end
 
   for _, file in ipairs(vim.v.oldfiles) do
+    local protocol = has_protocol(file)
     if utils.iswin then
       file = file:gsub("/", "\\")
     end
-    local file_stat = vim.uv.fs_stat(file)
-    if file_stat and file_stat.type == "file" and not vim.tbl_contains(results, file) and file ~= current_file then
+    local file_stat = vim.loop.fs_stat(file)
+    if
+      ((file_stat and file_stat.type == "file") or (protocol and protocol ~= "file://" and protocol ~= "term://"))
+      and not vim.tbl_contains(results, file)
+      and file ~= current_file
+    then
       table.insert(results, file)
     end
   end


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

Fixes #3520, resurrects #3521

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- Locally, results were the same as those documented in #3521.

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.12.2
Build type: Release
LuaJIT 2.1.1774638290
Run "nvim -V1 -v" for more info
```
* Operating system and version: **macOS 26.5**
# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
