### PR TITLE
fix(pickers): highlight match against rendered buffer line

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -457,6 +457,12 @@ function Picker:highlight_one_row(results_bufnr, prompt, display, row)
     return
   end
 
+  -- Highlight against the line as it exists in the buffer, not the caller's
+  -- `display`: update_prefix may have written a caret whose byte width differs
+  -- from the entry_prefix `display` was built with, which would shift the
+  -- sorter's byte offsets onto the wrong columns. Fall back to `display` only
+  -- if the row can't be read (e.g. an invalid/empty buffer).
+  display = api.nvim_buf_get_lines(results_bufnr, row, row + 1, false)[1] or display
   local highlights = self.sorter:highlighter(prompt, display)
 
   if highlights then


### PR DESCRIPTION
# Description

`Picker:highlight_one_row` was given the `display` string that `entry_adder`
built using `entry_prefix`, then passed that to the sorter's highlighter to
compute match positions. The sorter (e.g. telescope-fzf-native) returns **byte**
offsets, which are painted onto the results buffer line.

The problem: by the time the highlight runs, `update_prefix` may have replaced
the line's leading prefix with `selection_caret`, and a caret can have a
different *byte* width than `entry_prefix` even when both are the same display
width — e.g. `selection_caret = " █ "` is 5 bytes (the `█`, U+2588, is 3 bytes)
while `entry_prefix = "   "` is 3 bytes. The byte offsets were computed against
the 3-byte-prefixed string but applied to the 5-byte-prefixed buffer line, so
every match highlight is shifted left by the difference.

Only the selected row goes through `update_prefix` with the caret, so the bug
surfaces on the auto-selected first row — i.e. on the first search, before any
keystroke redraws the row through the (correct) selection path.

This fixes it by highlighting against the line as it actually exists in the
buffer rather than the caller's `display`, making the byte offsets line up with
the rendered prefix regardless of its width. The `display` argument is kept as a
fallback for the rare case the row can't be read.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Reproduced manually before and after the change with the minimal config below,
and confirmed the existing suite, stylua, and luacheck stay green.

Minimal repro config:

```lua
require("telescope").setup({
  defaults = {
    entry_prefix = "   ",     -- 3 bytes
    selection_caret = " █ ",  -- 5 bytes (U+2588 is 3 bytes), same display width
  },
})
require("telescope").load_extension("fzf")
```

Steps:
1. `:Telescope find_files` in a repo containing a file whose path matches a
   query mid-string (e.g. `src/schemas/order_schema.js`).
2. Type `order`.
3. Before the fix: the match highlight on the auto-selected first row lands left
   of `order` (on `s/`), because the offsets were shifted by the 2-byte prefix
   difference.
   
<img width="1920" height="1080" alt="image_2026_06_12_19_26_02" src="https://github.com/user-attachments/assets/ac37ebfd-16a5-4785-b2d7-6947c30a1b03" />

4. After the fix: the match highlight lands exactly where it needs to.

<img width="1920" height="1080" alt="image_2026_06_12_23_34_39" src="https://github.com/user-attachments/assets/74e4d641-7a42-4e35-81a6-d2cc4ab72f17" />

- [x] manual repro above — highlight lands on the query on the selected row
- [x] `make test`, `stylua --check .`, and `make lint` all pass

**Configuration**:
* Neovim version: NVIM v0.12.3
* Operating system and version: Arch Linux (Linux 7.0.11-arch1-1 x86_64 GNU/Linux)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas