### PR TITLE
fix(diagnostics): preserve diagnostic code field

### DIFF
--- a/lua/telescope/builtin/__diagnostics.lua
+++ b/lua/telescope/builtin/__diagnostics.lua
@@ -113,6 +113,7 @@ local diagnostics_to_tbl = function(opts)
       lnum = diagnostic.lnum + 1,
       col = diagnostic.col + 1,
       text = vim.trim(diagnostic.message:gsub("[\n]", "")),
+      code = diagnostic.code,
       type = severities[diagnostic.severity] or severities[1],
     }
   end

--- a/lua/tests/automated/diagnostics_spec.lua
+++ b/lua/tests/automated/diagnostics_spec.lua
@@ -1,0 +1,66 @@
+local diagnostics = require "telescope.builtin.__diagnostics"
+local pickers = require "telescope.pickers"
+
+local eq = assert.are.same
+
+describe("builtin diagnostics", function()
+  local bufnr
+  local ns
+  local old_pickers_new
+  local previous_bufnr
+
+  before_each(function()
+    old_pickers_new = pickers.new
+    previous_bufnr = vim.api.nvim_get_current_buf()
+    ns = vim.api.nvim_create_namespace "telescope-test-diagnostics"
+    bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(bufnr, vim.fn.tempname() .. ".py")
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "def example(a, b): pass" })
+    vim.api.nvim_set_current_buf(bufnr)
+  end)
+
+  after_each(function()
+    pickers.new = old_pickers_new
+    vim.diagnostic.reset(ns, bufnr)
+
+    if previous_bufnr and vim.api.nvim_buf_is_valid(previous_bufnr) then
+      vim.api.nvim_set_current_buf(previous_bufnr)
+    end
+
+    if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end
+  end)
+
+  it("preserves the diagnostic code for custom entry makers", function()
+    vim.diagnostic.set(ns, bufnr, {
+      {
+        lnum = 0,
+        col = 4,
+        severity = vim.diagnostic.severity.WARN,
+        message = "too many arguments",
+        code = "PLR0913",
+      },
+    })
+
+    local captured_entry
+    pickers.new = function()
+      return { find = function() end }
+    end
+
+    diagnostics.get {
+      bufnr = 0,
+      entry_maker = function(entry)
+        captured_entry = entry
+        return {
+          value = entry,
+          ordinal = entry.text,
+          display = entry.text,
+        }
+      end,
+    }
+
+    assert.is_not_nil(captured_entry)
+    eq("PLR0913", captured_entry.code)
+  end)
+end)


### PR DESCRIPTION
# Description

Preserve the original diagnostic `code` field when Telescope preprocesses diagnostics for the diagnostics picker. This lets custom `entry_maker` callbacks access codes such as Ruff's `PLR0913`.

Fixes #3673

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `luac -p lua/telescope/builtin/__diagnostics.lua lua/tests/automated/diagnostics_spec.lua`
- [x] `nvim --headless --noplugin -u scripts/minimal_init.vim -c "PlenaryBustedFile lua/tests/automated/diagnostics_spec.lua"`
- [x] `make test`
- [x] `make lint`
- [x] `npx --yes @johnnymorganz/stylua-bin --check .`

**Configuration**:
* Neovim version (nvim --version): NVIM v0.12.3
* Operating system and version: Ubuntu 24.04 / Linux 6.8.0-117-generic

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (no comments needed for this small field preservation)
- [x] I have made corresponding changes to the documentation (lua annotations; not applicable)
