### PR TITLE
Fix: replace usage of `fnameescape()` with `bufadd()` approach when instantiating a new buffer

### DIFF
--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -94,9 +94,13 @@ do
       )
     end
     if buf_command ~= "drop" and buf_command ~= "tab drop" then
-      vim.cmd(string.format("%s %d", buf_command, bufnr))
+      pcall(function()
+        vim.cmd(string.format("%s %d", buf_command, bufnr))
+      end)
     else
-      vim.cmd { cmd = buf_command, args = { api.nvim_buf_get_name(bufnr) } }
+      pcall(function()
+        vim.cmd { cmd = buf_command, args = { api.nvim_buf_get_name(bufnr) } }
+      end)
     end
   end
 end

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -193,7 +193,6 @@ action_set.edit = function(prompt_bufnr, command)
     if api.nvim_buf_get_name(0) ~= filename or command ~= "edit" then
       filename = vim.fs.normalize(filename)
       local bufnr = vim.fn.bufadd(filename)
-      vim.fn.bufload(bufnr)
       vim.bo[bufnr].buflisted = true
       edit_buffer(command, bufnr)
     end

--- a/lua/telescope/actions/set.lua
+++ b/lua/telescope/actions/set.lua
@@ -10,7 +10,6 @@
 local api = vim.api
 
 local log = require "telescope.log"
-local Path = require "plenary.path"
 local state = require "telescope.state"
 local utils = require "telescope.utils"
 
@@ -97,7 +96,7 @@ do
     if buf_command ~= "drop" and buf_command ~= "tab drop" then
       vim.cmd(string.format("%s %d", buf_command, bufnr))
     else
-      vim.cmd(string.format("%s %s", buf_command, vim.fn.fnameescape(api.nvim_buf_get_name(bufnr))))
+      vim.cmd { cmd = buf_command, args = { api.nvim_buf_get_name(bufnr) } }
     end
   end
 end
@@ -192,8 +191,11 @@ action_set.edit = function(prompt_bufnr, command)
     -- check if we didn't pick a different buffer
     -- prevents restarting lsp server
     if api.nvim_buf_get_name(0) ~= filename or command ~= "edit" then
-      filename = Path:new(filename):normalize(vim.uv.cwd())
-      pcall(vim.cmd, string.format("%s %s", command, vim.fn.fnameescape(filename)))
+      filename = vim.fs.normalize(filename)
+      local bufnr = vim.fn.bufadd(filename)
+      vim.fn.bufload(bufnr)
+      vim.bo[bufnr].buflisted = true
+      edit_buffer(command, bufnr)
     end
   end
 

--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -37,7 +37,7 @@ function from_entry.path(entry, validate, escape)
     end
   end
   if escape then
-    -- WARNING: relies on `isfname` and does not escape `(` and `)`
+    -- WARNING: relies on `isfname`, thus does not escape `(` and `)` on Windows
     return vim.fn.fnameescape(path)
   end
   return path

--- a/lua/telescope/from_entry.lua
+++ b/lua/telescope/from_entry.lua
@@ -37,6 +37,7 @@ function from_entry.path(entry, validate, escape)
     end
   end
   if escape then
+    -- WARNING: relies on `isfname` and does not escape `(` and `)`
     return vim.fn.fnameescape(path)
   end
   return path


### PR DESCRIPTION
# Description

PLEASE NOTE: I am no neovim expert, please review this carefully. I did my best to ensure this PR is high quality and to think of every area this affects.

This PR removes the usage of `fnameescape` and replaces it with a different approach that introduces `bufadd()` to instantiate a new buffer.

- fixes #2446
- fixes remaining issues in #1171

## What
- replace `vim.cmd` string approach with table approach, as it removes the need for `fnameescape`
- replace `vim.cmd` + `fnameescape()` with `vim.fs.normalize()` + `bufadd()` and `bufload()` approach when creating a new buffer
- use `vim.fs.normalize` instead of plenary's `normalize` method, when opening a file
- add warning comment to `fnameescape` usage here: https://github.com/nvim-telescope/telescope.nvim/blob/9377230aa5305d9e9aca4ed8dadf1070fb4aa9fc/lua/telescope/from_entry.lua#L40

## Why
- recommended fix in https://github.com/neovim/neovim/issues/23530#issuecomment-4767653795
- avoids flawed `fnameescape` escaping method which relies on `isfname`. Because `isfname` does not include the `(` and `)` chars by default, `fnameescape` is unable to escape parentheses, which causes #2446.
- `vim.fs.normalize` uses `/` instead of `\`, which is required for `bufadd()` to work correctly and avoids the issues when using `\` as the path separator

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I ran `make test` and all tests succeeded
- [x] I tested opening a file at `src\app\(protected)\layout.tsx` with my own configuration. Without my fix this results in issue #2446, with my fix it works as expected.
- [ ] testing `drop` and `tab drop` commands (because they are affected by this PR too)
- [ ] testing all of the above on linux

**Configuration**:
* Neovim version (nvim --version): v0.11.6
* Operating system and version: Windows 11 Home (25H2, OS build 26200.8655)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
  **Does it need comments?**
- [ ] I have made corresponding changes to the documentation (lua annotations)
  **Doesn't need changes to the documentation as it's not a breaking change.**
