### PR TITLE
fix(sorters): allow prefilter tags containing whitespace

### DIFF
--- a/lua/telescope/sorters.lua
+++ b/lua/telescope/sorters.lua
@@ -580,16 +580,22 @@ local filter_function = function(opts)
   local scoring_function = utils.if_nil(opts.filter_function, substr_matcher)
   local tag = utils.if_nil(opts.tag, "ordinal")
 
+  local d = opts.delimiter
+  -- tags may contain whitespace, e.g. when a plugin prepends icons to the LSP
+  -- symbol kinds, so a fully enclosed tag takes precedence over the lenient
+  -- pattern that allows omitting the closing delimiter
+  local enclosed_filter = "^(" .. d .. "[^" .. d .. "]+" .. d .. ")"
+  local filter = "^(" .. d .. "%S+" .. "[" .. d .. "%s]" .. ")"
+
   return function(_, prompt, entry)
-    local filter = "^(" .. opts.delimiter .. "(%S+)" .. "[" .. opts.delimiter .. "%s]" .. ")"
-    local matched = prompt:match(filter)
+    local matched = prompt:match(enclosed_filter) or prompt:match(filter)
 
     if matched == nil then
       return 0, prompt
     end
     -- clear prompt of tag
     prompt = prompt:sub(#matched + 1, -1)
-    local query = vim.trim(matched:gsub(opts.delimiter, ""))
+    local query = vim.trim(matched:gsub(d, ""))
     return scoring_function(_, query, entry[tag], _), prompt
   end
 end


### PR DESCRIPTION
Fixes #3675

### Root cause

`sorters.prefilter` (used by `lsp_document_symbols`, `lsp_workspace_symbols`, `treesitter` and `diagnostics`) matched the tag typed in the prompt with:

```lua
"^(" .. delimiter .. "(%S+)" .. "[" .. delimiter .. "%s]" .. ")"
```

`%S+` means a tag can never contain whitespace. The tag values come from `entry.symbol_type`, which telescope parses out of the `[<kind>] <name>` text produced by `vim.lsp.util.symbols_to_items()`, i.e. straight from `vim.lsp.protocol.SymbolKind`.

Plugins that add icons to LSP kinds patch that table — e.g. `MiniIcons.tweak_lsp_kind()` rewrites each kind to `icon .. ' ' .. kind`. The tags then look like `:<icon> field:`, and because of the space the pattern only ever matched `:<icon> `, so `<C-l>` completion inserted a tag that filtered nothing out.

### Fix

Try a fully delimiter-enclosed tag first (which may contain spaces), and fall back to the existing pattern that permits omitting the closing delimiter. The pattern is anchored and cannot cross a delimiter, so `:variable: str:x` still resolves to the tag `variable` with `str:x` left for the fuzzy sorter; both patterns are now also built once per sorter instead of on every entry.

### Verification

No neovim + LSP + mini.icons environment was set up; verified by reviewing the data flow above and by checking the two patterns against representative prompts:

| prompt | matched tag | remaining prompt |
|---|---|---|
| `:<icon> field: foo` | `:<icon> field:` | ` foo` |
| `:variable: foo` | `:variable:` | ` foo` |
| `:variable foo` | `:variable ` | `foo` |
| `:variable: str:x` | `:variable:` | ` str:x` |
| `foo` | none | `foo` |

Behaviour for whitespace-free tags is unchanged.