### PR TITLE
docs(readme): fix formatting and add fzf-native load_extension note

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ This section should guide you to run your first builtin pickers.
 * [sharkdp/fd](https://github.com/sharkdp/fd) (finder)
 * [devicons](https://github.com/nvim-tree/nvim-web-devicons) (icons)
 
-We also strongly suggest installing a native telescope sorter to significantly improve
+We also strongly suggest installing a native telescope sorter extension to significantly improve
 sorting performance:
 * [telescope-fzf-native.nvim](https://github.com/nvim-telescope/telescope-fzf-native.nvim)
 or
 * [telescope-fzy-native.nvim](https://github.com/nvim-telescope/telescope-fzy-native.nvim).
+
 For more information and a performance benchmark take a look at the
 [Extensions](https://github.com/nvim-telescope/telescope.nvim/wiki/Extensions)
 wiki.
@@ -81,6 +82,10 @@ e.g. using [lazy.nvim](https://github.com/folke/lazy.nvim)
     }
 }
 ```
+
+> [!NOTE]
+> To get `fzf-native` loaded and working with Telescope, you need to call `load_extension`, somewhere after the `setup` function: `require('telescope').load_extension('fzf')`.
+> For more details, see the [fzf-native documentation](https://github.com/nvim-telescope/telescope-fzf-native.nvim#telescope-setup-and-configuration).
 
 ### Checkhealth
 


### PR DESCRIPTION
I noticed a few minor UX issues in the README that confused me as a new user (and will likely confuse others like myself). I grouped these small improvements into one PR:

1. Added the word "extension" to the sentence introducing native sorters. This helps connect the mental dot that fzf-native is not just a background dependency, but an actual Telescope extension. 
2. Added a short note (borrowed directly from the fzf-native README for consistency) about calling "require('telescope').load_extension('fzf')". The installation guide recommends adding fzf-native to the dependencies block, which made me assume it will lazy-load or work out-of-the-box. Included a link to the fzf-native docs for reference.
3. Fixed a minor markdown formatting issue where "For more information..." was rendering as part of the bulleted list.