### PR TITLE
fix(finders): stop yielding per entry in oneshot replay loop

### DIFF
--- a/lua/telescope/finders/async_oneshot_finder.lua
+++ b/lua/telescope/finders/async_oneshot_finder.lua
@@ -87,7 +87,7 @@ return function(opts)
       local current_count = num_results
       for index = 1, current_count do
         -- TODO: Figure out scheduling...
-        if index % await_count then
+        if index % await_count == 0 then
           async.util.scheduler()
         end
 


### PR DESCRIPTION
`index % await_count` is always truthy in Lua (0 included), so the oneshot finder's replay loop yields once per entry instead of once per `await_count`. The per-entry yields let redraws expose the partially re-scored list as a brief flash of unrelated results when typing quickly in large directories (related: #3342).

The streaming loop's per-entry yield is left as is; there it also escapes the libuv fast-event context.

Developed with LLM's help; reviewed and tested by me (`make test`, manual repro on a ~5k-file directory).
