### PR TITLE
fix(pickers): show selection caret while results are still streaming

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -579,6 +579,16 @@ function Picker:find()
   local status_updater = self:get_status_updater(self.prompt_win, self.prompt_bufnr)
   local debounced_status = debounce.throttle_leading(status_updater, 50)
 
+  -- Keep a selection (and its caret) live while results are still streaming in,
+  -- so <CR> selects the current best result before the finder finishes. See #3257.
+  -- Throttled so we don't redraw the caret and previewer on every incoming entry.
+  local debounced_selection = debounce.throttle_leading(function()
+    if self.closed or self:is_done() then
+      return
+    end
+    self:_do_selection(self:_get_prompt() or "")
+  end, 50)
+
   local tx, rx = channel.mpsc()
   self._on_lines = tx.send
 
@@ -658,7 +668,7 @@ function Picker:find()
         self.manager = EntryManager:new(self.max_results, self.entry_adder, self.stats)
 
         self:_reset_highlights()
-        local process_result = self:get_result_processor(find_id, prompt, debounced_status)
+        local process_result = self:get_result_processor(find_id, prompt, debounced_status, debounced_selection)
         local process_complete = self:get_result_completor(self.results_bufnr, find_id, prompt, status_updater)
 
         local ok, msg = pcall(function()
@@ -1397,14 +1407,17 @@ end
 ---@param find_id number
 ---@param prompt string
 ---@param status_updater function
+---@param update_selection function throttled callback that (re)draws the selection while results stream in
 ---@return function
-function Picker:get_result_processor(find_id, prompt, status_updater)
+function Picker:get_result_processor(find_id, prompt, status_updater, update_selection)
   local count = 0
 
   local cb_add = function(score, entry)
     -- may need the prompt for tiebreak
     self.manager:add_entry(self, score, entry, prompt)
     status_updater { completed = false }
+    -- draw/refresh the caret so a selection exists mid-search (#3257)
+    update_selection()
   end
 
   local cb_filter = function(_)


### PR DESCRIPTION
# Description

Draw the selection while results are still streaming in, so the caret shows up and `<CR>` works during a long search instead of only after it finishes.

Fixes #3257

The selection (and therefore the caret) was only ever set from `get_result_completor`, which runs once the finder is done. On a slow finder (live_grep in a big tree, find_files over a huge dir) that means there's no selected entry at all while results trickle in: no caret, and hitting Enter does nothing until completion. The entries themselves are already in the buffer during the search, there's just no selection pointing at one.

Fix hooks a throttled `_do_selection` into the result processor, right next to the existing `status_updater` call, so the selection gets (re)drawn as entries arrive. It reuses the same `throttle_leading(..., 50)` pattern the status counter already uses, so we're not redrawing the caret and re-running the previewer on every single entry. The completor still does its final `_do_selection`, so the end state is unchanged; this just makes the selection live sooner. `selection_strategy = "none"` is untouched since `_do_selection` already no-ops there.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Existing automated suite: `PlenaryBustedDirectory lua/tests/automated/` — all green (picker specs included, no regressions).
- [x] Scripted repro with a deliberately slow finder (entries at 150/300/450ms, completion delayed to 3s), probed mid-search at 800ms:
  - before: `selection=nil`, no caret line
  - after: `selection="alpha"`, results line reads `> alpha` — caret drawn and entry selectable well before completion

Repro finder used:

```lua
local function slow_finder(_, process_result, process_complete)
  for i, v in ipairs { "alpha", "bravo", "charlie" } do
    vim.defer_fn(function() process_result { value = v, ordinal = v, display = v } end, i * 150)
  end
  vim.defer_fn(process_complete, 3000)
end
```

**Configuration**:
* Neovim version (nvim --version): NVIM v0.11.7
* Operating system and version: Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
