### PR TITLE
fix(pickers): Ignore nil entries in get_substr_matcher

### DIFF
--- a/lua/telescope/sorters.lua
+++ b/lua/telescope/sorters.lua
@@ -543,7 +543,7 @@ sorters.get_substr_matcher = function()
   return Sorter:new {
     highlighter = substr_highlighter(make_display),
     scoring_function = function(_, prompt, _, entry)
-      if #prompt == 0 then
+      if #prompt == 0 or entry == nil then
         return 1
       end
 


### PR DESCRIPTION
I noticed that with some sources the sorter was sometimes getting nil values for the entry parameter, and it was causing it to emit a warning and stop working. Adding a check at the top of the scoring_functions fixes the problem and sorting works as expected.