### PR TITLE
Add ref count to picker and enable cursor exit from prompt buffer

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -324,6 +324,7 @@ function Picker:new(opts)
     __scrolling_limit = tonumber(utils.if_nil(opts.temp__scrolling_limit, 250)),
 
     __locations_input = utils.if_nil(opts.__locations_input, false),
+    _counter = 0,
   }, self)
 
   obj.create_layout = opts.create_layout or config.values.create_layout or default_create_layout
@@ -369,6 +370,27 @@ function Picker:new(opts)
   return obj
 end
 
+function Picker:add_ref()
+  self._counter = self._counter + 1
+  if (self._counter > 1) then
+    utils.notify("Picker:add_ref", {'_counter > 1', level = "WARN"})
+  end
+end
+
+function Picker:dec_ref()
+  self._counter = self._counter - 1
+  if (self._counter < 0) then
+    self._counter = 0
+    utils.notify("Picker:dec_ref", {'_counter < 0', level = "WARN"})
+  end
+end
+
+function Picker:get_ref()
+  self._counter = self._counter + 1
+  if (self._counter ~= 1) and (self._counter ~= 0) then
+    utils.notify("Picker:get_ref", {'_counter = ' .. self._counter, level = "WARN"})
+  end
+end
 --- Take an index and get a row.
 ---@note: Rows are 0-indexed, and `index` is 1 indexed (table index)
 ---@param index number: the index in line_manager
@@ -1569,6 +1591,11 @@ end
 function pickers.on_close_prompt(prompt_bufnr)
   local status = state.get_status(prompt_bufnr)
   local picker = status.picker
+
+  if picker._counter ~= 0 then
+    return
+  end
+
   require("telescope.actions.state").get_current_history():reset()
 
   if type(picker.cache_picker) == "table" then

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -372,23 +372,23 @@ end
 
 function Picker:add_ref()
   self._counter = self._counter + 1
-  if (self._counter > 1) then
-    utils.notify("Picker:add_ref", {'_counter > 1', level = "WARN"})
+  if self._counter > 1 then
+    utils.notify("Picker:add_ref", { "_counter > 1", level = "WARN" })
   end
 end
 
 function Picker:dec_ref()
   self._counter = self._counter - 1
-  if (self._counter < 0) then
+  if self._counter < 0 then
     self._counter = 0
-    utils.notify("Picker:dec_ref", {'_counter < 0', level = "WARN"})
+    utils.notify("Picker:dec_ref", { "_counter < 0", level = "WARN" })
   end
 end
 
 function Picker:get_ref()
   self._counter = self._counter + 1
   if (self._counter ~= 1) and (self._counter ~= 0) then
-    utils.notify("Picker:get_ref", {'_counter = ' .. self._counter, level = "WARN"})
+    utils.notify("Picker:get_ref", { "_counter = " .. self._counter, level = "WARN" })
   end
 end
 --- Take an index and get a row.


### PR DESCRIPTION
Add ref count to picker and enable cursor exit from prompt buffer #2778

# Description

Add ref count to picker and enable cursor exit from prompt buffer.

Fixes # (issue)
Because I want to move cursor into previewer window, I map [\<Tab\>] to a focus_preview (refer to #2778).

```
  local function focus_preview(prompt_bufnr)
    local action_state = require 'telescope.actions.state'
    local picker = action_state.get_current_picker(prompt_bufnr)
    local prompt_win = picker.prompt_win
    local previewer = picker.previewer
    local bufnr = previewer.state.bufnr or previewer.state.termopen_bufnr
    local winid = previewer.state.winid or vim.fn.win_findbuf(bufnr)[1]
    vim.keymap.set('n', '<Tab>', function()
      picker:dec_ref()
      vim.api.nvim_set_current_win(prompt_win)
    end, { buffer = bufnr })
    picker:add_ref()
    vim.api.nvim_set_current_win(winid)
    -- api.nvim_set_current_win(winid)
  end
```

However the picker will close when I press [\<Tab\>]. I fount that the picker will be closed when cursor leave prompt buffer because of the code below.
https://github.com/nvim-telescope/telescope.nvim/blob/40aedd8a68c78a656a10a8d62d80c54af59420fb/lua/telescope/pickers.lua#L701-L709

So I add  a ref count and interfaces to It.

https://github.com/JPLaoC/telescope.nvim/blob/f12458737181c4f7a5716f9ee4323564c5bf53bf/lua/telescope/pickers.lua#L327-L329

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list relevant details about your configuration

- Map focus_preview to [\<Tab\>]
- press [\<Tab\>] in prompt window, the cursor will move into previewer window
- I can yank or press j,k,h,l to move cursor
- press [\<Tab\>] in previewer, the cursor can move back to prompt again

**Configuration**:
* Neovim version (nvim --version):
```
NVIM v0.12.5
Build type: Release
LuaJIT 2.1.1774638290
```
* Operating system and version:
```
Linux ab5540d9581f 6.18.46-1-lts #1 SMP PREEMPT_DYNAMIC Sun, 23 Aug 2026 14:20:15 +0000 x86_64 x86_64 x86_64 GNU/Linux
```

# Checklist:

- [ X] My code follows the style guidelines of this project (stylua)
- [ X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (lua annotations)
