### PR TITLE
feat(preview): allow BufReadCmd to enable custom scheme previews

### DIFF
--- a/lua/telescope/previewers/buffer_previewer.lua
+++ b/lua/telescope/previewers/buffer_previewer.lua
@@ -231,6 +231,34 @@ local handle_file_preview = function(filepath, bufnr, stat, opts)
   end)
 end
 
+---Attempt to load a buffer for a URI-like entry (e.g. `fugitive://...`) that
+---may be populated via `BufReadCmd`. This buffer can then be used as a content
+---source for the previewer.
+---@param entry table: the entry to load
+---@return integer|nil bufnr: the loaded bufnr, or nil if a buffer couldn't be loaded.
+local get_src_buf_for_uri = function(entry)
+  local name = from_entry.path(entry, false, false)
+  -- Require two or more scheme characters to avoid matching windows drive letters.
+  if type(name) ~= "string" or not name:match "^%a[%w+.-]+://" then
+    return nil
+  end
+  local bufnr = vim.uri_to_bufnr(name)
+  if not api.nvim_buf_is_loaded(bufnr) then
+    -- runs the plugin's BufReadCmd
+    pcall(vim.fn.bufload, bufnr)
+    local ok = api.nvim_buf_is_loaded(bufnr)
+      and (api.nvim_buf_line_count(bufnr) > 1 or api.nvim_buf_get_lines(bufnr, 0, 1, false)[1] ~= "")
+    if not ok then
+      -- Buffer still empty probably means no BufReadCmd present, don't leave a
+      -- useless buffer around.
+      pcall(api.nvim_buf_delete, bufnr, { force = true })
+      return nil
+    end
+  end
+
+  return bufnr
+end
+
 local PREVIEW_TIMEOUT_MS = 250
 local PREVIEW_FILESIZE_MB = 25
 local PREVIEW_HIGHLIGHT_MB = 1
@@ -553,18 +581,34 @@ previewers.vimgrep = defaulter(function(opts)
       -- builtin.buffers: bypass path validation for terminal buffers that don't have appropriate path
       local has_buftype = entry.bufnr and api.nvim_buf_is_valid(entry.bufnr) and vim.bo[entry.bufnr].buftype ~= ""
         or false
+      -- The buffer to copy from when there is no readable path.
+      local src_bufnr = has_buftype and entry.bufnr or nil
       local p
-      if not has_buftype then
+      if not src_bufnr then
         p = from_entry.path(entry, true, false)
         if p == nil or p == "" then
-          return
+          -- It's not a path on disk. It may be a URI populated via a BufReadCmd autocmd.
+          src_bufnr = get_src_buf_for_uri(entry)
+          if not src_bufnr then
+            return
+          end
+        elseif p == "[No Name]" and entry.bufnr then
+          -- Workaround for unnamed buffer when using builtin.buffers
+          src_bufnr = entry.bufnr
         end
       end
 
-      -- Workaround for unnamed buffer when using builtin.buffer
-      if entry.bufnr and (p == "[No Name]" or has_buftype) then
-        local lines = api.nvim_buf_get_lines(entry.bufnr, 0, -1, false)
+      if src_bufnr then
+        local lines = api.nvim_buf_get_lines(src_bufnr, 0, -1, false)
         api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+        ---@type string|nil
+        local ft = vim.bo[src_bufnr].filetype
+        if not ft or ft == "" then
+          ft = vim.filetype.match { buf = src_bufnr }
+        end
+        if ft then
+          putils.highlighter(self.state.bufnr, ft, { preview = opts.preview })
+        end
         -- schedule so that the lines are actually there and can be jumped onto when we call jump_to_line
         vim.schedule(function()
           jump_to_line(self, self.state.bufnr, entry)


### PR DESCRIPTION
This pull request is a refinement of my proposal at https://github.com/nvim-telescope/telescope.nvim/issues/3021#issuecomment-5467179402.

Disclaimer: I acknowledge that I am well versed in neither telescope's nor neovim's internals. It is possible that this approach has pitfalls I'm not aware of, and I am open to feedback up to and including "this is fundamentally a bad idea because ...". That said, it has worked well thus far for the cases I've tried with one exception (see `oil://` testing note below), including my own extension related to $DAYJOB that loads remote content via `BufReadCmd`.

# Description

The vimgrep/quickfix buffer previewer skips entries that are not readable filesystem paths. This prevents previews from working for files that use a URI scheme, such as vim-fugitive's `fugitive://`.

Plugins supporting a URI scheme like that are most likely supplying buffer content via the `BufReadCmd`. Detect scheme-like URIs and load their buffer so that `BufReadCmd` can supply that content.

Fixes #3021.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Basic functionality:
  To test the basic functionality of loading the content and setting a name-based filetype, `:luafile` the following:
  
  ```lua
  vim.api.nvim_create_autocmd("BufReadCmd", {
    pattern = "demofs://*",
    callback = function(args)
      vim.api.nvim_buf_set_lines(args.buf, 0, -1, false, {
        "-- content for " .. vim.api.nvim_buf_get_name(args.buf),
        "local function hello() end",
        "return hello",
      })
      vim.bo[args.buf].buftype = "nofile"
    end,
  })
                                                                  
  vim.fn.setqflist {
    {
      filename = "demofs://example/one.lua",
      lnum = 2,
      col = 1,
      text = "local function hello() end",
    },
  }
  require("telescope.builtin").quickfix()
  ```
  
  <img width="1057" height="171" alt="20260904_00h25m12s_grim" src="https://github.com/user-attachments/assets/3368de94-d98b-464b-b01c-badd77d43452" />

- [x] Non-extension-based filetype:
  If you have fugitive installed, you can also add some URI from a fugitive buffer. This additionally demonstrates that the filetype used for highlighting the preview buffer is determined from the source buffer even if the name isn't enough to determine the filetype.
  
  ```lua
    {
      filename = "fugitive:///home/brian/.dotfiles/.git//81efcf2496cf3b7d59fed5175013515fcae47a4e",
      lnum = 2,
      col = 1,
      text = "parent 1ce461a19a1035b9e251ad5546870c3c3b4b8c7a",
    },
  ```
  
  <img width="1147" height="192" alt="20260904_00h26m53s_grim" src="https://github.com/user-attachments/assets/b5e51629-46ea-4ef3-ad4e-c58bd1233308" />

- [ ] Asynchronous `BufReadCmd`
  I also tested with `oil://...` URIs handled by stevearc/oil.nvim. That plugin loads the content via `uv.fs_stat(path, vim.schedule_wrap(...))` which doesn't seem to play nicely with the approach of copying the content out of the new buffer immediately. I'm not sure if there's really a path forward here with this approach (and that could be an indicator that this approach isn't ideal).

**Configuration**:
* Neovim version (nvim --version):

```
NVIM v0.12.5
Build type: Release
LuaJIT 2.1.1785763465
```

* Operating system and version:
NixOS unstable: 26.11.20260829.d2f6794 (Zokor)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (lua annotations)
